### PR TITLE
chore: refresh stale in-code docstrings + Cargo description

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -481,9 +481,8 @@ fn print_stats(bpffs_root: &Path) {
     // §4.6 counter names, indexed by `StatIdx` discriminants. Order
     // matches `crates/modules/fast-path/bpf/src/maps.rs::StatIdx`.
     // Append-only — adding new entries at the end is fine; renumbering
-    // breaks dashboards. Previous versions hardcoded 19 and silently
-    // dropped `err_head_shift` (index 19); Phase 1 fixes that in
-    // passing and adds the 12 custom-FIB counters (indices 20-31).
+    // breaks dashboards. Indices 0-19 are the kernel-fib counter set;
+    // 20-31 were appended in the Option F custom-FIB rollout (§4.11).
     const NAMES: [&str; 32] = [
         "rx_total",
         "matched_v4",

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,12 @@
 //! `packetframe` — PacketFrame CLI.
 //!
-//! See SPEC.md §7.4 for the subcommand surface. PR #4 wires `run` to
-//! load + attach the fast-path module via aya, persists the pin
-//! registry, and blocks on SIGTERM/SIGINT for graceful exit. `detach`
-//! and `status` read the pin registry and the live stats map
-//! respectively. The `reconfigure` flow (SIGHUP → delta-only reconcile)
-//! lands with PR #6.
+//! See SPEC.md §7.4 for the subcommand surface. `run` loads + attaches
+//! the fast-path module via aya, persists the pin registry, and blocks
+//! on SIGTERM/SIGINT for graceful exit. `detach` and `status` read the
+//! pin registry and the live stats map respectively. SIGHUP triggers a
+//! delta-only reconcile (allowlists, VLAN-resolve, devmap) without
+//! detaching. `fib` (Option F, Phase 3.8 — see SPEC.md §4.11) opens
+//! the pinned custom-FIB maps directly for inspection.
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod breaker;

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -160,14 +160,17 @@ pub enum ModuleDirective {
     /// validation, temporary).
     ForwardingMode(ForwardingMode),
     /// RouteSource configuration — where the custom FIB gets its
-    /// routes. Phase 1 accepts the directive but doesn't yet start
-    /// a live RouteSource; Phase 3 wires up the BMP station.
+    /// routes. Currently only `bmp <addr>:<port>`; the BMP station
+    /// is spawned by the RouteController when this is set and
+    /// `forwarding-mode` is `custom-fib` or `compare`.
     RouteSource(RouteSourceSpec),
     /// Max entries for the custom-FIB LPM tries and side arrays.
     /// Accepted but **not yet runtime-applied** — aya / kernel
-    /// allocate maps at compile-time sizes. Phase 1 documents the
-    /// directive so operator config forward-compatibility holds;
-    /// actual runtime sizing requires a recompile of the BPF ELF.
+    /// allocate maps at compile-time sizes set in
+    /// `crates/modules/fast-path/bpf/src/maps.rs`. The directive is
+    /// preserved for operator config forward-compatibility; actual
+    /// runtime sizing requires a recompile of the BPF ELF with
+    /// matching constants.
     FibSize(FibSizeDirective),
     /// Default ECMP hash tuple width (3, 4, or 5). Written into
     /// `FIB_CONFIG.default_hash_mode` at load time.
@@ -202,8 +205,9 @@ impl FromStr for ForwardingMode {
     }
 }
 
-/// RouteSource configuration. Only `bmp <addr>:<port>` is accepted
-/// in Phase 1; other variants land alongside their implementations.
+/// RouteSource configuration. Currently only `bmp <addr>:<port>` is
+/// supported; other variants would land alongside their concrete
+/// `RouteSource` impls if added.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RouteSourceSpec {
     /// BMP station listen address. Bird dials out to this
@@ -213,9 +217,8 @@ pub enum RouteSourceSpec {
     Bmp { addr: String, port: u16 },
 }
 
-/// One `fib-*-max-entries` directive. Phase 1 accepts these but
-/// doesn't runtime-apply — see the struct-level doc on
-/// [`ModuleDirective::FibSize`].
+/// One `fib-*-max-entries` directive. Parsed but not runtime-applied
+/// — see the doc on [`ModuleDirective::FibSize`].
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum FibSizeDirective {
     FibV4MaxEntries(u32),
@@ -774,10 +777,9 @@ where
     Ok(wrap(n))
 }
 
-/// Parse `route-source <kind> <args...>`. Phase 1 accepts only
-/// `bmp <addr>:<port>`. Other kinds become parse errors so
-/// operators get an explicit message if they configure something
-/// that hasn't landed yet.
+/// Parse `route-source <kind> <args...>`. Currently only
+/// `bmp <addr>:<port>` is supported. Unknown kinds become parse
+/// errors with an explicit message.
 fn parse_route_source<'a>(
     line: usize,
     mut rest: impl Iterator<Item = &'a str>,
@@ -821,7 +823,7 @@ fn parse_route_source<'a>(
         }
         other => Err(ConfigError::parse(
             line,
-            format!("route-source `{other}` unknown (Phase 1 supports only `bmp <addr>:<port>`)"),
+            format!("route-source `{other}` unknown (only `bmp <addr>:<port>` is supported)"),
         )),
     }
 }

--- a/crates/common/src/module.rs
+++ b/crates/common/src/module.rs
@@ -141,16 +141,15 @@ pub struct SubsystemHealth {
 
 /// Structured health report returned by `Module::health_check`.
 ///
-/// Phase 1 shape carries an overall state + a `Vec<SubsystemHealth>`
-/// populated by modules with internal subsystems (e.g. fast-path's
-/// RouteController, which aggregates BMP + netlink + FibProgrammer
-/// freshness once Phase 2+ lands). Modules without subsystems
-/// return `HealthReport::default()` — an empty, healthy report.
+/// Carries an overall state plus a `Vec<SubsystemHealth>` for
+/// modules with internal subsystems — e.g. fast-path's
+/// RouteController, which can report BMP + netlink + FibProgrammer
+/// freshness independently. Modules without subsystems return
+/// `HealthReport::default()` (an empty, healthy report).
 ///
-/// Added in Phase 1 of Option F (custom-FIB migration) because the
-/// prior `ModuleResult<()>` surface couldn't express partial-degraded
-/// states across multiple control-plane subsystems. No dashboards
-/// consume this yet; Phase 3.5 wires it into `packetframe status`.
+/// Added during the Option F custom-FIB rollout because the prior
+/// `ModuleResult<()>` surface couldn't express partial-degraded
+/// states across multiple control-plane subsystems.
 #[derive(Debug, Clone, Default)]
 pub struct HealthReport {
     pub overall: HealthState,
@@ -166,8 +165,9 @@ impl HealthReport {
 }
 
 /// Destination for Prometheus textfile emission from
-/// `Module::sample_metrics`. In v0.0.1 this wraps a `String` the loader
-/// flushes; v0.1 adds labels, timestamps, and the textfile atomic-rename.
+/// `Module::sample_metrics`. Wraps a `String` the loader flushes;
+/// the cli's [`MetricsExporter`](../../../cli/src/metrics.rs)
+/// handles labels, timestamps, and the atomic write-then-rename.
 #[derive(Debug)]
 pub struct MetricsWriter<'a> {
     pub out: &'a mut String,
@@ -201,10 +201,8 @@ pub trait Module: Send + Sync {
 
     /// Structured health readback. Returns a [`HealthReport`] the
     /// caller can render in `packetframe status`, feed to circuit
-    /// breakers, or expose via Prometheus. Phase 1 return type
-    /// replaces the earlier `ModuleResult<()>` which couldn't carry
-    /// per-subsystem detail; modules without subsystems return
-    /// `Ok(HealthReport::default())`.
+    /// breakers, or expose via Prometheus. Modules without
+    /// subsystems return `Ok(HealthReport::default())`.
     fn health_check(&self, ctx: &HealthCtx) -> ModuleResult<HealthReport>;
 }
 

--- a/crates/modules/fast-path/Cargo.toml
+++ b/crates/modules/fast-path/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "PacketFrame fast-path module (BPF object via build.rs; loader wiring lands in PR #4)"
+description = "PacketFrame fast-path module: XDP forwarding (kernel-fib or custom-fib via BMP), allowlist + VLAN handling, optional BMP control plane"
 build = "build.rs"
 
 [lib]

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -61,7 +61,8 @@ pub fn aligned_bpf_copy() -> Vec<u8> {
 }
 
 /// `true` when `build.rs` produced a real BPF ELF; `false` when the build
-/// fell back to an empty stub (CI-only BPF builds per the PR #3 plan).
+/// fell back to an empty stub (build.rs uses a stub when bpf-linker / the
+/// nightly toolchain isn't available, so macOS dev loops still compile).
 /// Const-evaluable so tests can early-return or be `cfg`-gated on it.
 pub const FAST_PATH_BPF_AVAILABLE: bool = !FAST_PATH_BPF.is_empty();
 
@@ -183,7 +184,9 @@ impl Module for FastPathModule {
     }
 
     fn sample_metrics(&self, _out: &mut MetricsWriter<'_>) -> ModuleResult<()> {
-        // Prometheus textfile emission lands in PR #6. No-op here.
+        // Module-side hook is a no-op; the cli's MetricsExporter
+        // (`crates/cli/src/metrics.rs`) reads STATS + the FIB
+        // snapshot from pinned maps directly on its 15 s cadence.
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Pure-comment cleanup that landed on the Phase 3.8 branch a moment after [PR #26](https://github.com/unredacted/packetframe/pull/26) merged. No behavior change.

Removes stale forward-looking phase / PR-# references from in-code docstrings now that the work they referred to has shipped:

- `crates/modules/fast-path/Cargo.toml` description: \`loader wiring lands in PR #4\` → real one-liner.
- `crates/cli/src/main.rs` top-level docstring: drops PR #4 / PR #6 references; mentions \`fib\` subcommand.
- `crates/cli/src/loader.rs` counter-NAMES comment: frames 0-19 as kernel-fib set, 20-31 as Option F.
- `crates/common/src/config.rs` ForwardingMode / RouteSourceSpec / FibSizeDirective doc strings.
- `crates/common/src/module.rs` HealthReport / Module::health_check / MetricsWriter docs.
- `crates/modules/fast-path/src/lib.rs` stub-build + sample_metrics comments.

## Test plan

- [x] \`cargo check --workspace --all-targets\` clean.
- [x] \`cargo test --workspace --lib\` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)