### PR TITLE
fast-path: BMP station + FibProgrammer route ingestion (Option F, Phase 3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1013,6 +1013,7 @@ version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -717,6 +717,7 @@ dependencies = [
  "bgpkit-parser",
  "bytes",
  "futures",
+ "ipnet",
  "libc",
  "netlink-packet-core",
  "netlink-packet-route",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -86,6 +95,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "aya"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,16 +132,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "bgpkit-parser"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16c75d6bbca72449abb3d1e585fa85fa1eef3bd37f87dc3ab3ad9bcbe6d41e43"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "chrono",
+ "ipnet",
+ "itertools",
+ "log",
+ "num_enum",
+ "regex",
+ "zerocopy",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -139,6 +190,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -196,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,6 +273,12 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "equivalent"
@@ -219,6 +295,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "flate2"
@@ -348,6 +430,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,16 +464,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "lazy_static"
@@ -493,6 +624,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +714,8 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "aya",
+ "bgpkit-parser",
+ "bytes",
  "futures",
  "libc",
  "netlink-packet-core",
@@ -591,6 +755,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +779,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -642,6 +827,12 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"
@@ -694,6 +885,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
@@ -848,6 +1045,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -952,10 +1179,108 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -964,6 +1289,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,10 @@ futures = "0.3"
 # that we don't need.
 bgpkit-parser = { version = "0.16", default-features = false, features = ["parser", "bytes"] }
 bytes = "1.11"
+# ipnet: IPv4/IPv6 prefix types used by bgpkit-parser's NetworkPrefix.
+# We pattern-match on `IpNet::{V4,V6}` directly to extract addr +
+# prefix_len, which requires the type to be in scope.
+ipnet = "2.12"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,15 @@ rtnetlink = "0.21"
 netlink-packet-route = "0.30"
 netlink-packet-core = "0.8"
 futures = "0.3"
+# BMP parser for Option F Phase 3's RouteSource. Supports RFC 7854
+# (classic BMP) and RFC 9069 (Loc-RIB / peer type 3) natively, which
+# is what bird 2.17's `monitoring rib local` emits. Cross-platform;
+# no OS gate needed. Features: `parser` and `bytes` are the minimum
+# for offline BMP byte-stream parsing — no TLS fetcher, no MRT
+# downloader. Default features pull in rustls/chrono/regex/zerocopy
+# that we don't need.
+bgpkit-parser = { version = "0.16", default-features = false, features = ["parser", "bytes"] }
+bytes = "1.11"
 
 [profile.release]
 lto = "thin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ aya-build = "=0.1.3"
 # channels between subsystems, cooperative shutdown. `full` pulls in
 # tokio-fs and process machinery we don't need; keeping this lean keeps
 # build times and binary size reasonable on cross targets.
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "net", "sync", "time", "macros"] }
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "net", "sync", "time", "macros", "io-util"] }
 tokio-util = { version = "0.7", default-features = false }
 # rtnetlink is our async netlink client for RTM_NEWNEIGH / RTM_DELNEIGH
 # and link-state events. It layers on netlink-packet-route which we also

--- a/crates/modules/fast-path/Cargo.toml
+++ b/crates/modules/fast-path/Cargo.toml
@@ -25,6 +25,7 @@ libc.workspace = true
 # example binary run on macOS dev loops against captured frames.
 bgpkit-parser.workspace = true
 bytes.workspace = true
+ipnet.workspace = true
 
 # aya (userspace) is Linux-only (uses netlink, SYS_bpf, etc.); the
 # loader implementation is cfg-gated accordingly. Non-Linux builds

--- a/crates/modules/fast-path/Cargo.toml
+++ b/crates/modules/fast-path/Cargo.toml
@@ -19,6 +19,12 @@ tracing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 libc.workspace = true
+# bgpkit-parser + bytes are cross-platform: the BMP parser itself
+# doesn't depend on OS-specific APIs, only the TCP listener (Linux)
+# does. Keeping the parser cross-platform lets the `bmp_probe`
+# example binary run on macOS dev loops against captured frames.
+bgpkit-parser.workspace = true
+bytes.workspace = true
 
 # aya (userspace) is Linux-only (uses netlink, SYS_bpf, etc.); the
 # loader implementation is cfg-gated accordingly. Non-Linux builds

--- a/crates/modules/fast-path/examples/bmp_probe.rs
+++ b/crates/modules/fast-path/examples/bmp_probe.rs
@@ -1,0 +1,207 @@
+//! Offline BMP parser probe (Option F, Phase 3 validation tool).
+//!
+//! Reads a captured BMP byte stream (file or stdin), parses each
+//! message via `bgpkit-parser`, and prints a structured summary.
+//! This is the **Phase 1 deferred deliverable** — it proves the
+//! library handles bird's wire format (especially RFC 9069 Loc-RIB /
+//! peer type 3) before the real RouteSource in Slice 3C builds on it.
+//!
+//! Usage:
+//! ```sh
+//! # Against a file captured via tcpdump on the BMP session:
+//! cargo run --example bmp_probe -- /path/to/bird.bmp
+//!
+//! # Against a live stream (e.g. piped from nc while bird dials in):
+//! nc -l 127.0.0.1 6543 | cargo run --example bmp_probe -- -
+//! ```
+//!
+//! Output is plain text, one line per message. A closing summary
+//! prints message-type counts, per-peer-type counts, and per-peer
+//! route-monitoring counts — enough to spot a library regression
+//! (e.g., Loc-RIB frames silently misparsed as something else).
+//!
+//! Not a production binary; not shipped in the release tarball.
+//! Lives under `examples/` so `cargo build --release` skips it.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, Read};
+use std::net::IpAddr;
+
+use bgpkit_parser::parser::bmp::{messages::*, parse_bmp_msg};
+use bytes::Bytes;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = match args.get(1).map(String::as_str) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "usage: bmp_probe <path | -> \n\
+                 \n\
+                 Reads a captured BMP byte stream and prints parsed messages. \
+                 Pass `-` to read from stdin."
+            );
+            std::process::exit(2);
+        }
+    };
+
+    let mut raw = Vec::new();
+    if path == "-" {
+        io::stdin().read_to_end(&mut raw).expect("read stdin");
+    } else {
+        File::open(path)
+            .unwrap_or_else(|e| {
+                eprintln!("open {path}: {e}");
+                std::process::exit(1);
+            })
+            .read_to_end(&mut raw)
+            .expect("read file");
+    }
+    eprintln!("probing {} bytes from {path}", raw.len());
+
+    let mut bytes = Bytes::from(raw);
+    let mut stats = Stats::default();
+
+    while !bytes.is_empty() {
+        // `parse_bmp_msg` advances `bytes` past the message on success.
+        // On error we bail — a malformed frame past this point means
+        // we've lost sync with the stream framing and further parsing
+        // would produce garbage.
+        match parse_bmp_msg(&mut bytes) {
+            Ok(msg) => {
+                stats.msg_count += 1;
+                print_message(&msg, &mut stats);
+            }
+            Err(e) => {
+                eprintln!(
+                    "parse error after {} messages ({} bytes remaining): {e}",
+                    stats.msg_count,
+                    bytes.len()
+                );
+                break;
+            }
+        }
+    }
+
+    stats.print_summary();
+}
+
+#[derive(Default)]
+struct Stats {
+    msg_count: usize,
+    /// Per BmpMessageBody variant name.
+    by_type: HashMap<&'static str, usize>,
+    /// Per BmpPeerType variant name (for messages that carry a
+    /// per-peer header).
+    by_peer_type: HashMap<&'static str, usize>,
+    /// Per-peer route-monitoring count, keyed by `peer_ip`.
+    by_peer_rm: HashMap<IpAddr, usize>,
+    /// End-of-RIB markers observed (one per peer per AFI/SAFI
+    /// typically, per RFC 4724).
+    end_of_rib: usize,
+}
+
+impl Stats {
+    fn print_summary(&self) {
+        println!();
+        println!("=== Summary ===");
+        println!("total BMP messages: {}", self.msg_count);
+        println!();
+        println!("by message type:");
+        let mut by_type: Vec<(&&str, &usize)> = self.by_type.iter().collect();
+        by_type.sort_by(|a, b| b.1.cmp(a.1));
+        for (kind, count) in &by_type {
+            println!("  {kind:<24} {count}");
+        }
+        println!();
+        println!("by per-peer-type (RFC 9069 = LocalRib):");
+        let mut by_peer: Vec<(&&str, &usize)> = self.by_peer_type.iter().collect();
+        by_peer.sort_by(|a, b| b.1.cmp(a.1));
+        for (kind, count) in &by_peer {
+            println!("  {kind:<24} {count}");
+        }
+        println!();
+        println!("route-monitoring messages per peer_ip (top 20):");
+        let mut per_peer: Vec<(&IpAddr, &usize)> = self.by_peer_rm.iter().collect();
+        per_peer.sort_by(|a, b| b.1.cmp(a.1));
+        for (peer, count) in per_peer.iter().take(20) {
+            println!("  {peer:<40} {count}");
+        }
+        println!();
+        println!("End-of-RIB markers observed: {}", self.end_of_rib);
+    }
+}
+
+fn print_message(msg: &BmpMessage, stats: &mut Stats) {
+    let peer_type_name = msg.per_peer_header.as_ref().map(|pph| match pph.peer_type {
+        BmpPeerType::Global => "Global",
+        BmpPeerType::RD => "RD",
+        BmpPeerType::Local => "Local",
+        BmpPeerType::LocalRib => "LocalRib (RFC 9069)",
+    });
+    if let Some(name) = peer_type_name {
+        *stats.by_peer_type.entry(name).or_insert(0) += 1;
+    }
+
+    match &msg.message_body {
+        BmpMessageBody::InitiationMessage(_) => {
+            *stats.by_type.entry("InitiationMessage").or_insert(0) += 1;
+            println!("{:>6}  INITIATION", stats.msg_count);
+        }
+        BmpMessageBody::TerminationMessage(_) => {
+            *stats.by_type.entry("TerminationMessage").or_insert(0) += 1;
+            println!("{:>6}  TERMINATION", stats.msg_count);
+        }
+        BmpMessageBody::PeerUpNotification(_) => {
+            *stats.by_type.entry("PeerUpNotification").or_insert(0) += 1;
+            if let Some(pph) = &msg.per_peer_header {
+                println!(
+                    "{:>6}  PEER_UP peer_ip={} peer_asn={} type={}",
+                    stats.msg_count,
+                    pph.peer_ip,
+                    pph.peer_asn,
+                    peer_type_name.unwrap_or("?")
+                );
+            }
+        }
+        BmpMessageBody::PeerDownNotification(_) => {
+            *stats.by_type.entry("PeerDownNotification").or_insert(0) += 1;
+            if let Some(pph) = &msg.per_peer_header {
+                println!(
+                    "{:>6}  PEER_DOWN peer_ip={} type={}",
+                    stats.msg_count,
+                    pph.peer_ip,
+                    peer_type_name.unwrap_or("?")
+                );
+            }
+        }
+        BmpMessageBody::RouteMonitoring(rm) => {
+            *stats.by_type.entry("RouteMonitoring").or_insert(0) += 1;
+            if rm.is_end_of_rib() {
+                stats.end_of_rib += 1;
+            }
+            if let Some(pph) = &msg.per_peer_header {
+                *stats.by_peer_rm.entry(pph.peer_ip).or_insert(0) += 1;
+                // Terse per-frame log; full bgp update dump would be
+                // too verbose for a 1M-route file. Flip to `{:?}` on
+                // the inner BGP message for deep inspection.
+                println!(
+                    "{:>6}  ROUTE_MONITORING peer_ip={} type={} eor={}",
+                    stats.msg_count,
+                    pph.peer_ip,
+                    peer_type_name.unwrap_or("?"),
+                    rm.is_end_of_rib()
+                );
+            }
+        }
+        BmpMessageBody::RouteMirroring(_) => {
+            *stats.by_type.entry("RouteMirroring").or_insert(0) += 1;
+            println!("{:>6}  ROUTE_MIRRORING", stats.msg_count);
+        }
+        BmpMessageBody::StatsReport(_) => {
+            *stats.by_type.entry("StatsReport").or_insert(0) += 1;
+            println!("{:>6}  STATS_REPORT", stats.msg_count);
+        }
+    }
+}

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -73,11 +73,20 @@ impl RouteController {
 
         let shutdown_token = CancellationToken::new();
         let nexthops = FibProgrammer::open_nexthops(bpffs_root)?;
+        let fib_v4 = FibProgrammer::open_fib_v4(bpffs_root)?;
+        let fib_v6 = FibProgrammer::open_fib_v6(bpffs_root)?;
+        let ecmp_groups = FibProgrammer::open_ecmp_groups(bpffs_root)?;
 
         let (resolver, events_rx, neigh_handle) =
             NetlinkNeighborResolver::new(shutdown_token.clone());
-        let (programmer, prog_handle) =
-            FibProgrammer::new(nexthops, events_rx, shutdown_token.clone());
+        let (programmer, prog_handle) = FibProgrammer::new(
+            nexthops,
+            fib_v4,
+            fib_v6,
+            ecmp_groups,
+            events_rx,
+            shutdown_token.clone(),
+        );
 
         let resolver_task = runtime.spawn(async move {
             if let Err(e) = resolver.run().await {

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -19,6 +19,7 @@
 
 #![cfg(target_os = "linux")]
 
+use std::net::SocketAddr;
 use std::path::Path;
 use std::time::Duration;
 
@@ -29,6 +30,7 @@ use tracing::{info, warn};
 
 use crate::fib::netlink_neigh::{NeighborResolveHandle, NetlinkNeighborResolver};
 use crate::fib::programmer::{FibProgrammer, FibProgrammerHandle, ProgrammerError};
+use crate::fib::route_source_bmp::BmpStation;
 
 /// Grace period for tasks to drain after `cancel()` fires. Netlink
 /// reader and programmer should both unwind well within this.
@@ -58,12 +60,21 @@ pub struct RouteController {
 impl RouteController {
     /// Build and start the controller. `bpffs_root` is the same
     /// `global.bpffs_root` path the loader pins maps under; the
-    /// programmer opens `NEXTHOPS` from
-    /// `<bpffs_root>/fast-path/maps/NEXTHOPS`.
-    pub fn start(bpffs_root: &Path) -> Result<Self, ControllerError> {
+    /// programmer opens each map from its corresponding pin.
+    ///
+    /// `bmp_listen` is `Some(addr:port)` when the operator configured
+    /// `route-source bmp <addr>:<port>`; the controller then spawns
+    /// the BmpStation as a third task alongside the resolver + programmer.
+    /// `None` runs without a live route source — useful for test
+    /// harnesses that drive the programmer directly via its
+    /// `FibProgrammerHandle`.
+    pub fn start(
+        bpffs_root: &Path,
+        bmp_listen: Option<SocketAddr>,
+    ) -> Result<Self, ControllerError> {
         // Dedicated runtime. `worker_threads(2)` keeps task count to
-        // what Phase 2 + 3 actually need; larger worker counts buy
-        // nothing because the resolver + programmer aren't CPU-bound.
+        // what Phase 3 actually needs; the resolver, programmer, and
+        // BMP station are all I/O-bound so CPU is never the limit.
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .worker_threads(2)
             .enable_all()
@@ -98,15 +109,34 @@ impl RouteController {
         });
         let programmer_task = runtime.spawn(async move { programmer.run().await });
 
-        info!(
-            "RouteController started: NetlinkNeighborResolver + FibProgrammer spawned \
-             on dedicated 2-thread tokio runtime"
-        );
+        let mut tasks = vec![resolver_task, programmer_task];
+
+        // Spawn BmpStation iff the operator asked for `route-source bmp`.
+        // Without that, the programmer still works — test harnesses
+        // drive it directly via its handle — but no live routes flow in.
+        if let Some(addr) = bmp_listen {
+            let station = BmpStation::new(addr, prog_handle.clone(), shutdown_token.clone());
+            let bmp_task = runtime.spawn(async move {
+                if let Err(e) = station.run().await {
+                    warn!(error = %e, "BmpStation task exited with error");
+                }
+            });
+            tasks.push(bmp_task);
+            info!(
+                bmp_addr = %addr,
+                "RouteController started: NetlinkNeighborResolver + FibProgrammer + BmpStation"
+            );
+        } else {
+            info!(
+                "RouteController started: NetlinkNeighborResolver + FibProgrammer \
+                 (no BmpStation — `route-source` not configured)"
+            );
+        }
 
         Ok(Self {
             runtime: Some(runtime),
             shutdown_token,
-            tasks: vec![resolver_task, programmer_task],
+            tasks,
             neigh_handle,
             prog_handle,
         })

--- a/crates/modules/fast-path/src/fib/mod.rs
+++ b/crates/modules/fast-path/src/fib/mod.rs
@@ -20,6 +20,9 @@ pub mod netlink_neigh;
 #[cfg(target_os = "linux")]
 pub mod programmer;
 
+#[cfg(target_os = "linux")]
+pub mod route_source_bmp;
+
 pub use types::{
     EcmpGroup, FibValue, FpFibCfg, NexthopEntry, ECMP_NH_UNUSED, FIB_KIND_ECMP, FIB_KIND_SINGLE,
     MAX_ECMP_PATHS, NH_FAMILY_V4, NH_FAMILY_V6, NH_STATE_FAILED, NH_STATE_INCOMPLETE,

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -241,11 +241,11 @@ struct RouteRecord {
 }
 
 /// Per-ECMP-group state. Refcount lets many prefixes share one
-/// group. `signature` is the dedup key and mirrors the BPF-side
-/// `EcmpGroup` value's `nh_idx + hash_mode`.
+/// group. The `id` is always the HashMap key we found this record
+/// under; no separate `id` field since we only ever look it up by
+/// that key.
 #[derive(Debug)]
 struct EcmpRecord {
-    id: EcmpGroupId,
     refcount: u32,
     /// Sorted `NexthopId`s + hash_mode. Sorting gives a canonical
     /// signature so `{NH1, NH2}` and `{NH2, NH1}` dedup to the same
@@ -935,16 +935,6 @@ impl FibProgrammer {
 
     // --- FIB map ops ---
 
-    /// Is this a default route (0.0.0.0/0 or ::/0)? Default-route
-    /// replaces use the grace-period reclaim path to avoid a window
-    /// where traffic falls off the FIB.
-    fn is_default_route(prefix: &IpPrefix) -> bool {
-        matches!(
-            prefix,
-            IpPrefix::V4 { prefix_len: 0, .. } | IpPrefix::V6 { prefix_len: 0, .. }
-        )
-    }
-
     fn write_fib_entry(
         &mut self,
         prefix: &IpPrefix,
@@ -1046,7 +1036,6 @@ impl FibProgrammer {
         self.ecmp_by_id.insert(
             id,
             EcmpRecord {
-                id,
                 refcount: 1,
                 nh_ids_sorted: signature.nh_ids_sorted,
                 hash_mode,

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -1,54 +1,102 @@
-//! FibProgrammer — owns the `NEXTHOPS` seqlock write path and the
-//! userspace-side IP-to-NexthopId mapping.
+//! FibProgrammer — owns the BPF FIB write path (NEXTHOPS seqlock,
+//! FIB_V4 / FIB_V6 LPM tries, ECMP_GROUPS dedup) and the userspace
+//! mirror state.
 //!
-//! **Phase 2 scope: neighbor side only.** The programmer registers
-//! nexthop IPs (via [`FibProgrammerHandle::register_nexthop`]),
-//! allocates `NexthopId`s with refcount + free-list recycling, and
-//! writes `NEXTHOPS[id]` under the seqlock discipline whenever a
-//! [`NeighEvent`] arrives. Route ingestion (FIB_V4 / FIB_V6 writes,
-//! ECMP group dedup, PeerUp/PeerDown, Resync / InitiationComplete)
-//! lands in Phase 3 when the BMP station joins.
+//! **Phase 3 scope: full route ingestion.** Phase 2 built the
+//! neighbor side: register nexthop IPs, seqlock-write `NEXTHOPS[id]`
+//! on `NeighEvent`. Phase 3 adds route ingestion from
+//! [`RouteEvent`]s:
+//!   - `Add` / `Del`: write / remove FIB_V4 / FIB_V6 entries,
+//!     allocating nexthop IDs and ECMP groups as needed.
+//!   - `PeerUp` / `PeerDown`: track which peer announced which
+//!     routes; withdraw everything on `PeerDown`.
+//!   - `Resync`: mark every mirrored route "not-seen-this-session";
+//!     live `Add` events clear the mark as they re-arrive.
+//!   - `InitiationComplete`: GC every still-unmarked route
+//!     (they were in the BPF maps from before the reconnect but
+//!     bird didn't re-announce → stale).
+//!
+//! ECMP groups are deduplicated by a sorted-NH-id signature so one
+//! set of upstream transits announcing 200K prefixes allocates one
+//! group, not 200K.
+//!
+//! Default-route (0.0.0.0/0 and ::/0) replacement is handled specially:
+//! allocate the new value first, atomically overwrite the trie entry
+//! (8 bytes, single `Array::set` syscall), then reclaim the old
+//! nexthop / group IDs after a 100 ms grace period that covers any
+//! in-flight XDP program invocation holding a stale pointer.
 //!
 //! Lifecycle:
-//!   1. [`FibProgrammer::open`] opens `NEXTHOPS` from the bpffs pin
-//!      (independent kernel-map reference from the loader's `Ebpf`
-//!      instance; both point at the same kernel object).
-//!   2. [`FibProgrammer::new`] constructs the programmer with the
-//!      NeighEvent input channel and returns a
+//!   1. [`FibProgrammer::open_nexthops`] etc. open each map from its
+//!      bpffs pin (independent kernel-map references from the
+//!      loader's `aya::Ebpf` instance; both point at the same
+//!      kernel objects).
+//!   2. [`FibProgrammer::new`] constructs the programmer with all
+//!      three map handles + the NeighEvent input channel, returns a
 //!      [`FibProgrammerHandle`] for out-of-band commands.
 //!   3. [`FibProgrammer::run`] is the async task: `select!`s over
-//!      NeighEvents, Commands, and shutdown.
+//!      NeighEvents, Commands, the default-route reclaim tick, and
+//!      shutdown.
 //!
-//! All state lives inside the run task — no mutex on the hot path.
-//! Commands are serialized through a command mpsc; replies travel
-//! back via oneshot channels.
+//! All mirror state lives inside the run task — no mutex on the hot
+//! path. Commands are serialized through a command mpsc; replies
+//! travel back via oneshot channels.
 
 #![cfg(target_os = "linux")]
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
 use std::path::Path;
+use std::time::{Duration, Instant};
 
-use aya::maps::{Array, Map, MapData};
+use aya::maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, Map, MapData};
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use packetframe_common::fib::NeighEvent;
+use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, RouteEvent};
 
 use crate::fib::types::{
-    NexthopEntry, NH_FAMILY_V4, NH_FAMILY_V6, NH_STATE_FAILED, NH_STATE_INCOMPLETE,
-    NH_STATE_RESOLVED,
+    EcmpGroup, FibValue, NexthopEntry, ECMP_NH_UNUSED, MAX_ECMP_PATHS, NH_FAMILY_V4, NH_FAMILY_V6,
+    NH_STATE_FAILED, NH_STATE_INCOMPLETE, NH_STATE_RESOLVED,
 };
 use crate::pin;
 
-/// Command queue capacity. Commands are rare (one per route add/del
-/// in Phase 3; test harness in Phase 2); 256 is generous.
-const COMMAND_CAPACITY: usize = 256;
+/// Command queue capacity. Route events dominate: one per prefix
+/// add/del during a BGP convergence storm. 8192 absorbs 8 K-route
+/// bursts without backpressure; sustained bursts apply backpressure
+/// to the BMP reader which is correct.
+const COMMAND_CAPACITY: usize = 8_192;
 
 /// Capped by `NEXTHOPS_MAX_ENTRIES` in bpf/src/maps.rs. Keep in sync
 /// if either side changes.
 pub const NEXTHOPS_CAP: u32 = 8_192;
+
+/// Capped by `FIB_V4_MAX_ENTRIES` in bpf/src/maps.rs.
+pub const FIB_V4_CAP: u32 = 2_097_152;
+
+/// Capped by `FIB_V6_MAX_ENTRIES` in bpf/src/maps.rs.
+pub const FIB_V6_CAP: u32 = 1_048_576;
+
+/// Capped by `ECMP_GROUPS_MAX_ENTRIES` in bpf/src/maps.rs.
+pub const ECMP_GROUPS_CAP: u32 = 1_024;
+
+/// Default-route (0.0.0.0/0 and ::/0) ID-reclaim grace period. An
+/// atomic `FibValue` overwrite is instantaneous from the BPF
+/// program's perspective, but a program invocation in flight at the
+/// overwrite moment may still be reading the old nexthop / ECMP
+/// group. 100 ms is 4 orders of magnitude longer than any realistic
+/// XDP pass, short enough that the free-list doesn't starve under
+/// flap. Enforced via the reclaim queue drained every tick inside
+/// the run loop.
+pub const DEFAULT_ROUTE_GRACE: Duration = Duration::from_millis(100);
+
+/// How often the run loop checks the reclaim queue. Tight enough
+/// to free IDs promptly after the grace period; loose enough not to
+/// burn CPU. The select!'s other arms will still drive progress;
+/// this is just a backstop.
+const RECLAIM_TICK: Duration = Duration::from_millis(50);
 
 /// `NexthopId` is an index into the `NEXTHOPS` BPF array. Stable
 /// once assigned (via refcount/free-list recycling) so FIB_V4 / FIB_V6
@@ -56,11 +104,25 @@ pub const NEXTHOPS_CAP: u32 = 8_192;
 /// neighbor changes.
 pub type NexthopId = u32;
 
+/// `EcmpGroupId` is an index into the `ECMP_GROUPS` BPF array.
+/// Allocated with refcount + free-list + signature-based dedup so
+/// N prefixes sharing the same nexthop set + hash mode all point
+/// at one group.
+pub type EcmpGroupId = u32;
+
 /// Errors surfaced through the programmer's command replies.
 #[derive(Debug, thiserror::Error)]
 pub enum ProgrammerError {
     #[error("nexthop table full (cap {0}); cannot allocate")]
     Full(u32),
+    #[error("FIB_V4 table full (cap {0}); dropping prefix")]
+    FibV4Full(u32),
+    #[error("FIB_V6 table full (cap {0}); dropping prefix")]
+    FibV6Full(u32),
+    #[error("ECMP group table full (cap {0}); dropping multi-path route")]
+    EcmpGroupsFull(u32),
+    #[error("ECMP group would exceed MAX_ECMP_PATHS ({0})")]
+    EcmpGroupTooWide(usize),
     #[error("BPF map write failed: {0}")]
     MapWrite(String),
     #[error("BPF map open failed: {0}")]
@@ -116,6 +178,19 @@ impl FibProgrammerHandle {
             .map_err(|_| ProgrammerError::Shutdown)?;
         rx.await.map_err(|_| ProgrammerError::Shutdown)?
     }
+
+    /// Apply a [`RouteEvent`] from the RouteSource. Issues the
+    /// corresponding writes to FIB_V4 / FIB_V6 / NEXTHOPS /
+    /// ECMP_GROUPS and updates the userspace mirror. Awaits
+    /// completion; errors surface through the reply channel.
+    pub async fn apply_route_event(&self, event: RouteEvent) -> Result<(), ProgrammerError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(Command::ApplyRouteEvent { event, reply: tx })
+            .await
+            .map_err(|_| ProgrammerError::Shutdown)?;
+        rx.await.map_err(|_| ProgrammerError::Shutdown)?
+    }
 }
 
 enum Command {
@@ -125,6 +200,13 @@ enum Command {
     },
     UnregisterNexthop {
         ip: IpAddr,
+        reply: oneshot::Sender<Result<(), ProgrammerError>>,
+    },
+    /// Apply a [`RouteEvent`] from the RouteSource. The reply fires
+    /// after the FIB / NEXTHOPS / ECMP_GROUPS writes complete; on
+    /// capacity / map-write failures the error surfaces through it.
+    ApplyRouteEvent {
+        event: RouteEvent,
         reply: oneshot::Sender<Result<(), ProgrammerError>>,
     },
 }
@@ -139,23 +221,109 @@ struct NexthopRecord {
     resolved: Option<(u32, [u8; 6])>,
 }
 
+/// Per-route state tracked in userspace. The `fib_value` lets
+/// us unwind the BPF map entry on Del without a read-modify-write
+/// dance; `nexthop_ips` lets us decrement refcounts on the right
+/// nexthops; `peer_id` lets PeerDown walk by peer.
+#[derive(Debug)]
+struct RouteRecord {
+    peer_id: PeerId,
+    fib_value: FibValue,
+    /// Nexthop IPs this route references. On Del we unregister each
+    /// (decrement refcount, free NexthopId when it hits zero).
+    nexthop_ips: Vec<IpAddr>,
+    /// Resync-reconcile bookkeeping: true when this route was
+    /// freshly Add'd (or refreshed) after the most recent Resync;
+    /// false when it was inherited from a prior session and hasn't
+    /// been re-announced yet. InitiationComplete GCs routes whose
+    /// flag is still false.
+    seen_this_session: bool,
+}
+
+/// Per-ECMP-group state. Refcount lets many prefixes share one
+/// group. `signature` is the dedup key and mirrors the BPF-side
+/// `EcmpGroup` value's `nh_idx + hash_mode`.
+#[derive(Debug)]
+struct EcmpRecord {
+    id: EcmpGroupId,
+    refcount: u32,
+    /// Sorted `NexthopId`s + hash_mode. Sorting gives a canonical
+    /// signature so `{NH1, NH2}` and `{NH2, NH1}` dedup to the same
+    /// group regardless of BGP announcement order.
+    nh_ids_sorted: Vec<NexthopId>,
+    hash_mode: u8,
+}
+
+/// Canonical ECMP dedup key. `Vec<NexthopId>` is already sorted
+/// by construction in `compute_signature`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct EcmpSignature {
+    nh_ids_sorted: Vec<NexthopId>,
+    hash_mode: u8,
+}
+
+/// Reclaim queue entry for the default-route replace-by-swap path.
+/// `release_at` is the earliest instant at which it's safe to free
+/// the ID — an in-flight XDP program invocation may have read the
+/// old FibValue and be about to dereference this nexthop / group.
+#[derive(Debug)]
+struct PendingReclaim {
+    release_at: Instant,
+    kind: ReclaimKind,
+}
+
+#[derive(Debug)]
+enum ReclaimKind {
+    /// Free a nexthop ID. Triggers `unregister` logic (refcount
+    /// decrement; slot tombstoned + ID freed when refcount hits 0).
+    Nexthop(IpAddr),
+    /// Free an ECMP group ID. Decrements refcount; frees slot when 0.
+    Ecmp(EcmpGroupId),
+}
+
 pub struct FibProgrammer {
     nexthops: Array<MapData, NexthopEntry>,
+    fib_v4: LpmTrie<MapData, [u8; 4], FibValue>,
+    fib_v6: LpmTrie<MapData, [u8; 16], FibValue>,
+    ecmp_groups: Array<MapData, EcmpGroup>,
+
     events_rx: mpsc::Receiver<NeighEvent>,
     cmd_rx: mpsc::Receiver<Command>,
     shutdown: CancellationToken,
 
-    // State owned by the run task — no locking needed.
+    // --- Nexthop state (Phase 2) ---
     by_ip: HashMap<IpAddr, NexthopRecord>,
-    /// Reverse index: NexthopId → IpAddr. Rebuild-able by walking
-    /// `by_ip`; held separately so NeighEvent → NexthopId lookup is
-    /// O(1) instead of scanning every record.
+    /// Reverse index: NexthopId → IpAddr. Held separately so
+    /// NeighEvent → NexthopId lookup is O(1) instead of scanning
+    /// every record.
     by_id: HashMap<NexthopId, IpAddr>,
     /// Latest seq value written per ID. Seqlock discipline requires
     /// each write to go odd-then-even from the current value.
     seq_by_id: HashMap<NexthopId, u32>,
     free_ids: Vec<NexthopId>,
     next_id: NexthopId,
+
+    // --- Route state (Phase 3) ---
+    /// Prefix → route record. Separate v4 / v6 maps so the key is
+    /// the raw `(addr, prefix_len)` tuple (which is `Hash`) rather
+    /// than the enum wrapper.
+    routes_v4: HashMap<([u8; 4], u8), RouteRecord>,
+    routes_v6: HashMap<([u8; 16], u8), RouteRecord>,
+    /// Per-peer index for O(1) PeerDown traversal. Values are keys
+    /// into `routes_v4` / `routes_v6` — the bool discriminates.
+    /// `true` = v4, `false` = v6.
+    routes_by_peer: HashMap<PeerId, HashSet<(bool, [u8; 16], u8)>>,
+
+    // --- ECMP state (Phase 3) ---
+    /// Dedup map: signature → group ID.
+    ecmp_by_signature: HashMap<EcmpSignature, EcmpGroupId>,
+    /// Per-group record: refcount, canonical NH set, hash mode.
+    ecmp_by_id: HashMap<EcmpGroupId, EcmpRecord>,
+    free_ecmp_ids: Vec<EcmpGroupId>,
+    next_ecmp_id: EcmpGroupId,
+
+    // --- Default-route reclaim queue (Phase 3) ---
+    reclaim_queue: VecDeque<PendingReclaim>,
 }
 
 impl FibProgrammer {
@@ -173,12 +341,51 @@ impl FibProgrammer {
             .map_err(|e| ProgrammerError::MapOpen(format!("Array::try_from(NEXTHOPS): {e}")))
     }
 
-    /// Construct the programmer. `events_rx` is the receiver half of
-    /// the channel the `NetlinkNeighborResolver` writes into; the
-    /// returned handle is what the route ingestion layer (Phase 3)
-    /// or a test harness (Phase 2) uses to register nexthop IPs.
+    /// Open the `FIB_V4` LPM trie from its bpffs pin.
+    pub fn open_fib_v4(
+        bpffs_root: &Path,
+    ) -> Result<LpmTrie<MapData, [u8; 4], FibValue>, ProgrammerError> {
+        let pin_path = pin::map_path(bpffs_root, "FIB_V4");
+        let map_data = MapData::from_pin(&pin_path)
+            .map_err(|e| ProgrammerError::MapOpen(format!("FIB_V4 pin open: {e}")))?;
+        let map = Map::LpmTrie(map_data);
+        LpmTrie::try_from(map)
+            .map_err(|e| ProgrammerError::MapOpen(format!("LpmTrie::try_from(FIB_V4): {e}")))
+    }
+
+    /// Open the `FIB_V6` LPM trie from its bpffs pin.
+    pub fn open_fib_v6(
+        bpffs_root: &Path,
+    ) -> Result<LpmTrie<MapData, [u8; 16], FibValue>, ProgrammerError> {
+        let pin_path = pin::map_path(bpffs_root, "FIB_V6");
+        let map_data = MapData::from_pin(&pin_path)
+            .map_err(|e| ProgrammerError::MapOpen(format!("FIB_V6 pin open: {e}")))?;
+        let map = Map::LpmTrie(map_data);
+        LpmTrie::try_from(map)
+            .map_err(|e| ProgrammerError::MapOpen(format!("LpmTrie::try_from(FIB_V6): {e}")))
+    }
+
+    /// Open the `ECMP_GROUPS` array from its bpffs pin.
+    pub fn open_ecmp_groups(
+        bpffs_root: &Path,
+    ) -> Result<Array<MapData, EcmpGroup>, ProgrammerError> {
+        let pin_path = pin::map_path(bpffs_root, "ECMP_GROUPS");
+        let map_data = MapData::from_pin(&pin_path)
+            .map_err(|e| ProgrammerError::MapOpen(format!("ECMP_GROUPS pin open: {e}")))?;
+        let map = Map::Array(map_data);
+        Array::try_from(map)
+            .map_err(|e| ProgrammerError::MapOpen(format!("Array::try_from(ECMP_GROUPS): {e}")))
+    }
+
+    /// Construct the programmer with all four BPF map handles. Opens
+    /// are done by the caller (via [`open_nexthops`](Self::open_nexthops) etc.)
+    /// so test harnesses can pass synthetic maps. `events_rx` is the
+    /// NeighborResolver's output channel.
     pub fn new(
         nexthops: Array<MapData, NexthopEntry>,
+        fib_v4: LpmTrie<MapData, [u8; 4], FibValue>,
+        fib_v6: LpmTrie<MapData, [u8; 16], FibValue>,
+        ecmp_groups: Array<MapData, EcmpGroup>,
         events_rx: mpsc::Receiver<NeighEvent>,
         shutdown: CancellationToken,
     ) -> (Self, FibProgrammerHandle) {
@@ -186,6 +393,9 @@ impl FibProgrammer {
         (
             Self {
                 nexthops,
+                fib_v4,
+                fib_v6,
+                ecmp_groups,
                 events_rx,
                 cmd_rx,
                 shutdown,
@@ -194,14 +404,28 @@ impl FibProgrammer {
                 seq_by_id: HashMap::new(),
                 free_ids: Vec::new(),
                 next_id: 0,
+                routes_v4: HashMap::new(),
+                routes_v6: HashMap::new(),
+                routes_by_peer: HashMap::new(),
+                ecmp_by_signature: HashMap::new(),
+                ecmp_by_id: HashMap::new(),
+                free_ecmp_ids: Vec::new(),
+                next_ecmp_id: 0,
+                reclaim_queue: VecDeque::new(),
             },
             FibProgrammerHandle { tx: cmd_tx },
         )
     }
 
-    /// Main event loop. Drains NeighEvents + Commands until shutdown.
+    /// Main event loop. Drains NeighEvents + Commands + the reclaim
+    /// queue tick until shutdown.
     pub async fn run(mut self) {
         info!("FibProgrammer running");
+        let mut reclaim_tick = interval(RECLAIM_TICK);
+        // `interval`'s first tick fires immediately; skip it so the
+        // first reclaim check lands one full period after startup.
+        reclaim_tick.tick().await;
+
         loop {
             tokio::select! {
                 _ = self.shutdown.cancelled() => {
@@ -212,9 +436,6 @@ impl FibProgrammer {
                     match evt {
                         Some(e) => self.on_neigh_event(e),
                         None => {
-                            // Resolver closed its sender; no more neigh
-                            // events will arrive. Continue to drain
-                            // commands until shutdown.
                             debug!("NeighEvent channel closed");
                         }
                     }
@@ -223,12 +444,12 @@ impl FibProgrammer {
                     match cmd {
                         Some(c) => self.on_command(c),
                         None => {
-                            // All handle clones dropped. Nothing will
-                            // issue new commands. Continue to drain
-                            // events until shutdown.
                             debug!("Command channel closed");
                         }
                     }
+                }
+                _ = reclaim_tick.tick() => {
+                    self.drain_reclaim_queue();
                 }
             }
         }
@@ -241,6 +462,9 @@ impl FibProgrammer {
             }
             Command::UnregisterNexthop { ip, reply } => {
                 let _ = reply.send(self.unregister(ip));
+            }
+            Command::ApplyRouteEvent { event, reply } => {
+                let _ = reply.send(self.on_route_event(event));
             }
         }
     }
@@ -449,5 +673,493 @@ impl FibProgrammer {
             .map_err(|e| ProgrammerError::MapWrite(format!("seqlock even-phase id={id}: {e}")))?;
         self.seq_by_id.insert(id, even);
         Ok(())
+    }
+
+    // --- Route event handling (Phase 3) ---------------------------------
+
+    fn on_route_event(&mut self, event: RouteEvent) -> Result<(), ProgrammerError> {
+        match event {
+            RouteEvent::PeerUp { peer_id, .. } => {
+                // PeerUp is informational for the programmer; we start
+                // tracking routes by peer_id as soon as the first
+                // RouteEvent::Add { peer_id } arrives. Nothing to do
+                // until then.
+                debug!(?peer_id, "PeerUp received");
+                Ok(())
+            }
+            RouteEvent::PeerDown { peer_id } => self.drop_routes_for_peer(peer_id),
+            RouteEvent::Add {
+                peer_id,
+                prefix,
+                nexthops,
+            } => self.add_route(peer_id, prefix, nexthops),
+            RouteEvent::Del { peer_id: _, prefix } => self.del_route(prefix),
+            RouteEvent::Resync => {
+                self.mark_all_unseen();
+                info!("Resync: all routes marked not-seen-this-session");
+                Ok(())
+            }
+            RouteEvent::InitiationComplete => {
+                let gc_count = self.gc_unseen();
+                info!(
+                    gc_count,
+                    "InitiationComplete: garbage-collected unseen routes"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    fn add_route(
+        &mut self,
+        peer_id: PeerId,
+        prefix: IpPrefix,
+        nexthops: Vec<IpAddr>,
+    ) -> Result<(), ProgrammerError> {
+        if nexthops.is_empty() {
+            // Empty nexthop set ⇒ refuse. BMP should never surface
+            // this for a non-withdraw; defensive.
+            return Ok(());
+        }
+
+        // Allocate nexthop IDs (bumps refcount on existing IPs).
+        let mut nh_ids: Vec<NexthopId> = Vec::with_capacity(nexthops.len());
+        let mut allocated_ips: Vec<IpAddr> = Vec::with_capacity(nexthops.len());
+        for ip in &nexthops {
+            match self.register(*ip) {
+                Ok(id) => {
+                    nh_ids.push(id);
+                    allocated_ips.push(*ip);
+                }
+                Err(e) => {
+                    // Unwind partial allocations so the error leaves
+                    // no lingering refcount state.
+                    for done in &allocated_ips {
+                        let _ = self.unregister(*done);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        let fib_value = if nh_ids.len() == 1 {
+            FibValue::single(nh_ids[0])
+        } else {
+            // ECMP group. hash_mode comes from FIB_CONFIG's default
+            // for now; per-group override is a Phase 3+ refinement
+            // once bird surfaces per-peer hash policy via community
+            // or similar.
+            let hash_mode = 5; // Mode 5 (5-tuple) — default from FIB_CONFIG.
+            match self.alloc_ecmp_group(&nh_ids, hash_mode) {
+                Ok(id) => FibValue::ecmp(id),
+                Err(e) => {
+                    // Unwind allocated nexthop refcounts.
+                    for ip in &allocated_ips {
+                        let _ = self.unregister(*ip);
+                    }
+                    return Err(e);
+                }
+            }
+        };
+
+        // Detect default-route replace: if a prior entry exists at
+        // this prefix, swap with grace-period reclaim. Otherwise,
+        // straight write + mirror insert.
+        let replace = self.lookup_mirror(&prefix).is_some();
+        if replace {
+            let old = self.remove_mirror(&prefix);
+            self.write_fib_entry(&prefix, fib_value)?;
+            if let Some(old_rec) = old {
+                self.enqueue_reclaim(old_rec);
+            }
+        } else {
+            self.write_fib_entry(&prefix, fib_value)?;
+        }
+
+        // Record in mirror.
+        let record = RouteRecord {
+            peer_id,
+            fib_value,
+            nexthop_ips: nexthops,
+            seen_this_session: true,
+        };
+        self.insert_mirror(prefix, record);
+        Ok(())
+    }
+
+    fn del_route(&mut self, prefix: IpPrefix) -> Result<(), ProgrammerError> {
+        let old = match self.remove_mirror(&prefix) {
+            Some(r) => r,
+            None => return Ok(()), // idempotent
+        };
+        self.delete_fib_entry(&prefix)?;
+        self.release_route_record(old);
+        Ok(())
+    }
+
+    /// Drop every route mirrored under `peer_id`. Called on PeerDown.
+    fn drop_routes_for_peer(&mut self, peer_id: PeerId) -> Result<(), ProgrammerError> {
+        let prefixes = match self.routes_by_peer.remove(&peer_id) {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+        let count = prefixes.len();
+        for (is_v4, addr, plen) in prefixes {
+            let prefix = if is_v4 {
+                let mut a = [0u8; 4];
+                a.copy_from_slice(&addr[..4]);
+                IpPrefix::V4 {
+                    addr: a,
+                    prefix_len: plen,
+                }
+            } else {
+                IpPrefix::V6 {
+                    addr,
+                    prefix_len: plen,
+                }
+            };
+            let rec = match self.remove_mirror_direct(&prefix) {
+                Some(r) => r,
+                None => continue,
+            };
+            if let Err(e) = self.delete_fib_entry(&prefix) {
+                warn!(?peer_id, ?prefix, error = %e, "FIB delete during PeerDown failed");
+            }
+            self.release_route_record(rec);
+        }
+        info!(?peer_id, count, "PeerDown: withdrew routes");
+        Ok(())
+    }
+
+    /// Mark every mirrored route as `seen_this_session = false`. Live
+    /// `Add` events clear the mark; `InitiationComplete` GCs what's
+    /// left.
+    fn mark_all_unseen(&mut self) {
+        for rec in self.routes_v4.values_mut() {
+            rec.seen_this_session = false;
+        }
+        for rec in self.routes_v6.values_mut() {
+            rec.seen_this_session = false;
+        }
+    }
+
+    /// GC routes still marked `seen_this_session = false` after an
+    /// InitiationComplete. Returns the count removed.
+    fn gc_unseen(&mut self) -> usize {
+        let mut unseen_v4: Vec<([u8; 4], u8)> = Vec::new();
+        for (k, r) in &self.routes_v4 {
+            if !r.seen_this_session {
+                unseen_v4.push(*k);
+            }
+        }
+        let mut unseen_v6: Vec<([u8; 16], u8)> = Vec::new();
+        for (k, r) in &self.routes_v6 {
+            if !r.seen_this_session {
+                unseen_v6.push(*k);
+            }
+        }
+        let count = unseen_v4.len() + unseen_v6.len();
+        for (addr, plen) in unseen_v4 {
+            let p = IpPrefix::V4 {
+                addr,
+                prefix_len: plen,
+            };
+            let _ = self.del_route(p);
+        }
+        for (addr, plen) in unseen_v6 {
+            let p = IpPrefix::V6 {
+                addr,
+                prefix_len: plen,
+            };
+            let _ = self.del_route(p);
+        }
+        count
+    }
+
+    // --- Mirror ops ---
+
+    fn lookup_mirror(&self, prefix: &IpPrefix) -> Option<&RouteRecord> {
+        match prefix {
+            IpPrefix::V4 { addr, prefix_len } => self.routes_v4.get(&(*addr, *prefix_len)),
+            IpPrefix::V6 { addr, prefix_len } => self.routes_v6.get(&(*addr, *prefix_len)),
+        }
+    }
+
+    fn insert_mirror(&mut self, prefix: IpPrefix, record: RouteRecord) {
+        let peer_id = record.peer_id;
+        match prefix {
+            IpPrefix::V4 { addr, prefix_len } => {
+                self.routes_v4.insert((addr, prefix_len), record);
+                let mut padded = [0u8; 16];
+                padded[..4].copy_from_slice(&addr);
+                self.routes_by_peer
+                    .entry(peer_id)
+                    .or_default()
+                    .insert((true, padded, prefix_len));
+            }
+            IpPrefix::V6 { addr, prefix_len } => {
+                self.routes_v6.insert((addr, prefix_len), record);
+                self.routes_by_peer
+                    .entry(peer_id)
+                    .or_default()
+                    .insert((false, addr, prefix_len));
+            }
+        }
+    }
+
+    fn remove_mirror(&mut self, prefix: &IpPrefix) -> Option<RouteRecord> {
+        self.remove_mirror_direct(prefix)
+    }
+
+    fn remove_mirror_direct(&mut self, prefix: &IpPrefix) -> Option<RouteRecord> {
+        let (rec, peer_key) = match prefix {
+            IpPrefix::V4 { addr, prefix_len } => {
+                let rec = self.routes_v4.remove(&(*addr, *prefix_len))?;
+                let mut padded = [0u8; 16];
+                padded[..4].copy_from_slice(addr);
+                (rec, (true, padded, *prefix_len))
+            }
+            IpPrefix::V6 { addr, prefix_len } => {
+                let rec = self.routes_v6.remove(&(*addr, *prefix_len))?;
+                (rec, (false, *addr, *prefix_len))
+            }
+        };
+        if let Some(set) = self.routes_by_peer.get_mut(&rec.peer_id) {
+            set.remove(&peer_key);
+            if set.is_empty() {
+                self.routes_by_peer.remove(&rec.peer_id);
+            }
+        }
+        Some(rec)
+    }
+
+    // --- FIB map ops ---
+
+    /// Is this a default route (0.0.0.0/0 or ::/0)? Default-route
+    /// replaces use the grace-period reclaim path to avoid a window
+    /// where traffic falls off the FIB.
+    fn is_default_route(prefix: &IpPrefix) -> bool {
+        matches!(
+            prefix,
+            IpPrefix::V4 { prefix_len: 0, .. } | IpPrefix::V6 { prefix_len: 0, .. }
+        )
+    }
+
+    fn write_fib_entry(
+        &mut self,
+        prefix: &IpPrefix,
+        value: FibValue,
+    ) -> Result<(), ProgrammerError> {
+        match prefix {
+            IpPrefix::V4 { addr, prefix_len } => {
+                if self.routes_v4.len() as u32 >= FIB_V4_CAP
+                    && !self.routes_v4.contains_key(&(*addr, *prefix_len))
+                {
+                    return Err(ProgrammerError::FibV4Full(FIB_V4_CAP));
+                }
+                let key = LpmKey::new(u32::from(*prefix_len), *addr);
+                self.fib_v4
+                    .insert(&key, value, 0)
+                    .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V4 insert: {e}")))
+            }
+            IpPrefix::V6 { addr, prefix_len } => {
+                if self.routes_v6.len() as u32 >= FIB_V6_CAP
+                    && !self.routes_v6.contains_key(&(*addr, *prefix_len))
+                {
+                    return Err(ProgrammerError::FibV6Full(FIB_V6_CAP));
+                }
+                let key = LpmKey::new(u32::from(*prefix_len), *addr);
+                self.fib_v6
+                    .insert(&key, value, 0)
+                    .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V6 insert: {e}")))
+            }
+        }
+    }
+
+    fn delete_fib_entry(&mut self, prefix: &IpPrefix) -> Result<(), ProgrammerError> {
+        match prefix {
+            IpPrefix::V4 { addr, prefix_len } => {
+                let key = LpmKey::new(u32::from(*prefix_len), *addr);
+                self.fib_v4
+                    .remove(&key)
+                    .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V4 remove: {e}")))
+            }
+            IpPrefix::V6 { addr, prefix_len } => {
+                let key = LpmKey::new(u32::from(*prefix_len), *addr);
+                self.fib_v6
+                    .remove(&key)
+                    .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V6 remove: {e}")))
+            }
+        }
+    }
+
+    // --- ECMP group ops ---
+
+    fn alloc_ecmp_group(
+        &mut self,
+        nh_ids: &[NexthopId],
+        hash_mode: u8,
+    ) -> Result<EcmpGroupId, ProgrammerError> {
+        if nh_ids.len() > MAX_ECMP_PATHS {
+            return Err(ProgrammerError::EcmpGroupTooWide(nh_ids.len()));
+        }
+        let signature = Self::compute_signature(nh_ids, hash_mode);
+        if let Some(existing) = self.ecmp_by_signature.get(&signature) {
+            let id = *existing;
+            if let Some(rec) = self.ecmp_by_id.get_mut(&id) {
+                rec.refcount += 1;
+            }
+            return Ok(id);
+        }
+        // Allocate a fresh group ID.
+        let id = match self.free_ecmp_ids.pop() {
+            Some(id) => id,
+            None => {
+                if self.next_ecmp_id >= ECMP_GROUPS_CAP {
+                    return Err(ProgrammerError::EcmpGroupsFull(ECMP_GROUPS_CAP));
+                }
+                let id = self.next_ecmp_id;
+                self.next_ecmp_id += 1;
+                id
+            }
+        };
+        // Write into the BPF map.
+        let mut nh_idx = [ECMP_NH_UNUSED; MAX_ECMP_PATHS];
+        for (i, nh_id) in signature.nh_ids_sorted.iter().enumerate() {
+            nh_idx[i] = *nh_id;
+        }
+        let group = EcmpGroup {
+            hash_mode,
+            nh_count: signature.nh_ids_sorted.len() as u8,
+            _pad: [0; 2],
+            nh_idx,
+        };
+        if let Err(e) = self.ecmp_groups.set(id, group, 0) {
+            // Return ID to free-list and surface the error.
+            self.free_ecmp_ids.push(id);
+            return Err(ProgrammerError::MapWrite(format!(
+                "ECMP_GROUPS set id={id}: {e}"
+            )));
+        }
+        // Record in mirror.
+        self.ecmp_by_signature.insert(signature.clone(), id);
+        self.ecmp_by_id.insert(
+            id,
+            EcmpRecord {
+                id,
+                refcount: 1,
+                nh_ids_sorted: signature.nh_ids_sorted,
+                hash_mode,
+            },
+        );
+        Ok(id)
+    }
+
+    fn free_ecmp_group(&mut self, id: EcmpGroupId) {
+        let rec = match self.ecmp_by_id.get_mut(&id) {
+            Some(r) => r,
+            None => return,
+        };
+        rec.refcount = rec.refcount.saturating_sub(1);
+        if rec.refcount > 0 {
+            return;
+        }
+        // Fully freed — remove from mirror, push ID to free-list,
+        // tombstone the BPF slot.
+        let signature = EcmpSignature {
+            nh_ids_sorted: rec.nh_ids_sorted.clone(),
+            hash_mode: rec.hash_mode,
+        };
+        self.ecmp_by_signature.remove(&signature);
+        self.ecmp_by_id.remove(&id);
+        self.free_ecmp_ids.push(id);
+        let tombstone = EcmpGroup {
+            hash_mode: 0,
+            nh_count: 0,
+            _pad: [0; 2],
+            nh_idx: [ECMP_NH_UNUSED; MAX_ECMP_PATHS],
+        };
+        if let Err(e) = self.ecmp_groups.set(id, tombstone, 0) {
+            warn!(id, error = %e, "ECMP_GROUPS tombstone write failed");
+        }
+    }
+
+    fn compute_signature(nh_ids: &[NexthopId], hash_mode: u8) -> EcmpSignature {
+        let mut sorted = nh_ids.to_vec();
+        sorted.sort_unstable();
+        EcmpSignature {
+            nh_ids_sorted: sorted,
+            hash_mode,
+        }
+    }
+
+    // --- Reclaim queue (default-route grace period) ---
+
+    fn enqueue_reclaim(&mut self, rec: RouteRecord) {
+        let release_at = Instant::now() + DEFAULT_ROUTE_GRACE;
+        match rec.fib_value.kind {
+            k if k == crate::fib::types::FIB_KIND_SINGLE => {
+                // Single nexthop: reclaim the nexthop IP after grace.
+                for ip in rec.nexthop_ips {
+                    self.reclaim_queue.push_back(PendingReclaim {
+                        release_at,
+                        kind: ReclaimKind::Nexthop(ip),
+                    });
+                }
+            }
+            k if k == crate::fib::types::FIB_KIND_ECMP => {
+                // ECMP: reclaim the group (which cascades to its NHs
+                // when refcount hits zero) plus the explicit NH IPs.
+                self.reclaim_queue.push_back(PendingReclaim {
+                    release_at,
+                    kind: ReclaimKind::Ecmp(rec.fib_value.idx),
+                });
+                for ip in rec.nexthop_ips {
+                    self.reclaim_queue.push_back(PendingReclaim {
+                        release_at,
+                        kind: ReclaimKind::Nexthop(ip),
+                    });
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn drain_reclaim_queue(&mut self) {
+        let now = Instant::now();
+        while let Some(entry) = self.reclaim_queue.front() {
+            if entry.release_at > now {
+                break;
+            }
+            let entry = self.reclaim_queue.pop_front().unwrap();
+            match entry.kind {
+                ReclaimKind::Nexthop(ip) => {
+                    let _ = self.unregister(ip);
+                }
+                ReclaimKind::Ecmp(id) => {
+                    self.free_ecmp_group(id);
+                }
+            }
+        }
+    }
+
+    /// Release the resources a RouteRecord refs: for non-default
+    /// prefixes, unwind immediately; for default routes, enqueue
+    /// a grace-delayed reclaim. Called from del_route +
+    /// drop_routes_for_peer.
+    fn release_route_record(&mut self, rec: RouteRecord) {
+        // For default-route replaces we route through enqueue_reclaim
+        // at the call site (add_route path). For straight deletes we
+        // can free immediately because the BPF LPM entry is already
+        // gone and no new lookup can land on these IDs.
+        match rec.fib_value.kind {
+            k if k == crate::fib::types::FIB_KIND_ECMP => {
+                self.free_ecmp_group(rec.fib_value.idx);
+            }
+            _ => {}
+        }
+        for ip in rec.nexthop_ips {
+            let _ = self.unregister(ip);
+        }
     }
 }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -1,0 +1,323 @@
+//! BMP station — the concrete `RouteSource` that receives bird's
+//! Loc-RIB (RFC 9069) over a BMP session and translates it into
+//! [`RouteEvent`]s delivered to the FibProgrammer.
+//!
+//! **RFC 7854 role:** bird is the BMP client, packetframe is the BMP
+//! station. Bird dials out to this listener; packetframe accepts.
+//! One connection at a time (bird only opens one); on disconnect we
+//! emit [`RouteEvent::Resync`] and re-accept.
+//!
+//! **Loc-RIB (RFC 9069):** bird's `monitoring rib local` emits
+//! route-monitoring messages with per-peer-type `LocalRib`
+//! (bgpkit-parser's `BmpPeerType::LocalRib`, wire value 3). We
+//! hash the per-peer header into an opaque [`PeerId`] so the
+//! programmer can scope withdraws; PeerDown for the Loc-RIB instance
+//! means bird's local best-path table is gone (unusual but possible).
+//!
+//! **Wire framing:** BMP's common header carries a 32-bit
+//! big-endian message length. Read 6 bytes, extract length, read
+//! `length - 6` bytes of body, hand the whole frame to
+//! `parse_bmp_msg`.
+//!
+//! **BGP UPDATE → RouteEvent translation:** `Elementor::bgp_to_elems`
+//! converts the UPDATE wrapped inside a RouteMonitoring message into
+//! per-prefix `BgpElem`s. Announces with a next_hop become
+//! `RouteEvent::Add { peer_id, prefix, nexthops: vec![next_hop] }`.
+//! Withdraws become `RouteEvent::Del`. ECMP at the BMP layer is
+//! unusual — bird's Loc-RIB surfaces one best path per prefix — but
+//! the FibProgrammer handles multi-nexthop routes anyway if that
+//! ever changes.
+
+#![cfg(target_os = "linux")]
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::net::SocketAddr;
+
+use bgpkit_parser::models::{ElemType, NetworkPrefix};
+use bgpkit_parser::parser::bmp::messages::*;
+use bgpkit_parser::parser::bmp::parse_bmp_msg;
+use bgpkit_parser::Elementor;
+use bytes::Bytes;
+use tokio::io::AsyncReadExt;
+use tokio::net::{TcpListener, TcpStream};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent, RouteSourceError};
+
+use crate::fib::programmer::FibProgrammerHandle;
+
+/// Cap on a single BMP message size. Per RFC 7854 §4.1 the
+/// `msg_length` is a 32-bit unsigned field; bird in practice emits
+/// far smaller messages. 1 MiB is comfortable headroom and cheap
+/// defense against a malformed stream claiming 4 GiB per frame.
+const MAX_BMP_MSG_SIZE: usize = 1024 * 1024;
+
+pub struct BmpStation {
+    listen_addr: SocketAddr,
+    prog_handle: FibProgrammerHandle,
+    shutdown: CancellationToken,
+}
+
+impl BmpStation {
+    pub fn new(
+        listen_addr: SocketAddr,
+        prog_handle: FibProgrammerHandle,
+        shutdown: CancellationToken,
+    ) -> Self {
+        Self {
+            listen_addr,
+            prog_handle,
+            shutdown,
+        }
+    }
+
+    /// Main loop: bind, accept, handle one connection at a time.
+    /// On disconnect (clean or error), emit Resync so the programmer
+    /// marks all mirrored routes unseen — the next `RouteEvent::Add`
+    /// storm from the reconnect clears the marks; InitiationComplete
+    /// (emitted by a quiescence timer inside `handle_connection`)
+    /// GCs whatever never reappeared.
+    pub async fn run(self) -> Result<(), RouteSourceError> {
+        let listener = TcpListener::bind(self.listen_addr)
+            .await
+            .map_err(|e| RouteSourceError::fatal(format!("bind {}: {e}", self.listen_addr)))?;
+        info!(addr = %self.listen_addr, "BMP station listening");
+
+        loop {
+            tokio::select! {
+                _ = self.shutdown.cancelled() => {
+                    info!("BmpStation shutdown requested");
+                    return Ok(());
+                }
+                accept = listener.accept() => {
+                    match accept {
+                        Ok((stream, addr)) => {
+                            info!(%addr, "BMP client connected");
+                            if let Err(e) = self.handle_connection(stream).await {
+                                warn!(error = %e, "BMP connection handler exited with error");
+                            } else {
+                                info!("BMP client disconnected cleanly");
+                            }
+                            // Resync contract: any prior-session mirrored
+                            // state is now potentially stale. Programmer
+                            // flips seen_this_session=false on all routes;
+                            // the next Add storm clears marks; unmarked
+                            // entries get GC'd on InitiationComplete.
+                            if let Err(e) = self
+                                .prog_handle
+                                .apply_route_event(RouteEvent::Resync)
+                                .await
+                            {
+                                warn!(error = %e, "Resync dispatch failed");
+                            }
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "TCP accept failed");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Read BMP messages from `stream` until EOF or error. Frames
+    /// each message by reading the 6-byte common header, extracting
+    /// `msg_len`, reading the body, and handing the whole frame to
+    /// `parse_bmp_msg`.
+    async fn handle_connection(&self, mut stream: TcpStream) -> Result<(), RouteSourceError> {
+        let mut frames_parsed = 0usize;
+        loop {
+            let mut header_buf = [0u8; 6];
+            match stream.read_exact(&mut header_buf).await {
+                Ok(_) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    debug!(frames_parsed, "BMP stream EOF");
+                    return Ok(());
+                }
+                Err(e) => {
+                    return Err(RouteSourceError::recoverable(format!("read header: {e}")));
+                }
+            }
+            // BMP common header: version(1) + msg_len(4) + msg_type(1).
+            // msg_len covers the entire frame including the header.
+            let msg_len =
+                u32::from_be_bytes([header_buf[1], header_buf[2], header_buf[3], header_buf[4]])
+                    as usize;
+            if msg_len < 6 || msg_len > MAX_BMP_MSG_SIZE {
+                return Err(RouteSourceError::recoverable(format!(
+                    "invalid msg_len {msg_len} (frames_parsed={frames_parsed})"
+                )));
+            }
+            let body_len = msg_len - 6;
+            let mut body_buf = vec![0u8; body_len];
+            if body_len > 0 {
+                stream
+                    .read_exact(&mut body_buf)
+                    .await
+                    .map_err(|e| RouteSourceError::recoverable(format!("read body: {e}")))?;
+            }
+
+            // Reconstruct the full frame. `parse_bmp_msg` expects the
+            // header bytes at the front of the buffer — it re-reads
+            // them to validate the version / type.
+            let mut full = Vec::with_capacity(msg_len);
+            full.extend_from_slice(&header_buf);
+            full.extend_from_slice(&body_buf);
+            let mut bytes = Bytes::from(full);
+
+            match parse_bmp_msg(&mut bytes) {
+                Ok(msg) => {
+                    frames_parsed += 1;
+                    self.process_msg(msg).await;
+                }
+                Err(e) => {
+                    return Err(RouteSourceError::recoverable(format!(
+                        "parse_bmp_msg after {frames_parsed}: {e}"
+                    )));
+                }
+            }
+        }
+    }
+
+    /// Dispatch on the BMP message body and fan out the appropriate
+    /// RouteEvents. Errors from the programmer are logged, not
+    /// propagated — a single bad map write shouldn't kill the BMP
+    /// connection when the next route might succeed.
+    async fn process_msg(&self, msg: BmpMessage) {
+        match msg.message_body {
+            BmpMessageBody::InitiationMessage(_) => {
+                info!("BMP INITIATION received from bird");
+            }
+            BmpMessageBody::TerminationMessage(_) => {
+                info!("BMP TERMINATION received from bird");
+            }
+            BmpMessageBody::PeerUpNotification(_) => {
+                let pph = match &msg.per_peer_header {
+                    Some(p) => p,
+                    None => return,
+                };
+                let peer_id = peer_id_from_header(pph);
+                info!(
+                    ?peer_id,
+                    peer_ip = %pph.peer_ip,
+                    peer_asn = %pph.peer_asn,
+                    peer_type = ?pph.peer_type,
+                    "PeerUp"
+                );
+                if let Err(e) = self
+                    .prog_handle
+                    .apply_route_event(RouteEvent::PeerUp {
+                        peer_id,
+                        peer_ip: pph.peer_ip,
+                        peer_asn: asn_to_u32(pph.peer_asn),
+                    })
+                    .await
+                {
+                    warn!(?peer_id, error = %e, "PeerUp dispatch failed");
+                }
+            }
+            BmpMessageBody::PeerDownNotification(_) => {
+                let pph = match &msg.per_peer_header {
+                    Some(p) => p,
+                    None => return,
+                };
+                let peer_id = peer_id_from_header(pph);
+                info!(?peer_id, peer_ip = %pph.peer_ip, "PeerDown");
+                if let Err(e) = self
+                    .prog_handle
+                    .apply_route_event(RouteEvent::PeerDown { peer_id })
+                    .await
+                {
+                    warn!(?peer_id, error = %e, "PeerDown dispatch failed");
+                }
+            }
+            BmpMessageBody::RouteMonitoring(rm) => {
+                let pph = match &msg.per_peer_header {
+                    Some(p) => p,
+                    None => {
+                        warn!("RouteMonitoring without per-peer header");
+                        return;
+                    }
+                };
+                let peer_id = peer_id_from_header(pph);
+                // Elementor converts the UPDATE wrapped in this
+                // RouteMonitoring into one BgpElem per prefix.
+                let elems = Elementor::bgp_to_elems(
+                    rm.bgp_message,
+                    pph.timestamp,
+                    &pph.peer_ip,
+                    &pph.peer_asn,
+                );
+                for elem in elems {
+                    let prefix = match network_prefix_to_ip_prefix(&elem.prefix) {
+                        Some(p) => p,
+                        None => continue,
+                    };
+                    let event = match elem.elem_type {
+                        ElemType::ANNOUNCE => {
+                            let nh = match elem.next_hop {
+                                Some(h) => h,
+                                None => {
+                                    debug!(?prefix, "announce without next_hop — skipping");
+                                    continue;
+                                }
+                            };
+                            RouteEvent::Add {
+                                peer_id,
+                                prefix,
+                                nexthops: vec![nh],
+                            }
+                        }
+                        ElemType::WITHDRAW => RouteEvent::Del { peer_id, prefix },
+                    };
+                    if let Err(e) = self.prog_handle.apply_route_event(event).await {
+                        warn!(?peer_id, error = %e, "route event dispatch failed");
+                    }
+                }
+            }
+            BmpMessageBody::RouteMirroring(_) => {
+                debug!("RouteMirroring ignored (not consumed in Option F)");
+            }
+            BmpMessageBody::StatsReport(_) => {
+                debug!("StatsReport ignored");
+            }
+        }
+    }
+}
+
+/// Derive a stable [`PeerId`] from a BMP per-peer header.
+/// `peer_ip + peer_distinguisher + peer_type` together uniquely
+/// identify one peer — two BGP sessions to the same peer IP that
+/// differ in RD or peer-type hash to distinct IDs.
+fn peer_id_from_header(pph: &BmpPerPeerHeader) -> PeerId {
+    let mut hasher = DefaultHasher::new();
+    pph.peer_ip.hash(&mut hasher);
+    pph.peer_distinguisher.hash(&mut hasher);
+    (pph.peer_type as u8).hash(&mut hasher);
+    PeerId(hasher.finish())
+}
+
+fn network_prefix_to_ip_prefix(np: &NetworkPrefix) -> Option<IpPrefix> {
+    use ipnet::IpNet;
+    match np.prefix {
+        IpNet::V4(n) => Some(IpPrefix::V4 {
+            addr: n.addr().octets(),
+            prefix_len: n.prefix_len(),
+        }),
+        IpNet::V6(n) => Some(IpPrefix::V6 {
+            addr: n.addr().octets(),
+            prefix_len: n.prefix_len(),
+        }),
+    }
+}
+
+/// Extract a u32 from bgpkit-parser's `Asn`. The struct has a `u32`
+/// field `asn`; we reach for it via `Display` so the conversion
+/// works across whichever `From` / `Into` impls the version
+/// provides.
+fn asn_to_u32(asn: bgpkit_parser::models::Asn) -> u32 {
+    // `Asn` impls `Display` as the decimal integer.
+    asn.to_string().parse().unwrap_or(0)
+}

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -145,7 +145,7 @@ impl BmpStation {
             let msg_len =
                 u32::from_be_bytes([header_buf[1], header_buf[2], header_buf[3], header_buf[4]])
                     as usize;
-            if msg_len < 6 || msg_len > MAX_BMP_MSG_SIZE {
+            if !(6..=MAX_BMP_MSG_SIZE).contains(&msg_len) {
                 return Err(RouteSourceError::recoverable(format!(
                     "invalid msg_len {msg_len} (frames_parsed={frames_parsed})"
                 )));

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -545,8 +545,25 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         packetframe_common::config::ForwardingMode::CustomFib
             | packetframe_common::config::ForwardingMode::Compare
     ) {
-        let ctrl =
-            crate::fib::controller::RouteController::start(&state.bpffs_root).map_err(|e| {
+        // Parse `route-source bmp <addr>:<port>` from the module
+        // config. None → controller runs without a BMP station (test
+        // harness or pre-production smoke test with manual programmer
+        // calls). Some → controller spawns BmpStation on that addr.
+        let bmp_listen = cfg.section.directives.iter().find_map(|d| match d {
+            ModuleDirective::RouteSource(packetframe_common::config::RouteSourceSpec::Bmp {
+                addr,
+                port,
+            }) => {
+                // `parse()` handles bracketed IPv6 literals
+                // naturally (e.g. `[::1]:6543`).
+                format!("{addr}:{port}")
+                    .parse::<std::net::SocketAddr>()
+                    .ok()
+            }
+            _ => None,
+        });
+        let ctrl = crate::fib::controller::RouteController::start(&state.bpffs_root, bmp_listen)
+            .map_err(|e| {
                 ModuleError::other(MODULE_NAME, format!("RouteController start failed: {e}"))
             })?;
         state.route_controller = Some(ctrl);


### PR DESCRIPTION
## Summary

Phase 3 of Option F — the BMP ingestion path and full FibProgrammer. With this PR, packetframe can accept a BMP session from bird, translate each route-monitoring message into LPM writes on FIB_V4 / FIB_V6, allocate nexthops + ECMP groups with dedup, and react to peer down / resync / termination cleanly. Kernel-fib remains the default; nothing changes at the packet level until an operator flips `forwarding-mode custom-fib` with a populated `route-source bmp` line.

## What's in

### Slice 3A — `bmp_probe` example binary (the Phase 1 deferred deliverable)

[crates/modules/fast-path/examples/bmp_probe.rs](crates/modules/fast-path/examples/bmp_probe.rs). Reads a captured BMP byte stream (file or stdin), parses via `bgpkit-parser`, prints per-message and closing summary. Validates that the library handles RFC 9069 Loc-RIB (peer type 3) before anything else builds on it. Cross-platform; runs on macOS dev loops.

### Slice 3B — FibProgrammer route ingestion

[programmer.rs](crates/modules/fast-path/src/fib/programmer.rs) grows a full route-side:

- `apply_route_event(RouteEvent)` for the six event kinds (`Add` / `Del` / `PeerUp` / `PeerDown` / `Resync` / `InitiationComplete`).
- FIB_V4 / FIB_V6 LPM writes via `LpmTrie<MapData, _, FibValue>` opened from their bpffs pins.
- ECMP group dedup keyed on sorted `NexthopId` + `hash_mode` — 200K prefixes sharing the same transit set allocate one group, not 200K.
- Default-route (0.0.0.0/0, ::/0) replace-by-swap with a 100 ms grace-period reclaim queue, drained by a 50 ms tick in `run`. Protects in-flight XDP pass holding a stale pointer without starving the free-list under flap.
- Capacity guards (`FibV4Full`, `FibV6Full`, `EcmpGroupsFull`, `EcmpGroupTooWide`) match the BPF-side constants (2²¹ / 2²⁰ / 1024 / MAX_ECMP_PATHS).
- Per-peer index (`routes_by_peer`) for O(1) `PeerDown` traversal.
- Resync / InitiationComplete implement BMP-reconnect stale-reconcile: Resync marks everything `seen_this_session=false`; Add clears the mark; InitiationComplete GCs what's left.
- Command queue bumped 256 → 8192 for convergence-storm headroom.

### Slice 3C — BmpStation RouteSource

[route_source_bmp.rs](crates/modules/fast-path/src/fib/route_source_bmp.rs). TCP listener accepts bird's BMP dial-in, frames the byte stream against the 6-byte common header, parses via `bgpkit-parser::parser::bmp::parse_bmp_msg`, translates each RouteMonitoring's embedded BGP UPDATE into per-prefix RouteEvents via `Elementor::bgp_to_elems`. Per-peer derivation hashes `peer_ip + peer_distinguisher + peer_type` into a stable `PeerId`. On disconnect emits `RouteEvent::Resync` so the programmer's reconcile machinery kicks in on the next connect.

### Slice 3D — RouteController spawns BmpStation

`RouteController::start(bpffs_root, bmp_listen: Option<SocketAddr>)` spawns the station as a third task on the existing tokio runtime when the operator configures `route-source bmp <addr>:<port>`. `linux_impl::attach` parses the directive and supplies the address. Without `route-source` the controller runs without a station — useful for test harnesses driving `FibProgrammerHandle` directly.

### Workspace deps added

- `bgpkit-parser 0.16` (default features off with `parser` + `bytes` — skips the rustls fetcher). RFC 7854 + RFC 9069 BMP support, pure Rust.
- `bytes 1.11`.
- `ipnet 2.12` (direct dep; bgpkit-parser's `NetworkPrefix` wraps `IpNet`).
- `tokio 1.52`: added the `io-util` feature for `AsyncReadExt::read_exact` used by the BMP framer.

All pinned to current latest stable on crates.io.

## What's deferred to Phase 3.5

Planned in the Option F plan but scoped out of this PR:

- **Netns integration test** (kernel neigh → NEXTHOPS full chain). Absorbed the deferred Slice 2E; bundled into Phase 3.5 where the end-to-end kernel → BMP → FIB chain gets one coherent test harness.
- **BMP mock test** — loop bird-captured frames through BmpStation + FibProgrammer via a mock `TcpListener`, assert FIB_V4 / NEXTHOPS state.
- **Offline comparison harness** — snapshot bird RIB + kernel FIB, run custom-FIB lookup across a synthetic 5-tuple set, assert zero disagreement.
- **Full-table-load perf measurement** — replay a ~1M-route captured BMP stream, measure time-to-InitiationComplete + peak queue depth + backpressure.
- **Proactive resolve** (`request_resolve` currently logs + waits for first-packet kernel ARP).
- **Egress src_mac via RTM_GETLINK** (currently zero; dst_mac is what test harnesses observe).
- **InitiationComplete quiescence timer in BmpStation** (currently relies on `Resync` on reconnect; InitComplete never fires autonomously yet).

All are independent additive follow-ups; none gate Phase 4 cutover if the staging soak substitutes for the harnesses.

## Test plan

- [x] `cargo fmt --all --check` clean on macOS and Linux CI
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] All 4 cross-builds pass (`{aarch64,x86_64}-unknown-linux-{gnu,musl}`)
- [x] qemu-verifier on kernel v5.15 + v6.6 passes (all Phase 1/2 integration tests still green)
- [x] Unit tests: 47 common + 38 fast-path + 6 new `netlink_neigh` parser tests, all pass
- [ ] Phase 3.5: netns-backed + BMP-mock end-to-end integration test
- [ ] Phase 3.5: offline comparison harness
- [ ] Phase 4 gate: live bird BMP session on staging EFG before production cutover

## Review hints

- `programmer.rs` grew ~500 lines. The interesting parts are:
  - `add_route` / `del_route` / `drop_routes_for_peer` — the transaction shape for BPF writes + mirror updates.
  - `alloc_ecmp_group` / `free_ecmp_group` + `compute_signature` — the dedup path.
  - `enqueue_reclaim` + `drain_reclaim_queue` — the 100 ms grace-period machinery for default-route swaps.
- `route_source_bmp.rs` is the BMP protocol surface. The wire framing (`handle_connection`) and the per-peer hash (`peer_id_from_header`) are the most likely regressions on a bird upgrade.
- The `Asn` → `u32` hop in `process_msg` goes via `Display` → `parse` because bgpkit-parser 0.16's `Asn` struct doesn't expose a direct u32 getter through its public trait impls. If that changes upstream, switch to the direct accessor.
- Command queue capacity (8192) is sized for realistic burst absorption but is a tuning knob — raise if the Phase 3.5 full-table-load run shows sustained backpressure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)