### PR TITLE
packaging: ship .deb packages with systemd service

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,6 +116,22 @@ jobs:
           - x86_64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v6
+        with:
+          # `git log -1 --pretty=%ct <ref>` below needs the tagged commit
+          # in history. Default fetch-depth=1 is fine for tag pushes (the
+          # tag *is* the checked-out commit) but workflow_dispatch on a
+          # branch needs more history to resolve the ref.
+          fetch-depth: 0
+
+      # Reproducibility: derive SOURCE_DATE_EPOCH from the tag commit so
+      # both rustc-embedded timestamps and the .deb archive's file mtimes
+      # are deterministic. Same value across all matrix legs ensures the
+      # binary contents (and the .deb wrapping it) match across runners.
+      - name: Set SOURCE_DATE_EPOCH from tag commit
+        run: |
+          set -euo pipefail
+          SDE=$(git log -1 --pretty=%ct "${GITHUB_REF_NAME}")
+          echo "SOURCE_DATE_EPOCH=${SDE}" >> "${GITHUB_ENV}"
 
       - name: Install Rust (stable + target)
         run: |
@@ -159,8 +175,10 @@ jobs:
             echo "PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o"
             echo "PACKETFRAME_PROBE_BPF_OBJ_PATH=/project/prebuilt-bpf/probe.bpf.o"
           } >> "${GITHUB_ENV}"
-          # Forward both env vars into the container.
-          echo "CROSS_CONTAINER_OPTS=-e PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o -e PACKETFRAME_PROBE_BPF_OBJ_PATH=/project/prebuilt-bpf/probe.bpf.o" >> "${GITHUB_ENV}"
+          # Forward env vars into the container. SOURCE_DATE_EPOCH is also
+          # forwarded so rustc-embedded timestamps inside the cross build
+          # match the tag commit time set in GITHUB_ENV earlier.
+          echo "CROSS_CONTAINER_OPTS=-e PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o -e PACKETFRAME_PROBE_BPF_OBJ_PATH=/project/prebuilt-bpf/probe.bpf.o -e SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}" >> "${GITHUB_ENV}"
 
       - name: Build release
         run: cross build --release --workspace --target ${{ matrix.target }}
@@ -178,11 +196,47 @@ jobs:
           ( cd dist && tar czf "${STEM}.tar.gz" "${STEM}" )
           ( cd dist && sha256sum "${STEM}.tar.gz" > "${STEM}.tar.gz.sha256" )
 
+      # cargo-deb runs only for the gnu targets — .deb is for glibc-based
+      # Debian-family distros, and the existing musl tarballs cover the
+      # static-binary use case. Pinned version: bump deliberately.
+      - name: Install cargo-deb
+        if: contains(matrix.target, '-gnu')
+        run: |
+          if ! command -v cargo-deb >/dev/null 2>&1 || \
+             [ "$(cargo deb --version 2>/dev/null | awk '{print $2}')" != "2.7.0" ]; then
+            cargo install --locked --force cargo-deb --version 2.7.0
+          fi
+
+      - name: Build .deb
+        if: contains(matrix.target, '-gnu')
+        run: |
+          set -euo pipefail
+          # Strip the leading `v` so the .deb version is plain semver (e.g.
+          # 0.2.2), matching what `dpkg -s packetframe` will report.
+          DEB_VERSION="${GITHUB_REF_NAME#v}"
+          STEM="packetframe-${GITHUB_REF_NAME}-${{ matrix.target }}"
+          # SOURCE_DATE_EPOCH is already in GITHUB_ENV from the earlier
+          # step; cargo-deb honors it for archive mtimes and the
+          # changelog Date field. --no-build because cross already
+          # produced the binary at target/<triple>/release/packetframe.
+          # --no-strip because the workspace release profile already
+          # stripped, and the host's `strip` can't read a cross-built
+          # arm64 ELF anyway.
+          cargo deb --no-build --no-strip \
+            --target "${{ matrix.target }}" \
+            -p packetframe-cli \
+            --deb-version "${DEB_VERSION}" \
+            --output dist/
+          # Append .deb hash to the per-target .sha256 so the publish
+          # job's combined SHA256SUMS picks it up automatically.
+          ( cd dist && sha256sum *.deb >> "${STEM}.tar.gz.sha256" )
+
       - uses: actions/upload-artifact@v7
         with:
           name: release-${{ matrix.target }}
           path: |
             dist/*.tar.gz
+            dist/*.deb
             dist/*.sha256
           retention-days: 7
           if-no-files-found: error

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build release test lint fmt clean help
+.PHONY: build release test lint fmt clean deb help
 
 CARGO ?= cargo
 TARGETS := aarch64-unknown-linux-musl x86_64-unknown-linux-musl aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu
@@ -11,6 +11,7 @@ help:
 	@echo "  make test         cargo test across the workspace"
 	@echo "  make lint         cargo fmt --check + cargo clippy"
 	@echo "  make fmt          cargo fmt"
+	@echo "  make deb          host-arch .deb via cargo-deb (Linux/glibc only)"
 	@echo "  make clean        cargo clean"
 
 build:
@@ -37,6 +38,13 @@ fmt:
 
 clean:
 	$(CARGO) clean
+
+# Host-arch .deb. Sets SOURCE_DATE_EPOCH from HEAD's commit time so
+# rebuilds at the same commit produce byte-identical .deb files (cargo-deb
+# honors it for archive mtimes; rustc honors it for embedded timestamps).
+# Cross-arch .debs are CI-only; see .github/workflows/release.yml.
+deb:
+	SOURCE_DATE_EPOCH=$$(git log -1 --pretty=%ct HEAD) $(CARGO) deb -p packetframe-cli
 
 # bpf-test target is defined by v0.1 when BPF sources exist
 bpf-test:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,26 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 
 ## Install
 
-From a [GitHub release](https://github.com/unredacted/packetframe/releases):
+Releases are published on the [GitHub releases page](https://github.com/unredacted/packetframe/releases) as both `.deb` packages (Debian / Ubuntu, `amd64` and `arm64`) and `.tar.gz` archives (any Linux, four target triples).
+
+### Debian / Ubuntu (.deb)
+
+```sh
+VERSION=v0.2.2
+ARCH=$(dpkg --print-architecture)   # amd64 or arm64
+
+curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/packetframe_${VERSION#v}_${ARCH}.deb"
+curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/SHA256SUMS"
+sha256sum -c SHA256SUMS --ignore-missing
+
+sudo apt-get install ./packetframe_${VERSION#v}_${ARCH}.deb
+```
+
+Installs `/usr/bin/packetframe`, the systemd unit at `/lib/systemd/system/packetframe.service`, and an example config at `/etc/packetframe/example.conf`. The service is **not** auto-started — copy the example to `/etc/packetframe/packetframe.conf`, edit per the [Quickstart](#quickstart), then `sudo systemctl enable --now packetframe`. Requires glibc ≥ 2.31 (Debian 11+ / Ubuntu 20.04+).
+
+### Tarball (any Linux)
+
+For musl-static deployments, non-Debian distros, or anything else:
 
 ```sh
 VERSION=v0.2.2

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,3 +31,49 @@ signal-hook.workspace = true
 default = ["fast-path", "probe"]
 fast-path = ["dep:packetframe-fast-path"]
 probe = ["dep:packetframe-probe"]
+
+# cargo-deb metadata. CI builds the .deb in the release workflow via
+# `cargo deb --no-build --target <triple>` after the cross-compiled
+# binary is in place. Local builds run `make deb` (host-arch only).
+[package.metadata.deb]
+name = "packetframe"
+maintainer = "PacketFrame maintainers <noreply@unredacted.org>"
+copyright = "Copyright (C) 2024-2026 Unredacted contributors"
+license-file = ["../../LICENSE", "0"]
+extended-description = """\
+PacketFrame is a modular eBPF data plane for Linux packet forwarding.
+The fast-path module attaches per-interface XDP programs that forward
+allowlisted traffic at the driver level, bypassing iptables and conntrack.
+See /usr/share/doc/packetframe/README.md for documentation.\
+"""
+section = "net"
+priority = "optional"
+# Workspace `[profile.release]` sets `strip = true`, so cargo-deb's own
+# strip step would re-run on an already-stripped binary — and on CI it
+# would shell out to the host's `strip`, which can't read cross-built
+# arm64 ELFs. Skip it.
+strip = false
+# dpkg-shlibdeps doesn't work cross-arch on the Ubuntu CI runner, so
+# pin the glibc dependency floor explicitly. 2.31 = Ubuntu 20.04 /
+# Debian 11 (oldest supported glibc as of 2026).
+depends = "libc6 (>= 2.31)"
+assets = [
+    ["target/release/packetframe", "/usr/bin/packetframe", "755"],
+    ["../../conf/example.conf", "/etc/packetframe/example.conf", "644"],
+    ["../../README.md", "/usr/share/doc/packetframe/README.md", "644"],
+]
+
+# Built-in systemd-units integration: cargo-deb generates the
+# postinst/prerm/postrm maintainer scripts to register the unit with
+# systemctl. enable+start are off because the daemon needs an
+# operator-supplied interface list before it can do anything useful;
+# auto-starting would just produce a noisy first-launch failure.
+# `restart-after-upgrade = true` keeps a running daemon alive across
+# `apt upgrade` (the SIGTERM handler preserves pins per SPEC.md §8.5).
+[package.metadata.deb.systemd-units]
+unit-name = "packetframe"
+unit-scripts = "debian"
+enable = false
+start = false
+restart-after-upgrade = true
+stop-on-upgrade = false

--- a/crates/cli/debian/packetframe.service
+++ b/crates/cli/debian/packetframe.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=PacketFrame eBPF data plane
+Documentation=https://github.com/unredacted/packetframe
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/packetframe run
+Restart=on-failure
+RestartSec=5
+User=root
+Group=root
+StateDirectory=packetframe
+StateDirectoryMode=0750
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=packetframe
+KillMode=mixed
+KillSignal=SIGTERM
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- New: first-class Debian (.deb) packaging for `amd64` and `arm64` (gnu targets), built in the existing release workflow alongside the tarballs. Each .deb installs `/usr/bin/packetframe`, `/etc/packetframe/example.conf`, and a systemd unit at `/lib/systemd/system/packetframe.service`.
- Service ships **disabled** — the daemon needs an operator-supplied interface list before it can do anything useful, so auto-starting would just produce a noisy first-launch failure. Operators copy `example.conf` → `packetframe.conf`, edit, then `systemctl enable --now packetframe`.
- Reproducible by default: `SOURCE_DATE_EPOCH` is derived from the tag commit and threaded into the cross container so rustc-embedded timestamps and `.deb` archive mtimes match across runners. Verified with a workspace YAML lint and `cargo metadata --no-deps`.

## Why

The README already references `systemctl reload packetframe` ([README.md:145](https://github.com/unredacted/packetframe/blob/main/README.md?plain=1#L145)) — systemd is the intended deployment shape — but no unit file ships in tree, so every operator hand-writes their own. Shipping a `.deb` collapses install + unit + state-dir creation into one `apt install`, while preserving the tarball flow for musl-static / non-Debian users.

## What's in this PR

| Path | Change |
|---|---|
| [crates/cli/debian/packetframe.service](https://github.com/unredacted/packetframe/blob/deb-packaging-systemd-service/crates/cli/debian/packetframe.service) | new — systemd unit (Type=simple, root, StateDirectory=packetframe, no ExecReload) |
| [crates/cli/Cargo.toml](https://github.com/unredacted/packetframe/blob/deb-packaging-systemd-service/crates/cli/Cargo.toml) | `[package.metadata.deb]` + `[package.metadata.deb.systemd-units]` |
| [.github/workflows/release.yml](https://github.com/unredacted/packetframe/blob/deb-packaging-systemd-service/.github/workflows/release.yml) | `SOURCE_DATE_EPOCH` setup + cross-container env passthrough + cargo-deb build steps gated to `-gnu` targets + `dist/*.deb` artifact glob |
| [Makefile](https://github.com/unredacted/packetframe/blob/deb-packaging-systemd-service/Makefile) | `make deb` target (host-arch only, with `SOURCE_DATE_EPOCH` from `HEAD`) |
| [README.md](https://github.com/unredacted/packetframe/blob/deb-packaging-systemd-service/README.md) | new §Debian/Ubuntu (.deb) install subsection above the existing tarball block |

No version bump. No changes to `LICENSE`, `Cargo.toml` workspace metadata, the BPF crates, or the `bpf`/`publish` jobs. `.deb` hashes append to the per-target `.sha256`, so the existing combined `SHA256SUMS` + GPG sign flow in the `publish` job covers them automatically — no signing-pipeline changes needed.

## Notable design choices

- **`cargo-deb` over `nfpm` / hand-rolled**: Rust-native, reads workspace metadata, supports cross-target via `--target`, has built-in `[package.metadata.deb.systemd-units]` maintainer-script generation. Pinned to `2.7.0` in CI.
- **gnu-only**: `.deb` is for glibc-based distros; musl `.deb`s would be confusing. Existing musl tarballs cover the static-binary use case.
- **`strip = false`** in the metadata: workspace `[profile.release]` already sets `strip = true`, and the host's `strip` can't read cross-built arm64 ELFs anyway. Pass `--no-strip` to cargo-deb so it doesn't try.
- **`depends = "libc6 (>= 2.31)"`** hard-coded: `dpkg-shlibdeps` doesn't work cross-arch on Ubuntu CI runners. 2.31 = Debian 11 / Ubuntu 20.04 (oldest supported as of 2026).
- **No `ExecReload`** — the `Reconfigure` subcommand is currently stubbed and SIGHUP isn't caught. Default SIGHUP disposition is `Term`, which would *kill* the daemon. Add it in the same PR that wires up SIGHUP/reconfigure.
- **`restart-after-upgrade = true`** keeps a running daemon alive across `apt upgrade` (the SIGTERM handler preserves pins per SPEC.md §8.5). On `apt remove`, cargo-deb's generated prerm calls `systemctl stop`.

## Test plan

Local sanity (already done):
- [x] `cargo metadata --no-deps` parses the new `[package.metadata.deb]` block cleanly
- [x] `cargo fmt --all --check` clean
- [x] `cargo check --workspace` exits 0 on macOS dev host (BPF stub-fallback warnings expected per CLAUDE.md)
- [x] `release.yml` parses as valid YAML; build job has 12 steps, cargo-deb steps gated on `contains(matrix.target, '-gnu')`

Reviewer / pre-merge to-dos (Linux box / VM required):
- [ ] `make deb` end-to-end → produces `target/debian/packetframe_0.2.2-1_amd64.deb` (or similar)
- [ ] `dpkg-deb -c <deb>` lists `/usr/bin/packetframe`, `/lib/systemd/system/packetframe.service`, `/etc/packetframe/example.conf`
- [ ] `dpkg-deb -I <deb>` shows `Architecture: amd64`, `Depends: libc6 (>= 2.31)`, `Section: net`
- [ ] `lintian <deb>` — expect zero errors (warnings on missing manpage are acceptable)
- [ ] On a fresh Debian 12 / Ubuntu 22.04 VM: `sudo apt install ./packetframe_*.deb` → `systemctl status packetframe` shows "loaded; disabled". Postinst printed the "edit /etc/packetframe/packetframe.conf" hint
- [ ] Create config, `systemctl enable --now packetframe`, confirm `/var/lib/packetframe/` was created with mode 0750, journal shows tracing output
- [ ] `apt remove` stops service + removes binary; `apt purge` removes `/etc/packetframe/example.conf`
- [ ] Reproducibility: trigger `workflow_dispatch` with `dry_run: true` twice on the same SHA → resulting `.deb` files have identical sha256
- [ ] Tag-release dry run: real tag push → confirm `gpg --verify SHA256SUMS.asc && sha256sum -c SHA256SUMS --ignore-missing` covers the `.deb` files

## Out of scope (explicitly)

- apt repo hosting (users `apt install ./packetframe_*.deb` from a downloaded file)
- rpm packaging
- `ExecReload` wiring (lands with SIGHUP/reconfigure)
- AppArmor / SELinux profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)