### PR TITLE
Fix outage: devmap check before packet mutation; auto-populate from /sys/class/net

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ $RECYCLE.BIN/
 # Local plan scratch from the session (kept out of the repo)
 /plans/
 .claude/
+crates/modules/fast-path/bpf/target/

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -316,7 +316,66 @@ fn reconfigure_from_signal(
     }
 }
 
+/// Look for a live `packetframe run` daemon via `/proc`. Returns the
+/// pid of the first match, None if none found. Only our own process
+/// name is matched (not arbitrary substrings), so a text editor
+/// holding a `packetframe.conf` file doesn't false-positive.
+#[cfg(target_os = "linux")]
+fn daemon_pid() -> Option<u32> {
+    let self_pid = std::process::id();
+    let entries = std::fs::read_dir("/proc").ok()?;
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let pid: u32 = match name.to_str().and_then(|s| s.parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        if pid == self_pid {
+            continue;
+        }
+        let comm_path = format!("/proc/{pid}/comm");
+        let comm = match std::fs::read_to_string(&comm_path) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if comm.trim() == "packetframe" {
+            // Confirm it's actually the `run` subcommand, not e.g.
+            // `packetframe detach` from another shell.
+            let cmdline_path = format!("/proc/{pid}/cmdline");
+            if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
+                if cmdline.split('\0').any(|a| a == "run") {
+                    return Some(pid);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(not(target_os = "linux"))]
+fn daemon_pid() -> Option<u32> {
+    None
+}
+
 pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
+    // Refuse to detach while a `packetframe run` daemon is live. The
+    // daemon holds PinnedLink FDs in-process; unlinking the bpffs pin
+    // paths alone doesn't drop the kernel-side bpf_link refcount, so
+    // the XDP program stays attached even after `detach` claims
+    // success. The operator needs to SIGTERM/kill the daemon first.
+    // Confirmed outage-adjacent on the reference EFG 2026-04-21 — the
+    // detach ran, reported clean, but `ip link show` still had
+    // `xdpgeneric` attached.
+    if let Some(pid) = daemon_pid() {
+        return Err(format!(
+            "a `packetframe run` daemon is still running (pid {pid}); \
+             stop it first (e.g. `kill {pid}`) before detaching. \
+             Detach unlinks bpffs pins, but the kernel-side bpf_link \
+             holds refs through the daemon's open FDs — both have to \
+             be released for the iface to actually detach."
+        ));
+    }
+
     let (bpffs_root, state_dir) = match config {
         Some(p) => {
             let c = Config::from_file(p).map_err(|e| format!("config parse: {e}"))?;

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -274,6 +274,20 @@ fn dispatch_fib(
                 None => (fib.ifindex, VLAN_NONE),
             };
 
+            // Defensive devmap pre-check (§4.4 step 9d) — **before any
+            // packet mutation**. A prior version rewrote L2 + ran VLAN
+            // choreography first, then decided to XDP_PASS when the
+            // egress ifindex wasn't in REDIRECT_DEVMAP. That handed the
+            // kernel a mangled packet (wrong MACs, TTL decremented, maybe
+            // pushed/popped tag) and silently black-holed forwarded
+            // traffic. Confirmed outage cause on the reference EFG
+            // 2026-04-21. If we can't redirect, we must leave the
+            // packet pristine.
+            if REDIRECT_DEVMAP.get(egress_ifindex).is_none() {
+                bump_stat(StatIdx::PassNotInDevmap);
+                return Ok(xdp_action::XDP_PASS);
+            }
+
             // TTL/hop_limit + csum first — IP header's position in
             // memory doesn't change with adjust_head, only its offset
             // from `data` does.
@@ -297,13 +311,6 @@ fn dispatch_fib(
                 return Ok(xdp_action::XDP_ABORTED);
             }
 
-            // Defensive devmap pre-check (§4.4 step 9d). `egress_ifindex`
-            // is the *actual* physical port we redirect to, which may
-            // differ from `fib.ifindex` when we resolved a subif.
-            if REDIRECT_DEVMAP.get(egress_ifindex).is_none() {
-                bump_stat(StatIdx::PassNotInDevmap);
-                return Ok(xdp_action::XDP_PASS);
-            }
             match REDIRECT_DEVMAP.redirect(egress_ifindex, 0) {
                 Ok(_) => {
                     bump_stat(StatIdx::FwdOk);

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -339,14 +339,31 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         .ok_or_else(|| ModuleError::other(MODULE_NAME, "REDIRECT_DEVMAP map missing from ELF"))?;
     let mut devmap: DevMapHash<_> = DevMapHash::try_from(devmap_map)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("REDIRECT_DEVMAP try_from: {e}")))?;
-    for (iface, _mode, ifindex) in &attach_dirs {
-        devmap.insert(*ifindex, *ifindex, None, 0).map_err(|e| {
-            ModuleError::other(
-                MODULE_NAME,
-                format!("REDIRECT_DEVMAP insert {iface} (ifindex {ifindex}): {e}"),
-            )
-        })?;
+
+    // Populate REDIRECT_DEVMAP with every UP Ethernet-type iface on the
+    // host, not just the attach ifaces. The FIB lookup is dynamic — on
+    // a BGP edge, routes change and the egress iface for any given
+    // packet is determined at lookup time. Hardcoding the attach list
+    // as the egress allowlist breaks any topology where ingress ≠
+    // egress (classic edge router: trunks in, WAN out).
+    //
+    // Filter: `/sys/class/net/<iface>/type == 1` (ARPHRD_ETHER — covers
+    // physical NICs, bridges, VLAN subifs, veth) AND operstate is `up`
+    // or `unknown` (some virtual ifaces never report operstate). Skip
+    // loopback (type 772) + tunnels (various non-1 types).
+    let targets = enumerate_redirect_targets();
+    let mut inserted = 0usize;
+    for (iface, ifindex) in &targets {
+        if let Err(e) = devmap.insert(*ifindex, *ifindex, None, 0) {
+            warn!(iface = %iface, ifindex, error = %e, "REDIRECT_DEVMAP insert skipped");
+            continue;
+        }
+        inserted += 1;
     }
+    info!(
+        count = inserted,
+        "REDIRECT_DEVMAP populated from /sys/class/net (Ethernet-type, UP)"
+    );
 
     populate_vlan_resolve(state)?;
 
@@ -686,6 +703,54 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("remove pins: {e}")))?;
     info!("fast-path pins removed; kernel detached");
     Ok(())
+}
+
+/// Walk `/sys/class/net` and return the `(name, ifindex)` of every
+/// iface that's a viable XDP redirect target:
+///
+/// - `type == 1` (ARPHRD_ETHER) — covers physical NICs, bridges,
+///   VLAN subifs, veth, bonded masters. Excludes loopback (772),
+///   PPP, SLIP, tunnels (`ip_vti`, `ip6tnl`, `ip_tunnel`, tailscale,
+///   WireGuard, etc. which use ARPHRD_NONE or similar).
+/// - operstate is `up` or `unknown`. Some virtual ifaces never
+///   transition to `up` even when they're carrying traffic; accept
+///   them rather than over-exclude.
+///
+/// Callers of this must tolerate the returned set changing between
+/// invocations (new ifaces come up, old ones go down). Reconcile
+/// should re-enumerate on SIGHUP.
+pub(crate) fn enumerate_redirect_targets() -> Vec<(String, u32)> {
+    let mut out = Vec::new();
+    let Ok(entries) = std::fs::read_dir("/sys/class/net") else {
+        return out;
+    };
+    for entry in entries.flatten() {
+        let name = match entry.file_name().into_string() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let base = format!("/sys/class/net/{name}");
+        // ARPHRD_* type check: "1" == ARPHRD_ETHER.
+        let type_ok = std::fs::read_to_string(format!("{base}/type"))
+            .map(|s| s.trim() == "1")
+            .unwrap_or(false);
+        if !type_ok {
+            continue;
+        }
+        // operstate filter: up or unknown.
+        let operstate_ok = std::fs::read_to_string(format!("{base}/operstate"))
+            .map(|s| matches!(s.trim(), "up" | "unknown"))
+            .unwrap_or(false);
+        if !operstate_ok {
+            continue;
+        }
+        let ifindex = match if_nametoindex(&name) {
+            Ok(i) => i,
+            Err(_) => continue,
+        };
+        out.push((name, ifindex));
+    }
+    out
 }
 
 /// Emit a warning if two or more of the attach ifaces share a bridge

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -39,7 +39,7 @@ pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
     let v4 = reconcile_allow_v4(state, cfg)?;
     let v6 = reconcile_allow_v6(state, cfg)?;
     let vlan = reconcile_vlan_resolve(state)?;
-    let devmap_purged = purge_stale_devmap(state)?;
+    let devmap = reconcile_devmap(state)?;
 
     info!(
         v4_added = v4.added,
@@ -48,7 +48,8 @@ pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
         v6_removed = v6.removed,
         vlan_added = vlan.added,
         vlan_removed = vlan.removed,
-        devmap_purged = devmap_purged.removed,
+        devmap_added = devmap.added,
+        devmap_removed = devmap.removed,
         "SIGHUP reconcile applied"
     );
     Ok(())
@@ -237,11 +238,19 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
     Ok(delta)
 }
 
-/// Purge REDIRECT_DEVMAP entries whose ifindex no longer resolves via
-/// `if_indextoname` — an iface that disappeared between attach and
-/// reconcile. Covers the "stale devmap after hot-unplug" case called
-/// out in the SPEC §4.5 reconcile note.
-fn purge_stale_devmap(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
+/// Reconcile REDIRECT_DEVMAP against the current `/sys/class/net`
+/// enumeration of viable Ethernet-type redirect targets. Adds any new
+/// ifaces that came up since the last reconcile, purges any whose
+/// ifindex no longer resolves via `if_indextoname`. Covers both the
+/// new-iface-hot-plug case and the stale-iface-hot-unplug case.
+fn reconcile_devmap(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
+    use std::collections::HashSet;
+
+    let desired: HashSet<u32> = crate::linux_impl::enumerate_redirect_targets()
+        .into_iter()
+        .map(|(_, ifindex)| ifindex)
+        .collect();
+
     let map = state
         .ebpf
         .map_mut("REDIRECT_DEVMAP")
@@ -249,16 +258,27 @@ fn purge_stale_devmap(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
     let mut devmap: DevMapHash<_> = DevMapHash::try_from(map)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("REDIRECT_DEVMAP try_from: {e}")))?;
 
-    let stale: Vec<u32> = devmap
-        .keys()
-        .filter_map(Result::ok)
-        .filter(|ifindex| !ifindex_exists(*ifindex))
-        .collect();
+    let current: HashSet<u32> = devmap.keys().filter_map(Result::ok).collect();
 
     let mut delta = DeltaCount::default();
-    for ifindex in stale {
-        // DevMapHash::remove takes u32 by value, not by reference.
-        match devmap.remove(ifindex) {
+    for ifindex in desired.difference(&current) {
+        // DevMapHash value is an ifindex u32; for simple forward-to-self
+        // the value equals the key.
+        match devmap.insert(*ifindex, *ifindex, None, 0) {
+            Ok(()) => {
+                delta.added += 1;
+                info!(ifindex, "REDIRECT_DEVMAP added (iface came up)");
+            }
+            Err(e) => warn!(ifindex, error = %e, "REDIRECT_DEVMAP insert failed"),
+        }
+    }
+    for ifindex in current.difference(&desired) {
+        // Only purge ifaces that the kernel no longer knows about;
+        // an iface in `current` but down at enumeration time stays.
+        if ifindex_exists(*ifindex) {
+            continue;
+        }
+        match devmap.remove(*ifindex) {
             Ok(()) => {
                 delta.removed += 1;
                 info!(ifindex, "REDIRECT_DEVMAP stale entry purged");


### PR DESCRIPTION
## Incident

2026-04-21, edge1-mci1-net, v0.1.0-rc2 flip of \`dry-run off\` took the /24 of servers offline. Symptoms:
- \`fwd_ok = 0\`
- \`pass_not_in_devmap\` ≈ \`matched_v4\` (every matched packet hit the devmap-miss path)
- Customer IPs unreachable from outside

## Two bugs, both fixed

### 1. Packet mutation before devmap pre-check (outage cause)

The fast path decremented TTL, rewrote L2 MACs, and ran VLAN push/pop choreography *before* checking \`REDIRECT_DEVMAP\`. On miss, it returned \`XDP_PASS\` with a mangled packet — kernel stack got frames with wrong MACs, decremented TTL, maybe a pushed VLAN tag, and forwarded them nowhere useful.

**Fix**: reorder in \`dispatch_fib\`. Devmap check runs ahead of all mutation. Pass-path packets stay pristine.

### 2. REDIRECT_DEVMAP scope mismatch (design flaw that tripped #1)

v0.0.1 populated the devmap with only the attach-scope ifaces. On any topology where ingress ≠ egress (classic IXP edge: trunks in, WAN out), the FIB consistently returned an egress ifindex not in the devmap, tripping bug #1 on every outbound packet. The devmap is a capability allowlist (filters non-XDP-capable targets like tunnels, loopback), not a policy allowlist — **the FIB is the source of truth for egress selection**.

**Fix**: \`enumerate_redirect_targets()\` walks \`/sys/class/net\` and returns every operationally-up Ethernet-type iface. Populated at attach; SIGHUP reconcile diffs against a fresh scan. No user-facing config change — just works for BGP-dynamic topologies.

## Bonus: \`packetframe detach\` safety check

Now refuses while a \`packetframe run\` daemon is live. Previously, running detach while the daemon held \`PinnedLink\` FDs would unlink the bpffs pin paths but NOT detach the kernel bpf_link — the subcommand reported success but \`ip link show\` still had \`xdpgeneric\` attached. Now errors with a clear "stop the daemon first" message.

## SPEC.md updates

- §4.4 step 9 reordered — devmap pre-check moves to step (b), before TTL/MAC/VLAN mutation
- §4.5 \`redirect_devmap\` row rewritten — now populated from \`/sys/class/net\`, not from attach list
- New §11.13 "Outage finding — packet mutation before devmap pre-check"

## Test plan

- [x] CI green
- [ ] Deploy v0.1.0-rc3 on edge1-mci1-net, flip \`dry-run off\`, watch for \`fwd_ok\` climbing + \`pass_not_in_devmap\` staying near zero + /24 reachable throughout

## Known gap — deferred to PR #12

A CI fixture for the pass-path-mutation invariant ("allowlist hit + FIB egress to non-devmap iface → XDP_PASS with packet byte-equal to original") needs a netns-based harness with real routes. \`bpf_prog_test_run\` can't synthesize that without separate test infra. Opening as PR #12 groundwork once this is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)