### PR TITLE
README: polish for public v0.1.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,64 +1,71 @@
 # PacketFrame
 
-PacketFrame is a modular eBPF data-plane framework written in pure Rust. It
-provides a pluggable runtime for discrete datapath modules (fast-path
-forwarding, egress randomization, DDoS mitigation, flow sampling) that can be
-loaded, attached to network interfaces, observed, and detached independently.
+PacketFrame is a modular eBPF data-plane framework written in pure Rust.
+It provides a pluggable runtime for discrete datapath modules —
+fast-path forwarding, egress randomization, DDoS mitigation, flow
+sampling — that can be loaded, attached to network interfaces,
+observed, and detached independently.
 
-The MVP module — and the reason the project exists — is `fast-path`, which
-takes forwarded packets for allowlisted prefixes off the kernel's
+The MVP module, and the reason the project exists, is `fast-path`:
+it takes forwarded packets for allowlisted prefixes off the kernel's
 conntrack/netfilter hot path by intercepting them at XDP ingress and
-redirecting them via `bpf_fib_lookup` + `bpf_redirect_map`. The design
-spec lives alongside the project internally; inline code comments cite
-section numbers (e.g. "SPEC.md §4.2") as breadcrumbs.
+redirecting via `bpf_fib_lookup` + `bpf_redirect_map`. The design
+spec lives alongside the project internally; inline code comments
+cite section numbers (e.g. `§4.2`) as breadcrumbs.
 
 ## Status
 
-v0.1 ships the full fast-path module:
+v0.1 ships the full fast-path module and a general-purpose `probe`
+diagnostic:
 
-- **XDP ingress + allowlist match** per interface, IPv4 and IPv6, with
-  LPM-trie prefix lookups.
-- **VLAN ingress parse + egress push/pop/rewrite** for VLAN-tagged
-  forwarding.
-- **`bpf_fib_lookup` + `bpf_redirect_map`** for forwarding decisions; the
-  kernel stack is only consulted for packets that the fast-path
+- **XDP ingress + allowlist match** per interface, IPv4 and IPv6,
+  with LPM-trie prefix lookups.
+- **VLAN ingress parse + egress push / pop / rewrite** for VLAN-tagged
+  forwarding topologies.
+- **`bpf_fib_lookup` + `bpf_redirect_map`** for forwarding decisions.
+  The kernel stack is only consulted for packets the fast path
   deliberately passes.
-- **bpffs pinning** of programs, maps, and links — SIGTERM exits the
-  loader without detaching attached ifaces; `packetframe detach` is the
-  explicit teardown.
-- **Live counter readback** via the pinned STATS map — `packetframe
-  status` works whether or not the loader is running.
-- **Prometheus textfile export** at 15s cadence (atomic write-then-rename)
-  with one counter per §4.6 stat plus a `packetframe_uptime_seconds`
-  gauge.
-- **SIGHUP reconcile** — delta-only updates to allowlists, VLAN resolve
+- **bpffs pinning** of programs, maps, and links. SIGTERM exits the
+  loader without detaching attached ifaces; `packetframe detach` is
+  the explicit teardown.
+- **Live counter readback** via the pinned STATS map —
+  `packetframe status` works whether or not the loader is running.
+- **Prometheus textfile export** at 15 s cadence (atomic
+  write-then-rename), one counter per stat plus a
+  `packetframe_uptime_seconds` gauge.
+- **SIGHUP reconcile** — delta-only updates to allowlists, VLAN-resolve
   map, and redirect devmap. A parse error on SIGHUP never kills the
   running data plane.
-- **Circuit breaker** — sampled error/match ratio, sticky trip flag in
-  `state-dir`, SIGUSR1-driven detach on trip. Restart refuses to
+- **Circuit breaker** — sampled error/match ratio, sticky trip flag
+  in `state-dir`, SIGUSR1-driven detach on trip. Restart refuses to
   re-attach while the flag is present.
-- **Feasibility probes** for kernel capabilities (`§2.1`) and per-interface
-  trial attach (`§2.3`).
+- **Feasibility probes** for kernel capabilities and per-interface
+  trial attach.
+- **`packetframe probe`** — attach a diagnostic-only XDP program to a
+  chosen iface for a fixed duration, dump the first 16 bytes of a
+  sample of packets, then detach. Useful for answering "what does
+  this driver hand to XDP?" without patching BPF.
+- **Driver-quirk workarounds** with a `driver-workaround` config
+  directive for per-driver opt-ins when a NIC's XDP path deviates
+  from the kernel's documented contract.
 
-The reference workflow is: validate the host with `packetframe
-feasibility`, attach in `dry-run on` to observe counters without
-redirecting, flip to `dry-run off` once the match/drop ratios look
-sane.
+The reference workflow is: validate the host with
+`packetframe feasibility`, attach in `dry-run on` to watch counters
+without redirecting, flip to `dry-run off` once the match / drop ratios
+look sane.
 
 ## Install
 
 From a GitHub Release tarball:
 
 ```sh
-VERSION=v0.1.0
+VERSION=v0.1.5   # check the Releases page for the latest
 TARGET=aarch64-unknown-linux-gnu   # also: x86_64-unknown-linux-{gnu,musl}, aarch64-unknown-linux-musl
 curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/packetframe-${VERSION}-${TARGET}.tar.gz"
 curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/SHA256SUMS"
-curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/SHA256SUMS.asc"
+curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/SHA256SUMS.asc"   # optional
 
-# (optional) verify the signature — GPG key ID in the release notes
-gpg --verify SHA256SUMS.asc SHA256SUMS
-
+gpg --verify SHA256SUMS.asc SHA256SUMS   # optional; GPG key ID in the release notes
 sha256sum -c SHA256SUMS --ignore-missing
 tar xzf "packetframe-${VERSION}-${TARGET}.tar.gz"
 
@@ -67,7 +74,7 @@ sudo install -m 0644 -D "packetframe-${VERSION}-${TARGET}/conf/example.conf" /et
 ```
 
 The shipped binaries embed the compiled BPF object; no separate
-`libbpf` or nightly toolchain is required at runtime.
+`libbpf`, `bpftool`, or nightly toolchain is required at runtime.
 
 ## Quickstart
 
@@ -77,8 +84,8 @@ Probe the host kernel first:
 sudo packetframe feasibility --human
 ```
 
-Write a minimal config (start with a single low-risk iface + `dry-run
-on`):
+Write a minimal config at `/etc/packetframe/packetframe.conf` (start
+with a single low-risk iface + `dry-run on`):
 
 ```
 global
@@ -101,23 +108,24 @@ per-interface trial attach probe:
 sudo packetframe feasibility --config /etc/packetframe/packetframe.conf --human
 ```
 
-Run the data plane in the foreground:
+Run the data plane in the foreground. `--config` defaults to
+`/etc/packetframe/packetframe.conf`, so the flag can be omitted on a
+standard deploy:
 
 ```sh
-sudo packetframe run --config /etc/packetframe/packetframe.conf
+sudo packetframe run
 ```
 
-In another shell, inspect live counters via the pinned STATS map
-(works with or without an active loader):
+In another shell, inspect live counters:
 
 ```sh
-packetframe status --config /etc/packetframe/packetframe.conf
+sudo packetframe status
 ```
 
 Tear down — removes bpffs pins and detaches attached ifaces:
 
 ```sh
-sudo packetframe detach --config /etc/packetframe/packetframe.conf
+sudo packetframe detach --all
 ```
 
 ## Attach modes
@@ -126,64 +134,99 @@ Each `attach <iface> <mode>` directive picks how the XDP program is
 bound to the interface:
 
 - `native` — driver-XDP. Lowest overhead. Requires the NIC driver to
-  implement XDP natively and to deliver packets to the program with a
-  standard Ethernet frame layout.
+  implement XDP natively and to deliver packets to the program with
+  the standard Ethernet frame layout.
 - `generic` — SKB-XDP. Runs after the kernel allocates an skb, so the
   kernel normalizes the frame before the program sees it. Higher
   per-packet overhead but works on every driver that supports XDP at
   all.
 - `auto` — try native first, fall back to generic on attach failure.
+  `auto` may also be downgraded at preprocessing on drivers known to
+  have native-mode bugs on the running kernel (see below).
 
-**Troubleshooting**: if `packetframe status` shows `rx_total`
-incrementing in lockstep with `pass_not_ip` while the `matched_*`
-counters stay at zero, the program is running but not parsing the
-frames it receives — typically a driver-specific native-mode delivery
-quirk. Re-attach with `generic` to confirm, then file an issue
-describing the NIC driver and kernel.
+### Known driver / kernel interactions
+
+PacketFrame refuses attach configurations it has empirical evidence
+are unsafe. Currently tracked:
+
+- **Marvell `rvu-nicpf` (OcteonTX2 / CN10K) on kernels older than
+  Linux v6.8**: native XDP attach leaks `non_qos_queues` count on
+  every program detach (kernel bug; fixed upstream in commit
+  `04f647c8e456`). Over a handful of attach/detach cycles the
+  driver's resource bookkeeping drifts and a subsequent page allocation
+  corrupts the kernel's freelist. v0.1.5+ hard-refuses explicit
+  `attach <iface> native` on this combination and downgrades
+  `auto` to `generic`. Operators who have backported the upstream fix
+  can opt out via `driver-workaround rvu-nicpf-head-shift off`.
+
+### Diagnosing driver-specific issues
+
+If `packetframe status` shows `rx_total` incrementing in lockstep
+with `pass_not_ip` while the `matched_*` counters stay at zero, the
+program is running but not parsing the frames it receives — typically
+a driver-specific native-mode delivery quirk. Use `packetframe probe`
+to inspect what the driver actually hands to XDP:
+
+```sh
+# Sample the first 16 bytes at data + 0 on a native-mode attach:
+sudo packetframe probe --iface eth0 --mode native --duration 2s
+
+# Sample at a larger offset if data + 0 appears to be headroom zeros:
+sudo packetframe probe --iface eth0 --mode native --duration 2s --offset 128
+
+# Compare to the skb-normalized view (what the kernel would see):
+sudo packetframe probe --iface eth0 --mode generic --duration 2s
+```
+
+The output dumps the raw bytes plus a one-line heuristic verdict
+("head bytes look like standard Ethernet" vs. "head bytes DO NOT look
+like Ethernet").
 
 ## Configuration
 
-`conf/example.conf` ships as the reference. Grammar notes:
+`conf/example.conf` ships as the reference. Grammar summary:
 
 - `global` and `module fast-path` blocks.
-- `attach <iface> <mode>`, where `mode` is `native` / `generic` / `auto`.
+- `attach <iface> <mode>`, where `mode` is `native` / `generic` /
+  `auto`.
 - `allow-prefix` / `allow-prefix6` for IPv4 and IPv6 prefixes (LPM,
-  src-or-dst match per §4.2).
+  src-or-dst match).
 - `dry-run on|off` gates actual redirects; when on, the program still
   counts matched packets but returns `XDP_PASS`.
 - `circuit-breaker drop-ratio X of matched window Ys threshold N` —
-  optional safety valve, see §4.9.
-- `metrics-textfile <path>` — Prometheus textfile target, written every
-  15 seconds.
+  optional safety valve.
+- `metrics-textfile <path>` — Prometheus textfile target, atomically
+  rewritten every 15 seconds.
+- `attach-settle-time <dur>` (global) — sleep between per-iface
+  attaches so each link settles before the next touches the driver.
+  Default 2s; raise on bridged topologies whose STP takes longer to
+  reconverge.
+- `driver-workaround <name> <auto|on|off>` — per-driver opt-ins for
+  known kernel-level quirks. See the *Known driver / kernel
+  interactions* section above for the catalog.
 
-SIGHUP re-reads the config and applies delta-only changes to allowlists
-and VLAN-resolve state without detaching. Attach-set changes (adding or
-removing an iface) require a restart.
+SIGHUP re-reads the config and applies delta-only changes to
+allowlists and VLAN-resolve state without detaching. Attach-set
+changes (adding or removing an iface) require a restart.
 
 ## Build from source
 
 ```sh
-# Host target
-make build
+make build        # host target, debug
+make release      # host target, release
+make release-all  # every published target (requires `cross`)
 
-# Release build for the current target
-make release
-
-# Every published target (requires `cross`)
-make release-all
-
-# Tests, lint, format
-make test
-make lint
-make fmt
+make test         # workspace tests
+make lint         # fmt --check + clippy -D warnings
+make fmt          # apply rustfmt
 ```
 
-Dependencies: a stable Rust toolchain (pinned in `rust-toolchain.toml`).
-The BPF crate lives at `crates/modules/fast-path/bpf/` and has its own
-pinned nightly toolchain + `bpf-linker`; CI installs those automatically.
-Cross-compiling to every release target uses
-[`cross`](https://github.com/cross-rs/cross); install it with
-`cargo install --locked cross`.
+Dependencies: a stable Rust toolchain (pinned in
+`rust-toolchain.toml`). The BPF crates live under
+`crates/modules/*/bpf/` and each has its own pinned nightly toolchain
++ `bpf-linker`; CI installs those automatically. Cross-compiling to
+every release target uses [`cross`](https://github.com/cross-rs/cross);
+install it with `cargo install --locked cross`.
 
 ## Project layout
 
@@ -193,13 +236,15 @@ packetframe/
 │   ├── common/                       # config, Module trait, §2.1 probes
 │   ├── cli/                          # the `packetframe` binary
 │   └── modules/
-│       └── fast-path/                # fast-path module
-│           └── bpf/                  # the BPF program (nightly toolchain)
+│       ├── fast-path/                # fast-path forwarding module
+│       │   └── bpf/                  # XDP fast-path BPF program (nightly toolchain)
+│       └── probe/                    # diagnostic probe module
+│           └── bpf/                  # probe BPF program (nightly toolchain)
 ├── conf/
-│   └── example.conf                  # reference config per §4.8
+│   └── example.conf                  # reference config
 └── .github/workflows/
     ├── ci.yml                        # fmt, clippy, test, cross-build
-    ├── qemu-verifier.yml             # §10.2 matrix: 5.15 + 6.6 kernels
+    ├── qemu-verifier.yml             # integration tests on 5.15 + 6.6 kernels
     └── release.yml                   # tag-triggered GitHub Release
 ```
 


### PR DESCRIPTION
## Summary

Public-facing README cleanup to reflect everything that's shipped through v0.1.5. Documentation only — no code changes.

## Changes

- **Install example** bumped from `VERSION=v0.1.0` to `VERSION=v0.1.5` + a note directing operators to the Releases page for the current tag.
- **Status bullets** now mention `packetframe probe` (shipped v0.1.0, #13) and `driver-workaround` config directives (v0.1.3+). Both existed but the README was silent.
- **Quickstart** uses the v0.1.5 default `--config` path so `sudo packetframe run` / `status` / `detach` work flag-free on a standard deploy.
- **New *Known driver / kernel interactions* subsection** under Attach modes, describing v0.1.5's refuse semantics for pre-v6.8 `rvu-nicpf` native mode and pointing operators at upstream commit `04f647c8e456` for backport.
- **Troubleshooting paragraph rewritten** around `packetframe probe` with three concrete invocations (offset 0 / offset 128 / generic) — that's now the documented diagnostic path for a driver-specific `pass_not_ip` flood, which is exactly the investigation that happened in the 2026-04-22 debugging session.
- **Configuration grammar list** gains `attach-settle-time` and `driver-workaround`, both of which existed but weren't mentioned.
- **Project layout** gains `crates/modules/probe/` alongside fast-path.
- **Minor**: softened a couple of "SPEC.md" references to "the design spec lives alongside the project internally" since the spec isn't in the repo.

## Test plan

- [ ] CI `fmt + clippy + test` green (no source changes → should be trivial).
- [ ] Markdown renders cleanly on the GitHub repo view.
- [ ] All internal links (`#quickstart`, `#attach-modes`, etc.) still resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)