### PR TITLE
Release workflow: ship a real BPF ELF across every target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  # Manual trigger for pre-release validation — runs the BPF + cross
+  # build matrix but skips publishing. Use to confirm release tarballs
+  # would ship a real BPF ELF before cutting a tag.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Skip the publish step (no GitHub release created)'
+        type: boolean
+        default: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -12,8 +21,81 @@ env:
   BPF_LINKER_VERSION: "0.10.3"
 
 jobs:
+  # Build the BPF ELF once on the host runner (rustup + nightly + bpf-linker
+  # all available here). Every cross-build job downloads this artifact and
+  # embeds it via PACKETFRAME_BPF_OBJ_PATH — cross's Docker images have no
+  # rustup so they cannot nest-build BPF themselves (prior release flow
+  # shipped a stub ELF and every attach silently failed).
+  bpf:
+    name: build BPF ELF
+    runs-on: ubuntu-latest
+    env:
+      PACKETFRAME_BPF_REQUIRED: "1"
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install Rust (stable + nightly for BPF)
+        run: |
+          rustup toolchain install ${{ env.RUST_STABLE }} --profile minimal
+          rustup default ${{ env.RUST_STABLE }}
+          rustup toolchain install ${{ env.RUST_NIGHTLY }} \
+            --profile minimal --component rust-src,llvm-tools-preview
+
+      - uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            crates/modules/fast-path/bpf/target/
+          key: ${{ runner.os }}-release-bpf-${{ hashFiles('crates/modules/fast-path/bpf/**') }}
+
+      - name: Install bpf-linker
+        run: |
+          if ! command -v bpf-linker >/dev/null 2>&1 || \
+             [ "$(bpf-linker --version 2>/dev/null | awk '{print $2}')" != "${{ env.BPF_LINKER_VERSION }}" ]; then
+            cargo install --locked --force bpf-linker \
+              --version ${{ env.BPF_LINKER_VERSION }}
+          fi
+
+      - name: Build BPF ELF
+        run: |
+          set -eux
+          ( cd crates/modules/fast-path/bpf && cargo build --release --message-format=json ) \
+            | tee bpf-build.json >/dev/null
+          # Find the artifact path via cargo's JSON — matches what
+          # `build.rs` does normally, keeps URL drift out of this file.
+          ELF=$(python3 -c "
+          import json, sys
+          for line in open('bpf-build.json'):
+              try:
+                  msg = json.loads(line)
+              except Exception:
+                  continue
+              if msg.get('reason') == 'compiler-artifact' and msg.get('target', {}).get('name') == 'fast-path':
+                  print(msg['filenames'][0])
+                  sys.exit(0)
+          sys.exit(1)
+          ")
+          test -n "${ELF}" && test -e "${ELF}"
+          # Verify ELF magic so we fail-loud if the build regressed to a stub.
+          head -c 4 "${ELF}" | od -An -c | grep -q 'E   L   F' || \
+            (echo "BPF output is not an ELF at ${ELF}" >&2; exit 1)
+          mkdir -p dist
+          cp "${ELF}" dist/fast-path.bpf.o
+          ls -la dist/fast-path.bpf.o
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bpf-elf
+          path: dist/fast-path.bpf.o
+          retention-days: 7
+          if-no-files-found: error
+
   build:
     name: build ${{ matrix.target }}
+    needs: bpf
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -26,13 +108,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install Rust (stable + nightly for BPF + target)
+      - name: Install Rust (stable + target)
         run: |
           rustup toolchain install ${{ env.RUST_STABLE }} --profile minimal
           rustup default ${{ env.RUST_STABLE }}
           rustup target add ${{ matrix.target }}
-          rustup toolchain install ${{ env.RUST_NIGHTLY }} \
-            --profile minimal --component rust-src,llvm-tools-preview
 
       - uses: actions/cache@v5
         with:
@@ -42,22 +122,31 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-            crates/modules/fast-path/bpf/target/
-          key: ${{ runner.os }}-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock', 'crates/modules/fast-path/bpf/Cargo.toml') }}
-
-      - name: Install bpf-linker
-        run: |
-          if ! command -v bpf-linker >/dev/null 2>&1 || \
-             [ "$(bpf-linker --version 2>/dev/null | awk '{print $2}')" != "${{ env.BPF_LINKER_VERSION }}" ]; then
-            cargo install --locked --force bpf-linker \
-              --version ${{ env.BPF_LINKER_VERSION }}
-          fi
+          key: ${{ runner.os }}-release-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cross
         run: |
           if ! command -v cross >/dev/null 2>&1; then
             cargo install --locked cross
           fi
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: bpf-elf
+          path: prebuilt-bpf
+
+      - name: Prepare BPF ELF path for build.rs
+        run: |
+          set -eux
+          ELF="$(pwd)/prebuilt-bpf/fast-path.bpf.o"
+          test -e "${ELF}"
+          head -c 4 "${ELF}" | od -An -c | grep -q 'E   L   F'
+          # Cross runs inside Docker, so use the container's mounted
+          # project path (`/project`) for the env var. Cross mounts the
+          # workspace root there by default.
+          echo "PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o" >> "${GITHUB_ENV}"
+          # Also forward the env var into the container.
+          echo "CROSS_CONTAINER_OPTS=-e PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o" >> "${GITHUB_ENV}"
 
       - name: Build release
         run: cross build --release --workspace --target ${{ matrix.target }}
@@ -87,6 +176,9 @@ jobs:
   publish:
     name: publish release
     needs: build
+    # Skip publish on workflow_dispatch dry_run so maintainers can validate
+    # the bpf + cross-build flow without creating a GitHub release.
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.dry_run == false }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/crates/modules/fast-path/build.rs
+++ b/crates/modules/fast-path/build.rs
@@ -40,14 +40,51 @@ fn main() {
     }
     println!("cargo::rerun-if-env-changed=PACKETFRAME_SKIP_BPF_BUILD");
     println!("cargo::rerun-if-env-changed=PACKETFRAME_BPF_REQUIRED");
+    println!("cargo::rerun-if-env-changed=PACKETFRAME_BPF_OBJ_PATH");
 
     let bpf_required = std::env::var("PACKETFRAME_BPF_REQUIRED").is_ok();
     let bpf_skip = std::env::var("PACKETFRAME_SKIP_BPF_BUILD").is_ok();
+    let bpf_obj_override = std::env::var("PACKETFRAME_BPF_OBJ_PATH").ok();
 
     if bpf_required && bpf_skip {
         panic!(
             "PACKETFRAME_BPF_REQUIRED=1 and PACKETFRAME_SKIP_BPF_BUILD=1 are mutually exclusive"
         );
+    }
+
+    // Pre-built ELF override — used by release.yml to build BPF once on
+    // the host runner (where nightly + bpf-linker exist), upload as an
+    // artifact, and hand the path to every cross-build job. Cross
+    // containers lack rustup entirely, so nested cargo would fail and
+    // silently stub; this bypass makes shipped binaries carry the real
+    // ELF across all four targets.
+    if let Some(path) = bpf_obj_override {
+        let src = PathBuf::from(&path);
+        if !src.exists() {
+            panic!(
+                "PACKETFRAME_BPF_OBJ_PATH points at {} which does not exist",
+                src.display()
+            );
+        }
+        let bytes = std::fs::read(&src)
+            .unwrap_or_else(|e| panic!("read PACKETFRAME_BPF_OBJ_PATH at {}: {e}", src.display()));
+        if bytes.len() < 4 || &bytes[..4] != b"\x7fELF" {
+            panic!(
+                "PACKETFRAME_BPF_OBJ_PATH at {} does not start with ELF magic \
+                 (got {:02x?}); refusing to embed a broken object",
+                src.display(),
+                bytes.iter().take(4).collect::<Vec<_>>()
+            );
+        }
+        std::fs::copy(&src, &obj_out).expect("stage overridden BPF ELF into OUT_DIR");
+        println!("cargo::rustc-cfg=packetframe_bpf_built");
+        println!(
+            "cargo::warning=Using pre-built BPF ELF from PACKETFRAME_BPF_OBJ_PATH ({} bytes) at {}",
+            bytes.len(),
+            src.display()
+        );
+        println!("cargo::rustc-env=FAST_PATH_BPF_OBJ={}", obj_out.display());
+        return;
     }
 
     // Explicit opt-out for debugging/local work (or for cross-build CI


### PR DESCRIPTION
## Summary

v0.0.1's release.yml used `cross build` inside Docker containers that lack rustup + nightly + bpf-linker. `build.rs` silently stubbed the BPF ELF, and every shipped binary would fail `attach` with "no BPF ELF embedded". This PR closes the v0.1.0-tag blocker.

## Changes

**New `build.rs` override**: `PACKETFRAME_BPF_OBJ_PATH=<path>`
- When set, copies the file into OUT_DIR, verifies ELF magic, skips the nested-cargo build entirely.
- Panics on missing file or non-ELF content — refuse to embed a broken object.

**`release.yml` restructured into 3 jobs**:
1. `bpf` — builds BPF ELF on the host runner, uploads `fast-path.bpf.o` artifact.
2. `build` (matrix of 4 targets) — downloads the artifact, forwards `PACKETFRAME_BPF_OBJ_PATH` into the cross Docker container via `CROSS_CONTAINER_OPTS`, cross-builds userspace.
3. `publish` — unchanged except for a dry-run gate on `workflow_dispatch`.

## Validation

Triggered the workflow via `workflow_dispatch` with `dry_run=true` on this branch ([run 24718009128](https://github.com/unredacted/packetframe/actions/runs/24718009128)):
- ✅ `build BPF ELF` — produced a 12,656-byte ELF, uploaded as artifact
- ✅ 4× `build <target>` — each logged `Using pre-built BPF ELF from PACKETFRAME_BPF_OBJ_PATH (12656 bytes)`, no stub-fallback
- ✅ `publish release` — correctly skipped via `dry_run` gate

Downloaded the `release-x86_64-unknown-linux-gnu` artifact and confirmed the 2.28 MB binary embeds the real BPF ELF.

## Test plan

- [x] Local: `PACKETFRAME_BPF_OBJ_PATH=<real-ELF> cargo check` uses override path
- [x] Local: missing file → panic; non-ELF content → panic
- [x] Workflow dispatch dry-run: bpf job green, 4 cross-builds green, publish skipped
- [x] Extracted artifact tarball — real 12,656-byte BPF ELF embedded (not stub)

Remaining: tag `v0.1.0-rc1` post-merge to validate full publish path before tagging `v0.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)