### PR TITLE
probe: add --offset N for diagnosing drivers that point xdp->data into headroom

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -118,6 +118,14 @@ enum Command {
         /// standard way to confirm a driver-specific non-conformance.
         #[arg(long, default_value = "auto", value_parser = parse_mode)]
         mode: packetframe_probe::AttachMode,
+        /// Byte offset at which the BPF program samples each packet's
+        /// head. Default `0` (start of `xdp->data`). Non-zero values
+        /// are for diagnosing drivers that point `xdp->data` into
+        /// headroom instead of at the packet — e.g. `--offset 128`
+        /// on rvu-nicpf pre-Linux-v6.8 to see the real Ethernet
+        /// header. Capped at 512.
+        #[arg(long, default_value_t = 0)]
+        offset: u16,
     },
 }
 
@@ -201,7 +209,8 @@ fn main() -> ExitCode {
             iface,
             duration,
             mode,
-        } => probe::run(iface, mode, duration),
+            offset,
+        } => probe::run(iface, mode, duration, offset),
     }
 }
 

--- a/crates/cli/src/probe.rs
+++ b/crates/cli/src/probe.rs
@@ -25,8 +25,8 @@ use crate::{EXIT_OK, EXIT_RUNTIME_ERROR, EXIT_STARTUP_ERROR};
 /// iface (hundreds to low thousands pps) doesn't fill the terminal.
 const MAX_TABLE_ROWS: usize = 64;
 
-pub fn run(iface: String, mode: AttachMode, duration: Duration) -> ExitCode {
-    match packetframe_probe::run(&iface, mode, duration) {
+pub fn run(iface: String, mode: AttachMode, duration: Duration, offset: u16) -> ExitCode {
+    match packetframe_probe::run(&iface, mode, duration, offset) {
         Ok(out) => {
             print_report(&iface, duration, &out);
             ExitCode::from(EXIT_OK)
@@ -43,6 +43,10 @@ pub fn run(iface: String, mode: AttachMode, duration: Duration) -> ExitCode {
             eprintln!("packetframe probe: {msg}");
             ExitCode::from(EXIT_STARTUP_ERROR)
         }
+        Err(e @ ProbeError::OffsetTooLarge { .. }) => {
+            eprintln!("packetframe probe: {e}");
+            ExitCode::from(EXIT_STARTUP_ERROR)
+        }
         Err(ProbeError::Other(msg)) => {
             eprintln!("packetframe probe: {msg}");
             ExitCode::from(EXIT_RUNTIME_ERROR)
@@ -52,8 +56,9 @@ pub fn run(iface: String, mode: AttachMode, duration: Duration) -> ExitCode {
 
 fn print_report(iface: &str, duration: Duration, out: &ProbeOutput) {
     println!(
-        "PacketFrame probe on {iface} (mode={} duration={:?})",
+        "PacketFrame probe on {iface} (mode={} offset={} duration={:?})",
         out.effective_mode.as_str(),
+        out.offset,
         duration
     );
     println!("{} samples collected", out.samples.len());

--- a/crates/modules/probe/bpf/src/main.rs
+++ b/crates/modules/probe/bpf/src/main.rs
@@ -22,7 +22,7 @@ use aya_ebpf::{
     bindings::xdp_action,
     helpers::gen::bpf_ktime_get_ns,
     macros::{map, xdp},
-    maps::RingBuf,
+    maps::{Array, RingBuf},
     programs::XdpContext,
 };
 use core::mem;
@@ -56,8 +56,46 @@ pub struct ProbeEvent {
 #[map]
 pub static EVENTS: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 
+/// Probe configuration, poked by userspace before attach. Single
+/// element. Value layout is `#[repr(C)]` + u16 + `[u8; 6]` padding
+/// reserved for future fields; keep the struct a multiple of 8 bytes
+/// so the `Array` map's per-CPU alignment rules hold on every target.
+///
+/// `offset` is the byte offset at which the BPF program samples the
+/// 16-byte head. Normally `0`, but some broken drivers point
+/// `xdp->data` into headroom instead of at the packet — the CLI
+/// surfaces `--offset N` so the operator can confirm where the packet
+/// really starts. `OTX2_HEAD_ROOM = 128` is the interesting value for
+/// rvu-nicpf on pre-upstream-v6.8 kernels; see SPEC.md §11.1(c).
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct ProbeCfg {
+    pub offset: u16,
+    pub _reserved: [u8; 6],
+}
+
+#[map]
+pub static CFG: Array<ProbeCfg> = Array::with_max_entries(1, 0);
+
+/// Upper cap on `offset`. Kept modest to keep the verifier's bounds
+/// analysis cheap and to avoid letting a bogus userspace value
+/// turn the probe into a distant-memory peek tool. 512 covers every
+/// real driver headroom I know of; bump if a pathological case shows
+/// up.
+const MAX_OFFSET: u16 = 512;
+
 #[xdp]
 pub fn probe(ctx: XdpContext) -> u32 {
+    // Read the userspace-supplied sample offset. Default 0 (sample at
+    // `data`). Clamp at `MAX_OFFSET` so a malformed userspace value
+    // can't turn this into an unbounded memory peek, and mask to u16
+    // so the verifier's bounds tracker stays tight.
+    let offset = CFG
+        .get(0)
+        .map(|c| c.offset)
+        .unwrap_or(0)
+        .min(MAX_OFFSET) as usize;
+
     // Reserve a slot before reading packet bytes — keeps the hot path
     // cheap when the ringbuf is full (no reads, no work). Rust's
     // `#[must_use]` on `RingBufEntry` enforces that we either submit
@@ -73,11 +111,12 @@ pub fn probe(ctx: XdpContext) -> u32 {
     let start = ctx.data();
     let end = ctx.data_end();
 
-    // Verifier-friendly bounds check for the 16-byte head read. On
-    // frames shorter than 16 bytes the entry is discarded — those
-    // are invalid Ethernet anyway and not what the operator is
-    // trying to diagnose.
-    if start + mem::size_of::<[u8; 16]>() > end {
+    // Verifier-friendly bounds check for the 16-byte head read at
+    // `start + offset`. Short packets (or a too-large offset on a
+    // small frame) discard the sample rather than fault — the probe
+    // is diagnostic; frames that don't fit just aren't interesting
+    // evidence and we keep forwarding.
+    if start + offset + mem::size_of::<[u8; 16]>() > end {
         entry.discard(0);
         return xdp_action::XDP_PASS;
     }
@@ -93,10 +132,11 @@ pub fn probe(ctx: XdpContext) -> u32 {
         let e = entry.as_mut_ptr();
         (*e).ts_ns = ts;
         (*e).pkt_len = pkt_len;
-        // Bounds-checked 16-byte read from packet head. `read_unaligned`
-        // is safe here because XDP context pointers have no guaranteed
-        // alignment and the verifier tracks the read range.
-        let p = start as *const [u8; 16];
+        // Bounds-checked 16-byte read at `start + offset`. The
+        // verifier has the tight [start, end) range and a clamped
+        // `offset ≤ MAX_OFFSET`, so `start + offset` is a
+        // well-defined in-range pointer.
+        let p = (start + offset) as *const [u8; 16];
         (*e).head = core::ptr::read_unaligned(p);
     }
 

--- a/crates/modules/probe/src/lib.rs
+++ b/crates/modules/probe/src/lib.rs
@@ -50,11 +50,17 @@ pub fn run(
     _iface: &str,
     _mode: AttachMode,
     _duration: std::time::Duration,
+    _offset: u16,
 ) -> Result<ProbeOutput, ProbeError> {
     Err(ProbeError::Unsupported(
         "packetframe probe is only supported on Linux".into(),
     ))
 }
+
+/// Matches the BPF-side `MAX_OFFSET`. Userspace rejects values above
+/// this with [`ProbeError::OffsetTooLarge`] so the operator gets a
+/// clear error rather than a silent clamp inside the BPF program.
+pub const MAX_OFFSET: u16 = 512;
 
 /// Attach mode the operator requested. Wire-compatible with the
 /// fast-path module's SPEC.md §2.3 semantics: `Native` is driver XDP,
@@ -87,6 +93,11 @@ pub struct ProbeOutput {
     pub effective_mode: AttachMode,
     /// Samples collected during the probe window. Ordered by arrival.
     pub samples: Vec<ProbeEvent>,
+    /// Offset (bytes) at which the BPF program sampled each packet's
+    /// head. Echoed back so the CLI can label the output — e.g. an
+    /// rvu-nicpf pre-v6.8 trace at `offset=128` shows the real frame
+    /// while `offset=0` shows the headroom zeros.
+    pub offset: u16,
     /// Whether the ringbuf went empty before the duration elapsed
     /// (false = probe exited on timer) vs. we kept seeing packets
     /// right up to the end (true). Useful for the CLI to hint at
@@ -104,6 +115,8 @@ pub enum ProbeError {
     NoBpf,
     #[error("unsupported: {0}")]
     Unsupported(String),
+    #[error("--offset {got} exceeds the BPF-side cap of {max}; the program clamps reads to stay verifier-friendly and avoid distant-memory peeks")]
+    OffsetTooLarge { got: u16, max: u16 },
     #[error("{0}")]
     Other(String),
 }
@@ -125,9 +138,31 @@ mod linux_impl {
         Ebpf,
     };
 
+    /// Layout mirror of `ProbeCfg` in `bpf/src/main.rs`. Bytes-for-
+    /// bytes equal — if you change one, change the other. `u16` +
+    /// `[u8; 6]` packs to 8 bytes; `repr(C)` with all-bit-patterns-
+    /// valid primitives makes `aya::Pod` safe to impl.
+    #[repr(C)]
+    #[derive(Copy, Clone, Debug)]
+    struct ProbeCfg {
+        offset: u16,
+        _reserved: [u8; 6],
+    }
+
+    // SAFETY: repr(C) + primitive fields + no padding → every bit
+    // pattern is valid.
+    unsafe impl aya::Pod for ProbeCfg {}
+
     /// Load the probe BPF ELF, attach it to `iface` in the requested
     /// mode, drain the ringbuf for `duration`, then detach. Returns
     /// samples in arrival order.
+    ///
+    /// `offset` selects the byte offset at which the BPF program
+    /// samples each packet's head — normally `0` (real frame start).
+    /// Non-zero values are for diagnosing drivers that point
+    /// `xdp->data` into headroom (e.g. `128` on rvu-nicpf pre-v6.8,
+    /// see SPEC.md §11.1(c)). Clamped to [`MAX_OFFSET`] — past that,
+    /// the function rejects rather than silently truncate.
     ///
     /// Uses a short (~50ms) poll interval on the ringbuf fd so
     /// ctrl-c / duration expiry is responsive even under load.
@@ -135,9 +170,16 @@ mod linux_impl {
         iface: &str,
         mode: AttachMode,
         duration: Duration,
+        offset: u16,
     ) -> Result<ProbeOutput, ProbeError> {
         if !PROBE_BPF_AVAILABLE {
             return Err(ProbeError::NoBpf);
+        }
+        if offset > MAX_OFFSET {
+            return Err(ProbeError::OffsetTooLarge {
+                got: offset,
+                max: MAX_OFFSET,
+            });
         }
 
         let ifindex = if_nametoindex(iface)?;
@@ -145,6 +187,26 @@ mod linux_impl {
         let mut bpf = Ebpf::load(PROBE_BPF).map_err(|e| {
             ProbeError::Other(format!("load probe BPF ELF via aya::Ebpf::load: {e}"))
         })?;
+
+        // Populate CFG before attach so the very first packet sees the
+        // operator-requested offset, not the default 0.
+        {
+            use aya::maps::Array;
+            let map = bpf
+                .map_mut("CFG")
+                .ok_or_else(|| ProbeError::Other("CFG map missing from probe ELF".into()))?;
+            let mut arr: Array<_, ProbeCfg> = Array::try_from(map)
+                .map_err(|e| ProbeError::Other(format!("Array::try_from CFG: {e}")))?;
+            arr.set(
+                0,
+                ProbeCfg {
+                    offset,
+                    _reserved: [0; 6],
+                },
+                0,
+            )
+            .map_err(|e| ProbeError::Other(format!("CFG set: {e}")))?;
+        }
 
         // Attach in the requested mode, with the same "auto" semantics
         // that the fast-path module uses — try native, fall back to
@@ -228,6 +290,7 @@ mod linux_impl {
         Ok(ProbeOutput {
             effective_mode,
             samples,
+            offset,
             saw_traffic,
             dropped_samples: 0,
         })


### PR DESCRIPTION
## Summary

- Add `packetframe probe --offset N` so the BPF program samples the 16-byte head at a caller-specified offset into `xdp->data` instead of always at `data + 0`.
- Plumbed via a single-entry BPF `Array<ProbeCfg>` CFG map: userspace writes `{ offset: u16 }` before attach; the program reads it, clamps to `MAX_OFFSET = 512`, and samples at `data + offset`.
- Default `offset = 0` is a no-op for correct drivers — everyone else keeps the v0.1.0 behaviour.

## Why

SPEC §11.1(c): on rvu-nicpf with Linux pre-v6.8, the driver's `otx2_xdp_rcv_pkt_handler` computes `xdp->data` from `cqe->sg.seg_addr - OTX2_HEAD_ROOM` — i.e. 128 bytes **before** the actual packet. Fixed upstream in [04f647c8e456](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=04f647c8e456) (Feb 2024, shipped in Linux v6.8) — but that backport hasn't landed in every downstream kernel yet. v0.1.0's probe always sampled at offset 0, so on affected kernels every sample was 128 bytes of zero-padded headroom.

With `--offset 128`, operators can now confirm the real Ethernet header is at `data + 128` on one command without a rebuild. This unblocks the PacketFrame fast-path `rvu-nicpf`-aware workaround (separate PR): runtime detection of the pattern → conditional `bpf_xdp_adjust_head(+128)` + `bpf_xdp_adjust_tail(+128)` on every packet.

## Test plan

- [ ] Host + QEMU CI green
- [ ] On the EFG: `packetframe probe --iface eth2 --mode native --offset 128 --duration 2s` shows the textbook Ethernet + IPv4 header (`... 08 00 45 ...`) at the head, matching the earlier generic-mode run at offset 0.
- [ ] Same command at `--offset 0` still shows the zero-padded headroom (regression check).
- [ ] `--offset 1024` rejected with a clear `OffsetTooLarge` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)