### PR TITLE
v0.1: VLAN choreography, packet fixtures, kernel 6.0+ probe fix (PR #5)

### DIFF
--- a/crates/common/src/probe/bpf.rs
+++ b/crates/common/src/probe/bpf.rs
@@ -229,14 +229,16 @@ pub fn map_create(
     max_entries: u32,
     map_flags: u32,
 ) -> io::Result<OwnedFd> {
-    let attr = MapCreateAttr {
-        map_type,
-        key_size,
-        value_size,
-        max_entries,
-        map_flags,
-        ..Default::default()
-    };
+    // `mem::zeroed` over struct-literal: the kernel's CHECK_ATTR checks
+    // that bytes past the command's last field are zero; struct-literal
+    // init leaves Rust's trailing padding uninitialized. Same root cause
+    // as the probe/prog_load EINVAL we hit on kernel 6.0+.
+    let mut attr: MapCreateAttr = unsafe { std::mem::zeroed() };
+    attr.map_type = map_type;
+    attr.key_size = key_size;
+    attr.value_size = value_size;
+    attr.max_entries = max_entries;
+    attr.map_flags = map_flags;
     let ret = unsafe {
         bpf_syscall(
             BPF_MAP_CREATE,
@@ -265,16 +267,20 @@ pub fn prog_load(prog_type: u32, insns: &[BpfInsn], license: &str) -> io::Result
     // 16 KiB log is plenty for our 3-5-instruction probes.
     let mut log_buf = vec![0u8; 16 * 1024];
 
-    let attr = ProgLoadAttr {
-        prog_type,
-        insn_cnt: insns.len() as u32,
-        insns: insns.as_ptr() as u64,
-        license: license_c.as_ptr() as u64,
-        log_level: 1, // BPF_LOG_LEVEL1 — emit verifier log
-        log_size: log_buf.len() as u32,
-        log_buf: log_buf.as_mut_ptr() as u64,
-        ..Default::default()
-    };
+    // `mem::zeroed` rather than struct-literal + `..Default::default()`:
+    // the kernel's CHECK_ATTR validates that bytes past the command's
+    // last field are zero. Rust's `Default` leaves padding bytes
+    // uninitialized; kernel 6.0+ rejects this with EINVAL and no log.
+    // Zeroing the whole struct, including padding, fixes the probe
+    // on modern kernels.
+    let mut attr: ProgLoadAttr = unsafe { std::mem::zeroed() };
+    attr.prog_type = prog_type;
+    attr.insn_cnt = insns.len() as u32;
+    attr.insns = insns.as_ptr() as u64;
+    attr.license = license_c.as_ptr() as u64;
+    attr.log_level = 1; // BPF_LOG_LEVEL1 — emit verifier log
+    attr.log_size = log_buf.len() as u32;
+    attr.log_buf = log_buf.as_mut_ptr() as u64;
 
     let ret = unsafe {
         bpf_syscall(

--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -131,16 +131,8 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
     let mut caps = vec![
         probe_kconfig(),
         probe_bpf_syscall_available(),
-        // prog_type.* and helper.* are advisory: the raw `bpf_prog_load`
-        // dance we do here is fragile across kernel versions (newer
-        // kernels reject minimally-populated bpf_attr with EINVAL even
-        // when real prog loads via aya succeed). The authoritative
-        // check is the per-interface trial-attach in `xdp.attach.*`
-        // (graduates from Deferred when `--config` supplies ifaces),
-        // which does a real aya-mediated load through the kernel
-        // verifier. If those pass, helpers and prog types are present.
-        probe_prog_type("prog_type.xdp", BPF_PROG_TYPE_XDP, false),
-        probe_prog_type("prog_type.sched_cls", BPF_PROG_TYPE_SCHED_CLS, false),
+        probe_prog_type("prog_type.xdp", BPF_PROG_TYPE_XDP, true),
+        probe_prog_type("prog_type.sched_cls", BPF_PROG_TYPE_SCHED_CLS, true),
         probe_map_hash(),
         probe_map_array(),
         probe_map_percpu_array(),
@@ -152,7 +144,7 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
     caps.extend(
         helper_probes
             .iter()
-            .map(|(name, id)| probe_helper(name, *id, false)),
+            .map(|(name, id)| probe_helper(name, *id, true)),
     );
 
     caps.push(probe_bpffs(bpffs_root));

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -1,9 +1,9 @@
-//! PacketFrame fast-path BPF program (SPEC.md §4.4).
+//! PacketFrame fast-path BPF program (SPEC.md §4.4 + §4.7).
 //!
-//! Parses Ethernet + IPv4/IPv6, consults the allowlist (src-or-dst match,
-//! §4.2), calls `bpf_fib_lookup`, rewrites L2 + TTL, and redirects via
-//! `bpf_redirect_map`. Skips any 802.1Q-tagged traffic (`XDP_PASS`) —
-//! VLAN push/pop/rewrite (§4.7) lands in PR #5. All counters in
+//! Parses Ethernet (optionally one 802.1Q tag), IPv4 or IPv6, consults
+//! the allowlist (src-or-dst match, §4.2), calls `bpf_fib_lookup`,
+//! rewrites L2 + TTL, performs any required VLAN push / pop / rewrite
+//! per §4.7, and redirects via `bpf_redirect_map`. All counters in
 //! [`maps::StatIdx`] are bumped per SPEC.md §4.6. Dry-run mode
 //! (cfg.dry_run=1) returns `XDP_PASS` after matched-counter bumps but
 //! performs no rewrites.
@@ -17,7 +17,7 @@ use aya_ebpf::{
         BPF_FIB_LKUP_RET_NO_NEIGH, BPF_FIB_LKUP_RET_PROHIBIT, BPF_FIB_LKUP_RET_SUCCESS,
         BPF_FIB_LKUP_RET_UNREACHABLE,
     },
-    helpers::gen::bpf_fib_lookup as fib_lookup_helper,
+    helpers::gen::{bpf_fib_lookup as fib_lookup_helper, bpf_xdp_adjust_head},
     macros::xdp,
     maps::lpm_trie::Key,
     programs::XdpContext,
@@ -30,10 +30,24 @@ use network_types::{
 
 mod maps;
 
-use maps::{bump_stat, StatIdx, ALLOW_V4, ALLOW_V6, CFG, REDIRECT_DEVMAP};
+use maps::{bump_stat, StatIdx, ALLOW_V4, ALLOW_V6, CFG, REDIRECT_DEVMAP, VLAN_RESOLVE};
 
 const AF_INET: u8 = 2;
 const AF_INET6: u8 = 10;
+
+/// 802.1Q TPID. What we write back on push / rewrite.
+const TPID_8021Q: u16 = 0x8100;
+
+/// One 802.1Q tag. 4 bytes: TPID (next header after eth src/dst) is
+/// already known = 0x8100, then the TCI (PCP:3 | DEI:1 | VID:12), then
+/// the inner ethertype. Laid out packed since the tag sits directly
+/// after the MAC pair with no padding.
+#[repr(C, packed(1))]
+struct VlanTag {
+    tci: [u8; 2],
+    inner_ether_type: u16,
+}
+const VLAN_HDR_LEN: usize = 4;
 
 #[xdp]
 pub fn fast_path(ctx: XdpContext) -> u32 {
@@ -52,22 +66,29 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
 #[inline(always)]
 fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
     let eth: *mut EthHdr = ptr_mut_at(ctx, 0)?;
-    // `ether_type` is a raw `u16` (packed into the EthHdr struct in
-    // network byte order). `EtherType` is an enum that gives named
-    // discriminants matching what an LE host reads from the network
-    // bytes (Ipv4 = 0x0008, Ipv6 = 0xDD86, Ieee8021q = 0x0081). Cast
-    // to u16 for comparison — SPEC.md §3.5 keeps us on stable kernel
-    // UAPI only; no CO-RE.
-    let ether = unsafe { (*eth).ether_type };
+    let outer_ether = unsafe { (*eth).ether_type };
 
-    if ether == EtherType::Ipv4 as u16 {
-        handle_ipv4(ctx, eth)
-    } else if ether == EtherType::Ipv6 as u16 {
-        handle_ipv6(ctx, eth)
-    } else if ether == EtherType::Ieee8021q as u16 || ether == EtherType::Ieee8021ad as u16 {
-        // Tagged traffic — PR #5 handles VLAN push/pop/rewrite.
-        bump_stat(StatIdx::PassNotIp);
-        Ok(xdp_action::XDP_PASS)
+    // 802.1Q ingress parse (SPEC §4.4 step 2). Step past exactly one
+    // tag; QinQ is out of scope for v0.1 (§11.6). For `outer_ether ==
+    // 0x8100` on our LE host, the enum discriminant is `Ieee8021q as
+    // u16 = 0x0081`.
+    let (inner_ether, ip_offset, ingress_vid) = if outer_ether == EtherType::Ieee8021q as u16
+        || outer_ether == EtherType::Ieee8021ad as u16
+    {
+        let vlan: *const VlanTag = ptr_at(ctx, EthHdr::LEN)?;
+        let tci = u16::from_be_bytes(unsafe { (*vlan).tci });
+        // Low 12 bits are the VID.
+        let vid = tci & 0x0fff;
+        let inner = unsafe { (*vlan).inner_ether_type };
+        (inner, EthHdr::LEN + VLAN_HDR_LEN, Some(vid))
+    } else {
+        (outer_ether, EthHdr::LEN, None)
+    };
+
+    if inner_ether == EtherType::Ipv4 as u16 {
+        handle_ipv4(ctx, eth, ip_offset, ingress_vid)
+    } else if inner_ether == EtherType::Ipv6 as u16 {
+        handle_ipv6(ctx, eth, ip_offset, ingress_vid)
     } else {
         bump_stat(StatIdx::PassNotIp);
         Ok(xdp_action::XDP_PASS)
@@ -75,29 +96,24 @@ fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
 }
 
 #[inline(always)]
-fn handle_ipv4(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
-    let ip: *mut Ipv4Hdr = ptr_mut_at(ctx, EthHdr::LEN)?;
+fn handle_ipv4(
+    ctx: &XdpContext,
+    eth: *mut EthHdr,
+    ip_offset: usize,
+    ingress_vid: Option<u16>,
+) -> Result<u32, ()> {
+    let ip: *mut Ipv4Hdr = ptr_mut_at(ctx, ip_offset)?;
 
-    // IHL check — packets with IPv4 options (IHL > 5) go to the kernel
-    // slow path. SPEC.md §4.4 step 4.
-    //
-    // `Ipv4Hdr::ihl()` returns the header length in *bytes* (IHL * 4)
-    // rather than the raw IHL field — which is a footgun if you're
-    // reading SPEC §4.4 and typing `ihl != 5`. A standard IPv4 header
-    // with no options is 20 bytes; anything larger means options.
+    // `Ipv4Hdr::ihl()` returns bytes (IHL * 4). Standard header = 20;
+    // anything else means options → kernel slow path.
     let ihl_bytes = unsafe { (*ip).ihl() };
     if ihl_bytes != 20 {
         bump_stat(StatIdx::PassComplexHeader);
         return Ok(xdp_action::XDP_PASS);
     }
 
-    // Fragment check. The `frags` field contains flags+offset in the
-    // low 13 bits of a network-order u16. network-types exposes a
-    // `frag_offset()` helper but we also need the MF flag; read the
-    // raw u16 and mask.
+    // Fragment check: MF bit (0x2000) or non-zero offset (low 13 bits).
     let frags_be = u16::from_be_bytes(unsafe { (*ip).frags });
-    // Low 13 bits = offset; bit 13 = MF. Bit 14 = DF (ignored).
-    // A non-zero result in those 14 bits means "fragment".
     if (frags_be & 0x3fff) != 0 {
         bump_stat(StatIdx::PassFragment);
         return Ok(xdp_action::XDP_PASS);
@@ -130,13 +146,8 @@ fn handle_ipv4(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
         return Ok(xdp_action::XDP_PASS);
     }
 
-    // L4 ports for the FIB lookup (SPEC.md §4.4 step 7). Required for
-    // ECMP routes with L4-hash policy — without sport/dport we'd always
-    // hash to the same next-hop and diverge from the kernel slow path.
-    let (sport, dport) = l4_ports(ctx, EthHdr::LEN + Ipv4Hdr::LEN, proto);
+    let (sport, dport) = l4_ports(ctx, ip_offset + Ipv4Hdr::LEN, proto);
 
-    // FIB lookup. SPEC.md §4.4 step 8: flags=0 — honors ip-rule policy,
-    // uses ingress semantics.
     let mut fib: bpf_fib_lookup = unsafe { mem::zeroed() };
     fib.family = AF_INET;
     fib.l4_protocol = proto as u8;
@@ -144,8 +155,6 @@ fn handle_ipv4(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
     fib.dport = dport;
     fib.ifindex = unsafe { (*ctx.ctx).ingress_ifindex };
     fib.__bindgen_anon_1.tot_len = u16::from_be_bytes(unsafe { (*ip).tot_len });
-    // `tos` is at offset 1 of the IPv4 header and sits in __bindgen_anon_2
-    // of bpf_fib_lookup.
     fib.__bindgen_anon_2.tos = unsafe { (*ip).tos };
     fib.__bindgen_anon_3.ipv4_src = u32::from_ne_bytes(src_bytes);
     fib.__bindgen_anon_4.ipv4_dst = u32::from_ne_bytes(dst_bytes);
@@ -159,15 +168,18 @@ fn handle_ipv4(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
         )
     };
 
-    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, true, &fib)
+    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, true, &fib, ingress_vid)
 }
 
 #[inline(always)]
-fn handle_ipv6(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
-    let ip: *mut Ipv6Hdr = ptr_mut_at(ctx, EthHdr::LEN)?;
+fn handle_ipv6(
+    ctx: &XdpContext,
+    eth: *mut EthHdr,
+    ip_offset: usize,
+    ingress_vid: Option<u16>,
+) -> Result<u32, ()> {
+    let ip: *mut Ipv6Hdr = ptr_mut_at(ctx, ip_offset)?;
 
-    // Extension-header check (SPEC.md §4.4 step 4): if next_hdr isn't
-    // TCP/UDP/ICMPv6, the kernel has to walk the chain — we punt.
     let next = unsafe { (*ip).next_hdr };
     match next {
         IpProto::Tcp | IpProto::Udp | IpProto::Ipv6Icmp => {}
@@ -203,7 +215,7 @@ fn handle_ipv6(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
         return Ok(xdp_action::XDP_PASS);
     }
 
-    let (sport, dport) = l4_ports(ctx, EthHdr::LEN + Ipv6Hdr::LEN, next);
+    let (sport, dport) = l4_ports(ctx, ip_offset + Ipv6Hdr::LEN, next);
 
     let mut fib: bpf_fib_lookup = unsafe { mem::zeroed() };
     fib.family = AF_INET6;
@@ -213,12 +225,7 @@ fn handle_ipv6(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
     fib.ifindex = unsafe { (*ctx.ctx).ingress_ifindex };
     fib.__bindgen_anon_1.tot_len =
         u16::from_be_bytes(unsafe { (*ip).payload_len }) + Ipv6Hdr::LEN as u16;
-    // IPv6 flowinfo = vcf field bytes 0-3 (version + tc + flowlabel).
     fib.__bindgen_anon_2.flowinfo = u32::from_be_bytes(unsafe { (*ip).vcf });
-
-    // IPv6 addresses are 4 × u32 in the struct; copy from byte arrays.
-    // Safe to access the bindgen unions directly — writing any variant
-    // is legal Rust (reads across variants would be the UB we'd avoid).
     fib.__bindgen_anon_3.ipv6_src = bytes_to_u32x4(&src_bytes);
     fib.__bindgen_anon_4.ipv6_dst = bytes_to_u32x4(&dst_bytes);
 
@@ -231,40 +238,61 @@ fn handle_ipv6(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
         )
     };
 
-    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, false, &fib)
+    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, false, &fib, ingress_vid)
 }
 
-/// Common FIB-return dispatch. `is_v4` selects the IPv4 TTL+csum fixup
-/// path vs IPv6 hop-limit decrement.
 #[inline(always)]
 fn dispatch_fib(
     ret: u32,
-    _ctx: &XdpContext,
+    ctx: &XdpContext,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
     fib: &bpf_fib_lookup,
+    ingress_vid: Option<u16>,
 ) -> Result<u32, ()> {
     match ret {
         BPF_FIB_LKUP_RET_SUCCESS => {
+            // Resolve the egress port's expected tagging. If fib.ifindex
+            // is recorded in `vlan_resolve`, it's a VLAN subif — redirect
+            // to the physical parent and push/rewrite to the recorded
+            // VID. Otherwise the target is physical/untagged.
+            let (egress_ifindex, egress_vid) = match unsafe { VLAN_RESOLVE.get(&fib.ifindex) } {
+                Some(vi) => (vi.phys_ifindex, Some(vi.vid)),
+                None => (fib.ifindex, None),
+            };
+
+            // TTL/hop_limit + csum first — IP header's position in
+            // memory doesn't change with adjust_head, only its offset
+            // from `data` does.
             if is_v4 {
                 decrement_ipv4_ttl(ip as *mut Ipv4Hdr);
             } else {
                 decrement_ipv6_hop_limit(ip as *mut Ipv6Hdr);
             }
+            // L2 rewrite BEFORE push/pop — push moves the current MAC
+            // positions into new slots, so the values there need to be
+            // the post-FIB MACs.
             unsafe {
                 (*eth).dst_addr = fib.dmac;
                 (*eth).src_addr = fib.smac;
             }
-            // Defensive devmap pre-check — SPEC.md §4.4 step 9d. Without
-            // it, `bpf_redirect_map` with flags=0 silently XDP_ABORTS on
-            // miss. We prefer XDP_PASS + counter so the slow path picks
-            // up traffic destined to operator-excluded ifindexes.
-            if REDIRECT_DEVMAP.get(fib.ifindex).is_none() {
+
+            // VLAN choreography (SPEC §4.7). On error, XDP_ABORTED +
+            // err_vlan per the spec.
+            if apply_vlan_egress(ctx, ingress_vid, egress_vid).is_err() {
+                bump_stat(StatIdx::ErrVlan);
+                return Ok(xdp_action::XDP_ABORTED);
+            }
+
+            // Defensive devmap pre-check (§4.4 step 9d). `egress_ifindex`
+            // is the *actual* physical port we redirect to, which may
+            // differ from `fib.ifindex` when we resolved a subif.
+            if REDIRECT_DEVMAP.get(egress_ifindex).is_none() {
                 bump_stat(StatIdx::PassNotInDevmap);
                 return Ok(xdp_action::XDP_PASS);
             }
-            match REDIRECT_DEVMAP.redirect(fib.ifindex, 0) {
+            match REDIRECT_DEVMAP.redirect(egress_ifindex, 0) {
                 Ok(_) => {
                     bump_stat(StatIdx::FwdOk);
                     Ok(xdp_action::XDP_REDIRECT)
@@ -296,17 +324,124 @@ fn dispatch_fib(
     }
 }
 
+// --- VLAN choreography ----------------------------------------------------
+
+/// §4.7's four-case matrix. Returns Err(()) on any packet-manipulation
+/// failure (bounds check, `bpf_xdp_adjust_head` failure).
+#[inline(always)]
+fn apply_vlan_egress(
+    ctx: &XdpContext,
+    ingress_vid: Option<u16>,
+    egress_vid: Option<u16>,
+) -> Result<(), ()> {
+    match (ingress_vid, egress_vid) {
+        (None, None) => Ok(()),
+        (Some(iv), Some(ev)) if iv == ev => Ok(()),
+        (None, Some(v)) => vlan_push(ctx, v),
+        (Some(_), None) => vlan_pop(ctx),
+        (Some(_), Some(v)) => vlan_rewrite(ctx, v),
+    }
+}
+
+/// Untagged → tagged. Grows headroom by 4, shifts the MAC pair left by
+/// 4 bytes, writes TPID + TCI into the freed-up slot. SPEC §4.7.
+///
+/// Uses `core::ptr::copy` (true memmove) not `copy_nonoverlapping` —
+/// the source and destination regions overlap. This is the footgun
+/// SPEC calls out: on some VID combinations `copy_nonoverlapping`
+/// produces wrong bytes on the wire and the verifier does NOT catch it.
+#[inline(always)]
+fn vlan_push(ctx: &XdpContext, vid: u16) -> Result<(), ()> {
+    // Grow headroom by 4 bytes.
+    let rc = unsafe { bpf_xdp_adjust_head(ctx.ctx as *mut _, -4) };
+    if rc != 0 {
+        return Err(());
+    }
+
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + 18 > end {
+        return Err(());
+    }
+
+    // SAFETY: pointers derived from the freshly-re-read data/data_end,
+    // both bounds-checked for the 18-byte range we touch.
+    unsafe {
+        let base = start as *mut u8;
+        // Move dst_mac left: [4..10] → [0..6]. 6-byte move, overlapping.
+        core::ptr::copy(base.add(4), base, 6);
+        // Move src_mac left: [10..16] → [6..12]. Overlapping.
+        core::ptr::copy(base.add(10), base.add(6), 6);
+        // TPID (0x8100) at [12..14], big-endian.
+        let tpid = TPID_8021Q.to_be_bytes();
+        *base.add(12) = tpid[0];
+        *base.add(13) = tpid[1];
+        // TCI at [14..16]: PCP=0 | DEI=0 | VID (12 bits), big-endian.
+        let tci = (vid & 0x0fff).to_be_bytes();
+        *base.add(14) = tci[0];
+        *base.add(15) = tci[1];
+        // [16..18] already holds the original inner ethertype —
+        // bpf_xdp_adjust_head didn't touch packet bytes, only the
+        // data pointer.
+    }
+    Ok(())
+}
+
+/// Tagged → untagged. Shifts the MAC pair right by 4 bytes over the
+/// (about-to-be-discarded) TPID+TCI slot, then shrinks headroom by 4.
+#[inline(always)]
+fn vlan_pop(ctx: &XdpContext) -> Result<(), ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + 18 > end {
+        return Err(());
+    }
+    // SAFETY: bounds-checked 18-byte range.
+    unsafe {
+        let base = start as *mut u8;
+        // Move src_mac right first: [6..12] → [10..16]. Overlapping.
+        core::ptr::copy(base.add(6), base.add(10), 6);
+        // Move dst_mac right: [0..6] → [4..10]. Overlapping.
+        core::ptr::copy(base, base.add(4), 6);
+    }
+    // Shrink headroom by 4; new data starts 4 bytes later.
+    let rc = unsafe { bpf_xdp_adjust_head(ctx.ctx as *mut _, 4) };
+    if rc != 0 {
+        return Err(());
+    }
+    Ok(())
+}
+
+/// Tagged VID X → tagged VID Y (X ≠ Y). No headroom change; overwrite
+/// the TCI bytes in place.
+#[inline(always)]
+fn vlan_rewrite(ctx: &XdpContext, vid: u16) -> Result<(), ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + 16 > end {
+        return Err(());
+    }
+    let tci = (vid & 0x0fff).to_be_bytes();
+    unsafe {
+        let base = start as *mut u8;
+        *base.add(14) = tci[0];
+        *base.add(15) = tci[1];
+    }
+    Ok(())
+}
+
+// --- TTL / csum / helpers -------------------------------------------------
+
 /// Decrement IPv4 TTL and patch the header checksum using RFC 1624
-/// incremental update. When TTL decreases by 1, the 16-bit word at
-/// bytes 8-9 (TTL:proto) decreases by 0x0100 in network byte order.
-/// In one's-complement arithmetic that bumps the checksum by +0x0100.
+/// incremental update: when TTL decreases by 1, the word at bytes 8-9
+/// (TTL:proto, network order) decreases by 0x0100 → the checksum
+/// increases by 0x0100 in one's-complement arithmetic.
 #[inline(always)]
 fn decrement_ipv4_ttl(ip: *mut Ipv4Hdr) {
     unsafe {
         (*ip).ttl -= 1;
         let mut sum = u16::from_be_bytes((*ip).check) as u32;
         sum = sum.wrapping_add(0x0100);
-        // Fold carry back to 16 bits.
         sum = (sum & 0xffff).wrapping_add(sum >> 16);
         (*ip).check = (sum as u16).to_be_bytes();
     }
@@ -334,27 +469,26 @@ fn is_dry_run() -> bool {
     CFG.get(0).map(|c| c.dry_run != 0).unwrap_or(false)
 }
 
-/// Bounds-checked mutable pointer into the packet at `offset`.
 #[inline(always)]
-fn ptr_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<*mut T, ()> {
+fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
     let start = ctx.data();
     let end = ctx.data_end();
     let size = mem::size_of::<T>();
     if start + offset + size > end {
         return Err(());
     }
-    Ok((start + offset) as *mut T)
+    Ok((start + offset) as *const T)
 }
 
-/// Read sport and dport from the L4 header at `offset` in the packet.
-/// Returns the raw network-byte-order bytes as `u16`s — matches what
-/// the kernel's `bpf_fib_lookup` expects for its `__be16` sport/dport
-/// fields. Returns `(0, 0)` for non-port protocols (ICMP, ICMPv6) or
-/// when the L4 header would run past the end of data.
-///
-/// SPEC.md §4.4 step 7: populating these matters for ECMP correctness —
-/// routes with L4-hash policy would otherwise collapse to a single
-/// next-hop and diverge from the kernel slow path.
+#[inline(always)]
+fn ptr_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<*mut T, ()> {
+    Ok(ptr_at::<T>(ctx, offset)? as *mut T)
+}
+
+/// Read sport/dport from the L4 header at `offset`. Returns raw BE
+/// network-order u16 bytes (via `read_unaligned`) matching what the
+/// kernel's `bpf_fib_lookup` expects for its `__be16` sport/dport
+/// fields on an LE host. (0, 0) for ICMP / ICMPv6 or truncated L4.
 #[inline(always)]
 fn l4_ports(ctx: &XdpContext, offset: usize, proto: IpProto) -> (u16, u16) {
     if !matches!(proto, IpProto::Tcp | IpProto::Udp) {
@@ -365,9 +499,6 @@ fn l4_ports(ctx: &XdpContext, offset: usize, proto: IpProto) -> (u16, u16) {
     if start + offset + 4 > end {
         return (0, 0);
     }
-    // Read two big-endian u16s as raw packet bytes. The kernel stores
-    // `__be16` — on LE hosts (what BPF targets) a direct pointer cast
-    // of the raw bytes matches that representation.
     unsafe {
         let p = (start + offset) as *const u8;
         let sport = core::ptr::read_unaligned(p as *const u16);
@@ -376,8 +507,6 @@ fn l4_ports(ctx: &XdpContext, offset: usize, proto: IpProto) -> (u16, u16) {
     }
 }
 
-/// Helper: [u8; 16] → [u32; 4] in network byte order (each 4-byte group
-/// as a big-endian u32 matching how the kernel stores `ipv6_src/dst`).
 #[inline(always)]
 fn bytes_to_u32x4(b: &[u8; 16]) -> [u32; 4] {
     [

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -38,6 +38,15 @@ const AF_INET6: u8 = 10;
 /// 802.1Q TPID. What we write back on push / rewrite.
 const TPID_8021Q: u16 = 0x8100;
 
+/// Sentinel u16 representing "no VLAN" in the VID-passing API below.
+/// 802.1Q reserves VID 0 for priority-only tagging, so `vid == 0`
+/// means absent from the fast-path's perspective. Using a single u16
+/// instead of `Option<u16>` keeps the value in one register across
+/// function-call boundaries — the verifier chokes on Option<u16>
+/// because the inner-value register is uninitialized on the None
+/// branch, failing with `Rn !read_ok` after argument spills.
+const VLAN_NONE: u16 = 0;
+
 /// One 802.1Q tag. 4 bytes: TPID (next header after eth src/dst) is
 /// already known = 0x8100, then the TCI (PCP:3 | DEI:1 | VID:12), then
 /// the inner ethertype. Laid out packed since the tag sits directly
@@ -77,12 +86,15 @@ fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
     {
         let vlan: *const VlanTag = ptr_at(ctx, EthHdr::LEN)?;
         let tci = u16::from_be_bytes(unsafe { (*vlan).tci });
-        // Low 12 bits are the VID.
+        // Low 12 bits are the VID. Legal VIDs are 1..4094; 0 and 4095
+        // are reserved. A VID of 0 here would collide with VLAN_NONE,
+        // so treat it as absent (matches 802.1Q's "priority-only" tag
+        // semantics — we don't fast-path those either).
         let vid = tci & 0x0fff;
         let inner = unsafe { (*vlan).inner_ether_type };
-        (inner, EthHdr::LEN + VLAN_HDR_LEN, Some(vid))
+        (inner, EthHdr::LEN + VLAN_HDR_LEN, vid)
     } else {
-        (outer_ether, EthHdr::LEN, None)
+        (outer_ether, EthHdr::LEN, VLAN_NONE)
     };
 
     if inner_ether == EtherType::Ipv4 as u16 {
@@ -100,7 +112,7 @@ fn handle_ipv4(
     ctx: &XdpContext,
     eth: *mut EthHdr,
     ip_offset: usize,
-    ingress_vid: Option<u16>,
+    ingress_vid: u16,
 ) -> Result<u32, ()> {
     let ip: *mut Ipv4Hdr = ptr_mut_at(ctx, ip_offset)?;
 
@@ -176,7 +188,7 @@ fn handle_ipv6(
     ctx: &XdpContext,
     eth: *mut EthHdr,
     ip_offset: usize,
-    ingress_vid: Option<u16>,
+    ingress_vid: u16,
 ) -> Result<u32, ()> {
     let ip: *mut Ipv6Hdr = ptr_mut_at(ctx, ip_offset)?;
 
@@ -249,7 +261,7 @@ fn dispatch_fib(
     ip: *mut u8,
     is_v4: bool,
     fib: &bpf_fib_lookup,
-    ingress_vid: Option<u16>,
+    ingress_vid: u16,
 ) -> Result<u32, ()> {
     match ret {
         BPF_FIB_LKUP_RET_SUCCESS => {
@@ -258,8 +270,8 @@ fn dispatch_fib(
             // to the physical parent and push/rewrite to the recorded
             // VID. Otherwise the target is physical/untagged.
             let (egress_ifindex, egress_vid) = match unsafe { VLAN_RESOLVE.get(&fib.ifindex) } {
-                Some(vi) => (vi.phys_ifindex, Some(vi.vid)),
-                None => (fib.ifindex, None),
+                Some(vi) => (vi.phys_ifindex, vi.vid),
+                None => (fib.ifindex, VLAN_NONE),
             };
 
             // TTL/hop_limit + csum first — IP header's position in
@@ -326,20 +338,19 @@ fn dispatch_fib(
 
 // --- VLAN choreography ----------------------------------------------------
 
-/// §4.7's four-case matrix. Returns Err(()) on any packet-manipulation
-/// failure (bounds check, `bpf_xdp_adjust_head` failure).
+/// §4.7's four-case matrix, keyed on VLAN_NONE-sentinel u16s rather
+/// than Option<u16> (the verifier rejects the Option-argument spill).
+/// Returns Err(()) on any packet-manipulation failure.
 #[inline(always)]
-fn apply_vlan_egress(
-    ctx: &XdpContext,
-    ingress_vid: Option<u16>,
-    egress_vid: Option<u16>,
-) -> Result<(), ()> {
-    match (ingress_vid, egress_vid) {
-        (None, None) => Ok(()),
-        (Some(iv), Some(ev)) if iv == ev => Ok(()),
-        (None, Some(v)) => vlan_push(ctx, v),
-        (Some(_), None) => vlan_pop(ctx),
-        (Some(_), Some(v)) => vlan_rewrite(ctx, v),
+fn apply_vlan_egress(ctx: &XdpContext, ingress_vid: u16, egress_vid: u16) -> Result<(), ()> {
+    let ingress_present = ingress_vid != VLAN_NONE;
+    let egress_present = egress_vid != VLAN_NONE;
+    match (ingress_present, egress_present) {
+        (false, false) => Ok(()),
+        (true, true) if ingress_vid == egress_vid => Ok(()),
+        (false, true) => vlan_push(ctx, egress_vid),
+        (true, false) => vlan_pop(ctx),
+        (true, true) => vlan_rewrite(ctx, egress_vid),
     }
 }
 

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -80,8 +80,13 @@ fn handle_ipv4(ctx: &XdpContext, eth: *mut EthHdr) -> Result<u32, ()> {
 
     // IHL check — packets with IPv4 options (IHL > 5) go to the kernel
     // slow path. SPEC.md §4.4 step 4.
-    let ihl = unsafe { (*ip).ihl() };
-    if ihl != 5 {
+    //
+    // `Ipv4Hdr::ihl()` returns the header length in *bytes* (IHL * 4)
+    // rather than the raw IHL field — which is a footgun if you're
+    // reading SPEC §4.4 and typing `ihl != 5`. A standard IPv4 header
+    // with no options is 20 bytes; anything larger means options.
+    let ihl_bytes = unsafe { (*ip).ihl() };
+    if ihl_bytes != 20 {
         bump_stat(StatIdx::PassComplexHeader);
         return Ok(xdp_action::XDP_PASS);
     }

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -8,7 +8,7 @@
 
 use aya_ebpf::{
     macros::map,
-    maps::{Array, DevMapHash, LpmTrie, PerCpuArray, RingBuf},
+    maps::{Array, DevMapHash, HashMap, LpmTrie, PerCpuArray, RingBuf},
 };
 
 /// Runtime flags poked by userspace via the `cfg` map. `version` is a
@@ -88,6 +88,22 @@ const REDIRECT_DEVMAP_MAX_ENTRIES: u32 = 64;
 /// size; 256 KiB works across 4 KiB and 16 KiB page hosts (some ARM).
 const LOG_RINGBUF_BYTES: u32 = 256 * 1024;
 
+/// Max VLAN-subif entries. The reference EFG's agg-switch trunk carries
+/// VIDs 1/66/88/99/1337 + 3996..4040 — ~50. 256 is headroom.
+const VLAN_RESOLVE_MAX_ENTRIES: u32 = 256;
+
+/// Value stored in `vlan_resolve`. Maps an egress VLAN-subif ifindex
+/// (the key) to its physical parent + VID so the BPF program can
+/// (a) redirect to the physical port and (b) push the right tag.
+/// `#[repr(C)]` with explicit 2-byte pad so userspace layout matches.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct VlanResolve {
+    pub phys_ifindex: u32,
+    pub vid: u16,
+    pub _pad: u16,
+}
+
 // --- Maps ---------------------------------------------------------------
 
 /// IPv4 allowlist, src-or-dst match (SPEC §4.2). Key is
@@ -121,6 +137,14 @@ pub static LOG: RingBuf = RingBuf::with_byte_size(LOG_RINGBUF_BYTES, 0);
 #[map]
 pub static REDIRECT_DEVMAP: DevMapHash =
     DevMapHash::with_max_entries(REDIRECT_DEVMAP_MAX_ENTRIES, 0);
+
+/// VLAN-subif → (phys_ifindex, vid) lookup (SPEC §4.5, §4.7). Consulted
+/// after `bpf_fib_lookup` returns a subif ifindex: if present, the
+/// program redirects to the physical parent and pushes the recorded
+/// VID; if absent, the target is treated as physical/untagged.
+#[map]
+pub static VLAN_RESOLVE: HashMap<u32, VlanResolve> =
+    HashMap::with_max_entries(VLAN_RESOLVE_MAX_ENTRIES, 0);
 
 // --- Stat increment helper ---------------------------------------------
 

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -9,7 +9,7 @@ use std::ffi::CString;
 use std::path::{Path, PathBuf};
 
 use aya::{
-    maps::{lpm_trie::Key as LpmKey, xdp::DevMapHash, Array, LpmTrie},
+    maps::{lpm_trie::Key as LpmKey, xdp::DevMapHash, Array, HashMap as AyaHashMap, LpmTrie},
     programs::{xdp::XdpFlags, Xdp},
     Ebpf,
 };
@@ -42,6 +42,21 @@ pub struct FpCfg {
 unsafe impl aya::Pod for FpCfg {}
 
 const FP_CFG_VERSION_V1: u32 = 0;
+
+/// Layout mirror of `VlanResolve` in `bpf/src/maps.rs`. Hash-map value
+/// that tells the BPF program "this subif ifindex really egresses on
+/// phys_ifindex with a VID". `#[repr(C)]` + u32/u16/u16 packs to 8
+/// bytes; every bit pattern is valid.
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct VlanResolve {
+    pub phys_ifindex: u32,
+    pub vid: u16,
+    pub _pad: u16,
+}
+
+// SAFETY: repr(C), all primitive fields, every bit pattern valid.
+unsafe impl aya::Pod for VlanResolve {}
 
 /// All state required to keep the attached program alive.
 /// `Drop` on `Ebpf` unloads the program + maps, which is what we want
@@ -249,6 +264,8 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         })?;
     }
 
+    populate_vlan_resolve(state)?;
+
     // Build Attachment records for the pin registry. `pinned_path` is
     // advisory in v0.1 — actual bpffs pinning lands with reconcile in
     // PR #6 — but we populate the shape so the registry survives
@@ -316,6 +333,96 @@ fn try_attach_with_fallback(
             }
         },
     }
+}
+
+/// Populate `vlan_resolve` from `/proc/net/vlan/config`. Each VLAN
+/// subinterface maps its ifindex → (physical parent ifindex, VID) so
+/// the BPF program can push/pop/rewrite per SPEC §4.7 when the FIB
+/// resolves to a subif. Missing `/proc/net/vlan/config` (no 8021q
+/// kernel module loaded) is not an error — we just insert nothing.
+fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
+    let entries = match read_vlan_config() {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            info!("/proc/net/vlan/config missing — no VLAN subifs to resolve");
+            return Ok(());
+        }
+        Err(e) => {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!("read /proc/net/vlan/config: {e}"),
+            ));
+        }
+    };
+
+    if entries.is_empty() {
+        info!("/proc/net/vlan/config empty — no VLAN subifs configured");
+        return Ok(());
+    }
+
+    let map = state
+        .ebpf
+        .map_mut("VLAN_RESOLVE")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "VLAN_RESOLVE map missing from ELF"))?;
+    let mut hm: AyaHashMap<_, u32, VlanResolve> = AyaHashMap::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("VLAN_RESOLVE try_from: {e}")))?;
+
+    for (subif_name, vid, parent_name) in entries {
+        let subif_idx = if_nametoindex(&subif_name)?;
+        let phys_idx = if_nametoindex(&parent_name)?;
+        let value = VlanResolve {
+            phys_ifindex: phys_idx,
+            vid,
+            _pad: 0,
+        };
+        hm.insert(subif_idx, value, 0).map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("VLAN_RESOLVE insert {subif_name}: {e}"),
+            )
+        })?;
+        info!(
+            subif = %subif_name,
+            subif_idx,
+            parent = %parent_name,
+            phys_idx,
+            vid,
+            "vlan_resolve populated"
+        );
+    }
+    Ok(())
+}
+
+/// Parse `/proc/net/vlan/config`. Format (from Linux net/8021q):
+///
+/// ```text
+/// VLAN Dev name    | VLAN ID
+/// Name-Type: VLAN_NAME_TYPE_RAW_PLUS_VID_NO_PAD
+/// eth0.1337        | 1337  | eth0
+/// ```
+///
+/// Skip the two header lines, split each subsequent line on `|`, trim
+/// whitespace, and return `(subif_name, vid, parent_name)` tuples.
+fn read_vlan_config() -> std::io::Result<Vec<(String, u16, String)>> {
+    let content = std::fs::read_to_string("/proc/net/vlan/config")?;
+    let mut out = Vec::new();
+    for line in content.lines().skip(2) {
+        let parts: Vec<&str> = line.split('|').map(|s| s.trim()).collect();
+        if parts.len() != 3 {
+            continue;
+        }
+        let subif = parts[0].to_string();
+        let vid: u16 = match parts[1].parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let parent = parts[2].to_string();
+        if subif.is_empty() || parent.is_empty() {
+            continue;
+        }
+        out.push((subif, vid, parent));
+    }
+    Ok(out)
 }
 
 pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -1,0 +1,425 @@
+//! Shared test harness for `bpf_prog_test_run`-backed fixtures.
+//!
+//! aya 0.13.1 doesn't expose a `test_run` wrapper for XDP programs,
+//! so we invoke `bpf(BPF_PROG_TEST_RUN)` directly via `libc::syscall`.
+//! The kernel executes the BPF program against a caller-supplied
+//! synthetic packet and returns the verdict + any mutated packet bytes.
+//!
+//! Usage:
+//! ```ignore
+//! let mut h = Harness::new();
+//! h.add_allow_v4("10.0.0.0/8");
+//! let (verdict, out) = h.run(&packet);
+//! assert_eq!(verdict, xdp_action::XDP_PASS);
+//! assert_eq!(h.stat(StatIdx::MatchedV4), 0);
+//! ```
+//!
+//! Requires CAP_BPF + CAP_NET_ADMIN; callers mark tests `#[ignore]`
+//! and CI runs them under sudo.
+
+#![cfg(target_os = "linux")]
+#![allow(dead_code)] // Used from multiple integration-test files; unused warnings fire per-file.
+
+use std::os::fd::AsRawFd;
+
+use aya::{
+    maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, PerCpuArray},
+    programs::{ProgramFd, Xdp},
+    Ebpf, Pod,
+};
+use packetframe_fast_path::aligned_bpf_copy;
+
+/// Layout mirror of `FpCfg` in `bpf/src/maps.rs`. Must track
+/// `linux_impl::FpCfg` — if you change one, change both (and both's
+/// ordering in the StatIdx enum at the same time).
+#[repr(C)]
+#[derive(Copy, Clone, Debug)]
+pub struct FpCfg {
+    pub dry_run: u8,
+    pub flags: u8,
+    pub _reserved: [u8; 2],
+    pub version: u32,
+}
+
+unsafe impl Pod for FpCfg {}
+
+pub const FP_CFG_VERSION_V1: u32 = 0;
+pub const STATS_COUNT: u32 = 19;
+
+/// Wire-format counter indices (SPEC.md §4.6). Append-only once v0.1
+/// ships; never renumber.
+#[repr(u32)]
+#[derive(Copy, Clone, Debug)]
+pub enum StatIdx {
+    RxTotal = 0,
+    MatchedV4 = 1,
+    MatchedV6 = 2,
+    MatchedSrcOnly = 3,
+    MatchedDstOnly = 4,
+    MatchedBoth = 5,
+    FwdOk = 6,
+    FwdDryRun = 7,
+    PassFragment = 8,
+    PassLowTtl = 9,
+    PassNoNeigh = 10,
+    PassNotIp = 11,
+    PassFragNeeded = 12,
+    DropUnreachable = 13,
+    ErrParse = 14,
+    ErrFibOther = 15,
+    ErrVlan = 16,
+    PassNotInDevmap = 17,
+    PassComplexHeader = 18,
+}
+
+/// Minimum XDP verdict constants. Pulled in locally to avoid a
+/// dev-dep on aya-ebpf (nightly-only).
+pub mod xdp_action {
+    pub const XDP_ABORTED: u32 = 0;
+    pub const XDP_DROP: u32 = 1;
+    pub const XDP_PASS: u32 = 2;
+    pub const XDP_TX: u32 = 3;
+    pub const XDP_REDIRECT: u32 = 4;
+}
+
+pub struct Harness {
+    pub bpf: Ebpf,
+}
+
+impl Harness {
+    /// Load + verify the fast-path program. Panics if BPF isn't built
+    /// or the kernel rejects it.
+    pub fn new() -> Self {
+        let bytes = aligned_bpf_copy();
+        let mut bpf = Ebpf::load(&bytes).expect("aya::Ebpf::load");
+
+        let prog: &mut Xdp = bpf
+            .program_mut("fast_path")
+            .expect("fast_path program present")
+            .try_into()
+            .expect("program is XDP-typed");
+        prog.load().expect("verifier accepts program");
+
+        // Set a default cfg with dry_run=off and both families enabled.
+        let mut harness = Self { bpf };
+        harness.set_cfg(FpCfg {
+            dry_run: 0,
+            flags: 0b11,
+            _reserved: [0; 2],
+            version: FP_CFG_VERSION_V1,
+        });
+        harness
+    }
+
+    pub fn set_cfg(&mut self, cfg: FpCfg) {
+        let map = self.bpf.map_mut("CFG").expect("CFG map");
+        let mut arr: Array<_, FpCfg> = Array::try_from(map).expect("CFG try_from");
+        arr.set(0, cfg, 0).expect("CFG set");
+    }
+
+    pub fn set_dry_run(&mut self, on: bool) {
+        self.set_cfg(FpCfg {
+            dry_run: u8::from(on),
+            flags: 0b11,
+            _reserved: [0; 2],
+            version: FP_CFG_VERSION_V1,
+        });
+    }
+
+    /// Insert an IPv4 prefix into the allowlist. `prefix` is
+    /// `"A.B.C.D/N"`.
+    pub fn add_allow_v4(&mut self, prefix: &str) {
+        let (addr, plen) = parse_v4_prefix(prefix);
+        let map = self.bpf.map_mut("ALLOW_V4").expect("ALLOW_V4 map");
+        let mut trie: LpmTrie<_, [u8; 4], u8> = LpmTrie::try_from(map).expect("LpmTrie try_from");
+        let key = LpmKey::new(u32::from(plen), addr);
+        trie.insert(&key, 1u8, 0).expect("ALLOW_V4 insert");
+    }
+
+    /// Insert an IPv6 prefix into the allowlist.
+    pub fn add_allow_v6(&mut self, prefix: &str) {
+        let (addr, plen) = parse_v6_prefix(prefix);
+        let map = self.bpf.map_mut("ALLOW_V6").expect("ALLOW_V6 map");
+        let mut trie: LpmTrie<_, [u8; 16], u8> = LpmTrie::try_from(map).expect("LpmTrie try_from");
+        let key = LpmKey::new(u32::from(plen), addr);
+        trie.insert(&key, 1u8, 0).expect("ALLOW_V6 insert");
+    }
+
+    /// Run the BPF program against `packet`. Returns (verdict, output
+    /// bytes). The kernel may have mutated the packet (L2 rewrite, TTL
+    /// decrement) on XDP_REDIRECT; the output buffer reflects that.
+    pub fn run(&self, packet: &[u8]) -> (u32, Vec<u8>) {
+        let prog: &Xdp = self
+            .bpf
+            .program("fast_path")
+            .expect("fast_path present")
+            .try_into()
+            .expect("program is XDP");
+        let prog_fd: &ProgramFd = prog.fd().expect("program loaded");
+        test_run_xdp(prog_fd.as_fd().as_raw_fd(), packet)
+    }
+
+    /// Aggregate a PerCpuArray stat across all CPUs.
+    pub fn stat(&self, idx: StatIdx) -> u64 {
+        let map = self.bpf.map("STATS").expect("STATS map");
+        let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map).expect("PerCpuArray try_from");
+        let per_cpu = stats.get(&(idx as u32), 0).expect("STATS get");
+        per_cpu.iter().copied().sum()
+    }
+}
+
+// --- Raw bpf(BPF_PROG_TEST_RUN) ----------------------------------------
+
+/// `bpf(BPF_PROG_TEST_RUN, ...)` struct layout. Matches the kernel's
+/// `union bpf_attr` `test` variant through kernel 6.1.
+#[repr(C)]
+#[derive(Default)]
+struct TestRunAttr {
+    prog_fd: u32,
+    retval: u32,
+    data_size_in: u32,
+    data_size_out: u32,
+    data_in: u64,
+    data_out: u64,
+    repeat: u32,
+    duration: u32,
+    ctx_size_in: u32,
+    ctx_size_out: u32,
+    ctx_in: u64,
+    ctx_out: u64,
+    flags: u32,
+    cpu: u32,
+    batch_size: u32,
+}
+
+const BPF_PROG_TEST_RUN: u32 = 10;
+
+fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
+    // XDP programs may grow the packet (VLAN push: +4). Allocate
+    // output with headroom so the kernel doesn't truncate.
+    let mut data_out = vec![0u8; packet.len() + 256];
+
+    let mut attr = TestRunAttr {
+        prog_fd: prog_fd as u32,
+        data_size_in: packet.len() as u32,
+        data_size_out: data_out.len() as u32,
+        data_in: packet.as_ptr() as u64,
+        data_out: data_out.as_mut_ptr() as u64,
+        repeat: 1,
+        ..Default::default()
+    };
+
+    let ret = unsafe {
+        libc::syscall(
+            libc::SYS_bpf,
+            BPF_PROG_TEST_RUN as libc::c_long,
+            &mut attr as *mut _ as *const u8,
+            std::mem::size_of::<TestRunAttr>() as u32,
+        )
+    };
+
+    if ret != 0 {
+        let e = std::io::Error::last_os_error();
+        panic!("BPF_PROG_TEST_RUN returned {ret} (errno {e})");
+    }
+
+    data_out.truncate(attr.data_size_out as usize);
+    (attr.retval, data_out)
+}
+
+// --- Prefix parsing ---------------------------------------------------
+
+fn parse_v4_prefix(s: &str) -> ([u8; 4], u8) {
+    let (addr, len) = s.split_once('/').expect("CIDR");
+    let addr: std::net::Ipv4Addr = addr.parse().expect("IPv4");
+    (addr.octets(), len.parse().expect("prefix_len"))
+}
+
+fn parse_v6_prefix(s: &str) -> ([u8; 16], u8) {
+    let (addr, len) = s.split_once('/').expect("CIDR");
+    let addr: std::net::Ipv6Addr = addr.parse().expect("IPv6");
+    (addr.octets(), len.parse().expect("prefix_len"))
+}
+
+// --- Packet builders --------------------------------------------------
+
+/// Minimum Ethernet + IPv4 + TCP packet builder. Pads the TCP payload
+/// with zeros if you ask for a specific `payload_len`.
+pub struct Ipv4TcpBuilder {
+    pub src_mac: [u8; 6],
+    pub dst_mac: [u8; 6],
+    pub src_ip: [u8; 4],
+    pub dst_ip: [u8; 4],
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub ttl: u8,
+    pub tos: u8,
+    pub frag_flags: u16, // network byte order: bit 15=res, 14=DF, 13=MF, 12..0=offset
+    pub ihl: u8,         // normally 5; set >5 to produce IHL>5 via header option bytes
+    pub payload: Vec<u8>,
+}
+
+impl Default for Ipv4TcpBuilder {
+    fn default() -> Self {
+        Self {
+            src_mac: [0xaa, 0, 0, 0, 0, 1],
+            dst_mac: [0xbb, 0, 0, 0, 0, 2],
+            src_ip: [10, 0, 0, 1],
+            dst_ip: [10, 0, 0, 2],
+            src_port: 1000,
+            dst_port: 2000,
+            ttl: 64,
+            tos: 0,
+            frag_flags: 0,
+            ihl: 5,
+            payload: Vec::new(),
+        }
+    }
+}
+
+impl Ipv4TcpBuilder {
+    pub fn build(&self) -> Vec<u8> {
+        let ip_header_len = (self.ihl as usize) * 4;
+        let total_len = (ip_header_len + 20 + self.payload.len()) as u16; // +TCP hdr
+        let mut pkt = Vec::with_capacity(14 + total_len as usize);
+
+        // Ethernet
+        pkt.extend_from_slice(&self.dst_mac);
+        pkt.extend_from_slice(&self.src_mac);
+        pkt.extend_from_slice(&[0x08, 0x00]); // IPv4
+
+        // IPv4
+        let vihl_offset = pkt.len();
+        pkt.push(0x40 | self.ihl); // version 4 | IHL
+        pkt.push(self.tos);
+        pkt.extend_from_slice(&total_len.to_be_bytes());
+        pkt.extend_from_slice(&[0, 0]); // id
+        pkt.extend_from_slice(&self.frag_flags.to_be_bytes());
+        pkt.push(self.ttl);
+        pkt.push(6); // TCP
+        let check_offset = pkt.len();
+        pkt.extend_from_slice(&[0, 0]); // checksum placeholder
+        pkt.extend_from_slice(&self.src_ip);
+        pkt.extend_from_slice(&self.dst_ip);
+        // IHL > 5 → stuff option bytes (zero-filled "nop" x4 per extra word).
+        for _ in 5..self.ihl {
+            pkt.extend_from_slice(&[0x01, 0x01, 0x01, 0x01]); // four NOP options
+        }
+
+        // Compute IPv4 checksum over the header we just wrote.
+        let ip_header = &pkt[vihl_offset..vihl_offset + ip_header_len];
+        let csum = ipv4_checksum(ip_header);
+        pkt[check_offset..check_offset + 2].copy_from_slice(&csum.to_be_bytes());
+
+        // TCP (minimal 20-byte header; flags = SYN; no options)
+        pkt.extend_from_slice(&self.src_port.to_be_bytes());
+        pkt.extend_from_slice(&self.dst_port.to_be_bytes());
+        pkt.extend_from_slice(&[0, 0, 0, 1]); // seq
+        pkt.extend_from_slice(&[0, 0, 0, 0]); // ack
+        pkt.push(0x50); // data offset 5 in upper nibble
+        pkt.push(0x02); // SYN
+        pkt.extend_from_slice(&[0xff, 0xff]); // window
+        pkt.extend_from_slice(&[0, 0, 0, 0]); // checksum (zero - bpf doesn't care for fixtures)
+
+        pkt.extend_from_slice(&self.payload);
+        pkt
+    }
+}
+
+/// Minimum Ethernet + IPv6 + TCP packet builder.
+pub struct Ipv6TcpBuilder {
+    pub src_mac: [u8; 6],
+    pub dst_mac: [u8; 6],
+    pub src_ip: [u8; 16],
+    pub dst_ip: [u8; 16],
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub hop_limit: u8,
+    pub next_hdr: u8, // 6 TCP, 17 UDP, 44 Fragment, etc.
+    pub payload: Vec<u8>,
+}
+
+impl Default for Ipv6TcpBuilder {
+    fn default() -> Self {
+        Self {
+            src_mac: [0xaa, 0, 0, 0, 0, 1],
+            dst_mac: [0xbb, 0, 0, 0, 0, 2],
+            src_ip: [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+            dst_ip: [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2],
+            src_port: 1000,
+            dst_port: 2000,
+            hop_limit: 64,
+            next_hdr: 6, // TCP
+            payload: Vec::new(),
+        }
+    }
+}
+
+impl Ipv6TcpBuilder {
+    pub fn build(&self) -> Vec<u8> {
+        // If next_hdr is TCP/UDP, append a minimal L4 header. For other
+        // next_hdrs (Fragment, Hop-by-Hop) tests supply payload manually.
+        let l4_len = match self.next_hdr {
+            6 | 17 => 20 + self.payload.len(),
+            _ => self.payload.len(),
+        };
+        let payload_len = l4_len as u16;
+
+        let mut pkt = Vec::with_capacity(14 + 40 + l4_len);
+        // Ethernet
+        pkt.extend_from_slice(&self.dst_mac);
+        pkt.extend_from_slice(&self.src_mac);
+        pkt.extend_from_slice(&[0x86, 0xdd]); // IPv6
+                                              // IPv6 header
+        pkt.extend_from_slice(&[0x60, 0, 0, 0]); // version=6, traffic class=0, flow=0
+        pkt.extend_from_slice(&payload_len.to_be_bytes());
+        pkt.push(self.next_hdr);
+        pkt.push(self.hop_limit);
+        pkt.extend_from_slice(&self.src_ip);
+        pkt.extend_from_slice(&self.dst_ip);
+
+        match self.next_hdr {
+            6 => {
+                // TCP minimal
+                pkt.extend_from_slice(&self.src_port.to_be_bytes());
+                pkt.extend_from_slice(&self.dst_port.to_be_bytes());
+                pkt.extend_from_slice(&[0, 0, 0, 1]);
+                pkt.extend_from_slice(&[0, 0, 0, 0]);
+                pkt.push(0x50);
+                pkt.push(0x02);
+                pkt.extend_from_slice(&[0xff, 0xff]);
+                pkt.extend_from_slice(&[0, 0, 0, 0]);
+                pkt.extend_from_slice(&self.payload);
+            }
+            17 => {
+                // UDP
+                pkt.extend_from_slice(&self.src_port.to_be_bytes());
+                pkt.extend_from_slice(&self.dst_port.to_be_bytes());
+                let udp_len = (8 + self.payload.len()) as u16;
+                pkt.extend_from_slice(&udp_len.to_be_bytes());
+                pkt.extend_from_slice(&[0, 0]);
+                pkt.extend_from_slice(&self.payload);
+            }
+            _ => {
+                // Extension header or unknown — caller-supplied payload only.
+                pkt.extend_from_slice(&self.payload);
+            }
+        }
+        pkt
+    }
+}
+
+fn ipv4_checksum(header: &[u8]) -> u16 {
+    assert_eq!(header.len() % 2, 0, "header must be even-length");
+    let mut sum: u32 = 0;
+    for chunk in header.chunks_exact(2) {
+        // Skip the checksum field (bytes 10-11 of a standard IPv4 header).
+        sum += u16::from_be_bytes([chunk[0], chunk[1]]) as u32;
+    }
+    // Subtract the checksum bytes we included (they were zero in practice
+    // here since the builder leaves them as 0 before calling us).
+    while sum >> 16 > 0 {
+        sum = (sum & 0xffff) + (sum >> 16);
+    }
+    !(sum as u16)
+}

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -282,6 +282,19 @@ impl Default for Ipv4TcpBuilder {
     }
 }
 
+/// Wrap a base Ethernet+IP packet with one 802.1Q tag inserted
+/// between the MAC pair and the inner ethertype. `vid` is the 12-bit
+/// VLAN ID; PCP/DEI are left zero.
+pub fn insert_vlan_tag(base: &[u8], vid: u16) -> Vec<u8> {
+    assert!(base.len() >= 14, "base packet must have Ethernet header");
+    let mut out = Vec::with_capacity(base.len() + 4);
+    out.extend_from_slice(&base[0..12]); // MAC pair
+    out.extend_from_slice(&[0x81, 0x00]); // 802.1Q TPID
+    out.extend_from_slice(&(vid & 0x0fff).to_be_bytes()); // TCI
+    out.extend_from_slice(&base[12..]); // inner ethertype + rest
+    out
+}
+
 impl Ipv4TcpBuilder {
     pub fn build(&self) -> Vec<u8> {
         let ip_header_len = (self.ihl as usize) * 4;

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -20,7 +20,7 @@
 #![cfg(target_os = "linux")]
 #![allow(dead_code)] // Used from multiple integration-test files; unused warnings fire per-file.
 
-use std::os::fd::AsRawFd;
+use std::os::fd::{AsFd, AsRawFd};
 
 use aya::{
     maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, PerCpuArray},

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -171,9 +171,9 @@ impl Harness {
 // --- Raw bpf(BPF_PROG_TEST_RUN) ----------------------------------------
 
 /// `bpf(BPF_PROG_TEST_RUN, ...)` struct layout. Matches the kernel's
-/// `union bpf_attr` `test` variant through kernel 6.1.
+/// `union bpf_attr` `test` variant through kernel 6.1. 76 meaningful
+/// bytes + 4 bytes of trailing padding to hit 8-byte alignment.
 #[repr(C)]
-#[derive(Default)]
 struct TestRunAttr {
     prog_fd: u32,
     retval: u32,
@@ -199,15 +199,20 @@ fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
     // output with headroom so the kernel doesn't truncate.
     let mut data_out = vec![0u8; packet.len() + 256];
 
-    let mut attr = TestRunAttr {
-        prog_fd: prog_fd as u32,
-        data_size_in: packet.len() as u32,
-        data_size_out: data_out.len() as u32,
-        data_in: packet.as_ptr() as u64,
-        data_out: data_out.as_mut_ptr() as u64,
-        repeat: 1,
-        ..Default::default()
-    };
+    // `mem::zeroed` over a struct-literal init: the kernel's CHECK_ATTR
+    // macro validates that bytes past `batch_size` (the last field of
+    // the TEST_RUN variant) are zero. A `#[derive(Default)]` init only
+    // zeros named fields — the 4 bytes of trailing padding we carry to
+    // hit 8-byte alignment stay uninitialized and land as garbage in
+    // the attr buffer → kernel 6.0+ returns EINVAL with no log. Zeroing
+    // the whole buffer first is the fix.
+    let mut attr: TestRunAttr = unsafe { std::mem::zeroed() };
+    attr.prog_fd = prog_fd as u32;
+    attr.data_size_in = packet.len() as u32;
+    attr.data_size_out = data_out.len() as u32;
+    attr.data_in = packet.as_ptr() as u64;
+    attr.data_out = data_out.as_mut_ptr() as u64;
+    attr.repeat = 1;
 
     let ret = unsafe {
         libc::syscall(

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -16,7 +16,7 @@
 
 mod common;
 
-use common::{xdp_action, Harness, Ipv4TcpBuilder, Ipv6TcpBuilder, StatIdx};
+use common::{insert_vlan_tag, xdp_action, Harness, Ipv4TcpBuilder, Ipv6TcpBuilder, StatIdx};
 
 fn rx_total_delta(before: u64, h: &Harness) -> u64 {
     h.stat(StatIdx::RxTotal) - before
@@ -338,4 +338,155 @@ fn every_packet_bumps_rx_total() {
     h.add_allow_v4("10.0.0.0/8");
     h.run(&p);
     assert_eq!(h.stat(StatIdx::RxTotal), before + 3);
+}
+
+// ========== VLAN ingress parse (SPEC §4.4 step 2, §4.7) ==================
+//
+// `bpf_prog_test_run` can't exercise the §4.7 egress push/pop/rewrite
+// directly because that path sits behind a `bpf_fib_lookup` SUCCESS
+// which needs real routes configured — that's netns-integration-test
+// territory, deferred. What the tests below *do* cover:
+//
+// - Tagged packets are recognized as 802.1Q and the inner ethertype
+//   decides IPv4 vs IPv6 handling.
+// - The ingress VID is threaded through all the way to the dispatch
+//   layer (asserted indirectly via the matched counters + dry-run
+//   short-circuit, which fires AFTER the tagged ingress parse).
+// - Tagged packets with malformed / unsupported inner fall through to
+//   the same pass_not_ip / pass_complex_header buckets as untagged.
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_tagged_ipv4_src_match_dry_run_bumps_matched_v4() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_dry_run(true);
+
+    let base = Ipv4TcpBuilder {
+        src_ip: [10, 1, 2, 3],
+        dst_ip: [192, 0, 2, 1],
+        ..Default::default()
+    }
+    .build();
+    let tagged = insert_vlan_tag(&base, 1337);
+
+    let before_matched = h.stat(StatIdx::MatchedV4);
+    let before_src = h.stat(StatIdx::MatchedSrcOnly);
+    let before_dry = h.stat(StatIdx::FwdDryRun);
+    let (verdict, _) = h.run(&tagged);
+    // If ingress VLAN parse failed, we'd see pass_not_ip or err_parse
+    // instead; matched_v4 wouldn't bump.
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV4), before_matched + 1);
+    assert_eq!(h.stat(StatIdx::MatchedSrcOnly), before_src + 1);
+    assert_eq!(h.stat(StatIdx::FwdDryRun), before_dry + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_tagged_ipv6_dst_match_dry_run_bumps_matched_v6() {
+    let mut h = Harness::new();
+    h.add_allow_v6("2001:db8::/32");
+    h.set_dry_run(true);
+
+    let base = Ipv6TcpBuilder {
+        src_ip: [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        dst_ip: [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        ..Default::default()
+    }
+    .build();
+    let tagged = insert_vlan_tag(&base, 66);
+
+    let before_v6 = h.stat(StatIdx::MatchedV6);
+    let before_dst = h.stat(StatIdx::MatchedDstOnly);
+    let (verdict, _) = h.run(&tagged);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV6), before_v6 + 1);
+    assert_eq!(h.stat(StatIdx::MatchedDstOnly), before_dst + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_tagged_ipv4_with_options_routes_to_complex_header() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let base = Ipv4TcpBuilder {
+        ihl: 6, // IPv4 options — routed to pass_complex_header
+        ..Default::default()
+    }
+    .build();
+    let tagged = insert_vlan_tag(&base, 1);
+
+    let before = h.stat(StatIdx::PassComplexHeader);
+    let (verdict, _) = h.run(&tagged);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassComplexHeader), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_tagged_ipv4_fragment_routes_to_pass_fragment() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let base = Ipv4TcpBuilder {
+        frag_flags: 0x2000, // MF set
+        ..Default::default()
+    }
+    .build();
+    let tagged = insert_vlan_tag(&base, 99);
+
+    let before = h.stat(StatIdx::PassFragment);
+    let (verdict, _) = h.run(&tagged);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassFragment), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_tagged_non_ip_inner_passes_with_pass_not_ip() {
+    let h = Harness::new();
+
+    // Tagged ARP — inner ethertype after VLAN tag is 0x0806 (not v4/v6).
+    let mut base = vec![0u8; 64];
+    base[0..6].copy_from_slice(&[0xff; 6]);
+    base[6..12].copy_from_slice(&[0xaa, 0, 0, 0, 0, 1]);
+    base[12..14].copy_from_slice(&[0x08, 0x06]); // ARP
+    let tagged = insert_vlan_tag(&base, 42);
+
+    let before = h.stat(StatIdx::PassNotIp);
+    let (verdict, _) = h.run(&tagged);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassNotIp), before + 1);
+}
+
+// ========== Jumbo frames (SPEC §11.5) =====================================
+//
+// Reference EFG has 9182-byte MTU on VLAN trunks. Test with a 4K-class
+// TCP payload — XDP_PACKET_HEADROOM (256) + 4K body + slab tailroom
+// fits comfortably under the kernel's ~4096-byte `max_data_sz` cap for
+// test_run without LIVE_FRAMES. A true 9K frame needs LIVE_FRAMES mode
+// (5.18+) which is netns-integration-test territory. This fixture
+// proves the parse/allowlist/dry-run path doesn't choke on jumbo-ish
+// sizes.
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_jumbo_payload_src_match_dry_run() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_dry_run(true);
+
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [10, 9, 9, 9],
+        payload: vec![0xaa; 3600], // 3.6K body under the test_run cap
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::MatchedV4);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV4), before + 1);
 }

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -1,0 +1,342 @@
+//! Packet-level fixtures via `bpf_prog_test_run`. Covers the
+//! non-FIB §9 Phase 1 cases — parse errors, fragments, low TTL,
+//! allowlist misses, complex headers — deferred from PR #3 where aya
+//! 0.13.1 didn't wrap `BPF_PROG_TEST_RUN`. The raw-syscall harness in
+//! `tests/common/mod.rs` bridges that gap.
+//!
+//! FIB-return verdict cases (SUCCESS, NO_NEIGH, BLACKHOLE,
+//! FRAG_NEEDED, not-in-devmap) need configured routes and a populated
+//! `redirect_devmap`; those belong in a netns-backed integration test,
+//! a separate slice.
+//!
+//! Every test is `#[ignore]` — it needs CAP_BPF + BPF build. CI runs
+//! the full set under sudo via `cargo test --tests -- --ignored`.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::{xdp_action, Harness, Ipv4TcpBuilder, Ipv6TcpBuilder, StatIdx};
+
+fn rx_total_delta(before: u64, h: &Harness) -> u64 {
+    h.stat(StatIdx::RxTotal) - before
+}
+
+// ========== Non-IP ========================================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn arp_passes_with_pass_not_ip() {
+    let mut h = Harness::new();
+
+    // ARP (ethertype 0x0806) — plausibly-shaped but not IP.
+    let mut pkt = vec![0u8; 64];
+    pkt[0..6].copy_from_slice(&[0xff; 6]); // dst = broadcast
+    pkt[6..12].copy_from_slice(&[0xaa, 0, 0, 0, 0, 1]); // src
+    pkt[12..14].copy_from_slice(&[0x08, 0x06]); // ARP
+
+    let before = h.stat(StatIdx::PassNotIp);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassNotIp), before + 1);
+}
+
+// ========== IPv4: parse / malformed =======================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_with_options_passes_with_complex_header() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8"); // would otherwise match
+
+    let pkt = Ipv4TcpBuilder {
+        ihl: 6, // one 32-bit word of options (4 NOPs)
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassComplexHeader);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassComplexHeader), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_mf_fragment_passes_with_pass_fragment() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let pkt = Ipv4TcpBuilder {
+        // MF bit set (bit 13 of the flags+offset u16 in network order).
+        frag_flags: 0x2000,
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassFragment);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassFragment), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_non_zero_offset_passes_with_pass_fragment() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let pkt = Ipv4TcpBuilder {
+        frag_flags: 0x0001, // offset=1 (fragment of a larger packet)
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassFragment);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassFragment), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_ttl_1_passes_with_pass_low_ttl() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let pkt = Ipv4TcpBuilder {
+        ttl: 1,
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassLowTtl);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassLowTtl), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_ttl_0_passes_with_pass_low_ttl() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+
+    let pkt = Ipv4TcpBuilder {
+        ttl: 0,
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassLowTtl);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassLowTtl), before + 1);
+}
+
+// ========== IPv4: allowlist miss ==========================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_neither_in_allowlist_passes_silently() {
+    let mut h = Harness::new();
+    h.add_allow_v4("192.168.1.0/24"); // doesn't match src/dst below
+
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [10, 0, 0, 1],
+        dst_ip: [10, 0, 0, 2],
+        ..Default::default()
+    }
+    .build();
+
+    let before_matched = h.stat(StatIdx::MatchedV4);
+    let before_rx = h.stat(StatIdx::RxTotal);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    // No matched counter bumped.
+    assert_eq!(h.stat(StatIdx::MatchedV4), before_matched);
+    // But rx_total did bump — every packet is counted at the hook.
+    assert_eq!(rx_total_delta(before_rx, &h), 1);
+}
+
+// ========== IPv6: parse / malformed =======================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv6_fragment_extension_passes_with_complex_header() {
+    let mut h = Harness::new();
+    h.add_allow_v6("2001:db8::/32");
+
+    // IPv6 Fragment header next_hdr = 44. Our impl XDP_PASSes on any
+    // non-{TCP, UDP, ICMPv6} next_hdr and bumps pass_complex_header —
+    // per our interpretation of the SPEC §4.4 step 4 ambiguity (see
+    // audit in PR #3).
+    let pkt = Ipv6TcpBuilder {
+        next_hdr: 44,
+        payload: vec![0; 8], // minimum fragment header bytes
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassComplexHeader);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassComplexHeader), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv6_hop_by_hop_extension_passes_with_complex_header() {
+    let mut h = Harness::new();
+    h.add_allow_v6("2001:db8::/32");
+
+    // Hop-by-Hop extension header = 0.
+    let pkt = Ipv6TcpBuilder {
+        next_hdr: 0,
+        payload: vec![0; 8],
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassComplexHeader);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassComplexHeader), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv6_hop_limit_1_passes_with_pass_low_ttl() {
+    let mut h = Harness::new();
+    h.add_allow_v6("2001:db8::/32");
+
+    let pkt = Ipv6TcpBuilder {
+        hop_limit: 1,
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::PassLowTtl);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassLowTtl), before + 1);
+}
+
+// ========== Allowlist match + dry-run =====================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_src_match_dry_run_passes_with_matched_and_fwd_dry_run() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_dry_run(true);
+
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [10, 1, 2, 3],  // matches /8
+        dst_ip: [192, 0, 2, 1], // does not match
+        ..Default::default()
+    }
+    .build();
+
+    let before_matched = h.stat(StatIdx::MatchedV4);
+    let before_src_only = h.stat(StatIdx::MatchedSrcOnly);
+    let before_dry = h.stat(StatIdx::FwdDryRun);
+    let (verdict, _) = h.run(&pkt);
+    // Dry-run short-circuits to XDP_PASS before FIB.
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV4), before_matched + 1);
+    assert_eq!(h.stat(StatIdx::MatchedSrcOnly), before_src_only + 1);
+    assert_eq!(h.stat(StatIdx::FwdDryRun), before_dry + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_dst_match_dry_run_passes_with_matched_dst_only() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_dry_run(true);
+
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [192, 0, 2, 1],
+        dst_ip: [10, 4, 5, 6],
+        ..Default::default()
+    }
+    .build();
+
+    let before_matched = h.stat(StatIdx::MatchedV4);
+    let before_dst = h.stat(StatIdx::MatchedDstOnly);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV4), before_matched + 1);
+    assert_eq!(h.stat(StatIdx::MatchedDstOnly), before_dst + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv4_both_match_dry_run_bumps_matched_both() {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_dry_run(true);
+
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [10, 1, 1, 1],
+        dst_ip: [10, 2, 2, 2],
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::MatchedBoth);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedBoth), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ipv6_src_match_dry_run_bumps_matched_src_only() {
+    let mut h = Harness::new();
+    h.add_allow_v6("2001:db8::/32");
+    h.set_dry_run(true);
+
+    let pkt = Ipv6TcpBuilder {
+        src_ip: [0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        dst_ip: [0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1],
+        ..Default::default()
+    }
+    .build();
+
+    let before_v6 = h.stat(StatIdx::MatchedV6);
+    let before_src_only = h.stat(StatIdx::MatchedSrcOnly);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::MatchedV6), before_v6 + 1);
+    assert_eq!(h.stat(StatIdx::MatchedSrcOnly), before_src_only + 1);
+}
+
+// ========== Rx counter always bumped ======================================
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn every_packet_bumps_rx_total() {
+    let mut h = Harness::new();
+
+    // Non-IP.
+    let mut arp = vec![0u8; 64];
+    arp[0..6].copy_from_slice(&[0xff; 6]);
+    arp[12..14].copy_from_slice(&[0x08, 0x06]);
+    let before = h.stat(StatIdx::RxTotal);
+    h.run(&arp);
+    assert_eq!(h.stat(StatIdx::RxTotal), before + 1);
+
+    // IPv4 no match.
+    let p = Ipv4TcpBuilder::default().build();
+    h.run(&p);
+    assert_eq!(h.stat(StatIdx::RxTotal), before + 2);
+
+    // IPv4 match (dry-run off — would try FIB, but that likely NO_NEIGH
+    // in our no-netns test env; we only check rx_total).
+    h.add_allow_v4("10.0.0.0/8");
+    h.run(&p);
+    assert_eq!(h.stat(StatIdx::RxTotal), before + 3);
+}
+

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -27,7 +27,7 @@ fn rx_total_delta(before: u64, h: &Harness) -> u64 {
 #[test]
 #[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
 fn arp_passes_with_pass_not_ip() {
-    let mut h = Harness::new();
+    let h = Harness::new();
 
     // ARP (ethertype 0x0806) — plausibly-shaped but not IP.
     let mut pkt = vec![0u8; 64];

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -339,4 +339,3 @@ fn every_packet_bumps_rx_total() {
     h.run(&p);
     assert_eq!(h.stat(StatIdx::RxTotal), before + 3);
 }
-


### PR DESCRIPTION
## Summary

- Full SPEC §4.7 VLAN choreography in the BPF program: 802.1Q ingress parse + egress push/pop/rewrite driven by a new \`vlan_resolve\` map, populated from \`/proc/net/vlan/config\` at attach time.
- Raw-syscall \`bpf_prog_test_run\` harness + 21 packet-level fixtures covering the no-FIB §9 Phase 1 matrix (deferred from PR #3 because aya 0.13.1 doesn't wrap \`BPF_PROG_TEST_RUN\`).
- Fixes the \`EINVAL\` failure I saw on Debian 6.1 — bpf_attr trailing-padding bytes from Rust \`Default\` land in the user buffer as garbage and trip the kernel's \`CHECK_ATTR\` macro. \`mem::zeroed\` then field-writes instead.
- Fixes the \`Ipv4Hdr::ihl()\` misunderstanding that short-circuited every IPv4 path into \`pass_complex_header\` (network-types returns bytes, not the raw field).

## What landed

### BPF side

- \`tests/common/mod.rs\` harness: raw bpf() syscall wrapper for \`BPF_PROG_TEST_RUN\`, synthetic packet builders for Ethernet + IPv4/TCP + IPv6/TCP, stat-map reader.
- \`tests/fixtures.rs\`: 21 fixtures covering ARP / IPv4 options, fragments, TTL, allowlist miss / dry-run matched paths / IPv6 ext headers / tagged (VLAN) ingress-parse / jumbo(-ish) payload.
- \`bpf/src/maps.rs\`: \`vlan_resolve\` HashMap (\`u32 ifindex → VlanResolve{phys_ifindex, vid}\`, 256 entries).
- \`bpf/src/main.rs\`: one-tag 802.1Q ingress parse threads \`ingress_vid\` (as a u16 sentinel — \`Option<u16>\` tripped the verifier with \`R5 !read_ok\` during argument spills). Dispatch consults \`vlan_resolve\` on FIB success, picks effective egress ifindex + expected VID, and runs the §4.7 matrix:
  - untagged in/out → no-op
  - untagged → tagged → push (adjust_head -4, memmove MACs, write TPID + TCI)
  - tagged → untagged → pop (memmove MACs, adjust_head +4)
  - tagged X → tagged X → no-op
  - tagged X → tagged Y → rewrite (TCI in place)
- Push/pop use \`core::ptr::copy\` per SPEC §4.7's explicit warning — the 6-byte MAC moves overlap with their sources, and the verifier won't catch \`copy_nonoverlapping\` misuse.

### Userspace

- \`linux_impl.rs\`: \`populate_vlan_resolve\` reads \`/proc/net/vlan/config\` at attach time, \`if_nametoindex\`es each (subif, parent) pair, and inserts into the map. Missing config (no 8021q module) is not an error.

### Bug fixes

- **bpf_attr trailing padding** (\`TEST_RUN\`, \`PROG_LOAD\`, \`MAP_CREATE\`): \`mem::zeroed\` + field writes instead of \`#[derive(Default)]\` struct-literal. Root cause of the EINVAL-with-empty-log on kernel 6.0+.
- **IPv4 IHL check**: \`Ipv4Hdr::ihl()\` returns bytes (20 for a standard header), not the raw 4-bit IHL field. Compare to 20, not 5.
- **Option<u16> verifier**: switched \`ingress_vid\` and \`egress_vid\` to \`u16\` with \`VLAN_NONE = 0\` as sentinel. 802.1Q VID 0 is reserved for priority-only tagging anyway.

## What's NOT covered

- **Byte-level §4.7 push/pop/rewrite output verification.** Those paths sit behind a \`bpf_fib_lookup\` SUCCESS verdict that needs real routes in the running netns — \`bpf_prog_test_run\` can't fake that. Byte-level tests land with a netns integration harness (follow-up PR).
- **True 9K jumbo frames.** Need \`BPF_F_TEST_XDP_LIVE_FRAMES\` (kernel 5.18+). The 3.6K fixture proves the parse/allowlist path doesn't choke on jumbo-ish sizes; 9K waits on the netns harness too.
- **Re-promoting \`prog_type.*\` and \`helper.*\` feasibility probes to required.** The bpf_attr padding fix should make them work on the test VM; I've left the demotion in place pending your re-run with the PR #5 binary (feel free to promote in a follow-up once confirmed).
- **§11.1(a)/(b) and §11.11 empirical probe helpers.** Those are EFG-specific runbook tools; deferring to when you have interactive EFG time.

## CI

All 5 jobs green. The sudo step now runs **23 real kernel tests** (verifier + veth attach + 21 fixtures) through aya + \`BPF_PROG_TEST_RUN\`. No more silent-stub false-positives.