### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: short


### PR DESCRIPTION
Potential fix for [https://github.com/unredacted/packetframe/security/code-scanning/3](https://github.com/unredacted/packetframe/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/ci.yml` so all jobs inherit least-privilege token access.

Best fix here (without changing functionality): define workflow-level:

- `permissions:`
  - `contents: read`

This is the minimal permission needed for checkout and typical CI read operations. No write scopes are required by the shown steps.

Change location: insert the block near the top of `.github/workflows/ci.yml`, directly after the `on:` trigger section (after line 6) and before `env:` (line 8).

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
