### PR TITLE
v0.1: QEMU verifier CI (PR #7)

### DIFF
--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -21,21 +21,17 @@ env:
 
 jobs:
   qemu:
-    name: qemu (kernel ${{ matrix.kernel_label }})
+    name: qemu (kernel ${{ matrix.kernel_tag }})
     runs-on: ubuntu-latest
     env:
       PACKETFRAME_BPF_REQUIRED: "1"
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - kernel_label: "5.15"
-            # Canonical mainline PPA — rebuild of upstream v5.15 for
-            # Ubuntu. First 5.15.0 mainline build.
-            kernel_url: https://kernel.ubuntu.com/mainline/v5.15/amd64/linux-image-unsigned-5.15.0-051500-generic_5.15.0-051500.202110312130_amd64.deb
-          - kernel_label: "6.6"
-            # 6.6 LTS — first mainline 6.6.0 build.
-            kernel_url: https://kernel.ubuntu.com/mainline/v6.6/amd64/linux-image-unsigned-6.6.0-060600-generic_6.6.0-060600.202310291843_amd64.deb
+        # Canonical's mainline PPA hosts rebuilds of upstream releases.
+        # We discover the actual .deb URL at runtime (build timestamps
+        # vary per version) from the directory listing.
+        kernel_tag: ["v5.15", "v6.6"]
     steps:
       - uses: actions/checkout@v6
 
@@ -56,9 +52,9 @@ jobs:
             ~/.cargo/git/db/
             target/
             crates/modules/fast-path/bpf/target/
-          key: ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_label }}-${{ hashFiles('**/Cargo.lock', 'crates/modules/fast-path/bpf/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_tag }}-${{ hashFiles('**/Cargo.lock', 'crates/modules/fast-path/bpf/Cargo.toml') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_label }}-
+            ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_tag }}-
             ${{ runner.os }}-cargo-qemu-
             ${{ runner.os }}-cargo-check-
 
@@ -85,11 +81,22 @@ jobs:
       - name: Fetch kernel image
         run: |
           set -eux
-          curl -fsSL --retry 3 -o /tmp/kernel.deb '${{ matrix.kernel_url }}'
+          # Discover the .deb URL from the PPA directory listing —
+          # Canonical's mainline builds have timestamped filenames that
+          # change per revision, so hardcoding the URL is brittle.
+          BASE="https://kernel.ubuntu.com/mainline/${{ matrix.kernel_tag }}/amd64/"
+          DEB=$(curl -fsSL "${BASE}" \
+            | grep -oE 'linux-image-unsigned-[0-9][^"]*generic_[^"]*_amd64\.deb' \
+            | sort -u \
+            | head -1)
+          test -n "${DEB}"
+          echo "Fetching ${BASE}${DEB}"
+          curl -fsSL --retry 3 -o /tmp/kernel.deb "${BASE}${DEB}"
           dpkg-deb -x /tmp/kernel.deb /tmp/kernel-root
           KERNEL=$(find /tmp/kernel-root -name 'vmlinuz-*' | head -1)
           test -n "${KERNEL}"
           ls -la "${KERNEL}"
+          file "${KERNEL}"
           echo "KERNEL_PATH=${KERNEL}" >> "${GITHUB_ENV}"
 
       - name: Build integration tests
@@ -102,15 +109,22 @@ jobs:
       - name: Run integration tests in QEMU
         timeout-minutes: 15
         run: |
+          set -eux
+          # virtme-ng CLI reminder for future edits:
+          #   virtme-ng --help     # lists options
+          #   -r <vmlinuz|deb>     # kernel to boot
+          #   --memory <MB>        # VM memory
+          #   --pwd                # preserve cwd
+          #   --                   # everything after is the command
+          #
           # virtme-ng makes the host filesystem available R/W inside the
-          # guest and runs as root. `--pwd` preserves the working
-          # directory so cargo paths resolve. The guest inherits the
-          # host env, so `PACKETFRAME_BPF_REQUIRED` and the rustup
-          # toolchain discovery carry over.
-          virtme-ng --kimg "${KERNEL_PATH}" --memory 1024 --pwd -- bash -c '
+          # guest and runs as root, so `cargo test -- --ignored` (which
+          # needs CAP_BPF + CAP_NET_ADMIN to load/attach) works without
+          # `sudo`. Host env forwards in — `PACKETFRAME_BPF_REQUIRED`
+          # and the rustup toolchain discovery carry over.
+          virtme-ng --help | head -40 || true
+          virtme-ng -r "${KERNEL_PATH}" --memory 1024 --pwd -- bash -c '
             set -eux
             uname -a
-            # --ignored runs the sudo-gated suite that attaches real BPF
-            # programs. virtme-ng already has CAP_* so no sudo needed.
             cargo test -p packetframe-fast-path --tests -- --ignored --nocapture
           '

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -1,0 +1,116 @@
+name: QEMU verifier
+
+# SPEC.md §10.2: run the sudo-gated integration tests under two kernel
+# versions — 5.15 (EFG-parity) and 6.6 LTS (≥5.18 for
+# BPF_PROG_TEST_RUN_XDP_LIVE; the host CI job already covers whichever
+# kernel ubuntu-latest runners ship with, so this matrix targets
+# explicit EFG-parity + a modern LTS).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: short
+  # Pin versions so adding a matrix dimension doesn't drift toolchains.
+  RUST_STABLE: "1.95.0"
+  RUST_NIGHTLY: "nightly-2026-04-14"
+  BPF_LINKER_VERSION: "0.10.3"
+
+jobs:
+  qemu:
+    name: qemu (kernel ${{ matrix.kernel_label }})
+    runs-on: ubuntu-latest
+    env:
+      PACKETFRAME_BPF_REQUIRED: "1"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - kernel_label: "5.15"
+            # Canonical mainline PPA — rebuild of upstream v5.15 for
+            # Ubuntu. First 5.15.0 mainline build.
+            kernel_url: https://kernel.ubuntu.com/mainline/v5.15/amd64/linux-image-unsigned-5.15.0-051500-generic_5.15.0-051500.202110312130_amd64.deb
+          - kernel_label: "6.6"
+            # 6.6 LTS — first mainline 6.6.0 build.
+            kernel_url: https://kernel.ubuntu.com/mainline/v6.6/amd64/linux-image-unsigned-6.6.0-060600-generic_6.6.0-060600.202310291843_amd64.deb
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust stable + nightly (for BPF)
+        run: |
+          rustup install ${RUST_STABLE} --profile minimal
+          rustup default ${RUST_STABLE}
+          rustup install ${RUST_NIGHTLY} --profile minimal
+          rustup component add --toolchain ${RUST_NIGHTLY} rust-src llvm-tools-preview
+
+      - name: Cache cargo + BPF target
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+            crates/modules/fast-path/bpf/target/
+          key: ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_label }}-${{ hashFiles('**/Cargo.lock', 'crates/modules/fast-path/bpf/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-qemu-${{ matrix.kernel_label }}-
+            ${{ runner.os }}-cargo-qemu-
+            ${{ runner.os }}-cargo-check-
+
+      - name: Install bpf-linker
+        run: |
+          if ! command -v bpf-linker >/dev/null 2>&1 || \
+             [ "$(bpf-linker --version 2>/dev/null | awk '{print $2}')" != "${BPF_LINKER_VERSION}" ]; then
+            cargo install --locked --force bpf-linker --version ${BPF_LINKER_VERSION}
+          fi
+
+      - name: Install QEMU + virtme-ng
+        run: |
+          set -eux
+          sudo apt-get update
+          # virtme-ng is available in Ubuntu 24.04; fall back to pip
+          # (--break-system-packages needed on 24.04's externally-managed
+          # Python) if apt doesn't have it yet.
+          if ! sudo apt-get install -y qemu-system-x86 virtme-ng busybox-static; then
+            sudo apt-get install -y qemu-system-x86 busybox-static python3-pip
+            sudo pip3 install --break-system-packages virtme-ng
+          fi
+          virtme-ng --help >/dev/null
+
+      - name: Fetch kernel image
+        run: |
+          set -eux
+          curl -fsSL --retry 3 -o /tmp/kernel.deb '${{ matrix.kernel_url }}'
+          dpkg-deb -x /tmp/kernel.deb /tmp/kernel-root
+          KERNEL=$(find /tmp/kernel-root -name 'vmlinuz-*' | head -1)
+          test -n "${KERNEL}"
+          ls -la "${KERNEL}"
+          echo "KERNEL_PATH=${KERNEL}" >> "${GITHUB_ENV}"
+
+      - name: Build integration tests
+        run: |
+          # Build so the test binaries are ready to exec inside the VM.
+          # `--no-run` produces the ELFs without executing them on the
+          # host kernel.
+          cargo test -p packetframe-fast-path --tests --no-run
+
+      - name: Run integration tests in QEMU
+        timeout-minutes: 15
+        run: |
+          # virtme-ng makes the host filesystem available R/W inside the
+          # guest and runs as root. `--pwd` preserves the working
+          # directory so cargo paths resolve. The guest inherits the
+          # host env, so `PACKETFRAME_BPF_REQUIRED` and the rustup
+          # toolchain discovery carry over.
+          virtme-ng --kimg "${KERNEL_PATH}" --memory 1024 --pwd -- bash -c '
+            set -eux
+            uname -a
+            # --ignored runs the sudo-gated suite that attaches real BPF
+            # programs. virtme-ng already has CAP_* so no sudo needed.
+            cargo test -p packetframe-fast-path --tests -- --ignored --nocapture
+          '

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -123,10 +123,18 @@ jobs:
           # Pass the installed vmlinuz path (not the .deb). virtme-ng
           # discovers matching modules at /lib/modules/$VER on the host
           # and packages them into its generated initramfs.
+          # virtme-init resets PATH inside the guest. Source the
+          # runner's cargo env (rustup-provided) before running tests.
           virtme-ng \
             --run "${KERNEL_IMG}" \
             --pwd \
             --memory 1024 \
             --disable-kvm \
             --verbose \
-            -- bash -c 'set -eux; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'
+            -- bash -c '
+              set -eux
+              source "${HOME}/.cargo/env" || export PATH="/home/runner/.cargo/bin:${PATH}"
+              uname -a
+              which cargo
+              cargo test -p packetframe-fast-path --tests -- --ignored --nocapture
+            '

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -123,18 +123,14 @@ jobs:
           # Pass the installed vmlinuz path (not the .deb). virtme-ng
           # discovers matching modules at /lib/modules/$VER on the host
           # and packages them into its generated initramfs.
-          # virtme-init resets PATH inside the guest. Source the
-          # runner's cargo env (rustup-provided) before running tests.
+          # virtme-init starts the script with HOME=/ and `/` is RO
+          # (only the listed overlay paths are writable). Point
+          # HOME/CARGO_HOME/RUSTUP_HOME at the /home overlay so rustup
+          # can write its state without going read-only.
           virtme-ng \
             --run "${KERNEL_IMG}" \
             --pwd \
             --memory 1024 \
             --disable-kvm \
             --verbose \
-            -- bash -c '
-              set -eux
-              source "${HOME}/.cargo/env" || export PATH="/home/runner/.cargo/bin:${PATH}"
-              uname -a
-              which cargo
-              cargo test -p packetframe-fast-path --tests -- --ignored --nocapture
-            '
+            -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -65,18 +65,17 @@ jobs:
             cargo install --locked --force bpf-linker --version ${BPF_LINKER_VERSION}
           fi
 
-      - name: Install QEMU + virtme-ng
+      - name: Install QEMU + virtme
         run: |
           set -eux
           sudo apt-get update
-          # virtme-ng is available in Ubuntu 24.04; fall back to pip
-          # (--break-system-packages needed on 24.04's externally-managed
-          # Python) if apt doesn't have it yet.
-          if ! sudo apt-get install -y qemu-system-x86 virtme-ng busybox-static; then
-            sudo apt-get install -y qemu-system-x86 busybox-static python3-pip
-            sudo pip3 install --break-system-packages virtme-ng
-          fi
-          virtme-ng --help >/dev/null
+          # virtme-ng's `--run` takes a kernel *build directory*, not a
+          # pre-built vmlinuz path. Classic `virtme-run` has the stable
+          # `--kimg <path>` flag that accepts a raw vmlinuz; install that
+          # via pip (Ubuntu 24.04 dropped the `virtme` apt package).
+          sudo apt-get install -y qemu-system-x86 busybox-static python3-pip python3-virtualenv
+          sudo pip3 install --break-system-packages virtme
+          which virtme-run
 
       - name: Fetch kernel image
         run: |
@@ -110,21 +109,19 @@ jobs:
         timeout-minutes: 15
         run: |
           set -eux
-          # virtme-ng CLI reminder for future edits:
-          #   virtme-ng --help     # lists options
-          #   -r <vmlinuz|deb>     # kernel to boot
-          #   --memory <MB>        # VM memory
-          #   --pwd                # preserve cwd
-          #   --                   # everything after is the command
+          # virtme-run boots the target kernel via QEMU with the host
+          # rootfs mounted 9p. `--script-sh` runs a shell command and
+          # exits; stdout/stderr are forwarded. `--pwd` preserves the
+          # repo path so cargo resolves normally.
           #
-          # virtme-ng makes the host filesystem available R/W inside the
-          # guest and runs as root, so `cargo test -- --ignored` (which
-          # needs CAP_BPF + CAP_NET_ADMIN to load/attach) works without
-          # `sudo`. Host env forwards in — `PACKETFRAME_BPF_REQUIRED`
-          # and the rustup toolchain discovery carry over.
-          virtme-ng --help | head -40 || true
-          virtme-ng -r "${KERNEL_PATH}" --memory 1024 --pwd -- bash -c '
-            set -eux
-            uname -a
-            cargo test -p packetframe-fast-path --tests -- --ignored --nocapture
-          '
+          # `--force-initramfs` makes virtme build an initramfs rather
+          # than rely on the host's (the kernel .deb we downloaded has
+          # no matching initrd). `--qemu-opts` forces TCG because GHA
+          # runners may not expose /dev/kvm.
+          virtme-run \
+            --kimg "${KERNEL_PATH}" \
+            --memory 1024M \
+            --pwd \
+            --force-initramfs \
+            --qemu-opts -machine accel=tcg \
+            --script-sh 'set -eux; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -65,19 +65,17 @@ jobs:
             cargo install --locked --force bpf-linker --version ${BPF_LINKER_VERSION}
           fi
 
-      - name: Install QEMU + virtme
+      - name: Install QEMU + virtme-ng
         run: |
           set -eux
           sudo apt-get update
-          # virtme-ng's `--run` takes a kernel *build directory*, not a
-          # pre-built vmlinuz path. Classic `virtme-run` has the stable
-          # `--kimg <path>` flag that accepts a raw vmlinuz; install that
-          # via pip (Ubuntu 24.04 dropped the `virtme` apt package).
-          sudo apt-get install -y qemu-system-x86 busybox-static python3-pip python3-virtualenv
-          sudo pip3 install --break-system-packages virtme
-          which virtme-run
+          # virtme-ng is the maintained fork (classic virtme-run uses
+          # -watchdog which QEMU 8.x dropped). Its `--run <deb>` accepts
+          # a pre-built kernel package directly.
+          sudo apt-get install -y qemu-system-x86 virtme-ng busybox-static
+          virtme-ng --version || true
 
-      - name: Fetch + install kernel image
+      - name: Fetch kernel package
         run: |
           set -eux
           # Discover the .deb URL from the PPA directory listing —
@@ -91,33 +89,8 @@ jobs:
           test -n "${DEB}"
           echo "Fetching ${BASE}${DEB}"
           curl -fsSL --retry 3 -o /tmp/kernel.deb "${BASE}${DEB}"
-          # Also grab modules — virtme-run's `--installed-kernel` needs
-          # /lib/modules/$VER/ populated.
-          MODS_DEB=$(curl -fsSL "${BASE}" \
-            | grep -oE 'linux-modules-[0-9][^"]*generic_[^"]*_amd64\.deb' \
-            | sort -u \
-            | head -1)
-          test -n "${MODS_DEB}"
-          echo "Fetching ${BASE}${MODS_DEB}"
-          curl -fsSL --retry 3 -o /tmp/modules.deb "${BASE}${MODS_DEB}"
-          # Extract to a staging dir, then copy only /boot/* and
-          # /lib/modules/* into the host. Extracting the .deb directly
-          # to / with `dpkg-deb -x` changes parent-directory perms on
-          # /lib/, which in the prior iteration bricked
-          # /lib/x86_64-linux-gnu (cc linker couldn't find libm).
-          sudo rm -rf /tmp/kstage
-          sudo mkdir -p /tmp/kstage
-          sudo dpkg-deb -x /tmp/kernel.deb /tmp/kstage
-          sudo dpkg-deb -x /tmp/modules.deb /tmp/kstage
-          sudo cp -a /tmp/kstage/boot/. /boot/
-          sudo cp -a /tmp/kstage/lib/modules/. /lib/modules/
-          KVER=$(ls /tmp/kstage/lib/modules/ | grep -- '-generic$' | tail -1)
-          test -n "${KVER}"
-          sudo depmod -a "${KVER}"
-          ls -la "/boot/vmlinuz-${KVER}"
-          # Sanity: host toolchain still works after the install.
-          test -e /lib/x86_64-linux-gnu/libm.so.6
-          echo "KVER=${KVER}" >> "${GITHUB_ENV}"
+          ls -la /tmp/kernel.deb
+          echo "KERNEL_DEB=/tmp/kernel.deb" >> "${GITHUB_ENV}"
 
       - name: Build integration tests
         run: |
@@ -130,15 +103,14 @@ jobs:
         timeout-minutes: 15
         run: |
           set -eux
-          # virtme-run boots the target kernel via QEMU and mounts the
-          # host / as the guest root via 9p. --installed-kernel expects
-          # the kernel + modules to live under /boot and /lib/modules/
-          # on the host — we installed them in the previous step.
-          # --script-sh runs a command and exits; stdout is forwarded.
-          #
-          # --qemu-opts must come last (argparse REMAINDER).
-          WORKSPACE="$(pwd)"
-          virtme-run \
-            --installed-kernel "${KVER}" \
-            --script-sh "set -eux; cd '${WORKSPACE}'; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture" \
-            --qemu-opts -m 1024M -machine accel=tcg
+          # virtme-ng `--run <deb>` accepts a Debian/Ubuntu kernel .deb
+          # directly. Host / is mounted R/W in the guest via 9p, so
+          # cargo resolves the same paths inside as outside. `--pwd`
+          # preserves cwd. GHA runners may not expose /dev/kvm, so
+          # force TCG via --disable-kvm.
+          virtme-ng \
+            --run "${KERNEL_DEB}" \
+            --pwd \
+            --memory 1024 \
+            --disable-kvm \
+            -- bash -c 'set -eux; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -77,7 +77,7 @@ jobs:
           sudo pip3 install --break-system-packages virtme
           which virtme-run
 
-      - name: Fetch kernel image
+      - name: Fetch + install kernel image
         run: |
           set -eux
           # Discover the .deb URL from the PPA directory listing —
@@ -91,12 +91,23 @@ jobs:
           test -n "${DEB}"
           echo "Fetching ${BASE}${DEB}"
           curl -fsSL --retry 3 -o /tmp/kernel.deb "${BASE}${DEB}"
-          dpkg-deb -x /tmp/kernel.deb /tmp/kernel-root
-          KERNEL=$(find /tmp/kernel-root -name 'vmlinuz-*' | head -1)
-          test -n "${KERNEL}"
-          ls -la "${KERNEL}"
-          file "${KERNEL}"
-          echo "KERNEL_PATH=${KERNEL}" >> "${GITHUB_ENV}"
+          # Also grab modules — virtme-run's `--installed-kernel` needs
+          # /lib/modules/$VER/ populated.
+          MODS_DEB=$(curl -fsSL "${BASE}" \
+            | grep -oE 'linux-modules-[0-9][^"]*generic_[^"]*_amd64\.deb' \
+            | sort -u \
+            | head -1)
+          test -n "${MODS_DEB}"
+          echo "Fetching ${BASE}${MODS_DEB}"
+          curl -fsSL --retry 3 -o /tmp/modules.deb "${BASE}${MODS_DEB}"
+          # Install into host paths virtme-run will look at.
+          sudo dpkg-deb -x /tmp/kernel.deb /
+          sudo dpkg-deb -x /tmp/modules.deb /
+          KVER=$(ls /lib/modules/ | grep -- '-generic$' | tail -1)
+          test -n "${KVER}"
+          sudo depmod -a "${KVER}"
+          ls -la "/boot/vmlinuz-${KVER}"
+          echo "KVER=${KVER}" >> "${GITHUB_ENV}"
 
       - name: Build integration tests
         run: |
@@ -109,19 +120,15 @@ jobs:
         timeout-minutes: 15
         run: |
           set -eux
-          # virtme-run boots the target kernel via QEMU with the host
-          # rootfs mounted 9p. `--script-sh` runs a shell command and
-          # exits; stdout/stderr are forwarded. `--pwd` preserves the
-          # repo path so cargo resolves normally.
+          # virtme-run boots the target kernel via QEMU and mounts the
+          # host / as the guest root via 9p. --installed-kernel expects
+          # the kernel + modules to live under /boot and /lib/modules/
+          # on the host — we installed them in the previous step.
+          # --script-sh runs a command and exits; stdout is forwarded.
           #
-          # `--force-initramfs` makes virtme build an initramfs rather
-          # than rely on the host's (the kernel .deb we downloaded has
-          # no matching initrd). `--qemu-opts` forces TCG because GHA
-          # runners may not expose /dev/kvm.
+          # --qemu-opts must come last (argparse REMAINDER).
+          WORKSPACE="$(pwd)"
           virtme-run \
-            --kimg "${KERNEL_PATH}" \
-            --memory 1024M \
-            --pwd \
-            --force-initramfs \
-            --qemu-opts -machine accel=tcg \
-            --script-sh 'set -eux; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'
+            --installed-kernel "${KVER}" \
+            --script-sh "set -eux; cd '${WORKSPACE}'; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture" \
+            --qemu-opts -m 1024M -machine accel=tcg

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -75,22 +75,36 @@ jobs:
           sudo apt-get install -y qemu-system-x86 virtme-ng busybox-static
           virtme-ng --version || true
 
-      - name: Fetch kernel package
+      - name: Fetch + install kernel + modules
         run: |
           set -eux
-          # Discover the .deb URL from the PPA directory listing —
-          # Canonical's mainline builds have timestamped filenames that
-          # change per revision, so hardcoding the URL is brittle.
           BASE="https://kernel.ubuntu.com/mainline/${{ matrix.kernel_tag }}/amd64/"
-          DEB=$(curl -fsSL "${BASE}" \
+          IMG_DEB=$(curl -fsSL "${BASE}" \
             | grep -oE 'linux-image-unsigned-[0-9][^"]*generic_[^"]*_amd64\.deb' \
-            | sort -u \
-            | head -1)
-          test -n "${DEB}"
-          echo "Fetching ${BASE}${DEB}"
-          curl -fsSL --retry 3 -o /tmp/kernel.deb "${BASE}${DEB}"
-          ls -la /tmp/kernel.deb
-          echo "KERNEL_DEB=/tmp/kernel.deb" >> "${GITHUB_ENV}"
+            | sort -u | head -1)
+          MOD_DEB=$(curl -fsSL "${BASE}" \
+            | grep -oE 'linux-modules-[0-9][^"]*generic_[^"]*_amd64\.deb' \
+            | sort -u | head -1)
+          test -n "${IMG_DEB}" && test -n "${MOD_DEB}"
+          curl -fsSL --retry 3 -o /tmp/kernel.deb "${BASE}${IMG_DEB}"
+          curl -fsSL --retry 3 -o /tmp/modules.deb "${BASE}${MOD_DEB}"
+          # Stage then cp (direct dpkg-deb -x to / clobbered /lib perms
+          # on a previous iteration — see commit history).
+          sudo rm -rf /tmp/kstage
+          sudo mkdir -p /tmp/kstage
+          sudo dpkg-deb -x /tmp/kernel.deb /tmp/kstage
+          sudo dpkg-deb -x /tmp/modules.deb /tmp/kstage
+          sudo cp -a /tmp/kstage/boot/. /boot/
+          sudo cp -a /tmp/kstage/lib/modules/. /lib/modules/
+          KVER=$(ls /tmp/kstage/lib/modules/ | grep -- '-generic$' | tail -1)
+          test -n "${KVER}"
+          sudo depmod -a "${KVER}"
+          test -e "/boot/vmlinuz-${KVER}"
+          test -d "/lib/modules/${KVER}"
+          # Sanity: host toolchain still links.
+          test -e /lib/x86_64-linux-gnu/libm.so.6
+          echo "KVER=${KVER}" >> "${GITHUB_ENV}"
+          echo "KERNEL_IMG=/boot/vmlinuz-${KVER}" >> "${GITHUB_ENV}"
 
       - name: Build integration tests
         run: |
@@ -100,17 +114,16 @@ jobs:
           cargo test -p packetframe-fast-path --tests --no-run
 
       - name: Run integration tests in QEMU
-        timeout-minutes: 15
+        timeout-minutes: 10
         run: |
           set -eux
-          # virtme-ng `--run <deb>` accepts a Debian/Ubuntu kernel .deb
-          # directly. Host / is mounted R/W in the guest via 9p, so
-          # cargo resolves the same paths inside as outside. `--pwd`
-          # preserves cwd. GHA runners may not expose /dev/kvm, so
-          # force TCG via --disable-kvm.
+          # Pass the installed vmlinuz path (not the .deb). virtme-ng
+          # discovers matching modules at /lib/modules/$VER on the host
+          # and packages them into its generated initramfs.
           virtme-ng \
-            --run "${KERNEL_DEB}" \
+            --run "${KERNEL_IMG}" \
             --pwd \
             --memory 1024 \
             --disable-kvm \
+            --verbose \
             -- bash -c 'set -eux; uname -a; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture'

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -99,7 +99,10 @@ jobs:
           KVER=$(ls /tmp/kstage/lib/modules/ | grep -- '-generic$' | tail -1)
           test -n "${KVER}"
           sudo depmod -a "${KVER}"
-          test -e "/boot/vmlinuz-${KVER}"
+          # Canonical ships vmlinuz as 0600 root; virtme-ng runs as the
+          # non-root job user and can't read it otherwise.
+          sudo chmod 0644 "/boot/vmlinuz-${KVER}"
+          test -r "/boot/vmlinuz-${KVER}"
           test -d "/lib/modules/${KVER}"
           # Sanity: host toolchain still links.
           test -e /lib/x86_64-linux-gnu/libm.so.6

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -100,13 +100,23 @@ jobs:
           test -n "${MODS_DEB}"
           echo "Fetching ${BASE}${MODS_DEB}"
           curl -fsSL --retry 3 -o /tmp/modules.deb "${BASE}${MODS_DEB}"
-          # Install into host paths virtme-run will look at.
-          sudo dpkg-deb -x /tmp/kernel.deb /
-          sudo dpkg-deb -x /tmp/modules.deb /
-          KVER=$(ls /lib/modules/ | grep -- '-generic$' | tail -1)
+          # Extract to a staging dir, then copy only /boot/* and
+          # /lib/modules/* into the host. Extracting the .deb directly
+          # to / with `dpkg-deb -x` changes parent-directory perms on
+          # /lib/, which in the prior iteration bricked
+          # /lib/x86_64-linux-gnu (cc linker couldn't find libm).
+          sudo rm -rf /tmp/kstage
+          sudo mkdir -p /tmp/kstage
+          sudo dpkg-deb -x /tmp/kernel.deb /tmp/kstage
+          sudo dpkg-deb -x /tmp/modules.deb /tmp/kstage
+          sudo cp -a /tmp/kstage/boot/. /boot/
+          sudo cp -a /tmp/kstage/lib/modules/. /lib/modules/
+          KVER=$(ls /tmp/kstage/lib/modules/ | grep -- '-generic$' | tail -1)
           test -n "${KVER}"
           sudo depmod -a "${KVER}"
           ls -la "/boot/vmlinuz-${KVER}"
+          # Sanity: host toolchain still works after the install.
+          test -e /lib/x86_64-linux-gnu/libm.so.6
           echo "KVER=${KVER}" >> "${GITHUB_ENV}"
 
       - name: Build integration tests

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ $RECYCLE.BIN/
 
 # Local plan scratch from the session (kept out of the repo)
 /plans/
+.claude/

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -474,6 +474,17 @@ fn vlan_tagged_non_ip_inner_passes_with_pass_not_ip() {
 #[test]
 #[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
 fn ipv4_jumbo_payload_src_match_dry_run() {
+    // Kernel <5.18 caps BPF_PROG_TEST_RUN data at a page (~4 KiB);
+    // subtract headroom + headers and 3.6K exceeds it → EMSGSIZE. 5.18
+    // lifted the cap (via BPF_F_TEST_XDP_LIVE_FRAMES plumbing). Skip
+    // on older kernels so the QEMU 5.15 matrix can still run the rest
+    // of the suite. True 9K jumbo is netns-integration-test territory
+    // (SPEC §11.5) regardless.
+    if kernel_lt(5, 18) {
+        eprintln!("Skipping: jumbo fixture needs kernel ≥5.18 for BPF_PROG_TEST_RUN buffer cap");
+        return;
+    }
+
     let mut h = Harness::new();
     h.add_allow_v4("10.0.0.0/8");
     h.set_dry_run(true);
@@ -489,4 +500,17 @@ fn ipv4_jumbo_payload_src_match_dry_run() {
     let (verdict, _) = h.run(&pkt);
     assert_eq!(verdict, xdp_action::XDP_PASS);
     assert_eq!(h.stat(StatIdx::MatchedV4), before + 1);
+}
+
+/// Reads `/proc/sys/kernel/osrelease` and returns true when the running
+/// kernel is older than `target_major.target_minor`. Used to skip
+/// fixtures that exercise kernel features added after our EFG-parity
+/// baseline (5.15).
+fn kernel_lt(target_major: u32, target_minor: u32) -> bool {
+    let osrelease = std::fs::read_to_string("/proc/sys/kernel/osrelease").unwrap_or_default();
+    let prefix = osrelease.split('-').next().unwrap_or("");
+    let mut parts = prefix.split('.');
+    let maj: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let min: u32 = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (maj, min) < (target_major, target_minor)
 }


### PR DESCRIPTION
## Summary

SPEC.md §10.2: matrix the sudo-gated integration suite across kernel **5.15** (EFG-parity) and **6.6 LTS** (≥5.18 for `BPF_PROG_TEST_RUN_XDP_LIVE`). Both kernel jobs green plus the existing 5 CI jobs.

## How it works

- Fetches the image + modules .debs from Canonical's [mainline kernel PPA](https://kernel.ubuntu.com/mainline/) — URL discovery is dynamic (grep the directory listing) so build timestamps don't pin us.
- Extracts to `/tmp/kstage` then `cp -a` into `/boot` and `/lib/modules/$VER/` — extracting the .deb directly to `/` clobbers `/lib` perms and breaks the host linker (debugged during iteration).
- `chmod 0644 /boot/vmlinuz-$VER` so virtme-ng can read it as the non-root job user.
- `virtme-ng --run <vmlinuz> --pwd --memory 1024 --disable-kvm` boots via TCG (GHA runners don't reliably expose `/dev/kvm`) and runs the script inside the guest.
- Guest script sets `HOME=/home/runner` + `CARGO_HOME`/`RUSTUP_HOME` so rustup can write state (the guest's `/` is RO; `/home` is a writable overlay).

## Real finding surfaced during verification

Kernel **5.15** caps `BPF_PROG_TEST_RUN` data at one page (~4 KiB); the 3.6 KiB jumbo-ish fixture exceeds it and returns EMSGSIZE. 5.18 lifted the cap. Gated the jumbo test with a `/proc/sys/kernel/osrelease` version check — 5.15 runs 20 of 21 fixtures, 6.6 runs all 21. True 9K jumbo remains netns-integration-test territory (SPEC §11.5).

## Test plan

- [x] CI green on both kernel matrix jobs (2m50s / 3m4s)
- [x] All 5 existing CI jobs still green
- [x] Failing jumbo fixture skipped with a clear log message on <5.18