### PR TITLE
Add CLAUDE.md; fix license to GPL-3.0-or-later

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,64 @@
+# CLAUDE.md
+
+Project guidance for Claude Code sessions. Keep this file tight — skim it first, then dive in.
+
+## Project overview
+
+PacketFrame is a modular eBPF data plane written in pure Rust (aya + aya-ebpf). The MVP module is **fast-path**, which takes forwarded traffic for allowlisted prefixes off the kernel's conntrack/netfilter path via XDP ingress + `bpf_fib_lookup` + `bpf_redirect_map`. The design spec (`SPEC.md`) is deliberately **not** in the repo — inline code comments cite section numbers ("SPEC.md §4.2") as breadcrumbs for reviewers who have the spec. Don't re-add `SPEC.md`; it's in `.gitignore`.
+
+## Repo layout
+
+- `crates/common/` — config parser (SPEC.md §6), `Module` trait (§3.2), §2.1 capability probes
+- `crates/cli/` — the `packetframe` binary (clap subcommands)
+- `crates/modules/fast-path/` — fast-path module; v0.0.1 is a stub, the BPF program lands in PR #3
+- `conf/example.conf` — reference config per SPEC.md §4.8
+- `.github/workflows/` — `ci.yml` (fmt/clippy/test + 4× cross-build) and `release.yml` (tag-triggered tarballs)
+
+## Build & test
+
+```sh
+make test          # cargo test across the workspace
+make build         # debug build, host target
+make release       # release build, host target
+make release-all   # release build for all 4 published targets (requires `cross`)
+make lint          # cargo fmt --check + cargo clippy -D warnings
+make fmt           # cargo fmt
+```
+
+CI runs all of the above plus cross-builds for `{aarch64,x86_64}-unknown-linux-{musl,gnu}`.
+
+## License
+
+GPL-3.0-or-later. The three surfaces must agree: `LICENSE` (GPLv3 text), `Cargo.toml` workspace `license` field, `README.md` License section.
+
+## Platform constraints
+
+Linux-only code — BPF syscalls, `/proc/config.gz`, `/proc/sys/...`, bpffs — is gated behind `#[cfg(target_os = "linux")]`. Non-Linux hosts get `ENOSYS`-returning stubs so `cargo check`/`cargo test` succeed on macOS dev laptops. On macOS, `packetframe feasibility` correctly reports every BPF capability as **Fail** — that's expected behavior, not a bug to chase. `bpf_prog_test_run` fixtures (landing in PR #3) only run on Linux CI.
+
+## Toolchain
+
+Stable Rust is pinned via root `rust-toolchain.toml`. From PR #3 onward a second `rust-toolchain.toml` under `crates/modules/fast-path/bpf/` pins nightly for the BPF crate (aya-ebpf needs it). `bpf-linker` is pinned in CI via `cargo install --locked bpf-linker@<version>`. Don't unpin any of these — aya has had breaking API changes across minor versions.
+
+## Error handling
+
+Validate at system boundaries (`bpf()` syscall, sysfs/procfs reads, config parse). Trust framework guarantees inside — no fallbacks for conditions that can't occur. No backwards-compat shims for hypothetical future states; change the code directly when requirements change.
+
+## Spec tethering
+
+Comments reference spec sections, they don't restate them. Don't paraphrase the spec in docstrings unless the spec is genuinely unclear on a point. "SPEC.md §4.4 step 9d" is better than a prose recap that will drift. Read the cited section when touching the cited code.
+
+## Clippy policy
+
+CI runs `cargo clippy --workspace --all-targets --all-features -- -D warnings`. Cross-platform casts that are no-ops on one target but load-bearing on another (e.g. `statfs.f_type as i64` — `i64` already on glibc Linux x86_64, but `u32` on macOS) need a targeted `#[allow(clippy::unnecessary_cast)]` with a comment explaining *why* the cast stays. The pattern is established in [crates/common/src/probe/mod.rs](crates/common/src/probe/mod.rs) and [crates/common/src/probe/bpf.rs](crates/common/src/probe/bpf.rs).
+
+## PR workflow
+
+One feature branch per slice. Commit messages explain **why**, not what the diff already shows. CI must be green before asking for review (five jobs: fmt+clippy+test and four cross-builds). Amending unreviewed commits and `git push --force-with-lease` on a feature branch is fine pre-review — force-push to `main` is never fine. For v0.1 the slicing is in the plan file; keep PRs scoped to a single slice.
+
+## What not to change casually
+
+- `SPEC.md` stays out of the repo — it's in `.gitignore`.
+- License stays GPL-3.0-or-later across `LICENSE`, `Cargo.toml`, and `README.md`.
+- The `Module` trait in [crates/common/src/module.rs](crates/common/src/module.rs) is the public contract for every future module (randomizer, ddos, sampler) — breaking changes need a changelog note and coordinated updates.
+- Counter indices in the `stats` map (§4.6) are append-only once v0.1 ships — renumbering breaks operator dashboards.
+- Platform cfg gates: don't collapse the Linux-only/non-Linux split without also making the macOS dev loop still work.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 version = "0.0.1"
 edition = "2021"
 rust-version = "1.85"
-license = "Apache-2.0"
+license = "GPL-3.0-or-later"
 repository = "https://github.com/unredacted/packetframe"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -119,4 +119,4 @@ packetframe/
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+GPL-3.0-or-later. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` at the repo root — a skimmable guide for future Claude Code sessions covering project overview, repo layout, build/test commands, platform constraints, toolchain pinning, the clippy pattern for cross-platform casts, and the PR workflow.
- Fixes the three-way license mismatch: `LICENSE` was already GPLv3 but `Cargo.toml` and `README.md` said `Apache-2.0`. Aligns all three to `GPL-3.0-or-later` before any binary ships under the wrong metadata.

## Why

First of four planned slices for v0.1. Both changes are tiny, load-bearing, and unlock the subsequent BPF-heavy PRs cleanly: the license alignment prevents future releases from carrying incorrect SPDX metadata, and `CLAUDE.md` means each subsequent session starts aligned on conventions (spec tethering, platform cfg-gating, PR-branch policy) without reloading context.

The design spec (`SPEC.md`) stays out of the repo — `CLAUDE.md` documents this and explains the inline `"SPEC.md §X.Y"` breadcrumb convention so reviewers know what the section references mean.

## Reviewer notes

- `CLAUDE.md` is ~70 lines by design. Litmus test: it should answer "what's the license", "how do I run tests", "why do BPF probes fail on macOS", "where will BPF code live", and "what's the PR-branch policy" without anyone having to open the spec or the source.
- SPDX `GPL-3.0-or-later` (chosen over `GPL-3.0-only`) — code can also be used under later GPL versions when they exist. Standard FOSS default.
- No Rust source changes, no CI changes. All five CI jobs should stay green trivially.

## v0.1 slicing ahead

For context — future PRs in this v0.1 sequence, per the plan:

- **PR #3**: fast-path BPF program + `bpf_prog_test_run` fixtures (non-VLAN path), `crates/modules/fast-path/bpf/` with nightly toolchain, `aya-ebpf`/`aya`/`bpf-linker` pinned.
- **PR #4**: aya userspace loader — load/attach/detach/status, pin registry persistence, veth netns integration test. Fast-path runs end-to-end in dry-run.
- **PR #5**: VLAN choreography (§4.7) + §11.1/§11.11 empirical probes on the EFG.
- **PR #6**: Prometheus metrics, circuit breaker, SIGHUP reconcile, QEMU verifier CI (5.15 + modern).

## Test plan

- [x] CI green on all five jobs.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets --all-features -- -D warnings`, `cargo test --workspace` all clean locally (trivially — no Rust code changes).
- [x] Open `CLAUDE.md` cold and confirm the litmus-test questions are answerable from it alone.
- [x] Verify `Cargo.toml` workspace `license` field and README License section both read `GPL-3.0-or-later`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)