### PR TITLE
fast-path: egress src_mac + proactive resolve (Option F, Phase 3.6 A+B)

### DIFF
--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -140,11 +140,19 @@ pub trait NeighborResolver: Send {
 #[derive(Debug, Clone)]
 pub enum NeighEvent {
     /// A neighbor resolved successfully. Programmer writes
-    /// `{mac, ifindex}` into the corresponding `NexthopEntry`.
+    /// `{mac, ifindex, src_mac}` into the corresponding `NexthopEntry`.
+    /// `src_mac` is the MAC of the egress interface (i.e., the MAC
+    /// the XDP program writes as the Ethernet source address on
+    /// redirected frames). Added in Phase 3.6; pre-3.6 the programmer
+    /// wrote `0x00…00` here, which works on most switches but breaks
+    /// policy tools that inspect src_mac. `[0; 6]` is still a valid
+    /// value when the resolver couldn't look up the egress MAC — the
+    /// programmer writes whatever's provided.
     Learned {
         ip: IpAddr,
         mac: [u8; 6],
         ifindex: u32,
+        src_mac: [u8; 6],
     },
     /// Resolution failed after retries. Programmer marks the
     /// nexthop `Failed`; XDP packets for routes pointing at this

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -35,9 +35,12 @@ use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
 use netlink_packet_route::{
     link::{LinkAttribute, LinkMessage},
     neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage, NeighbourState},
+    route::RouteAttribute,
     RouteNetlinkMessage,
 };
-use rtnetlink::{new_connection, new_multicast_connection, MulticastGroup};
+use rtnetlink::{
+    new_connection, new_multicast_connection, Handle, MulticastGroup, RouteMessageBuilder,
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -144,7 +147,7 @@ impl NetlinkNeighborResolver {
         }
 
         let groups = [MulticastGroup::Neigh, MulticastGroup::Link];
-        let (connection, _handle, mut messages) = new_multicast_connection(&groups)
+        let (connection, handle, mut messages) = new_multicast_connection(&groups)
             .map_err(|e| NeighError::new(format!("new_multicast_connection: {e}")))?;
         tokio::spawn(connection);
         info!(
@@ -170,13 +173,10 @@ impl NetlinkNeighborResolver {
                 req = self.resolve_rx.recv() => {
                     match req {
                         Some(ip) => {
-                            // Phase 3.6 full proactive resolve lands in Slice 3.6B
-                            // (next commit). For this slice the handle still logs
-                            // and relies on first-packet kernel ARP.
-                            debug!(
-                                ?ip,
-                                "proactive resolve request queued (Phase 3.6B TODO)"
-                            );
+                            // Best-effort proactive resolve. If the route
+                            // lookup or neighbor add fails, log at debug
+                            // and fall back to first-packet kernel ARP.
+                            issue_proactive_resolve(&handle, ip).await;
                         }
                         None => {
                             // All NeighborResolveHandle clones dropped; continue
@@ -244,6 +244,88 @@ impl NetlinkNeighborResolver {
             }
             _ => {}
         }
+    }
+}
+
+/// Proactively kick kernel ARP/ND for `ip`. Looks up the route to
+/// find the egress ifindex, then issues `RTM_NEWNEIGH` with
+/// `state = NUD_NONE`. The kernel responds by starting resolution;
+/// the eventual `RTM_NEWNEIGH` with a resolved state arrives via the
+/// multicast subscription and turns into `NeighEvent::Learned` through
+/// the normal path.
+///
+/// Best-effort. If the route lookup can't find an egress (dest
+/// unroutable, or kernel's NETLINK_GET_STRICT_CHK doesn't accept our
+/// message shape), or the neighbor add fails (EEXIST because the
+/// neighbor already exists, permission issues, etc.), we log at debug
+/// and return. The fallback is "kernel resolves when real traffic
+/// arrives" — exactly what we'd get without proactive resolve, so
+/// the only cost of a proactive-resolve failure is one-packet latency
+/// on first forward.
+async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
+    let (oif, plen) = match ip {
+        IpAddr::V4(v4) => {
+            let req = RouteMessageBuilder::<IpAddr>::new()
+                .destination_prefix(IpAddr::V4(v4), 32)
+                .unwrap_or_else(|_| RouteMessageBuilder::<IpAddr>::new())
+                .build();
+            (lookup_oif(handle, req).await, 32u8)
+        }
+        IpAddr::V6(v6) => {
+            let req = RouteMessageBuilder::<IpAddr>::new()
+                .destination_prefix(IpAddr::V6(v6), 128)
+                .unwrap_or_else(|_| RouteMessageBuilder::<IpAddr>::new())
+                .build();
+            (lookup_oif(handle, req).await, 128u8)
+        }
+    };
+    let _ = plen; // retained for future per-family path divergence if needed
+    let oif = match oif {
+        Some(i) => i,
+        None => {
+            debug!(
+                ?ip,
+                "proactive resolve: route lookup returned no OIF; skipping"
+            );
+            return;
+        }
+    };
+    // Issue the RTM_NEWNEIGH with NUD_NONE. The kernel interprets
+    // "state NONE + no lladdr" as "initialize this neighbor and start
+    // resolving." Replace lets the call be idempotent — if the
+    // neighbor already exists, we quietly succeed.
+    match handle
+        .neighbours()
+        .add(oif, ip)
+        .state(NeighbourState::None)
+        .replace()
+        .execute()
+        .await
+    {
+        Ok(()) => debug!(?ip, oif, "proactive resolve kicked"),
+        Err(e) => debug!(?ip, oif, error = %e, "proactive resolve failed"),
+    }
+}
+
+/// Query the main routing table for `msg`, return the OIF of the
+/// first route returned. Kernel answers via a stream; we only care
+/// about the first entry — subsequent entries for multipath routes
+/// are handled at the programmer level via ECMP groups.
+async fn lookup_oif(
+    handle: &Handle,
+    msg: netlink_packet_route::route::RouteMessage,
+) -> Option<u32> {
+    let mut routes = handle.route().get(msg).execute();
+    match routes.try_next().await {
+        Ok(Some(route)) => {
+            for attr in route.attributes {
+                if let RouteAttribute::Oif(idx) = attr {
+                    return Some(idx);
+                }
+            }
+            None
+        }
+        _ => None,
     }
 }
 

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -28,13 +28,16 @@
 
 use std::net::IpAddr;
 
-use futures::StreamExt;
+use std::collections::HashMap;
+
+use futures::{StreamExt, TryStreamExt};
 use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
 use netlink_packet_route::{
+    link::{LinkAttribute, LinkMessage},
     neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage, NeighbourState},
     RouteNetlinkMessage,
 };
-use rtnetlink::{new_multicast_connection, MulticastGroup};
+use rtnetlink::{new_connection, new_multicast_connection, MulticastGroup};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -80,6 +83,12 @@ pub struct NetlinkNeighborResolver {
     events_tx: mpsc::Sender<NeighEvent>,
     resolve_rx: mpsc::Receiver<IpAddr>,
     shutdown: CancellationToken,
+    /// Cache mapping ifindex → egress MAC. Populated at startup via
+    /// a single `RTM_GETLINK` dump; maintained by `RTM_NEWLINK` /
+    /// `RTM_DELLINK` multicast events. Used to attach `src_mac` to
+    /// `NeighEvent::Learned` so the FibProgrammer writes the correct
+    /// Ethernet source address into `NEXTHOPS[id].src_mac`.
+    iface_mac: HashMap<u32, [u8; 6]>,
 }
 
 impl NetlinkNeighborResolver {
@@ -98,6 +107,7 @@ impl NetlinkNeighborResolver {
                 events_tx,
                 resolve_rx,
                 shutdown,
+                iface_mac: HashMap::new(),
             },
             events_rx,
             NeighborResolveHandle { resolve_tx },
@@ -107,6 +117,32 @@ impl NetlinkNeighborResolver {
     /// Main event loop. Runs until shutdown is signaled or the netlink
     /// stream closes unexpectedly.
     pub async fn run(mut self) -> Result<(), NeighError> {
+        // Seed the ifindex→MAC cache from an RTM_GETLINK dump BEFORE
+        // we start listening to the multicast stream. Otherwise a
+        // NEWNEIGH arriving in the first few microseconds after
+        // subscription would emit src_mac=[0;6] because we hadn't
+        // discovered the egress iface yet.
+        //
+        // The dump uses a separate unicast netlink connection; the
+        // multicast one below is dedicated to the event stream
+        // (RTM_NEWNEIGH/DELNEIGH/NEWLINK/DELLINK) so dump traffic
+        // doesn't compete with live events.
+        match dump_link_macs().await {
+            Ok(macs) => {
+                self.iface_mac = macs;
+                info!(
+                    count = self.iface_mac.len(),
+                    "ifindex→MAC cache seeded from RTM_GETLINK dump"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "RTM_GETLINK dump failed; src_mac will be [0;6] until RTM_NEWLINK events arrive"
+                );
+            }
+        }
+
         let groups = [MulticastGroup::Neigh, MulticastGroup::Link];
         let (connection, _handle, mut messages) = new_multicast_connection(&groups)
             .map_err(|e| NeighError::new(format!("new_multicast_connection: {e}")))?;
@@ -134,13 +170,12 @@ impl NetlinkNeighborResolver {
                 req = self.resolve_rx.recv() => {
                     match req {
                         Some(ip) => {
-                            // Phase 3: full proactive resolve (route lookup
-                            // → ifindex → `ip neigh add ... nud none`). For
-                            // now log and rely on first-packet kernel ARP.
+                            // Phase 3.6 full proactive resolve lands in Slice 3.6B
+                            // (next commit). For this slice the handle still logs
+                            // and relies on first-packet kernel ARP.
                             debug!(
                                 ?ip,
-                                "proactive resolve request queued (Phase 3 TODO; \
-                                 kernel will resolve on first matching packet)"
+                                "proactive resolve request queued (Phase 3.6B TODO)"
                             );
                         }
                         None => {
@@ -158,10 +193,19 @@ impl NetlinkNeighborResolver {
     /// [`NeighEvent`]s and push them into the events channel. Send
     /// errors (programmer too slow) log at debug because backpressure
     /// is expected during convergence bursts, not a bug.
-    async fn handle_packet(&self, packet: NetlinkMessage<RouteNetlinkMessage>) {
+    ///
+    /// Also maintains the `iface_mac` cache in response to RTM_NEWLINK
+    /// / RTM_DELLINK so `src_mac` on subsequent `NeighEvent::Learned`
+    /// reflects current egress MACs.
+    async fn handle_packet(&mut self, packet: NetlinkMessage<RouteNetlinkMessage>) {
         match packet.payload {
             NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewNeighbour(msg)) => {
-                if let Some(evt) = parse_neighbour_add(&msg) {
+                let src_mac = self
+                    .iface_mac
+                    .get(&msg.header.ifindex)
+                    .copied()
+                    .unwrap_or([0; 6]);
+                if let Some(evt) = parse_neighbour_add(&msg, src_mac) {
                     if let Err(e) = self.events_tx.send(evt).await {
                         debug!(error = %e, "NeighEvent::Learned send failed");
                     }
@@ -174,13 +218,26 @@ impl NetlinkNeighborResolver {
                     }
                 }
             }
+            NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewLink(msg)) => {
+                if let Some(mac) = extract_link_mac(&msg) {
+                    let ifindex = msg.header.index;
+                    let prev = self.iface_mac.insert(ifindex, mac);
+                    if prev != Some(mac) {
+                        debug!(
+                            ifindex,
+                            mac = format_args!(
+                                "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
+                                mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
+                            ),
+                            "iface MAC cached"
+                        );
+                    }
+                }
+            }
             NetlinkPayload::InnerMessage(RouteNetlinkMessage::DelLink(msg)) => {
-                // Link-down ⇒ every neighbor on that iface is implicitly
-                // gone. RTM_DELNEIGH events usually accompany it; Phase 2
-                // relies on those. Tracking per-ifindex neighbor sets to
-                // evict proactively lands in Phase 3 alongside route
-                // scoping.
-                debug!(ifindex = msg.header.index, "RTM_DELLINK observed");
+                let ifindex = msg.header.index;
+                self.iface_mac.remove(&ifindex);
+                debug!(ifindex, "RTM_DELLINK observed; MAC cache entry purged");
             }
             NetlinkPayload::Error(err) => {
                 warn!(?err, "netlink error message");
@@ -190,10 +247,61 @@ impl NetlinkNeighborResolver {
     }
 }
 
+/// Dump every link on the box via a single RTM_GETLINK-dump request;
+/// return a fresh ifindex→MAC map. Uses a dedicated unicast netlink
+/// connection — the main multicast one is owned by the select! loop.
+///
+/// Links without a usable MAC (e.g., tunnels, loopback, bridge masters
+/// before an attachment) are skipped silently; they'll show up in a
+/// later RTM_NEWLINK when their hardware address is set.
+async fn dump_link_macs() -> Result<HashMap<u32, [u8; 6]>, NeighError> {
+    let (connection, handle, _) =
+        new_connection().map_err(|e| NeighError::new(format!("new_connection: {e}")))?;
+    tokio::spawn(connection);
+
+    let mut macs: HashMap<u32, [u8; 6]> = HashMap::new();
+    let mut links = handle.link().get().execute();
+    while let Some(msg) = links
+        .try_next()
+        .await
+        .map_err(|e| NeighError::new(format!("link dump: {e}")))?
+    {
+        if let Some(mac) = extract_link_mac(&msg) {
+            macs.insert(msg.header.index, mac);
+        }
+    }
+    Ok(macs)
+}
+
+/// Pull the `Address` (IFLA_ADDRESS) attribute out of a LinkMessage
+/// if it's a plausible Ethernet MAC. Returns None for non-Ethernet
+/// links — tunnels encode the peer address in `Address` with varying
+/// widths, and a 6-byte address on a tunnel isn't semantically what
+/// we want as src_mac anyway.
+fn extract_link_mac(msg: &LinkMessage) -> Option<[u8; 6]> {
+    for attr in &msg.attributes {
+        if let LinkAttribute::Address(bytes) = attr {
+            if bytes.len() == 6 {
+                let mut mac = [0u8; 6];
+                mac.copy_from_slice(bytes);
+                // Skip the all-zero MAC some virtual ifaces present
+                // before they're configured — that would be worse than
+                // not providing one (looks like a real address).
+                if mac != [0; 6] {
+                    return Some(mac);
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Build a [`NeighEvent`] from an RTM_NEWNEIGH message. Returns
 /// `None` for transient or uninteresting states (`Incomplete` / `None`
-/// — no MAC yet; `Other` — unknown variant).
-fn parse_neighbour_add(msg: &NeighbourMessage) -> Option<NeighEvent> {
+/// — no MAC yet; `Other` — unknown variant). `src_mac` is the cached
+/// egress iface MAC (Phase 3.6); `[0; 6]` when the cache hasn't been
+/// populated for this ifindex yet.
+fn parse_neighbour_add(msg: &NeighbourMessage, src_mac: [u8; 6]) -> Option<NeighEvent> {
     let ip = extract_ip(&msg.attributes)?;
 
     match msg.header.state {
@@ -216,6 +324,7 @@ fn parse_neighbour_add(msg: &NeighbourMessage) -> Option<NeighEvent> {
                 ip,
                 mac,
                 ifindex: msg.header.ifindex,
+                src_mac,
             })
         }
         // Incomplete / None: resolution in progress, no MAC yet. The
@@ -271,6 +380,8 @@ mod tests {
         m
     }
 
+    const TEST_SRC_MAC: [u8; 6] = [0xbb, 0xbb, 0xbb, 0, 0, 42];
+
     #[test]
     fn learned_from_reachable() {
         let ip = Ipv4Addr::new(10, 0, 0, 1);
@@ -281,15 +392,17 @@ mod tests {
                 NeighbourAttribute::LinkLayerAddress(vec![0xaa, 0, 0, 0, 0, 1]),
             ],
         );
-        match parse_neighbour_add(&msg) {
+        match parse_neighbour_add(&msg, TEST_SRC_MAC) {
             Some(NeighEvent::Learned {
                 ip: got_ip,
                 mac,
                 ifindex,
+                src_mac,
             }) => {
                 assert_eq!(got_ip, IpAddr::V4(ip));
                 assert_eq!(mac, [0xaa, 0, 0, 0, 0, 1]);
                 assert_eq!(ifindex, 42);
+                assert_eq!(src_mac, TEST_SRC_MAC);
             }
             other => panic!("expected Learned, got {other:?}"),
         }
@@ -303,7 +416,7 @@ mod tests {
             vec![NeighbourAttribute::Destination(NeighbourAddress::Inet(ip))],
         );
         assert!(matches!(
-            parse_neighbour_add(&msg),
+            parse_neighbour_add(&msg, TEST_SRC_MAC),
             Some(NeighEvent::Failed { .. })
         ));
     }
@@ -315,7 +428,7 @@ mod tests {
             NeighbourState::Incomplete,
             vec![NeighbourAttribute::Destination(NeighbourAddress::Inet(ip))],
         );
-        assert!(parse_neighbour_add(&msg).is_none());
+        assert!(parse_neighbour_add(&msg, TEST_SRC_MAC).is_none());
     }
 
     #[test]
@@ -326,7 +439,7 @@ mod tests {
             NeighbourState::Reachable,
             vec![NeighbourAttribute::Destination(NeighbourAddress::Inet(ip))],
         );
-        assert!(parse_neighbour_add(&msg).is_none());
+        assert!(parse_neighbour_add(&msg, TEST_SRC_MAC).is_none());
     }
 
     #[test]

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -583,7 +583,12 @@ impl FibProgrammer {
         };
 
         let entry = match evt {
-            NeighEvent::Learned { mac, ifindex, .. } => {
+            NeighEvent::Learned {
+                mac,
+                ifindex,
+                src_mac,
+                ..
+            } => {
                 // Remember the MAC so later Failed/Gone → revert-to-Incomplete
                 // preserves the last-known-good for diagnostic use if we
                 // ever expose it. Actual forwarding uses the live state only.
@@ -595,14 +600,11 @@ impl FibProgrammer {
                     ifindex,
                     dst_mac: mac,
                     _pad0: [0; 2],
-                    // src_mac unresolved in Phase 2 — we don't yet
-                    // query the egress iface's MAC via netlink. Phase 3
-                    // fills this in alongside BMP peer tracking; for
-                    // Phase 2 tests the src MAC stays zero, which is
-                    // fine because the XDP program just writes
-                    // whatever it finds and the test harness observes
-                    // the dst MAC. Flagged for follow-up.
-                    src_mac: [0; 6],
+                    // src_mac is now provided by the resolver (Phase 3.6).
+                    // Falls back to [0; 6] if the resolver hasn't yet
+                    // cached the egress iface's MAC (link came up after
+                    // startup and we haven't seen its RTM_NEWLINK).
+                    src_mac,
                     _pad1: [0; 2],
                     state: NH_STATE_RESOLVED,
                     family,

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -273,21 +273,20 @@ Check:
 
 ## Known gaps
 
-The following are known limitations that will be addressed in Phase
-3.5+. Listed here so you don't spend time debugging behaviors that
-are known-missing:
+The following are known limitations. Listed here so you don't spend
+time debugging behaviors that are known-missing. Items marked ✅
+landed since the runbook was first written.
 
-- **Proactive resolve is a no-op.** `request_resolve(ip)` logs the
-  request but doesn't issue `RTM_NEWNEIGH NUD_NONE`. First-packet
-  kernel ARP is the fallback.
-- **`src_mac` is zero.** The MAC packetframe writes as the Ethernet
-  source address on redirected frames is currently `00:00:00:00:00:00`.
-  Switches don't generally care about src_mac for forwarding decisions,
-  but any policy-based tooling that does will trip on this. Phase 3.5+
-  adds RTM_GETLINK lookup of the egress iface MAC.
-- **InitiationComplete doesn't fire autonomously.** The programmer
-  receives `Resync` on BMP disconnect and reconcile on reconnect, but
-  the InitComplete signal that GCs stale entries is Phase 3.5+.
+- ✅ **Proactive resolve** (Phase 3.6). `request_resolve(ip)` now
+  issues `RTM_NEWNEIGH NUD_NONE` after looking up the route to find
+  the egress ifindex. Best-effort: if route lookup or neighbor add
+  fails, first-packet kernel ARP remains the fallback.
+- ✅ **`src_mac` via RTM_GETLINK** (Phase 3.6). The NeighborResolver
+  now caches `ifindex → MAC` from an RTM_GETLINK dump at startup and
+  RTM_NEWLINK / RTM_DELLINK multicast events thereafter.
+  `NEXTHOPS[id].src_mac` is the egress iface MAC, not zero.
+- ✅ **InitiationComplete quiescence timer** (Phase 3.5). Fires once
+  per BMP connection after 5 s of no RouteMonitoring frames.
 - **`packetframe-ctl fib dump/lookup/stats`** subcommands are not yet
   implemented. Use `packetframe status` + counter deltas for now.
 - **Prometheus metrics** are limited to the existing textfile counters
@@ -295,3 +294,9 @@ are known-missing:
   occupancy isn't exported yet.
 - **Offline comparison harness** isn't wired into CI yet; we rely on
   the staging soak + `compare` mode for pre-cutover validation.
+- **Netns integration test + BMP mock test** — Phase 3.6 ships the
+  code for both sides (resolver + BMP station) but the end-to-end
+  netns tests that drive `kernel neigh → NeighborResolver → NEXTHOPS`
+  and `captured BMP frames → BmpStation → FibProgrammer → FIB_V4` are
+  deferred to a follow-up. CI's qemu jobs still validate all unit
+  tests, and the staging soak validates the real thing end-to-end.


### PR DESCRIPTION
## Summary

Phase 3.6 closes the two behavioral gaps Phase 3.5's runbook flagged as load-bearing for production correctness: egress `src_mac` (was hardcoded `0x00…00`) and proactive neighbor resolve (was a no-op log). Both are best-effort with graceful fallback to pre-3.6 behavior, so nothing regresses if the new paths can't reach the kernel.

## What's in

### Slice 3.6A — egress `src_mac` via RTM_GETLINK

- `NeighEvent::Learned` grows a `src_mac: [u8; 6]` field (additive — existing pattern matches with `..` keep working).
- `NetlinkNeighborResolver` now owns an `ifindex → MAC` cache:
  - Seeded at startup via a one-shot RTM_GETLINK dump through a dedicated unicast rtnetlink connection.
  - Maintained at runtime by RTM_NEWLINK / RTM_DELLINK multicast events — NEWLINK inserts/refreshes, DELLINK evicts.
  - Attached to every `NeighEvent::Learned` so the FibProgrammer writes the correct Ethernet source MAC into `NEXTHOPS[id].src_mac`.
- `extract_link_mac` skips non-Ethernet links (tunnels, loopback) and all-zero MACs (virtual ifaces pre-configuration).
- Unit tests updated to thread a test src_mac through the parser; clean on macOS + all CI.

### Slice 3.6B — proactive resolve via RTM_NEWNEIGH NUD_NONE

- `NeighborResolveHandle::request_resolve(ip)` now does best-effort rather than log-and-forget:
  1. `handle.route().get(RouteMessageBuilder::<IpAddr>::new().destination_prefix(ip, 32_or_128).build())` — look up the route to find the egress OIF.
  2. `handle.neighbours().add(oif, ip).state(NeighbourState::None).replace().execute()` — tell the kernel "initialize this neighbor and start resolving." `.replace()` makes it idempotent across multiple callers referencing the same nexthop.
  3. The eventual resolved NEWNEIGH comes in via the existing multicast subscription and turns into `NeighEvent::Learned` normally.
- Failures at either step log at debug and return. Fallback is first-packet kernel ARP — the pre-3.6 Phase 3 behavior. Worst-case regression: one-packet latency on first forward to a new nexthop.

### Runbook

`docs/runbooks/custom-fib.md` known-gaps section updated — proactive resolve, src_mac, and InitiationComplete timer all flagged ✅ with phase references.

## What's deferred

Runbook captures these explicitly:

- **Netns integration test** (kernel neigh → `NEXTHOPS` via resolver).
- **BMP mock integration test** (captured frames → `BmpStation` → `FibProgrammer` → `FIB_V4`).
- **`packetframe-ctl fib dump/lookup/stats`** subcommands.
- **Prometheus FIB metrics** export.
- **Offline comparison harness**.

Each is independent; the Phase 4 cutover staging soak substitutes for the integration tests. Shipping these would materially improve CI coverage but they aren't cutover-blocking.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] All 4 cross-builds + qemu kernel v5.15 + qemu kernel v6.6 pass
- [x] Unit tests: `parse_neighbour_add` src_mac threading, runbook renders
- [ ] Staging soak: observe `NEXTHOPS[id].src_mac` non-zero after bird BMP session establishes
- [ ] Staging soak: observe a `tracepoint:neigh:*` event fire within tens of ms of `RouteEvent::Add` for a new nexthop — validates proactive resolve is reaching the kernel

## Review hints

- `issue_proactive_resolve` is the new bit. The `RouteMessageBuilder::<IpAddr>::new().destination_prefix(ip, 32_or_128)` call returns `Result` — `.unwrap_or_else(|_| ::new())` falls back to an empty message on the (unlikely) builder error, which then yields `None` from `lookup_oif` and the resolve is skipped. Not a panic path.
- `NeighEvent::Learned` is a breaking change in the literal sense (new field), but the only consumer that pattern-matched fields individually was the FibProgrammer, which is updated inline. Tests that used the event constructor (currently just unit tests in netlink_neigh.rs) were updated in the same commit.
- `extract_link_mac`'s filter — skipping all-zero MACs — is a defensive choice, not a correctness-load-bearing one. If a real Ethernet iface genuinely has a zero MAC we won't cache it, but that's already pathological; fall back to [0;6] via the resolver path is no worse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)