### PR TITLE
v0.1: pinning, metrics, reconcile, breaker, QEMU CI (PR #6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -357,6 +357,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "libc",
  "packetframe-common",
  "packetframe-fast-path",
  "serde_json",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -23,6 +23,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
 signal-hook.workspace = true
 
 [features]

--- a/crates/cli/src/breaker.rs
+++ b/crates/cli/src/breaker.rs
@@ -1,0 +1,142 @@
+//! Circuit-breaker sampler thread (SPEC.md §4.9, §8.3).
+//!
+//! Spawned when the module's config carries a `circuit-breaker`
+//! directive. On each tick of the configured window, reads the
+//! pinned STATS map and feeds the delta to
+//! [`packetframe_fast_path::breaker::CircuitBreaker`]. When the
+//! breaker trips:
+//!
+//! 1. Writes a sticky flag to `<state-dir>/breaker-tripped-<module>.flag`.
+//! 2. Raises SIGUSR1 so the main loop tears down and exits cleanly.
+//!
+//! The sticky flag survives restart; the main loop refuses attach at
+//! startup if the flag is present, matching SPEC §8.3's "sticky
+//! detach" requirement.
+
+#![cfg(all(target_os = "linux", feature = "fast-path"))]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use packetframe_common::config::CircuitBreakerSpec;
+use packetframe_fast_path::breaker::{CircuitBreaker, Decision};
+
+/// Shutdown-check granularity — how often the sampler wakes between
+/// window ticks to check for shutdown.
+const POLL: Duration = Duration::from_millis(250);
+
+pub struct BreakerSampler {
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl BreakerSampler {
+    pub fn start(spec: CircuitBreakerSpec, bpffs_root: PathBuf, state_dir: PathBuf) -> Self {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let handle = std::thread::Builder::new()
+            .name("pf-breaker".into())
+            .spawn(move || sampler_loop(spec, bpffs_root, state_dir, shutdown_clone))
+            .expect("spawn breaker sampler thread");
+        tracing::info!(
+            drop_ratio = spec.drop_ratio,
+            window_secs = spec.window.as_secs(),
+            threshold = spec.threshold,
+            "circuit-breaker sampler started"
+        );
+        Self {
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn shutdown(mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn sampler_loop(
+    spec: CircuitBreakerSpec,
+    bpffs_root: PathBuf,
+    state_dir: PathBuf,
+    shutdown: Arc<AtomicBool>,
+) {
+    let mut breaker = CircuitBreaker::new(spec);
+
+    loop {
+        // Wait `window` with periodic shutdown checks.
+        let deadline = Instant::now() + spec.window;
+        while Instant::now() < deadline {
+            if shutdown.load(Ordering::Relaxed) {
+                return;
+            }
+            std::thread::sleep(POLL);
+        }
+        if shutdown.load(Ordering::Relaxed) {
+            return;
+        }
+
+        let stats = match packetframe_fast_path::stats_from_pin(&bpffs_root) {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!(error = %e, "breaker: STATS read failed; skipping tick");
+                continue;
+            }
+        };
+
+        match breaker.sample(&stats) {
+            Decision::NoData => {}
+            Decision::Ok { ratio } => {
+                tracing::debug!(ratio, "breaker tick: healthy");
+            }
+            Decision::Bad { ratio, streak } => {
+                tracing::warn!(
+                    ratio,
+                    streak,
+                    threshold = spec.threshold,
+                    "breaker tick: over threshold"
+                );
+            }
+            Decision::Trip {
+                ratio,
+                window_drops,
+                window_matched,
+            } => {
+                tracing::error!(
+                    ratio,
+                    window_drops,
+                    window_matched,
+                    drop_ratio = spec.drop_ratio,
+                    "CIRCUIT BREAKER TRIPPED"
+                );
+                if let Err(e) = packetframe_fast_path::breaker::write_trip_flag(
+                    &state_dir,
+                    ratio,
+                    window_drops,
+                    window_matched,
+                    &spec,
+                ) {
+                    tracing::error!(error = %e, "breaker: writing trip flag failed");
+                }
+                raise_sigusr1();
+                return;
+            }
+        }
+    }
+}
+
+/// Raise SIGUSR1 on the current process so the main signal loop
+/// notices and initiates a detach-and-exit.
+fn raise_sigusr1() {
+    // SAFETY: getpid + kill are both thread-safe and take no refs.
+    let pid = unsafe { libc::getpid() };
+    unsafe {
+        libc::kill(pid, libc::SIGUSR1);
+    }
+}

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -152,9 +152,9 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         crate::metrics::MetricsExporter::start(path.clone(), config.global.bpffs_root.clone())
     });
 
-    tracing::info!("fast-path running — SIGTERM/SIGINT to exit without detaching (§8.5)");
+    tracing::info!("fast-path running — SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
 
-    wait_for_termination().map_err(RunError::Runtime)?;
+    drive_signal_loop(config_path, &mut modules).map_err(RunError::Runtime)?;
 
     // Stop the exporter first so its final write completes before
     // we drop any module state. The pin-backed STATS map would let
@@ -175,8 +175,13 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     Ok(())
 }
 
+/// Drive the signal loop: SIGHUP → re-parse + reconfigure every
+/// loaded module; SIGTERM/SIGINT → return so the caller can drop.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
-fn wait_for_termination() -> Result<(), String> {
+fn drive_signal_loop(
+    config_path: &Path,
+    modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+) -> Result<(), String> {
     use signal_hook::{
         consts::{SIGHUP, SIGINT, SIGTERM},
         iterator::Signals,
@@ -187,14 +192,8 @@ fn wait_for_termination() -> Result<(), String> {
 
     for sig in signals.forever() {
         match sig {
-            SIGHUP => {
-                // SPEC.md §8.4 / §4.5: delta-only reconcile lives in PR #6.
-                tracing::warn!("SIGHUP received; reconfigure flow not implemented in this release");
-            }
+            SIGHUP => reconfigure_from_signal(config_path, modules),
             SIGTERM | SIGINT => {
-                // SPEC.md §7.3 / §8.5: exit without detach. Pin-based
-                // program persistence requires PR #6; until then, exit
-                // *does* implicitly detach.
                 tracing::info!(signal = sig, "termination requested");
                 return Ok(());
             }
@@ -202,6 +201,45 @@ fn wait_for_termination() -> Result<(), String> {
         }
     }
     Ok(())
+}
+
+/// SIGHUP handler. Re-parses the config from `config_path` and calls
+/// `Module::reconfigure` on each loaded module. Parse failures and
+/// per-module reconfigure errors are logged and swallowed — a bad
+/// SIGHUP never kills the running data plane.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+fn reconfigure_from_signal(
+    config_path: &Path,
+    modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+) {
+    use packetframe_common::module::ModuleConfig;
+
+    tracing::info!(config = %config_path.display(), "SIGHUP received; reconfiguring");
+
+    let new_config = match Config::from_file(config_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "SIGHUP config parse failed; keeping current config");
+            return;
+        }
+    };
+
+    for (name, module) in modules.iter_mut() {
+        let section = match new_config.modules.iter().find(|m| &m.name == name) {
+            Some(s) => s,
+            None => {
+                tracing::warn!(
+                    module = %name,
+                    "module removed from config; reconfigure skipped (attach-set changes require restart)"
+                );
+                continue;
+            }
+        };
+        let mcfg = ModuleConfig::new(section, &new_config.global);
+        if let Err(e) = module.reconfigure(&mcfg) {
+            tracing::warn!(module = %name, error = %e, "reconfigure failed");
+        }
+    }
 }
 
 pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -134,22 +134,17 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         tracing::info!(module = %name, attachments = file.attachments.len(), "module attached");
     }
 
-    tracing::info!(
-        "fast-path running — SIGTERM/SIGINT to exit; detach on exit pending pin support (PR #6)"
-    );
+    tracing::info!("fast-path running — SIGTERM/SIGINT to exit without detaching (§8.5)");
 
     wait_for_termination().map_err(RunError::Runtime)?;
 
     // SPEC.md §7.3 / §8.5: SIGTERM/SIGINT must exit *without* detaching.
-    // In v0.1 there's no bpffs pinning yet, so dropping the `Ebpf`
-    // inside `modules` necessarily tears down the attach (the
-    // kernel-side `bpf_link` closes when its FD does). PR #6 will
-    // make this a true no-op-on-exit by pinning programs + maps
-    // before the drop. For now we deliberately *do not* call
-    // `Module::detach` here; the drop path is the same end state,
-    // and leaving it implicit keeps the exit intent aligned with
-    // what pinning will later honor.
-    tracing::info!("termination signal received; exiting (no explicit detach, per §8.5)");
+    // Dropping `modules` closes our userspace FDs (program, maps,
+    // links); the bpffs pins installed at attach time hold the kernel
+    // references, so the XDP attachment survives process exit. An
+    // explicit `Module::detach` tears the pins down — we deliberately
+    // don't call it here.
+    tracing::info!("termination signal received; exiting (pins hold the attach per §8.5)");
     drop(modules);
     Ok(())
 }
@@ -184,21 +179,21 @@ fn wait_for_termination() -> Result<(), String> {
 }
 
 pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
-    let state_dir = match config {
+    let (bpffs_root, state_dir) = match config {
         Some(p) => {
-            Config::from_file(p)
-                .map_err(|e| format!("config parse: {e}"))?
-                .global
-                .state_dir
+            let c = Config::from_file(p).map_err(|e| format!("config parse: {e}"))?;
+            (c.global.bpffs_root, c.global.state_dir)
         }
-        None => PathBuf::from(packetframe_common::config::DEFAULT_STATE_DIR),
+        None => (
+            PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
+            PathBuf::from(packetframe_common::config::DEFAULT_STATE_DIR),
+        ),
     };
 
-    if all {
-        tracing::warn!(
-            "`--all` requires bpffs pin sweep (PR #6); for now, honoring the pin registry only"
-        );
-    }
+    // v0.1 has one module (fast-path), so `--all` and the default case
+    // behave identically — both tear down every pin under the module's
+    // pin root. `--all` becomes meaningful once a second module ships.
+    let _ = all;
 
     #[cfg(feature = "fast-path")]
     {
@@ -208,7 +203,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
                 tracing::info!(
                     module = %file.module,
                     count = file.attachments.len(),
-                    "pin registry found"
+                    "pin registry found; tearing down"
                 );
                 for a in &file.attachments {
                     tracing::info!(
@@ -218,17 +213,25 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
                         "registered attachment"
                     );
                 }
-                tracing::warn!(
-                    "in-kernel detach without an active loader requires bpffs pinning (SPEC.md §8.5 + pinning support in PR #6); removing registry file only"
-                );
-                packetframe_fast_path::registry::remove(&state_dir)
-                    .map_err(|e| format!("registry remove: {e}"))?;
             }
             Ok(None) => {
-                tracing::info!("no pin registry found — nothing to detach");
+                tracing::info!("no pin registry found — sweeping bpffs pin root anyway");
             }
             Err(e) => return Err(format!("registry read: {e}")),
         }
+
+        // Unlink every pin under `<bpffs-root>/fast-path/`. Removing
+        // link pins triggers the kernel-side XDP detach (§8.5); the
+        // map and program pins are housekeeping.
+        packetframe_fast_path::pin::remove_all(&bpffs_root)
+            .map_err(|e| format!("remove pins under {}: {e}", bpffs_root.display()))?;
+        tracing::info!(
+            pin_root = %packetframe_fast_path::pin::module_root(&bpffs_root).display(),
+            "pins removed; kernel detached"
+        );
+
+        packetframe_fast_path::registry::remove(&state_dir)
+            .map_err(|e| format!("registry remove: {e}"))?;
     }
 
     Ok(())
@@ -265,10 +268,56 @@ pub fn status(config_path: &Path) -> Result<(), String> {
             }
             Err(e) => return Err(format!("registry read: {e}")),
         }
+
+        // Live counter readback from the pinned STATS map. Works
+        // whether or not the loader is running — the pin survives
+        // process exit (§8.5).
+        #[cfg(target_os = "linux")]
+        print_stats(&config.global.bpffs_root);
     }
 
-    eprintln!("note: live counter readback requires bpffs-pinned stats (PR #6)");
     Ok(())
+}
+
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+fn print_stats(bpffs_root: &Path) {
+    // §4.6 counter names, indexed by `StatIdx` discriminants. Order
+    // matches `crates/modules/fast-path/bpf/src/maps.rs::StatIdx`.
+    const NAMES: [&str; 19] = [
+        "rx_total",
+        "matched_v4",
+        "matched_v6",
+        "matched_src_only",
+        "matched_dst_only",
+        "matched_both",
+        "fwd_ok",
+        "fwd_dry_run",
+        "pass_fragment",
+        "pass_low_ttl",
+        "pass_no_neigh",
+        "pass_not_ip",
+        "pass_frag_needed",
+        "drop_unreachable",
+        "err_parse",
+        "err_fib_other",
+        "err_vlan",
+        "pass_not_in_devmap",
+        "pass_complex_header",
+    ];
+
+    match packetframe_fast_path::stats_from_pin(bpffs_root) {
+        Ok(values) => {
+            println!();
+            println!("counters (from {}):", bpffs_root.display());
+            let name_w = NAMES.iter().map(|n| n.len()).max().unwrap_or(20);
+            for (name, value) in NAMES.iter().zip(values.iter()) {
+                println!("  {name:<name_w$}  {value}");
+            }
+        }
+        Err(e) => {
+            eprintln!("note: STATS pin unavailable ({e}); loader may not be attached");
+        }
+    }
 }
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -57,6 +57,21 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
         }
     }
 
+    // Refuse startup if a circuit-breaker trip flag from a prior
+    // invocation is still present. The flag is sticky across kernel
+    // reboots — SPEC §8.3 — and must be cleared by an operator.
+    #[cfg(feature = "fast-path")]
+    {
+        let flag_path = packetframe_fast_path::breaker::trip_flag_path(&config.global.state_dir);
+        if flag_path.exists() {
+            return Err(RunError::Startup(format!(
+                "circuit-breaker trip flag present at {}; \
+                 investigate and `rm` it before restarting (SPEC §8.3 sticky detach)",
+                flag_path.display()
+            )));
+        }
+    }
+
     // Feasibility gate: refuse to attach if any required capability is
     // missing. The per-interface trial-attach probe (§2.3) runs here
     // too — if a specific iface can't receive an XDP program at all,
@@ -152,55 +167,114 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         crate::metrics::MetricsExporter::start(path.clone(), config.global.bpffs_root.clone())
     });
 
+    // Start circuit-breaker sampler(s) for each module that declared
+    // one. v0.1 has one module so this is at most one thread.
+    let mut breaker_samplers: Vec<crate::breaker::BreakerSampler> = Vec::new();
+    for section in &config.modules {
+        if let Some(spec) = extract_breaker_spec(section) {
+            breaker_samplers.push(crate::breaker::BreakerSampler::start(
+                spec,
+                config.global.bpffs_root.clone(),
+                config.global.state_dir.clone(),
+            ));
+        }
+    }
+
     tracing::info!("fast-path running — SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
 
-    drive_signal_loop(config_path, &mut modules).map_err(RunError::Runtime)?;
+    let termination = drive_signal_loop(config_path, &mut modules).map_err(RunError::Runtime)?;
 
-    // Stop the exporter first so its final write completes before
-    // we drop any module state. The pin-backed STATS map would let
-    // the exporter keep reading across the module drop, but running
-    // shutdown ordering explicitly keeps logs tidy.
+    // Stop the exporter + breaker sampler(s) first so their final
+    // writes complete before we touch module state.
     if let Some(m) = metrics_exporter {
         m.shutdown();
     }
+    for sampler in breaker_samplers {
+        sampler.shutdown();
+    }
 
-    // SPEC.md §7.3 / §8.5: SIGTERM/SIGINT must exit *without* detaching.
-    // Dropping `modules` closes our userspace FDs (program, maps,
-    // links); the bpffs pins installed at attach time hold the kernel
-    // references, so the XDP attachment survives process exit. An
-    // explicit `Module::detach` tears the pins down — we deliberately
-    // don't call it here.
-    tracing::info!("termination signal received; exiting (pins hold the attach per §8.5)");
-    drop(modules);
+    match termination {
+        Termination::ExitPreserveAttach => {
+            // SPEC.md §7.3 / §8.5: SIGTERM/SIGINT exit *without*
+            // detaching. Dropping `modules` closes our userspace FDs;
+            // the bpffs pins hold the kernel references, so the XDP
+            // attachment survives.
+            tracing::info!("termination signal received; exiting (pins hold the attach per §8.5)");
+            drop(modules);
+        }
+        Termination::BreakerTrip => {
+            // Breaker fired (SIGUSR1). Tear down pins so the kernel
+            // detaches; the sticky trip flag is already on disk so
+            // subsequent `run` invocations refuse to re-attach.
+            tracing::error!("circuit breaker tripped — detaching every module");
+            for (name, module) in modules.iter_mut() {
+                if let Err(e) = module.detach() {
+                    tracing::error!(module = %name, error = %e, "detach failed");
+                }
+            }
+            drop(modules);
+        }
+    }
     Ok(())
 }
 
-/// Drive the signal loop: SIGHUP → re-parse + reconfigure every
-/// loaded module; SIGTERM/SIGINT → return so the caller can drop.
+/// Look through a module section's directives and return its
+/// `CircuitBreakerSpec`, if present. Multiple directives of the same
+/// kind aren't rejected by the parser — take the last one if so.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+fn extract_breaker_spec(
+    section: &packetframe_common::config::ModuleSection,
+) -> Option<packetframe_common::config::CircuitBreakerSpec> {
+    section.directives.iter().rev().find_map(|d| match d {
+        packetframe_common::config::ModuleDirective::CircuitBreaker(s) => Some(*s),
+        _ => None,
+    })
+}
+
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+enum Termination {
+    /// SIGTERM/SIGINT: exit, leave pins in place.
+    ExitPreserveAttach,
+    /// SIGUSR1 from the breaker: detach, then exit.
+    BreakerTrip,
+}
+
+/// Drive the signal loop. Returns the termination reason the caller
+/// uses to decide whether to detach or preserve pins on exit.
+///
+/// - SIGHUP → re-parse config + reconfigure each loaded module.
+/// - SIGTERM/SIGINT → `Termination::ExitPreserveAttach` (keep pins).
+/// - SIGUSR1 → `Termination::BreakerTrip` (breaker fired; caller
+///   detaches). SIGUSR1 is raised by the breaker sampler thread on
+///   trip.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn drive_signal_loop(
     config_path: &Path,
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
-) -> Result<(), String> {
+) -> Result<Termination, String> {
     use signal_hook::{
-        consts::{SIGHUP, SIGINT, SIGTERM},
+        consts::{SIGHUP, SIGINT, SIGTERM, SIGUSR1},
         iterator::Signals,
     };
 
-    let mut signals =
-        Signals::new([SIGTERM, SIGINT, SIGHUP]).map_err(|e| format!("signal registration: {e}"))?;
+    let mut signals = Signals::new([SIGTERM, SIGINT, SIGHUP, SIGUSR1])
+        .map_err(|e| format!("signal registration: {e}"))?;
 
     for sig in signals.forever() {
         match sig {
             SIGHUP => reconfigure_from_signal(config_path, modules),
             SIGTERM | SIGINT => {
                 tracing::info!(signal = sig, "termination requested");
-                return Ok(());
+                return Ok(Termination::ExitPreserveAttach);
+            }
+            SIGUSR1 => {
+                tracing::warn!("SIGUSR1 received — breaker-triggered shutdown");
+                return Ok(Termination::BreakerTrip);
             }
             _ => {}
         }
     }
-    Ok(())
+    Ok(Termination::ExitPreserveAttach)
 }
 
 /// SIGHUP handler. Re-parses the config from `config_path` and calls

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -45,6 +45,18 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
         .validate_interfaces()
         .map_err(|e| RunError::Startup(e.to_string()))?;
 
+    // Fail fast if metrics-textfile can't be written — the exporter
+    // would retry silently every 15s otherwise.
+    if let Some(path) = &config.global.metrics_textfile {
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        if !parent.exists() {
+            return Err(RunError::Startup(format!(
+                "metrics-textfile parent dir {} does not exist",
+                parent.display()
+            )));
+        }
+    }
+
     // Feasibility gate: refuse to attach if any required capability is
     // missing. The per-interface trial-attach probe (§2.3) runs here
     // too — if a specific iface can't receive an XDP program at all,
@@ -134,9 +146,23 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         tracing::info!(module = %name, attachments = file.attachments.len(), "module attached");
     }
 
+    // Start the metrics exporter once STATS is pinned (which happens
+    // in the attach loop above).
+    let metrics_exporter = config.global.metrics_textfile.as_ref().map(|path| {
+        crate::metrics::MetricsExporter::start(path.clone(), config.global.bpffs_root.clone())
+    });
+
     tracing::info!("fast-path running — SIGTERM/SIGINT to exit without detaching (§8.5)");
 
     wait_for_termination().map_err(RunError::Runtime)?;
+
+    // Stop the exporter first so its final write completes before
+    // we drop any module state. The pin-backed STATS map would let
+    // the exporter keep reading across the module drop, but running
+    // shutdown ordering explicitly keeps logs tidy.
+    if let Some(m) = metrics_exporter {
+        m.shutdown();
+    }
 
     // SPEC.md §7.3 / §8.5: SIGTERM/SIGINT must exit *without* detaching.
     // Dropping `modules` closes our userspace FDs (program, maps,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -7,6 +7,8 @@
 //! respectively. The `reconfigure` flow (SIGHUP → delta-only reconcile)
 //! lands with PR #6.
 
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+mod breaker;
 mod feasibility;
 mod loader;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -55,13 +55,16 @@ enum Command {
         config: PathBuf,
     },
 
-    /// Detach attached programs recorded in the pin registry.
+    /// Detach attached programs by removing every pin under the
+    /// module's bpffs pin root. Removing a link pin triggers the
+    /// kernel-side XDP detach (SPEC.md §8.5); removing map + program
+    /// pins is housekeeping.
     Detach {
         #[arg(long)]
         config: Option<PathBuf>,
-        /// Tear down every PacketFrame pin, regardless of config.
-        /// v0.1 honors the registry only; `--all` requires pinning
-        /// (PR #6).
+        /// Tear down every PacketFrame pin across every module, not
+        /// just the one in the supplied config. v0.1 has one module
+        /// so this is equivalent to the default.
         #[arg(long)]
         all: bool,
     },

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -9,6 +9,8 @@
 
 mod feasibility;
 mod loader;
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+mod metrics;
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -1,0 +1,107 @@
+//! 15-second-cadence Prometheus textfile exporter (SPEC.md §7.3).
+//!
+//! Spawned by `packetframe run` when the config sets `metrics-textfile`.
+//! Reads the pinned STATS map and writes a Prometheus textfile
+//! atomically (write-then-rename), the convention Prometheus's
+//! textfile collector expects. On shutdown, performs one final write
+//! so the last-sampled values aren't lost between ticks.
+
+#![cfg(all(target_os = "linux", feature = "fast-path"))]
+
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+const INTERVAL: Duration = Duration::from_secs(15);
+/// Shutdown-check granularity so SIGTERM doesn't wait up to INTERVAL
+/// for the exporter to wake.
+const POLL: Duration = Duration::from_millis(250);
+
+pub struct MetricsExporter {
+    shutdown: Arc<AtomicBool>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl MetricsExporter {
+    pub fn start(textfile_path: PathBuf, bpffs_root: PathBuf) -> Self {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let shutdown_clone = shutdown.clone();
+        let handle = std::thread::Builder::new()
+            .name("pf-metrics".into())
+            .spawn(move || exporter_loop(textfile_path, bpffs_root, shutdown_clone))
+            .expect("spawn metrics thread");
+        tracing::info!("metrics exporter started; 15s cadence");
+        Self {
+            shutdown,
+            handle: Some(handle),
+        }
+    }
+
+    pub fn shutdown(mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            let _ = h.join();
+        }
+    }
+}
+
+fn exporter_loop(textfile_path: PathBuf, bpffs_root: PathBuf, shutdown: Arc<AtomicBool>) {
+    let start = Instant::now();
+    let mut next_write = Instant::now();
+
+    loop {
+        let now = Instant::now();
+        if now >= next_write {
+            let uptime = start.elapsed().as_secs();
+            if let Err(e) = write_once(&textfile_path, &bpffs_root, uptime) {
+                tracing::warn!(error = %e, "metrics write failed; will retry at next tick");
+            }
+            next_write = now + INTERVAL;
+        }
+
+        if shutdown.load(Ordering::Relaxed) {
+            // One final write so external collectors see the last
+            // state before this process exits.
+            let uptime = start.elapsed().as_secs();
+            let _ = write_once(&textfile_path, &bpffs_root, uptime);
+            return;
+        }
+
+        std::thread::sleep(POLL);
+    }
+}
+
+fn write_once(textfile_path: &Path, bpffs_root: &Path, uptime_seconds: u64) -> Result<(), String> {
+    let stats = packetframe_fast_path::stats_from_pin(bpffs_root)
+        .map_err(|e| format!("read STATS pin: {e}"))?;
+    let body = packetframe_fast_path::metrics::render_textfile(&stats, uptime_seconds);
+    atomic_write(textfile_path, body.as_bytes())
+        .map_err(|e| format!("atomic write {}: {e}", textfile_path.display()))?;
+    Ok(())
+}
+
+/// Write-then-rename. The rename is atomic on POSIX when source and
+/// dest are on the same filesystem — node_exporter's textfile
+/// collector relies on this to never read a half-written file.
+fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    // Use the same filename with `.tmp` appended so we stay on the
+    // same filesystem as the target (`with_extension("tmp")` would
+    // drop the `.prom` and prevent a second writer from
+    // distinguishing ours).
+    let tmp = path.with_file_name(format!(
+        "{}.tmp",
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("packetframe.prom"),
+    ));
+    {
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(contents)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}

--- a/crates/modules/fast-path/src/breaker.rs
+++ b/crates/modules/fast-path/src/breaker.rs
@@ -1,0 +1,228 @@
+//! Circuit breaker (SPEC.md §4.9, §8.3).
+//!
+//! A sampler thread polls the pinned STATS map every `window` seconds
+//! and computes the ratio of "bad" outcomes (`drop_unreachable +
+//! err_fib_other`) to matched traffic (`matched_v4 + matched_v6`) over
+//! the interval since the previous sample. If the ratio exceeds the
+//! configured drop-ratio for `threshold` consecutive samples, the
+//! breaker trips: writes a sticky flag under the state directory and
+//! raises SIGUSR1 so the main loop can detach the module.
+//!
+//! The state-dir flag survives a kernel reboot — that's deliberate.
+//! A tripped breaker refuses to re-attach on subsequent `packetframe
+//! run` invocations until an operator clears it. This matches SPEC
+//! §8.3's "sticky detach" requirement.
+
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use packetframe_common::config::CircuitBreakerSpec;
+
+use crate::MODULE_NAME;
+
+/// Discriminants from `bpf/src/maps.rs::StatIdx`. Wire format is
+/// append-only, so these indexes are stable once v0.1 ships.
+const STAT_MATCHED_V4: usize = 1;
+const STAT_MATCHED_V6: usize = 2;
+const STAT_DROP_UNREACHABLE: usize = 13;
+const STAT_ERR_FIB_OTHER: usize = 15;
+
+pub fn trip_flag_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(format!("breaker-tripped-{MODULE_NAME}.flag"))
+}
+
+pub fn is_tripped(state_dir: &Path) -> bool {
+    trip_flag_path(state_dir).exists()
+}
+
+/// Write the sticky trip flag. Best-effort: if the write fails,
+/// the main-loop detach still proceeds; the worst case is that the
+/// next restart re-attaches a breaker whose condition may have
+/// cleared — operator sees the same trip again.
+pub fn write_trip_flag(
+    state_dir: &Path,
+    ratio: f64,
+    window_drops: u64,
+    window_matched: u64,
+    spec: &CircuitBreakerSpec,
+) -> std::io::Result<()> {
+    let path = trip_flag_path(state_dir);
+    let body = format!(
+        "module: {MODULE_NAME}\n\
+         tripped_at: {:?}\n\
+         observed_ratio: {ratio}\n\
+         threshold_ratio: {}\n\
+         window_drops: {window_drops}\n\
+         window_matched: {window_matched}\n\
+         consecutive_samples_over: {}\n",
+        SystemTime::now(),
+        spec.drop_ratio,
+        spec.threshold,
+    );
+    std::fs::write(path, body)
+}
+
+/// What the sampler observed, minus I/O on STATS itself.
+#[derive(Debug)]
+pub enum Decision {
+    /// No matched traffic since last sample — can't divide.
+    NoData,
+    /// Under threshold.
+    Ok { ratio: f64 },
+    /// Over threshold but streak hasn't reached `threshold` samples yet.
+    Bad { ratio: f64, streak: u32 },
+    /// Streak reached `threshold` — trip.
+    Trip {
+        ratio: f64,
+        window_drops: u64,
+        window_matched: u64,
+    },
+}
+
+/// Stateful sliding-window evaluator. One instance per module. Owned
+/// by the sampler thread.
+pub struct CircuitBreaker {
+    spec: CircuitBreakerSpec,
+    prev_matched: u64,
+    prev_drops: u64,
+    consecutive_bad: u32,
+    primed: bool,
+}
+
+impl CircuitBreaker {
+    pub fn new(spec: CircuitBreakerSpec) -> Self {
+        Self {
+            spec,
+            prev_matched: 0,
+            prev_drops: 0,
+            consecutive_bad: 0,
+            primed: false,
+        }
+    }
+
+    /// Feed one STATS snapshot. Returns the sampler's verdict. The
+    /// first call primes the deltas but returns `NoData`.
+    pub fn sample(&mut self, stats: &[u64]) -> Decision {
+        assert!(
+            stats.len() > STAT_ERR_FIB_OTHER,
+            "STATS vec too short ({})",
+            stats.len()
+        );
+        let matched_total = stats[STAT_MATCHED_V4] + stats[STAT_MATCHED_V6];
+        let drops_total = stats[STAT_DROP_UNREACHABLE] + stats[STAT_ERR_FIB_OTHER];
+
+        if !self.primed {
+            self.prev_matched = matched_total;
+            self.prev_drops = drops_total;
+            self.primed = true;
+            return Decision::NoData;
+        }
+
+        let matched_delta = matched_total.saturating_sub(self.prev_matched);
+        let drops_delta = drops_total.saturating_sub(self.prev_drops);
+        self.prev_matched = matched_total;
+        self.prev_drops = drops_total;
+
+        if matched_delta == 0 {
+            // Keep the streak counter as-is; no matched traffic means
+            // we can't judge. Don't reset it to 0 (that would let
+            // a sustained bad period "escape" by alternating busy
+            // and idle windows).
+            return Decision::NoData;
+        }
+
+        let ratio = drops_delta as f64 / matched_delta as f64;
+        if ratio > self.spec.drop_ratio {
+            self.consecutive_bad += 1;
+            if self.consecutive_bad >= self.spec.threshold {
+                return Decision::Trip {
+                    ratio,
+                    window_drops: drops_delta,
+                    window_matched: matched_delta,
+                };
+            }
+            Decision::Bad {
+                ratio,
+                streak: self.consecutive_bad,
+            }
+        } else {
+            self.consecutive_bad = 0;
+            Decision::Ok { ratio }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn spec(ratio: f64, threshold: u32) -> CircuitBreakerSpec {
+        CircuitBreakerSpec {
+            drop_ratio: ratio,
+            denominator: packetframe_common::config::CircuitBreakerDenominator::Matched,
+            window: Duration::from_secs(5),
+            threshold,
+        }
+    }
+
+    fn stats(matched_v4: u64, drops: u64) -> Vec<u64> {
+        let mut s = vec![0u64; 19];
+        s[STAT_MATCHED_V4] = matched_v4;
+        s[STAT_DROP_UNREACHABLE] = drops;
+        s
+    }
+
+    #[test]
+    fn first_sample_primes_then_returns_no_data() {
+        let mut b = CircuitBreaker::new(spec(0.01, 3));
+        assert!(matches!(b.sample(&stats(100, 0)), Decision::NoData));
+    }
+
+    #[test]
+    fn healthy_traffic_reports_ok() {
+        let mut b = CircuitBreaker::new(spec(0.01, 3));
+        let _ = b.sample(&stats(100, 0));
+        let d = b.sample(&stats(200, 0));
+        assert!(matches!(d, Decision::Ok { .. }));
+    }
+
+    #[test]
+    fn trip_after_threshold_consecutive_bad() {
+        let mut b = CircuitBreaker::new(spec(0.01, 3));
+        // Prime.
+        let _ = b.sample(&stats(100, 0));
+        // Each sample: +1000 matched, +50 drops → ratio=0.05 > 0.01.
+        assert!(matches!(
+            b.sample(&stats(1100, 50)),
+            Decision::Bad { streak: 1, .. }
+        ));
+        assert!(matches!(
+            b.sample(&stats(2100, 100)),
+            Decision::Bad { streak: 2, .. }
+        ));
+        assert!(matches!(b.sample(&stats(3100, 150)), Decision::Trip { .. }));
+    }
+
+    #[test]
+    fn one_good_sample_resets_streak() {
+        let mut b = CircuitBreaker::new(spec(0.01, 3));
+        let _ = b.sample(&stats(100, 0));
+        let _ = b.sample(&stats(1100, 50)); // bad 1
+        let _ = b.sample(&stats(2100, 100)); // bad 2
+        let _ = b.sample(&stats(3100, 100)); // good (no new drops)
+                                             // Streak reset; one more bad should only be streak=1.
+        assert!(matches!(
+            b.sample(&stats(4100, 150)),
+            Decision::Bad { streak: 1, .. }
+        ));
+    }
+
+    #[test]
+    fn zero_matched_is_no_data_not_ok() {
+        let mut b = CircuitBreaker::new(spec(0.01, 3));
+        let _ = b.sample(&stats(100, 0));
+        // Drops happen but no matched traffic since prime.
+        assert!(matches!(b.sample(&stats(100, 10)), Decision::NoData));
+    }
+}

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -15,6 +15,7 @@ use packetframe_common::module::{
     ModuleError, ModuleResult,
 };
 
+pub mod breaker;
 pub mod metrics;
 pub mod pin;
 pub mod registry;

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -15,13 +15,14 @@ use packetframe_common::module::{
     ModuleError, ModuleResult,
 };
 
+pub mod pin;
 pub mod registry;
 
 #[cfg(target_os = "linux")]
 pub mod linux_impl;
 
 #[cfg(target_os = "linux")]
-pub use linux_impl::{trial_attach_native, TrialResult};
+pub use linux_impl::{stats_from_pin, trial_attach_native, TrialResult};
 
 pub const MODULE_NAME: &str = "fast-path";
 

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -15,6 +15,7 @@ use packetframe_common::module::{
     ModuleError, ModuleResult,
 };
 
+pub mod metrics;
 pub mod pin;
 pub mod registry;
 

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -23,6 +23,9 @@ pub mod registry;
 pub mod linux_impl;
 
 #[cfg(target_os = "linux")]
+pub mod reconcile;
+
+#[cfg(target_os = "linux")]
 pub use linux_impl::{stats_from_pin, trial_attach_native, TrialResult};
 
 pub const MODULE_NAME: &str = "fast-path";
@@ -143,10 +146,17 @@ impl Module for FastPathModule {
         Err(ModuleError::not_implemented(MODULE_NAME))
     }
 
+    #[cfg(target_os = "linux")]
+    fn reconfigure(&mut self, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+        let state = self
+            .state
+            .as_mut()
+            .ok_or_else(|| ModuleError::other(MODULE_NAME, "reconfigure called before load"))?;
+        reconcile::reconcile(state, cfg)
+    }
+
+    #[cfg(not(target_os = "linux"))]
     fn reconfigure(&mut self, _cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
-        // SPEC.md §4.5 calls for delta-only reconfigure. Full
-        // implementation (stale-entry purge, LPM delta vs. current)
-        // lands in PR #6 with the SIGHUP reconcile flow.
         Err(ModuleError::not_implemented(MODULE_NAME))
     }
 

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -78,15 +78,31 @@ pub struct ActiveState {
 }
 
 /// One XDP attach. `effective_mode` records what actually stuck in
-/// `Auto` mode so `status` can report it. `pinned_link` owns the
-/// PinnedLink returned from `FdLink::pin` — dropping it closes the
-/// userspace FD without unlinking the bpffs inode, so the kernel-side
-/// attach survives process exit.
+/// `Auto` mode so `status` can report it. `link` is either:
+///
+/// - `Pinned(PinnedLink)` — the happy path; dropping closes the
+///   userspace FD but leaves the bpffs inode, so the kernel attach
+///   survives process exit (§8.5).
+/// - `Transient(FdLink)` — pin syscall was rejected (e.g. EPERM on
+///   generic-mode XDP links on some kernels). The attach still works,
+///   but dropping the FdLink detaches the kernel-side XDP program.
+///   SIGTERM will detach these interfaces; native-mode ones persist.
 pub struct LinkRecord {
     pub iface: String,
     pub ifindex: u32,
     pub effective_mode: AttachMode,
-    pub pinned_link: PinnedLink,
+    pub link: LinkHandle,
+}
+
+pub enum LinkHandle {
+    Pinned(PinnedLink),
+    Transient(FdLink),
+}
+
+impl LinkHandle {
+    pub fn is_pinned(&self) -> bool {
+        matches!(self, LinkHandle::Pinned(_))
+    }
 }
 
 pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveState> {
@@ -263,18 +279,28 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // Attach each interface with trial-attach per §2.3: Auto → try
     // native first, fall back to generic on error; explicit Native or
     // Generic uses the requested mode directly (no fallback). Each
-    // attach pins its link under `<bpffs-root>/fast-path/links/<iface>`
-    // so the kernel attach survives process exit (§8.5).
+    // attach tries to pin its link under
+    // `<bpffs-root>/fast-path/links/<iface>` so the kernel attach
+    // survives process exit (§8.5). If pinning is kernel-rejected
+    // (e.g. EPERM on some kernels for generic-XDP links) the attach
+    // still succeeds but that specific link won't outlive the process.
     for (iface, mode, ifindex) in &attach_dirs {
-        let (effective_mode, pinned_link) =
+        let (effective_mode, link) =
             try_attach_with_fallback(prog, *ifindex, iface, *mode, &state.bpffs_root)?;
+        let persist = link.is_pinned();
         state.links.push(LinkRecord {
             iface: iface.clone(),
             ifindex: *ifindex,
             effective_mode,
-            pinned_link,
+            link,
         });
-        info!(iface, ifindex, ?effective_mode, "fast-path attached");
+        info!(
+            iface,
+            ifindex,
+            ?effective_mode,
+            persists_across_exit = persist,
+            "fast-path attached"
+        );
     }
 
     // Populate redirect_devmap with every attach-scope ifindex so the
@@ -379,7 +405,7 @@ fn try_attach_with_fallback(
     iface: &str,
     mode: AttachMode,
     bpffs_root: &Path,
-) -> ModuleResult<(AttachMode, PinnedLink)> {
+) -> ModuleResult<(AttachMode, LinkHandle)> {
     match mode {
         AttachMode::Native => attach_and_pin(
             prog,
@@ -427,12 +453,18 @@ fn try_attach_with_fallback(
     }
 }
 
-/// Attach + `take_link` + pin in one go. The returned `PinnedLink`
-/// holds both the bpffs path and the FD; dropping it closes the FD
-/// without removing the pin (see `pin::remove_all` for teardown).
+/// Attach + `take_link`, then try to pin. Returns:
 ///
-/// `mode_label` is only used for error message clarity — "native"
-/// vs "generic".
+/// - `LinkHandle::Pinned` on success — the kernel attach survives
+///   process exit via the bpffs inode.
+/// - `LinkHandle::Transient` if pinning was rejected (EPERM on
+///   generic-mode XDP links on some kernels, for instance). The
+///   attach still works, but dropping the returned `FdLink` detaches
+///   the kernel-side program.
+///
+/// Hard errors (attach fails, `take_link` fails, link isn't
+/// bpf_link_create-backed) remain hard errors — the caller bubbles
+/// them up.
 fn attach_and_pin(
     prog: &mut Xdp,
     ifindex: u32,
@@ -440,7 +472,7 @@ fn attach_and_pin(
     flags: XdpFlags,
     bpffs_root: &Path,
     mode_label: &str,
-) -> ModuleResult<PinnedLink> {
+) -> ModuleResult<LinkHandle> {
     let link_id = prog.attach_to_if_index(ifindex, flags).map_err(|e| {
         ModuleError::other(
             MODULE_NAME,
@@ -466,16 +498,46 @@ fn attach_and_pin(
         )
     })?;
     let pin_path = pin::link_path(bpffs_root, iface);
-    fd_link.pin(&pin_path).map_err(|e| {
-        ModuleError::other(
-            MODULE_NAME,
-            format!(
-                "pin link for {iface} at {}: {}",
-                pin_path.display(),
-                format_error_chain(&e)
-            ),
-        )
-    })
+    match fd_link.pin(&pin_path) {
+        Ok(pinned) => Ok(LinkHandle::Pinned(pinned)),
+        Err(err) => {
+            // Some kernels reject pinning for specific link types
+            // (observed: EPERM on generic-XDP links on 6.12). The
+            // attach itself is still valid; we just can't persist it
+            // across process exit. Open a fresh FdLink from the
+            // program's internal link tracking so we have something
+            // to hold (PinnedLink consumed the prior one on failure).
+            warn!(
+                iface,
+                pin_err = %format_error_chain(&err),
+                "link pin failed; attach will not survive process exit"
+            );
+            // Re-attach so we have an FdLink to hold. `attach_to_if_index`
+            // was already called; calling it again would double-attach
+            // which the kernel rejects. Fortunately `FdLink::pin`
+            // consumes `self` even on error — the link FD is already
+            // gone. Re-attach from scratch:
+            let link_id = prog.attach_to_if_index(ifindex, flags).map_err(|e| {
+                ModuleError::other(
+                    MODULE_NAME,
+                    format!("{mode_label} XDP re-attach to {iface} after pin failure: {e}"),
+                )
+            })?;
+            let owned_link = prog.take_link(link_id).map_err(|e| {
+                ModuleError::other(
+                    MODULE_NAME,
+                    format!("take_link after re-attach to {iface}: {e}"),
+                )
+            })?;
+            let fd_link: FdLink = owned_link.try_into().map_err(|e| {
+                ModuleError::other(
+                    MODULE_NAME,
+                    format!("XDP re-attach link for {iface} not FdLink: {e}"),
+                )
+            })?;
+            Ok(LinkHandle::Transient(fd_link))
+        }
+    }
 }
 
 /// Walk a std::error::Error's source chain and join into one display

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -542,7 +542,7 @@ fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
 ///
 /// Skip the two header lines, split each subsequent line on `|`, trim
 /// whitespace, and return `(subif_name, vid, parent_name)` tuples.
-fn read_vlan_config() -> std::io::Result<Vec<(String, u16, String)>> {
+pub(crate) fn read_vlan_config() -> std::io::Result<Vec<(String, u16, String)>> {
     let content = std::fs::read_to_string("/proc/net/vlan/config")?;
     let mut out = Vec::new();
     for line in content.lines().skip(2) {
@@ -584,7 +584,7 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
 }
 
 /// Wrap `libc::if_nametoindex`. Returns a clear error on failure.
-fn if_nametoindex(name: &str) -> ModuleResult<u32> {
+pub(crate) fn if_nametoindex(name: &str) -> ModuleResult<u32> {
     let c = CString::new(name).map_err(|_| {
         ModuleError::other(MODULE_NAME, format!("interface name `{name}` has NUL byte"))
     })?;

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -469,9 +469,27 @@ fn attach_and_pin(
     fd_link.pin(&pin_path).map_err(|e| {
         ModuleError::other(
             MODULE_NAME,
-            format!("pin link for {iface} at {}: {e}", pin_path.display()),
+            format!(
+                "pin link for {iface} at {}: {}",
+                pin_path.display(),
+                format_error_chain(&e)
+            ),
         )
     })
+}
+
+/// Walk a std::error::Error's source chain and join into one display
+/// string — aya's `SyscallError` hides the underlying `io::Error`
+/// behind `#[source]`, so plain `{}` drops the errno. This matters on
+/// any BPF syscall where the errno is the whole diagnostic.
+fn format_error_chain(err: &dyn std::error::Error) -> String {
+    let mut out = format!("{err}");
+    let mut source = err.source();
+    while let Some(s) = source {
+        out.push_str(&format!(": {s}"));
+        source = s.source();
+    }
+    out
 }
 
 /// Populate `vlan_resolve` from `/proc/net/vlan/config`. Each VLAN

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -45,7 +45,7 @@ pub struct FpCfg {
 // the struct into the kernel's array value slot.
 unsafe impl aya::Pod for FpCfg {}
 
-const FP_CFG_VERSION_V1: u32 = 0;
+pub(crate) const FP_CFG_VERSION_V1: u32 = 0;
 
 /// Layout mirror of `VlanResolve` in `bpf/src/maps.rs`. Hash-map value
 /// that tells the BPF program "this subif ifindex really egresses on
@@ -689,7 +689,7 @@ pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
 /// Read STATS directly from the bpffs pin — no live module required.
 /// Used by `packetframe status` when the loader isn't running.
 pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
-    use aya::maps::{MapData, PerCpuArray};
+    use aya::maps::{Map, MapData, PerCpuArray};
 
     let pin_path = pin::map_path(bpffs_root, "STATS");
     let map_data = MapData::from_pin(&pin_path).map_err(|e| {
@@ -698,7 +698,10 @@ pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
             format!("open STATS pin at {}: {e}", pin_path.display()),
         )
     })?;
-    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map_data)
+    // aya's `PerCpuArray::try_from` takes a `Map` enum, not a bare
+    // `MapData`; wrap before converting.
+    let map = Map::PerCpuArray(map_data);
+    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("STATS PerCpuArray: {e}")))?;
     read_stats(&stats)
 }

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -10,7 +10,11 @@ use std::path::{Path, PathBuf};
 
 use aya::{
     maps::{lpm_trie::Key as LpmKey, xdp::DevMapHash, Array, HashMap as AyaHashMap, LpmTrie},
-    programs::{xdp::XdpFlags, Xdp},
+    programs::{
+        links::{FdLink, PinnedLink},
+        xdp::XdpFlags,
+        Xdp,
+    },
     Ebpf,
 };
 use packetframe_common::{
@@ -19,7 +23,7 @@ use packetframe_common::{
 };
 use tracing::{info, warn};
 
-use crate::{aligned_bpf_copy, FAST_PATH_BPF_AVAILABLE, MODULE_NAME};
+use crate::{aligned_bpf_copy, pin, FAST_PATH_BPF_AVAILABLE, MODULE_NAME};
 
 /// Layout mirror of `FpCfg` in `bpf/src/maps.rs` (PR #3). `#[repr(C)]`
 /// with all-bit-patterns-valid primitive fields, so `aya::Pod` is safe
@@ -59,10 +63,13 @@ pub struct VlanResolve {
 unsafe impl aya::Pod for VlanResolve {}
 
 /// All state required to keep the attached program alive.
-/// `Drop` on `Ebpf` unloads the program + maps, which is what we want
-/// for a clean detach. SPEC.md §8.5 note: the loader can crash and the
-/// kernel will keep the program attached via pinning — pinning lands
-/// later in this PR; until then, a crash detaches.
+///
+/// After `attach`, the XDP program, every §4.5 map, and each per-iface
+/// link is pinned under `<bpffs-root>/fast-path/`. Dropping
+/// `ActiveState` closes our userspace FDs but the bpffs inodes hold
+/// the kernel references — SPEC.md §8.5 "exit without detach" works as
+/// soon as pinning is in place. `Module::detach` unlinks the pins,
+/// which is when the kernel actually tears everything down.
 pub struct ActiveState {
     pub ebpf: Ebpf,
     pub links: Vec<LinkRecord>,
@@ -71,12 +78,15 @@ pub struct ActiveState {
 }
 
 /// One XDP attach. `effective_mode` records what actually stuck in
-/// `Auto` mode so `status` can report it.
+/// `Auto` mode so `status` can report it. `pinned_link` owns the
+/// PinnedLink returned from `FdLink::pin` — dropping it closes the
+/// userspace FD without unlinking the bpffs inode, so the kernel-side
+/// attach survives process exit.
 pub struct LinkRecord {
     pub iface: String,
     pub ifindex: u32,
     pub effective_mode: AttachMode,
-    pub link_id: aya::programs::xdp::XdpLinkId,
+    pub pinned_link: PinnedLink,
 }
 
 pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveState> {
@@ -86,6 +96,26 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
             "no BPF ELF embedded in the binary — build with rustup + nightly + bpf-linker (see CLAUDE.md)",
         ));
     }
+
+    // Refuse startup when pins from a prior invocation survive.
+    // SPEC.md §8.5 "exit without detach" leaves pins in bpffs after
+    // SIGTERM; v0.1 does not adopt those — operator must run
+    // `packetframe detach --all` first. Full adoption (zero-disruption
+    // restart) is deferred.
+    if pin::has_existing_pins(ctx.bpffs_root) {
+        return Err(ModuleError::other(
+            MODULE_NAME,
+            format!(
+                "existing pins under {} from a prior invocation — \
+                 run `packetframe detach --all` before restarting \
+                 (v0.1 does not yet adopt in-place)",
+                pin::module_root(ctx.bpffs_root).display()
+            ),
+        ));
+    }
+
+    pin::ensure_dirs(ctx.bpffs_root)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("create bpffs pin dirs: {e}")))?;
 
     // aya doesn't expose an `Ebpf::load_with_options` that'd let us
     // skip BTF lookup; on the reference EFG (§2.2) BTF is absent but
@@ -232,14 +262,17 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
 
     // Attach each interface with trial-attach per §2.3: Auto → try
     // native first, fall back to generic on error; explicit Native or
-    // Generic uses the requested mode directly (no fallback).
+    // Generic uses the requested mode directly (no fallback). Each
+    // attach pins its link under `<bpffs-root>/fast-path/links/<iface>`
+    // so the kernel attach survives process exit (§8.5).
     for (iface, mode, ifindex) in &attach_dirs {
-        let (effective_mode, link_id) = try_attach_with_fallback(prog, *ifindex, iface, *mode)?;
+        let (effective_mode, pinned_link) =
+            try_attach_with_fallback(prog, *ifindex, iface, *mode, &state.bpffs_root)?;
         state.links.push(LinkRecord {
             iface: iface.clone(),
             ifindex: *ifindex,
             effective_mode,
-            link_id,
+            pinned_link,
         });
         info!(iface, ifindex, ?effective_mode, "fast-path attached");
     }
@@ -266,11 +299,17 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
 
     populate_vlan_resolve(state)?;
 
-    // Build Attachment records for the pin registry. `pinned_path` is
-    // advisory in v0.1 — actual bpffs pinning lands with reconcile in
-    // PR #6 — but we populate the shape so the registry survives
-    // incremental upgrades.
-    let pin_root = state.bpffs_root.join(MODULE_NAME);
+    // Pin program + every §4.5 map so `packetframe status` can read
+    // counters from a separate process and `packetframe detach` can
+    // find what to tear down. Pinning happens after population so a
+    // partial-load failure (above) doesn't leave half-initialized maps
+    // in bpffs.
+    pin_program_and_maps(state)?;
+
+    // Build Attachment records for the pin registry. `pinned_path`
+    // points at the real link pin — when `packetframe detach` runs,
+    // it unlinks this path, which is how the kernel-side attach tears
+    // down.
     Ok(state
         .links
         .iter()
@@ -282,57 +321,157 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 AttachMode::Auto => HookType::NativeXdp, // already resolved
             },
             prog_id,
-            pinned_path: pin_root.join(format!("prog-{}", l.iface)),
+            pinned_path: pin::link_path(&state.bpffs_root, &l.iface),
         })
         .collect())
+}
+
+/// Pin the fast-path program and every §4.5 map under the module's
+/// bpffs pin root. Called at the end of `attach` so partial failure
+/// in link attach doesn't leak pins.
+fn pin_program_and_maps(state: &mut ActiveState) -> ModuleResult<()> {
+    let prog_path = pin::program_path(&state.bpffs_root);
+    {
+        let prog: &mut Xdp = state
+            .ebpf
+            .program_mut(pin::PROGRAM_NAME)
+            .ok_or_else(|| ModuleError::other(MODULE_NAME, "fast_path program missing for pin"))?
+            .try_into()
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("pin: program not XDP: {e}")))?;
+        prog.pin(&prog_path).map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("pin program at {}: {e}", prog_path.display()),
+            )
+        })?;
+    }
+
+    for name in pin::MAP_NAMES {
+        let map = state.ebpf.map(name).ok_or_else(|| {
+            ModuleError::other(MODULE_NAME, format!("map {name} missing for pin"))
+        })?;
+        let path = pin::map_path(&state.bpffs_root, name);
+        map.pin(&path).map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("pin map {name} at {}: {e}", path.display()),
+            )
+        })?;
+    }
+
+    info!(
+        pin_root = %pin::module_root(&state.bpffs_root).display(),
+        "program + maps pinned"
+    );
+    Ok(())
 }
 
 /// §2.3: per-interface trial-attach. `Native` and `Generic` are explicit
 /// (no fallback); `Auto` tries native first, falls back to generic on
 /// any error. The spec calls out that `bpftool feature probe` is
-/// unreliable — we find out what works by actually trying.
+/// unreliable — we find out what works by actually trying. Each
+/// successful attach immediately pins its link under
+/// `<bpffs-root>/fast-path/links/<iface>` so the kernel attach
+/// survives process exit (§8.5).
 fn try_attach_with_fallback(
     prog: &mut Xdp,
     ifindex: u32,
     iface: &str,
     mode: AttachMode,
-) -> ModuleResult<(AttachMode, aya::programs::xdp::XdpLinkId)> {
+    bpffs_root: &Path,
+) -> ModuleResult<(AttachMode, PinnedLink)> {
     match mode {
-        AttachMode::Native => prog
-            .attach_to_if_index(ifindex, XdpFlags::DRV_MODE)
-            .map(|id| (AttachMode::Native, id))
-            .map_err(|e| {
-                ModuleError::other(
-                    MODULE_NAME,
-                    format!("native XDP attach to {iface} failed: {e}"),
-                )
-            }),
-        AttachMode::Generic => prog
-            .attach_to_if_index(ifindex, XdpFlags::SKB_MODE)
-            .map(|id| (AttachMode::Generic, id))
-            .map_err(|e| {
-                ModuleError::other(
-                    MODULE_NAME,
-                    format!("generic XDP attach to {iface} failed: {e}"),
-                )
-            }),
-        AttachMode::Auto => match prog.attach_to_if_index(ifindex, XdpFlags::DRV_MODE) {
-            Ok(id) => Ok((AttachMode::Native, id)),
-            Err(native_err) => {
-                warn!(iface, %native_err, "native XDP attach failed; falling back to generic");
-                prog.attach_to_if_index(ifindex, XdpFlags::SKB_MODE)
-                    .map(|id| (AttachMode::Generic, id))
-                    .map_err(|generic_err| {
-                        ModuleError::other(
-                            MODULE_NAME,
-                            format!(
-                                "auto XDP attach to {iface}: native failed ({native_err}), generic failed ({generic_err})"
-                            ),
-                        )
-                    })
+        AttachMode::Native => attach_and_pin(
+            prog,
+            ifindex,
+            iface,
+            XdpFlags::DRV_MODE,
+            bpffs_root,
+            "native",
+        )
+        .map(|p| (AttachMode::Native, p)),
+        AttachMode::Generic => attach_and_pin(
+            prog,
+            ifindex,
+            iface,
+            XdpFlags::SKB_MODE,
+            bpffs_root,
+            "generic",
+        )
+        .map(|p| (AttachMode::Generic, p)),
+        AttachMode::Auto => {
+            match attach_and_pin(
+                prog,
+                ifindex,
+                iface,
+                XdpFlags::DRV_MODE,
+                bpffs_root,
+                "native",
+            ) {
+                Ok(p) => Ok((AttachMode::Native, p)),
+                Err(native_err) => {
+                    warn!(iface, %native_err, "native XDP attach failed; falling back to generic");
+                    attach_and_pin(prog, ifindex, iface, XdpFlags::SKB_MODE, bpffs_root, "generic")
+                        .map(|p| (AttachMode::Generic, p))
+                        .map_err(|generic_err| {
+                            ModuleError::other(
+                                MODULE_NAME,
+                                format!(
+                                    "auto XDP attach to {iface}: native failed ({native_err}), generic failed ({generic_err})"
+                                ),
+                            )
+                        })
+                }
             }
-        },
+        }
     }
+}
+
+/// Attach + `take_link` + pin in one go. The returned `PinnedLink`
+/// holds both the bpffs path and the FD; dropping it closes the FD
+/// without removing the pin (see `pin::remove_all` for teardown).
+///
+/// `mode_label` is only used for error message clarity — "native"
+/// vs "generic".
+fn attach_and_pin(
+    prog: &mut Xdp,
+    ifindex: u32,
+    iface: &str,
+    flags: XdpFlags,
+    bpffs_root: &Path,
+    mode_label: &str,
+) -> ModuleResult<PinnedLink> {
+    let link_id = prog.attach_to_if_index(ifindex, flags).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("{mode_label} XDP attach to {iface} failed: {e}"),
+        )
+    })?;
+    let owned_link = prog.take_link(link_id).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("take_link after {mode_label} attach to {iface}: {e}"),
+        )
+    })?;
+    let fd_link: FdLink = owned_link.try_into().map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            // SPEC.md requires kernel ≥5.15; ≥5.9 gives us bpf_link_create
+            // + FdLink. On older kernels aya returns an NlLink which can't
+            // pin — that path is reachable only if someone runs on a
+            // kernel the probe missed.
+            format!(
+                "XDP link for {iface} is netlink-backed (kernel too old for bpf_link_create?): {e}",
+            ),
+        )
+    })?;
+    let pin_path = pin::link_path(bpffs_root, iface);
+    fd_link.pin(&pin_path).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("pin link for {iface} at {}: {e}", pin_path.display()),
+        )
+    })
 }
 
 /// Populate `vlan_resolve` from `/proc/net/vlan/config`. Each VLAN
@@ -426,21 +565,21 @@ fn read_vlan_config() -> std::io::Result<Vec<(String, u16, String)>> {
 }
 
 pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
-    // Drain links in reverse attach order so the last-attached
-    // interface is detached first — no practical consequence here but
-    // it matches typical lifecycle expectations.
+    // Drop every PinnedLink first: this closes our userspace FDs but
+    // the kernel keeps the attach alive via the bpffs inodes. Drain
+    // in reverse attach order — no practical consequence here, matches
+    // typical lifecycle expectations.
     while let Some(link) = state.links.pop() {
-        if let Some(prog) = state
-            .ebpf
-            .program_mut("fast_path")
-            .and_then(|p| <&mut Xdp>::try_from(p).ok())
-        {
-            if let Err(e) = prog.detach(link.link_id) {
-                warn!(iface = %link.iface, error = %e, "detach link failed; continuing");
-            }
-        }
-        info!(iface = %link.iface, "fast-path detached");
+        info!(iface = %link.iface, "fast-path detaching");
+        drop(link);
     }
+
+    // Unlink every pin under the module's pin root. Removing link
+    // pins triggers the kernel-side detach; removing map + program
+    // pins is housekeeping.
+    pin::remove_all(&state.bpffs_root)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("remove pins: {e}")))?;
+    info!("fast-path pins removed; kernel detached");
     Ok(())
 }
 
@@ -544,6 +683,29 @@ pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
         ModuleError::other(MODULE_NAME, format!("STATS PerCpuArray::try_from: {e}"))
     })?;
 
+    read_stats(&stats)
+}
+
+/// Read STATS directly from the bpffs pin — no live module required.
+/// Used by `packetframe status` when the loader isn't running.
+pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
+    use aya::maps::{MapData, PerCpuArray};
+
+    let pin_path = pin::map_path(bpffs_root, "STATS");
+    let map_data = MapData::from_pin(&pin_path).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("open STATS pin at {}: {e}", pin_path.display()),
+        )
+    })?;
+    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map_data)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("STATS PerCpuArray: {e}")))?;
+    read_stats(&stats)
+}
+
+fn read_stats<T: std::borrow::Borrow<aya::maps::MapData>>(
+    stats: &aya::maps::PerCpuArray<T, u64>,
+) -> ModuleResult<Vec<u64>> {
     let mut out = vec![0u64; 19];
     for (idx, slot) in out.iter_mut().enumerate() {
         let values = stats

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -38,19 +38,20 @@ pub const COUNTER_NAMES: [&str; 19] = [
 
 /// Render a Prometheus textfile body from stat values + module uptime.
 /// Every counter gets `# TYPE` and `# HELP` headers so Prometheus's
-/// textfile collector categorizes it correctly.
+/// textfile collector categorizes it correctly. Counter names that
+/// already end in `_total` (e.g. `rx_total`) get emitted as-is —
+/// Prometheus convention requires one `_total` suffix, not two.
 pub fn render_textfile(stats: &[u64], uptime_seconds: u64) -> String {
     let mut out = String::with_capacity(4096);
     for (name, value) in COUNTER_NAMES.iter().zip(stats.iter()) {
-        let _ = writeln!(
-            out,
-            "# HELP packetframe_{name}_total fast-path §4.6 counter"
-        );
-        let _ = writeln!(out, "# TYPE packetframe_{name}_total counter");
-        let _ = writeln!(
-            out,
-            "packetframe_{name}_total{{module=\"fast-path\"}} {value}"
-        );
+        let metric = if name.ends_with("_total") {
+            format!("packetframe_{name}")
+        } else {
+            format!("packetframe_{name}_total")
+        };
+        let _ = writeln!(out, "# HELP {metric} fast-path §4.6 counter");
+        let _ = writeln!(out, "# TYPE {metric} counter");
+        let _ = writeln!(out, "{metric}{{module=\"fast-path\"}} {value}");
     }
     let _ = writeln!(
         out,
@@ -81,10 +82,23 @@ mod tests {
         let stats = vec![0u64; 19];
         let body = render_textfile(&stats, 42);
         for name in COUNTER_NAMES {
-            let line = format!("packetframe_{name}_total{{module=\"fast-path\"}} 0");
+            let metric = if name.ends_with("_total") {
+                format!("packetframe_{name}")
+            } else {
+                format!("packetframe_{name}_total")
+            };
+            let line = format!("{metric}{{module=\"fast-path\"}} 0");
             assert!(body.contains(&line), "missing line: {line}");
         }
         assert!(body.contains("packetframe_uptime_seconds{module=\"fast-path\"} 42"));
+    }
+
+    #[test]
+    fn counter_names_ending_in_total_are_not_double_suffixed() {
+        let stats = vec![0u64; 19];
+        let body = render_textfile(&stats, 0);
+        assert!(body.contains("packetframe_rx_total{module=\"fast-path\"}"));
+        assert!(!body.contains("packetframe_rx_total_total"));
     }
 
     #[test]

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -1,0 +1,98 @@
+//! Prometheus textfile rendering for the fast-path STATS map
+//! (SPEC.md §7.3, §4.6).
+//!
+//! Counter names mirror the `StatIdx` discriminants in
+//! `bpf/src/maps.rs`. The order is append-only once v0.1 ships —
+//! renumbering `StatIdx` would break operator dashboards — so this
+//! table is implicitly ordered by discriminant. Runtime formatting
+//! depends on both lists matching: the zipping loop in
+//! `render_textfile` assumes `NAMES` and `stats` line up.
+
+use std::fmt::Write as _;
+
+/// Wire-format counter names, index-aligned with `StatIdx` in
+/// `bpf/src/maps.rs`. These become the `packetframe_<name>_total`
+/// metric names; changing any value changes the operator-facing
+/// metric name.
+pub const COUNTER_NAMES: [&str; 19] = [
+    "rx_total",
+    "matched_v4",
+    "matched_v6",
+    "matched_src_only",
+    "matched_dst_only",
+    "matched_both",
+    "fwd_ok",
+    "fwd_dry_run",
+    "pass_fragment",
+    "pass_low_ttl",
+    "pass_no_neigh",
+    "pass_not_ip",
+    "pass_frag_needed",
+    "drop_unreachable",
+    "err_parse",
+    "err_fib_other",
+    "err_vlan",
+    "pass_not_in_devmap",
+    "pass_complex_header",
+];
+
+/// Render a Prometheus textfile body from stat values + module uptime.
+/// Every counter gets `# TYPE` and `# HELP` headers so Prometheus's
+/// textfile collector categorizes it correctly.
+pub fn render_textfile(stats: &[u64], uptime_seconds: u64) -> String {
+    let mut out = String::with_capacity(4096);
+    for (name, value) in COUNTER_NAMES.iter().zip(stats.iter()) {
+        let _ = writeln!(
+            out,
+            "# HELP packetframe_{name}_total fast-path §4.6 counter"
+        );
+        let _ = writeln!(out, "# TYPE packetframe_{name}_total counter");
+        let _ = writeln!(
+            out,
+            "packetframe_{name}_total{{module=\"fast-path\"}} {value}"
+        );
+    }
+    let _ = writeln!(
+        out,
+        "# HELP packetframe_uptime_seconds seconds since the fast-path module attached"
+    );
+    let _ = writeln!(out, "# TYPE packetframe_uptime_seconds gauge");
+    let _ = writeln!(
+        out,
+        "packetframe_uptime_seconds{{module=\"fast-path\"}} {uptime_seconds}"
+    );
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn counter_names_match_stats_count() {
+        // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
+        // drift, the zip() in render_textfile silently truncates —
+        // this test catches that at unit-test time.
+        assert_eq!(COUNTER_NAMES.len(), 19);
+    }
+
+    #[test]
+    fn rendered_output_contains_every_counter() {
+        let stats = vec![0u64; 19];
+        let body = render_textfile(&stats, 42);
+        for name in COUNTER_NAMES {
+            let line = format!("packetframe_{name}_total{{module=\"fast-path\"}} 0");
+            assert!(body.contains(&line), "missing line: {line}");
+        }
+        assert!(body.contains("packetframe_uptime_seconds{module=\"fast-path\"} 42"));
+    }
+
+    #[test]
+    fn rendered_output_has_type_header_per_counter() {
+        let stats = vec![1u64; 19];
+        let body = render_textfile(&stats, 0);
+        let type_lines = body.lines().filter(|l| l.starts_with("# TYPE")).count();
+        // 19 counters + 1 uptime gauge
+        assert_eq!(type_lines, 20);
+    }
+}

--- a/crates/modules/fast-path/src/pin.rs
+++ b/crates/modules/fast-path/src/pin.rs
@@ -1,0 +1,212 @@
+//! bpffs pin path construction + lifecycle helpers (SPEC.md §8.2, §8.5).
+//!
+//! Pins live under `<bpffs-root>/<module-name>/{progs,maps,links}/`. The
+//! XDP program, every §4.5 map, and every per-iface link are pinned at
+//! attach time. This does two things:
+//!
+//! - `packetframe status` and `packetframe detach` can reach the kernel
+//!   state from a separate process (neither has an active loader).
+//! - The kernel-side XDP attachment outlives the loader. Dropping a
+//!   `PinnedLink` closes the userspace FD, but the bpffs inode keeps
+//!   the kernel reference alive until the pin path is unlinked. This
+//!   is what SPEC.md §8.5 "exit without detach" actually means in
+//!   concrete terms.
+//!
+//! v0.1 refuses startup when pins already exist from a prior
+//! invocation. Full adoption (zero-disruption daemon restart) is
+//! deferred — the operator runs `packetframe detach --all` to clean
+//! up before restarting.
+
+use std::path::{Path, PathBuf};
+
+use crate::MODULE_NAME;
+
+/// Every §4.5 map that gets pinned. Order is not significant.
+pub const MAP_NAMES: [&str; 7] = [
+    "ALLOW_V4",
+    "ALLOW_V6",
+    "CFG",
+    "STATS",
+    "REDIRECT_DEVMAP",
+    "VLAN_RESOLVE",
+    "LOG",
+];
+
+/// The XDP program's pinned basename.
+pub const PROGRAM_NAME: &str = "fast_path";
+
+pub fn module_root(bpffs_root: &Path) -> PathBuf {
+    bpffs_root.join(MODULE_NAME)
+}
+
+pub fn progs_dir(bpffs_root: &Path) -> PathBuf {
+    module_root(bpffs_root).join("progs")
+}
+
+pub fn maps_dir(bpffs_root: &Path) -> PathBuf {
+    module_root(bpffs_root).join("maps")
+}
+
+pub fn links_dir(bpffs_root: &Path) -> PathBuf {
+    module_root(bpffs_root).join("links")
+}
+
+pub fn program_path(bpffs_root: &Path) -> PathBuf {
+    progs_dir(bpffs_root).join(PROGRAM_NAME)
+}
+
+pub fn map_path(bpffs_root: &Path, name: &str) -> PathBuf {
+    maps_dir(bpffs_root).join(name)
+}
+
+pub fn link_path(bpffs_root: &Path, iface: &str) -> PathBuf {
+    links_dir(bpffs_root).join(iface)
+}
+
+/// Create the module's pin subdirectories if missing. The bpffs root
+/// itself must already be mounted — [`packetframe_common::probe`]'s
+/// `bpffs` probe checks that.
+pub fn ensure_dirs(bpffs_root: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(progs_dir(bpffs_root))?;
+    std::fs::create_dir_all(maps_dir(bpffs_root))?;
+    std::fs::create_dir_all(links_dir(bpffs_root))?;
+    Ok(())
+}
+
+/// True when any pinned object exists under the module's pin root.
+/// Startup checks this before fresh-loading — pinned state from a prior
+/// invocation must be cleaned via `packetframe detach --all` first.
+pub fn has_existing_pins(bpffs_root: &Path) -> bool {
+    for sub in [
+        progs_dir(bpffs_root),
+        maps_dir(bpffs_root),
+        links_dir(bpffs_root),
+    ] {
+        let entries = match std::fs::read_dir(&sub) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if entries.flatten().next().is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Remove every pin under the module's pin root. Called by
+/// `packetframe detach`. Missing files and missing directories are
+/// not errors — the post-condition is "no pins", regardless of
+/// starting state.
+///
+/// Removing a link pin causes the kernel to detach the XDP program
+/// from the iface. Removing the program and map pins is housekeeping
+/// — their kernel-side objects disappear once no FDs or links
+/// reference them.
+pub fn remove_all(bpffs_root: &Path) -> std::io::Result<()> {
+    // Remove links first so the kernel-side attach is gone before the
+    // program is unreferenced. Order is defensive — the kernel copes
+    // with reverse order too.
+    for sub in [
+        links_dir(bpffs_root),
+        maps_dir(bpffs_root),
+        progs_dir(bpffs_root),
+    ] {
+        let entries = match std::fs::read_dir(&sub) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+        for entry in entries.flatten() {
+            match std::fs::remove_file(entry.path()) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_shape() {
+        let root = Path::new("/sys/fs/bpf/packetframe");
+        assert_eq!(
+            module_root(root),
+            Path::new("/sys/fs/bpf/packetframe/fast-path")
+        );
+        assert_eq!(
+            program_path(root),
+            Path::new("/sys/fs/bpf/packetframe/fast-path/progs/fast_path")
+        );
+        assert_eq!(
+            map_path(root, "STATS"),
+            Path::new("/sys/fs/bpf/packetframe/fast-path/maps/STATS")
+        );
+        assert_eq!(
+            link_path(root, "eth0.1337"),
+            Path::new("/sys/fs/bpf/packetframe/fast-path/links/eth0.1337")
+        );
+    }
+
+    #[test]
+    fn has_existing_pins_false_when_empty() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        assert!(!has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn has_existing_pins_true_when_program_pinned() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        std::fs::write(program_path(&dir), b"fake").unwrap();
+        assert!(has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn has_existing_pins_true_when_map_pinned() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        std::fs::write(map_path(&dir, "STATS"), b"fake").unwrap();
+        assert!(has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_all_cleans_every_subdir() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        std::fs::write(program_path(&dir), b"fake").unwrap();
+        std::fs::write(map_path(&dir, "STATS"), b"fake").unwrap();
+        std::fs::write(link_path(&dir, "eth0"), b"fake").unwrap();
+        remove_all(&dir).unwrap();
+        assert!(!has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_all_idempotent() {
+        let dir = tempdir();
+        remove_all(&dir).unwrap();
+        remove_all(&dir).unwrap();
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn tempdir() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let p = std::env::temp_dir().join(format!(
+            "pf-pin-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -1,0 +1,283 @@
+//! SIGHUP reconcile: delta-only updates to the §4.5 map set
+//! (SPEC.md §4.5, §8.4).
+//!
+//! Called when the CLI `run` loop receives SIGHUP. The caller
+//! re-parses the config out of band and passes it here along with
+//! live map handles; this module computes the diff against in-kernel
+//! state and applies adds + removes without reloading the BPF
+//! program.
+//!
+//! Map updates aren't transactional — if an individual insert or
+//! delete fails we log it and continue. Partial-update state is
+//! strictly better than halting mid-reconcile. Attach-set changes
+//! (new iface or iface removed from the config) are **not** handled
+//! here; operators restart the loader for those.
+
+use std::collections::HashSet;
+
+use aya::maps::{lpm_trie::Key as LpmKey, xdp::DevMapHash, Array, HashMap as AyaHashMap, LpmTrie};
+use packetframe_common::{
+    config::ModuleDirective,
+    module::{ModuleConfig, ModuleError, ModuleResult},
+};
+use tracing::{info, warn};
+
+use crate::linux_impl::{
+    if_nametoindex, read_vlan_config, ActiveState, FpCfg, VlanResolve, FP_CFG_VERSION_V1,
+};
+use crate::MODULE_NAME;
+
+/// Per-map count of entries added and removed during reconcile.
+#[derive(Default, Debug)]
+pub struct DeltaCount {
+    pub added: usize,
+    pub removed: usize,
+}
+
+pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+    reconcile_cfg(state, cfg)?;
+    let v4 = reconcile_allow_v4(state, cfg)?;
+    let v6 = reconcile_allow_v6(state, cfg)?;
+    let vlan = reconcile_vlan_resolve(state)?;
+    let devmap_purged = purge_stale_devmap(state)?;
+
+    info!(
+        v4_added = v4.added,
+        v4_removed = v4.removed,
+        v6_added = v6.added,
+        v6_removed = v6.removed,
+        vlan_added = vlan.added,
+        vlan_removed = vlan.removed,
+        devmap_purged = devmap_purged.removed,
+        "SIGHUP reconcile applied"
+    );
+    Ok(())
+}
+
+fn reconcile_cfg(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+    let dry_run = cfg
+        .section
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::DryRun(v) => Some(*v),
+            _ => None,
+        })
+        .unwrap_or(false);
+
+    let new_cfg = FpCfg {
+        dry_run: u8::from(dry_run),
+        flags: 0b11,
+        _reserved: [0; 2],
+        version: FP_CFG_VERSION_V1,
+    };
+
+    let map = state
+        .ebpf
+        .map_mut("CFG")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "CFG map missing from ELF"))?;
+    let mut cfg_arr: Array<_, FpCfg> = Array::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG Array::try_from: {e}")))?;
+    cfg_arr
+        .set(0, new_cfg, 0)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG set: {e}")))?;
+    info!(dry_run, "CFG reconciled");
+    Ok(())
+}
+
+fn reconcile_allow_v4(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<DeltaCount> {
+    let desired: HashSet<(u32, [u8; 4])> = cfg
+        .section
+        .directives
+        .iter()
+        .filter_map(|d| match d {
+            ModuleDirective::AllowPrefix4(p) => Some((u32::from(p.prefix_len), p.addr.octets())),
+            _ => None,
+        })
+        .collect();
+
+    let map = state
+        .ebpf
+        .map_mut("ALLOW_V4")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "ALLOW_V4 map missing from ELF"))?;
+    let mut trie: LpmTrie<_, [u8; 4], u8> = LpmTrie::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("ALLOW_V4 try_from: {e}")))?;
+
+    let current: HashSet<(u32, [u8; 4])> = trie
+        .keys()
+        .filter_map(Result::ok)
+        .map(|k| (k.prefix_len(), k.data()))
+        .collect();
+
+    apply_prefix_delta::<[u8; 4]>(&mut trie, &desired, &current, "ALLOW_V4")
+}
+
+fn reconcile_allow_v6(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<DeltaCount> {
+    let desired: HashSet<(u32, [u8; 16])> = cfg
+        .section
+        .directives
+        .iter()
+        .filter_map(|d| match d {
+            ModuleDirective::AllowPrefix6(p) => Some((u32::from(p.prefix_len), p.addr.octets())),
+            _ => None,
+        })
+        .collect();
+
+    let map = state
+        .ebpf
+        .map_mut("ALLOW_V6")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "ALLOW_V6 map missing from ELF"))?;
+    let mut trie: LpmTrie<_, [u8; 16], u8> = LpmTrie::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("ALLOW_V6 try_from: {e}")))?;
+
+    let current: HashSet<(u32, [u8; 16])> = trie
+        .keys()
+        .filter_map(Result::ok)
+        .map(|k| (k.prefix_len(), k.data()))
+        .collect();
+
+    apply_prefix_delta::<[u8; 16]>(&mut trie, &desired, &current, "ALLOW_V6")
+}
+
+/// Insert every entry in `desired \ current`, then delete every entry
+/// in `current \ desired`. Adds-first ordering keeps a rename (remove+add
+/// of the same prefix) from ever having a window where neither exists.
+fn apply_prefix_delta<K>(
+    trie: &mut LpmTrie<&mut aya::maps::MapData, K, u8>,
+    desired: &HashSet<(u32, K)>,
+    current: &HashSet<(u32, K)>,
+    map_label: &str,
+) -> ModuleResult<DeltaCount>
+where
+    K: aya::Pod + Eq + std::hash::Hash + std::fmt::Debug,
+{
+    let mut delta = DeltaCount::default();
+    for (len, data) in desired.difference(current) {
+        let key = LpmKey::new(*len, *data);
+        match trie.insert(&key, 1u8, 0) {
+            Ok(()) => delta.added += 1,
+            Err(e) => warn!(map = map_label, prefix_len = *len, ?data, error = %e, "insert failed"),
+        }
+    }
+    for (len, data) in current.difference(desired) {
+        let key = LpmKey::new(*len, *data);
+        match trie.remove(&key) {
+            Ok(()) => delta.removed += 1,
+            Err(e) => warn!(map = map_label, prefix_len = *len, ?data, error = %e, "remove failed"),
+        }
+    }
+    Ok(delta)
+}
+
+fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
+    // Rebuild the desired set from /proc/net/vlan/config. Missing file
+    // means no VLAN subifs — desired is empty, which will remove any
+    // stale entries.
+    let vlan_entries = match read_vlan_config() {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!("read /proc/net/vlan/config: {e}"),
+            ));
+        }
+    };
+
+    let desired: HashSet<(u32, u32, u16)> = vlan_entries
+        .iter()
+        .filter_map(|(subif, vid, parent)| {
+            // Skip entries whose ifindexes don't resolve — the proc
+            // file is a snapshot; an iface may have disappeared between
+            // read and here.
+            let subif_idx = if_nametoindex(subif).ok()?;
+            let phys_idx = if_nametoindex(parent).ok()?;
+            Some((subif_idx, phys_idx, *vid))
+        })
+        .collect();
+
+    let map = state
+        .ebpf
+        .map_mut("VLAN_RESOLVE")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "VLAN_RESOLVE missing from ELF"))?;
+    let mut hm: AyaHashMap<_, u32, VlanResolve> = AyaHashMap::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("VLAN_RESOLVE try_from: {e}")))?;
+
+    // Gather current state — value is VlanResolve { phys_ifindex, vid }.
+    let current: HashSet<(u32, u32, u16)> = hm
+        .iter()
+        .filter_map(Result::ok)
+        .map(|(subif_idx, v)| (subif_idx, v.phys_ifindex, v.vid))
+        .collect();
+
+    let mut delta = DeltaCount::default();
+    for (subif_idx, phys_idx, vid) in desired.difference(&current) {
+        let value = VlanResolve {
+            phys_ifindex: *phys_idx,
+            vid: *vid,
+            _pad: 0,
+        };
+        match hm.insert(*subif_idx, value, 0) {
+            Ok(()) => {
+                delta.added += 1;
+                info!(subif_idx, phys_idx, vid, "VLAN_RESOLVE added");
+            }
+            Err(e) => warn!(subif_idx, error = %e, "VLAN_RESOLVE insert failed"),
+        }
+    }
+    for (subif_idx, _, _) in current.difference(&desired) {
+        match hm.remove(subif_idx) {
+            Ok(()) => {
+                delta.removed += 1;
+                info!(subif_idx, "VLAN_RESOLVE removed (subif gone)");
+            }
+            Err(e) => warn!(subif_idx, error = %e, "VLAN_RESOLVE remove failed"),
+        }
+    }
+    Ok(delta)
+}
+
+/// Purge REDIRECT_DEVMAP entries whose ifindex no longer resolves via
+/// `if_indextoname` — an iface that disappeared between attach and
+/// reconcile. Covers the "stale devmap after hot-unplug" case called
+/// out in the SPEC §4.5 reconcile note.
+fn purge_stale_devmap(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
+    let map = state
+        .ebpf
+        .map_mut("REDIRECT_DEVMAP")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "REDIRECT_DEVMAP missing from ELF"))?;
+    let mut devmap: DevMapHash<_> = DevMapHash::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("REDIRECT_DEVMAP try_from: {e}")))?;
+
+    let stale: Vec<u32> = devmap
+        .keys()
+        .filter_map(Result::ok)
+        .filter(|ifindex| !ifindex_exists(*ifindex))
+        .collect();
+
+    let mut delta = DeltaCount::default();
+    for ifindex in stale {
+        // DevMapHash::remove takes u32 by value, not by reference.
+        match devmap.remove(ifindex) {
+            Ok(()) => {
+                delta.removed += 1;
+                info!(ifindex, "REDIRECT_DEVMAP stale entry purged");
+            }
+            Err(e) => warn!(ifindex, error = %e, "REDIRECT_DEVMAP remove failed"),
+        }
+    }
+    Ok(delta)
+}
+
+/// Does the kernel still know this ifindex? Wraps `if_indextoname`;
+/// returns false on any error (ENXIO for an unknown index, EINVAL for
+/// impossible values, etc.).
+fn ifindex_exists(ifindex: u32) -> bool {
+    let mut buf = [0u8; libc::IF_NAMESIZE];
+    let ptr = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr().cast()) };
+    if ptr.is_null() {
+        return false;
+    }
+    let c = unsafe { std::ffi::CStr::from_ptr(ptr) };
+    !c.to_bytes().is_empty()
+}


### PR DESCRIPTION
## Summary

Closes the remaining v0.1 gaps from the slicing plan. Five logically-ordered commits, each reviewable on its own:

1. **bpffs pinning** (§8.2, §8.5) — programs + maps + links pinned under `<bpffs-root>/fast-path/`. SIGTERM exits without detaching because the bpffs inodes hold kernel refs; `packetframe detach` walks the pin root and unlinks everything (which triggers the kernel-side XDP detach); `packetframe status` reads live counters from the pinned STATS map via aya's `MapData::from_pin`.

2. **Prometheus textfile** (§7.3, §4.6) — 15s-cadence exporter thread writes `packetframe_<counter>_total{module="fast-path"}` lines plus a `packetframe_uptime_seconds` gauge via atomic write-then-rename.

3. **SIGHUP reconcile** (§4.5, §8.4) — delta-only LPM updates for ALLOW_V4/V6 with add-first-then-remove ordering so renames never have a window where neither exists. Re-reads `/proc/net/vlan/config` for VLAN_RESOLVE diffs, purges REDIRECT_DEVMAP entries whose ifindex no longer resolves. Bad SIGHUP input logs and swallows.

4. **Circuit breaker** (§4.9, §8.3) — 1s-resolution sampler (configurable window) computes `(drop_unreachable + err_fib_other) / (matched_v4 + matched_v6)` deltas. Trips after `threshold` consecutive over-ratio samples: writes a sticky flag to `<state-dir>/breaker-tripped-fast-path.flag` and raises SIGUSR1 so the main loop detaches. Startup refuses to re-attach while the flag exists.

## Deferred

**QEMU verifier CI** (§10.2) — the original plan bundled it here, but getting it right (virtme-ng setup, 5.15 + modern kernel matrix, sourcing kernel images reliably) needs its own iteration loop in CI. I'll ship it as the next PR (PR #7) rather than let it delay this one. The existing sudo-gated `cargo test -- --ignored` job still covers the GitHub runner kernel; what PR #7 adds is EFG-parity 5.15 coverage and the `BPF_PROG_TEST_RUN_XDP_LIVE` ≥5.18 path.

## Out of scope (tracked separately)

- Zero-disruption daemon restart via pin adoption. Today, restart-after-SIGTERM requires `packetframe detach --all` first. Adoption is additive on top of this PR.
- Netns byte-level §4.7 push/pop/rewrite verification — deferred until PR #7's QEMU harness lands.
- Release workflow real-BPF (needed before v0.1.0 tag).

## Test plan

- [ ] CI green on every commit (pre-review force-push is fine on this branch).
- [ ] Debian 6.12 VM: build + feasibility + attach + SIGTERM leaves kernel attached; subsequent `status` reads counters; `detach --all` clears pins; `run` after detach works cleanly.
- [ ] VM: SIGHUP with config delta (add/remove a prefix) — confirm `bpftool map dump name ALLOW_V4` reflects the change.
- [ ] VM: force-inject counter values via `bpftool map update` to simulate a breaker trip; confirm sampler writes the flag, SIGUSR1 fires, detach happens, subsequent `run` refuses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)