### PR TITLE
packaging: drop unsupported strip key from cargo-deb metadata

### DIFF
--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -48,11 +48,10 @@ See /usr/share/doc/packetframe/README.md for documentation.\
 """
 section = "net"
 priority = "optional"
-# Workspace `[profile.release]` sets `strip = true`, so cargo-deb's own
-# strip step would re-run on an already-stripped binary — and on CI it
-# would shell out to the host's `strip`, which can't read cross-built
-# arm64 ELFs. Skip it.
-strip = false
+# Workspace `[profile.release]` already strips, and the host's `strip`
+# can't read cross-built arm64 ELFs anyway. Skipping is handled at the
+# cargo-deb invocation site via the `--no-strip` CLI flag — there's no
+# `strip` key in [package.metadata.deb]; cargo-deb 2.7 rejects it.
 # dpkg-shlibdeps doesn't work cross-arch on the Ubuntu CI runner, so
 # pin the glibc dependency floor explicitly. 2.31 = Ubuntu 20.04 /
 # Debian 11 (oldest supported glibc as of 2026).


### PR DESCRIPTION
## Summary

The v0.2.3 release run ([25345232171](https://github.com/unredacted/packetframe/actions/runs/25345232171)) failed because cargo-deb 2.7.0 rejects `strip = false` in `[package.metadata.deb]` — that key doesn't exist in the schema. Both `-gnu` build legs hit the same TOML parse error at the `Build .deb` step. `publish` never ran, so no GitHub release was created at v0.2.3.

The intent of `strip = false` (don't re-strip an already-stripped binary; don't try to invoke the host's `strip` on cross-built arm64 ELFs) is already covered by the `--no-strip` flag on the cargo-deb invocation in [release.yml](.github/workflows/release.yml). The metadata key was redundant *and* invalid.

## Root cause

`cargo metadata --no-deps` (the local sanity check in the original PR) parses TOML but does **not** validate `[package.metadata.deb]` against cargo-deb's schema. Only cargo-deb itself does. So the bad key passed local checks and exploded in CI.

## Verification

Installed cargo-deb 2.7.0 locally and reproduced both the failure and the fix:

```sh
$ cargo install --locked cargo-deb --version 2.7.0
$ cargo deb --no-build --no-strip -p packetframe-cli --output /tmp/test.deb
warning: You're creating a package for your current operating system only (aarch64-apple-darwin) ...
/tmp/test.deb
$ ar -tv /tmp/test.deb
rw-r--r--       0/0             4 May  3 19:00 2026 debian-binary
rw-r--r--       0/0           860 May  3 19:00 2026 control.tar.xz
rw-r--r--       0/0        490588 May  3 19:00 2026 data.tar.xz
```

(Building on macOS produces a structurally valid `.deb` even though the contents target the wrong OS — what matters is that cargo-deb now *parses* the metadata and runs end-to-end. The cross-built CI run is what produces real artifacts.)

## Re-release plan (after merge)

The v0.2.3 tag exists but no release was published, so the cleanest path is to delete and re-cut. Options:

- **Re-cut v0.2.3** (recommended). After this PR merges:
  ```sh
  git push --delete origin v0.2.3
  git tag -d v0.2.3
  git checkout main && git pull
  git tag -a v0.2.3 -m \"v0.2.3\"
  git push origin v0.2.3
  ```
  Tag mutation is normal release-engineering when no release artifacts shipped, and v0.2.3 is the version already advertised in [README.md](README.md).

- **Skip to v0.2.4**: leave v0.2.3 as a ghost tag, open another version-bump PR for v0.2.4. More commit churn but no tag mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)