### PR TITLE
v0.1.5: version-gate native rvu-nicpf; default --config path

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -29,6 +29,21 @@ pub(crate) const EXIT_OK: u8 = 0;
 pub(crate) const EXIT_STARTUP_ERROR: u8 = 1;
 pub(crate) const EXIT_RUNTIME_ERROR: u8 = 2;
 
+/// Default config path used when the caller omits `--config`. Matches
+/// the systemd-unit install location in the deployment playbook so
+/// `packetframe run` alone works without flags on a standard deploy.
+pub(crate) const DEFAULT_CONFIG_PATH: &str = "/etc/packetframe/packetframe.conf";
+
+/// Resolve a caller-supplied `Option<PathBuf>` against the default.
+/// Returns the caller's value if `Some`; otherwise returns the default
+/// path unchanged. We deliberately don't stat the path here — the
+/// config parser emits a clear "I/O error reading {path}" if the
+/// default file is missing, which is a more actionable error than a
+/// generic "provide --config".
+pub(crate) fn config_path_or_default(caller: Option<PathBuf>) -> PathBuf {
+    caller.unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_PATH))
+}
+
 #[derive(Parser)]
 #[command(
     name = "packetframe",
@@ -58,8 +73,10 @@ enum Command {
 
     /// Run PacketFrame in the foreground: load + attach + block on signal.
     Run {
+        /// Path to the config file. Defaults to
+        /// `/etc/packetframe/packetframe.conf`.
         #[arg(long)]
-        config: PathBuf,
+        config: Option<PathBuf>,
     },
 
     /// Detach attached programs by removing every pin under the
@@ -67,6 +84,8 @@ enum Command {
     /// kernel-side XDP detach (SPEC.md §8.5); removing map + program
     /// pins is housekeeping.
     Detach {
+        /// Path to the config file. Defaults to
+        /// `/etc/packetframe/packetframe.conf`.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Tear down every PacketFrame pin across every module, not
@@ -78,14 +97,18 @@ enum Command {
 
     /// Show attach state and live counter values.
     Status {
+        /// Path to the config file. Defaults to
+        /// `/etc/packetframe/packetframe.conf`.
         #[arg(long)]
-        config: PathBuf,
+        config: Option<PathBuf>,
     },
 
     /// Re-read config and reconcile. Stubbed until PR #6.
     Reconfigure {
+        /// Path to the config file. Defaults to
+        /// `/etc/packetframe/packetframe.conf`.
         #[arg(long)]
-        config: PathBuf,
+        config: Option<PathBuf>,
     },
 
     /// Direct BPF map ops for debugging. Lands in PR #6 alongside
@@ -177,31 +200,50 @@ fn main() -> ExitCode {
     let cli = Cli::parse();
     match cli.command {
         Command::Feasibility { config, human } => run_feasibility(config, human),
-        Command::Run { config } => match loader::run(&config) {
-            Ok(()) => ExitCode::from(EXIT_OK),
-            Err(loader::RunError::Startup(msg)) => {
-                tracing::error!(error = %msg, "startup failed");
-                ExitCode::from(EXIT_STARTUP_ERROR)
+        Command::Run { config } => {
+            let path = config_path_or_default(config);
+            match loader::run(&path) {
+                Ok(()) => ExitCode::from(EXIT_OK),
+                Err(loader::RunError::Startup(msg)) => {
+                    tracing::error!(error = %msg, "startup failed");
+                    ExitCode::from(EXIT_STARTUP_ERROR)
+                }
+                Err(loader::RunError::Runtime(msg)) => {
+                    tracing::error!(error = %msg, "runtime error");
+                    ExitCode::from(EXIT_RUNTIME_ERROR)
+                }
             }
-            Err(loader::RunError::Runtime(msg)) => {
-                tracing::error!(error = %msg, "runtime error");
-                ExitCode::from(EXIT_RUNTIME_ERROR)
+        }
+        Command::Detach { config, all } => {
+            // `detach --all` with no config is still meaningful (rip
+            // every pin we can find). Only default the path for the
+            // scoped case where `config` is expected to name the
+            // module whose pins to tear down.
+            let path = config.or_else(|| {
+                if all {
+                    None
+                } else {
+                    Some(PathBuf::from(DEFAULT_CONFIG_PATH))
+                }
+            });
+            match loader::detach(path.as_deref(), all) {
+                Ok(()) => ExitCode::from(EXIT_OK),
+                Err(e) => {
+                    tracing::error!(error = %e);
+                    ExitCode::from(EXIT_RUNTIME_ERROR)
+                }
             }
-        },
-        Command::Detach { config, all } => match loader::detach(config.as_deref(), all) {
-            Ok(()) => ExitCode::from(EXIT_OK),
-            Err(e) => {
-                tracing::error!(error = %e);
-                ExitCode::from(EXIT_RUNTIME_ERROR)
+        }
+        Command::Status { config } => {
+            let path = config_path_or_default(config);
+            match loader::status(&path) {
+                Ok(()) => ExitCode::from(EXIT_OK),
+                Err(e) => {
+                    tracing::error!(error = %e);
+                    ExitCode::from(EXIT_RUNTIME_ERROR)
+                }
             }
-        },
-        Command::Status { config } => match loader::status(&config) {
-            Ok(()) => ExitCode::from(EXIT_OK),
-            Err(e) => {
-                tracing::error!(error = %e);
-                ExitCode::from(EXIT_RUNTIME_ERROR)
-            }
-        },
+        }
         Command::Reconfigure { .. } => not_implemented("reconfigure"),
         Command::Map { .. } => not_implemented("map"),
         #[cfg(feature = "probe")]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -54,6 +54,15 @@ pub(crate) const FP_CFG_VERSION_V1: u32 = 0;
 /// §11.1(c)). Keep in lockstep with the BPF side.
 pub(crate) const FP_CFG_FLAG_HEAD_SHIFT_128: u8 = 0b0000_0100;
 
+/// Minimum mainline Linux version that ships the rvu-nicpf XDP fix
+/// (commit 04f647c8e456). Kernels below this expose both the
+/// xdp.data_hard_start offset bug (workaroundable via head-shift) AND
+/// the `non_qos_queues` leak at XDP attach/detach (NOT workaroundable
+/// from userspace). On such kernels we refuse native-mode attach on
+/// rvu-nicpf ifaces unless the operator explicitly opts in via the
+/// `driver-workaround rvu-nicpf-head-shift on` override.
+const RVU_NICPF_FIXED_IN_KERNEL: (u32, u32) = (6, 8);
+
 /// Kernel driver names that trigger the head-shift workaround.
 /// `/sys/class/net/<iface>/device/driver` is a symlink into
 /// `/sys/bus/pci/drivers/<module_name>` — for this driver the kernel
@@ -303,6 +312,26 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         cfg.global.attach_settle_time,
     );
 
+    // Version-gate native-mode attach on rvu-nicpf kernels that lack
+    // the upstream fix (commit 04f647c8e456, Linux v6.8). That commit
+    // fixes two bugs in one patch: (1) the xdp.data_hard_start offset
+    // bug that v0.1.3 worked around via head-shift; (2) a
+    // `non_qos_queues` leak at `otx2_xdp_setup` that is *not* fixable
+    // from userspace — every native XDP attach leaks the count, and
+    // after enough attach/detach cycles the driver's queue sizing
+    // drifts and the page allocator's freelist gets a NULL write,
+    // producing the `get_page_from_freelist` NULL deref crash signature
+    // seen on edge1-mci1-net 2026-04-22 (SPEC §11.1(c)). This
+    // preprocessor runs *before* `try_attach_with_fallback` so we
+    // don't leak even once.
+    //
+    // `driver-workaround rvu-nicpf-head-shift = on` bypasses the
+    // check: operator takes responsibility. `= off` bypasses both
+    // the version check and the head-shift workaround, for operators
+    // who have backported the fix into a kernel whose uname still
+    // reports pre-v6.8.
+    let attach_dirs = rvu_nicpf_version_gate(attach_dirs, cfg)?;
+
     // Attach each interface with trial-attach per §2.3: Auto → try
     // native first, fall back to generic on error; explicit Native or
     // Generic uses the requested mode directly (no fallback). Each
@@ -511,6 +540,108 @@ fn apply_driver_quirks_cfg(state: &mut ActiveState, mcfg: &ModuleConfig<'_>) -> 
          kernel backport lands."
     );
     Ok(())
+}
+
+/// Read `/proc/sys/kernel/osrelease` (= `uname -r`) and parse the
+/// leading `major.minor`. Returns `None` if the file is unreadable
+/// or the format is unrecognizable — callers treat that as "can't
+/// prove the fix is present", i.e. the conservative path.
+fn kernel_version() -> Option<(u32, u32)> {
+    let osrelease = std::fs::read_to_string("/proc/sys/kernel/osrelease").ok()?;
+    let prefix = osrelease.split('-').next().unwrap_or(osrelease.trim());
+    let mut parts = prefix.trim().split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    let minor: u32 = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Return true if the running kernel's `major.minor` is at least the
+/// requested threshold. `None` from [`kernel_version`] returns false
+/// (conservative: treat as missing the fix).
+fn kernel_at_least(min: (u32, u32)) -> bool {
+    kernel_version().map(|v| v >= min).unwrap_or(false)
+}
+
+/// Walk the attach directives and decide whether native-mode attach is
+/// safe on each rvu-nicpf iface. Downgrades `Auto` to `Generic` with a
+/// warning on affected kernels; hard-errors on explicit `Native`
+/// unless the operator's `driver-workaround rvu-nicpf-head-shift`
+/// toggle opts into the known-unsafe path. Runs *before* any
+/// hardware-level XDP attach so the driver's attach-time bugs don't
+/// even get one chance to trip.
+fn rvu_nicpf_version_gate(
+    attach_dirs: Vec<(String, AttachMode, u32)>,
+    mcfg: &ModuleConfig<'_>,
+) -> ModuleResult<Vec<(String, AttachMode, u32)>> {
+    let toggle = mcfg
+        .section
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::DriverWorkaround(DriverWorkaround::RvuNicpfHeadShift(v)) => Some(*v),
+            _ => None,
+        })
+        .unwrap_or_default();
+
+    // `Off` = operator asserts they've backported the fix (or are
+    // otherwise certain native is safe). Skip both the version check
+    // and the later head-shift application. `On` = operator takes
+    // responsibility for the known-unsafe path and opts into both the
+    // head-shift workaround and skipping the version refusal.
+    if matches!(toggle, ToggleAutoOnOff::Off | ToggleAutoOnOff::On) {
+        return Ok(attach_dirs);
+    }
+
+    // `Auto` (default): check kernel version and refuse or downgrade.
+    let kernel_ok = kernel_at_least(RVU_NICPF_FIXED_IN_KERNEL);
+    if kernel_ok {
+        // v6.8+; the fix is present; native attach is safe.
+        return Ok(attach_dirs);
+    }
+
+    let mut out = Vec::with_capacity(attach_dirs.len());
+    for (iface, mode, ifindex) in attach_dirs {
+        let is_rvu = read_iface_driver(&iface)
+            .as_deref()
+            .is_some_and(|d| RVU_NICPF_DRIVERS.contains(&d));
+        let wants_native = matches!(mode, AttachMode::Native | AttachMode::Auto);
+        if !is_rvu || !wants_native {
+            out.push((iface, mode, ifindex));
+            continue;
+        }
+        match mode {
+            AttachMode::Native => {
+                return Err(ModuleError::other(
+                    MODULE_NAME,
+                    format!(
+                        "refusing native XDP attach on rvu-nicpf iface `{iface}`: kernel \
+                         {} lacks upstream fix (commit 04f647c8e456, Linux v6.8+) for two \
+                         rvu-nicpf bugs that together make native XDP unsafe on this driver \
+                         (SPEC §11.1(c)). Either (a) backport 04f647c8e456 into this \
+                         kernel, (b) switch `{iface}` to `attach … generic` (no attach-time \
+                         queue leak; slightly lower throughput), or (c) override with \
+                         `driver-workaround rvu-nicpf-head-shift on` to accept the known \
+                         crash risk",
+                        kernel_version()
+                            .map(|(a, b)| format!("{a}.{b}"))
+                            .unwrap_or_else(|| "<unknown>".into())
+                    ),
+                ));
+            }
+            AttachMode::Auto => {
+                warn!(
+                    iface = %iface,
+                    kernel = ?kernel_version(),
+                    "rvu-nicpf on pre-v6.8 kernel: downgrading `auto` to `generic` \
+                     (SPEC §11.1(c)). Upstream fix is commit 04f647c8e456; set \
+                     `driver-workaround rvu-nicpf-head-shift on` to force native anyway."
+                );
+                out.push((iface, AttachMode::Generic, ifindex));
+            }
+            AttachMode::Generic => unreachable!("filtered by wants_native check above"),
+        }
+    }
+    Ok(out)
 }
 
 /// Read the kernel driver name backing a netdev via


### PR DESCRIPTION
## Summary

Two operator-facing changes. Both were motivated by today's debugging session on edge1-mci1-net (three crashes across v0.1.3/v0.1.4 attempts).

### 1. Refuse native-mode attach on pre-v6.8 rvu-nicpf kernels

v0.1.3's head-shift workaround fixed ONE of two bugs in the pre-Linux-v6.8 rvu-nicpf XDP path. The other — a `pf->hw.non_qos_queues += pf->hw.xdp_queues` leak at `otx2_xdp_setup` with no decrement on detach — is a kernel driver bug we cannot reach from userspace. Each native-mode attach leaks the count; a handful of cycles later the driver walks off the end of a resource array and the page allocator's freelist gets a NULL pointer written into it. That's the exact `get_page_from_freelist+0x234` crash we saw today.

Upstream commit [`04f647c8e456`](https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=04f647c8e456) (Linux v6.8) fixes both bugs in one patch.

v0.1.5 now refuses to attempt the known-unsafe attach:

| config | pre-v6.8 kernel behaviour | v6.8+ behaviour |
|--------|---------------------------|-----------------|
| `attach … native` | **hard error** at preprocessing, naming the commit + three explicit remediation paths | unchanged — native attach proceeds |
| `attach … auto`   | downgrade to `generic` with a WARN log | unchanged — tries native, falls back as before |
| `attach … generic`| unchanged — generic XDP is always safe | unchanged |
| `driver-workaround rvu-nicpf-head-shift on` | override: accept unsafe native + apply head-shift | override: force head-shift (unsafe on fixed kernel; operator responsibility) |
| `driver-workaround rvu-nicpf-head-shift off` | override: skip version check + skip head-shift | same |

The version gate runs *before* `try_attach_with_fallback`, so even the trial attach doesn't fire the leak.

### 2. `--config` defaults to `/etc/packetframe/packetframe.conf`

Applies to `run`, `detach` (scoped), `status`, `reconfigure`. `detach --all` keeps its prior semantics. `feasibility`'s existing `Option<PathBuf>` is unchanged. Matches the systemd unit install path and lets `sudo packetframe run` work on a standard deploy.

## Test plan

- [ ] CI `fmt + clippy + test` green
- [ ] CI QEMU matrix green (both kernels; kernel-version parser runs on virtio-net in the verifier, no rvu-nicpf → gate never triggers)
- [ ] On the EFG: `packetframe run` (no `--config`) picks up `/etc/packetframe/packetframe.conf` and starts rc3-style generic attach cleanly.
- [ ] Sanity: edit config to `attach eth4 native` + no override on pre-v6.8 kernel → daemon refuses startup with the error message citing commit `04f647c8e456`.

## What this PR explicitly does NOT fix

- The kernel driver bugs themselves. UniFi needs to backport `04f647c8e456`. v0.1.5's gate is a safety rail around an external bug, not a fix for it.
- The `adjust_head`-not-reverted-on-`adjust_tail`-failure bug I flagged earlier — unreachable now that we refuse the native path by default, but worth revisiting if this code ever runs again on a broken kernel via the `= on` override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)