### PR TITLE
probe: copy PROBE_BPF into aligned Vec; fixes v0.1.1 "error parsing ELF data"

### DIFF
--- a/crates/modules/probe/src/lib.rs
+++ b/crates/modules/probe/src/lib.rs
@@ -16,12 +16,30 @@ pub const MODULE_NAME: &str = "probe";
 /// The compiled probe BPF ELF, staged by `build.rs` and embedded at
 /// crate-compile time. Empty (zero bytes) when the BPF toolchain
 /// isn't available — see [`PROBE_BPF_AVAILABLE`].
+///
+/// Note: `include_bytes!` returns a 1-byte-aligned slice. Passing it
+/// directly to `aya::Ebpf::load` fails with "Invalid ELF header size
+/// or alignment" on every non-8-byte-aligned placement — which is
+/// wherever the linker happens to drop a `.rodata` blob of the
+/// current size. v0.1.1's probe ELF grew from 1432 → 1608 bytes (CFG
+/// map added) and its in-binary address flipped from aligned to
+/// unaligned, which is how that release shipped broken. Callers must
+/// copy to an aligned buffer — use [`aligned_bpf_copy`].
 pub const PROBE_BPF: &[u8] = include_bytes!(env!("PROBE_BPF_OBJ"));
 
 /// `true` when `build.rs` produced a real probe BPF ELF; `false` when
 /// the build fell back to the stub. Const-evaluable for use in test
 /// early-returns and `#[cfg]`-like branches.
 pub const PROBE_BPF_AVAILABLE: bool = !PROBE_BPF.is_empty();
+
+/// Allocate an aligned `Vec<u8>` containing a copy of [`PROBE_BPF`].
+/// The system allocator aligns to at least 8 bytes on 64-bit
+/// platforms, which is enough for `object`'s ELF parser to read the
+/// header without tripping the alignment check (`parse_header` does
+/// `u64` reads at offset 0x20, so 1..7-byte offsets trap).
+pub fn aligned_bpf_copy() -> Vec<u8> {
+    PROBE_BPF.to_vec()
+}
 
 /// One packet sample. `#[repr(C)]` and layout-identical to the BPF
 /// program's `ProbeEvent` struct — the ringbuf delivers these bytes
@@ -184,8 +202,16 @@ mod linux_impl {
 
         let ifindex = if_nametoindex(iface)?;
 
-        let mut bpf = Ebpf::load(PROBE_BPF).map_err(|e| {
-            ProbeError::Other(format!("load probe BPF ELF via aya::Ebpf::load: {e}"))
+        // Heap-copy PROBE_BPF into an aligned `Vec<u8>` — passing the
+        // raw `include_bytes!` static to `Ebpf::load` fails on
+        // unaligned placements (v0.1.1 regression). The alignment
+        // pattern mirrors `packetframe-fast-path::aligned_bpf_copy`.
+        let bytes = aligned_bpf_copy();
+        let mut bpf = Ebpf::load(&bytes).map_err(|e| {
+            ProbeError::Other(format!(
+                "load probe BPF ELF via aya::Ebpf::load: {}",
+                fmt_error_chain(&e)
+            ))
         })?;
 
         // Populate CFG before attach so the very first packet sees the
@@ -381,5 +407,22 @@ mod linux_impl {
             )));
         }
         Ok(idx)
+    }
+
+    /// Render an error's full source chain into one string. aya's
+    /// `EbpfError::ParseError` display drops the inner `object`
+    /// error — so a bare `{e}` emits only `"error parsing ELF data"`
+    /// with no indication whether the cause is alignment, a truncated
+    /// header, a malformed section, etc. Walking `Error::source()`
+    /// picks up what the outer formatter skipped.
+    fn fmt_error_chain(e: &dyn std::error::Error) -> String {
+        let mut out = e.to_string();
+        let mut src = e.source();
+        while let Some(s) = src {
+            out.push_str(" → ");
+            out.push_str(&s.to_string());
+            src = s.source();
+        }
+        out
     }
 }

--- a/crates/modules/probe/tests/load_attach.rs
+++ b/crates/modules/probe/tests/load_attach.rs
@@ -22,7 +22,7 @@ use aya::{
     programs::{xdp::XdpFlags, Xdp},
     Ebpf,
 };
-use packetframe_probe::{PROBE_BPF, PROBE_BPF_AVAILABLE};
+use packetframe_probe::{aligned_bpf_copy, PROBE_BPF_AVAILABLE};
 
 const PEER_A: &str = "pf-probe-a";
 const PEER_B: &str = "pf-probe-b";
@@ -68,7 +68,11 @@ fn load_attach_detach_roundtrip_on_veth() {
         idx
     };
 
-    let mut bpf = Ebpf::load(PROBE_BPF).expect("aya::Ebpf::load probe");
+    // Use the aligned copy, same as production — passing the raw
+    // `PROBE_BPF` static trips aya's ELF header alignment check on
+    // unlucky placements (see v0.1.1 regression).
+    let bytes = aligned_bpf_copy();
+    let mut bpf = Ebpf::load(&bytes).expect("aya::Ebpf::load probe");
 
     // EVENTS map must be present and typed as a ring buffer. This
     // catches the common mis-declaration where a map ends up in the


### PR DESCRIPTION
## Summary

Fixes v0.1.1 shipping a broken probe binary on every host where the linker placed the 1608-byte `PROBE_BPF` static at a non-8-byte-aligned offset. aya's `Object::parse` calls `object::read::File::parse` which does u64 reads on the ELF header and fails with *"Invalid ELF header size or alignment"* unless the buffer is 8-byte-aligned.

aya wraps that as `ParseError::ElfError(object::read::Error)`, and the outer `#[error]` attribute drops the inner — so the user sees `error parsing BPF object: error parsing ELF data` with zero hint that alignment is the cause. I reproduced locally by slicing the v0.1.1 probe ELF into a padded buffer at offsets 0..15: every non-8-aligned offset failed with the exact error the EFG reported; offsets 0 and 8 parsed fine.

v0.1.0's probe (1432 bytes) worked by pure linker-placement luck. v0.1.1's (1608 bytes, after adding the `--offset` CFG map) didn't.

## Fix

- `packetframe-probe` gains `aligned_bpf_copy()` mirroring fast-path's same-name helper: heap-allocated `Vec<u8>` via `PROBE_BPF.to_vec()`, which Rust's global allocator aligns to at least 8 bytes on 64-bit targets.
- `linux_impl::run` now loads via `Ebpf::load(&aligned_bpf_copy())`.
- `tests/load_attach.rs` adopts the same pattern.
- Quality-of-life: the load error is now formatted via `fmt_error_chain`, which walks `std::error::Error::source()` so aya's inner `object` error surfaces. Future regressions of this class will be self-identifying.

## Why PR #13 / #14's `load_attach` test didn't catch this

`tests/load_attach.rs` was compiled from the same source as production but got lucky on placement — it passed CI on multiple kernels because `cargo test` binaries happened to land the PROBE_BPF static at an aligned offset. Forcing `aligned_bpf_copy()` in the test means future builds can't regress this way.

## Test plan

- [ ] CI fmt+clippy+test green
- [ ] QEMU 5.15 + 6.6 matrix green
- [ ] On the EFG (after v0.1.2 tarball): `sudo -E packetframe probe --iface eth2 --mode native --offset 128 --duration 2s` succeeds and shows the real Ethernet header at offset 128 — the theory-confirmation test v0.1.1 was supposed to enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)