### PR TITLE
release: attach .debs to GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,7 +296,14 @@ jobs:
           if [[ "${GITHUB_REF_NAME}" == *-* ]]; then
             PRERELEASE_FLAG="--prerelease"
           fi
-          FILES=(dist/*.tar.gz dist/SHA256SUMS)
+          # nullglob so an empty `dist/*.deb` expands to nothing rather
+          # than the literal string (which would make `gh release create`
+          # fail). The build job currently always emits .debs from the
+          # gnu legs, but defensive: also tolerates a future tag that
+          # ships only tarballs.
+          shopt -s nullglob
+          FILES=(dist/*.tar.gz dist/*.deb dist/SHA256SUMS)
+          shopt -u nullglob
           if [[ -f dist/SHA256SUMS.asc ]]; then
             FILES+=(dist/SHA256SUMS.asc)
           fi


### PR DESCRIPTION
## Summary

Fixes a missed integration in #39: the publish job's `Create GitHub release` step has a hardcoded `FILES=(dist/*.tar.gz dist/SHA256SUMS)` array that didn't include `dist/*.deb`. The build job produced the .debs and uploaded them as artifacts, the publish job downloaded them, and the combined `SHA256SUMS` already covered their hashes — but `gh release create` only attached the tarballs.

Effect: v0.2.3 shipped without `.deb` files on the [release page](https://github.com/unredacted/packetframe/releases/tag/v0.2.3), so the `apt install` snippet in the README pointed at a 404.

## Fix

Add `dist/*.deb` to the FILES array, gated by `nullglob` so an empty match expands to nothing rather than the literal string `dist/*.deb` (which would make `gh release create` error out trying to attach a non-existent file).

```diff
- FILES=(dist/*.tar.gz dist/SHA256SUMS)
+ shopt -s nullglob
+ FILES=(dist/*.tar.gz dist/*.deb dist/SHA256SUMS)
+ shopt -u nullglob
```

The build job currently always produces `.debs` from the gnu legs, but `nullglob` is cheap insurance against a future tag that ships only tarballs.

## v0.2.3 patched post-hoc

Without waiting for a re-cut, the v0.2.3 release was patched by re-uploading the `.deb`s from the still-retained build artifacts:

```sh
gh run download 25346282728 -n release-x86_64-unknown-linux-gnu -D x86_64
gh run download 25346282728 -n release-aarch64-unknown-linux-gnu -D aarch64
gh release upload v0.2.3 x86_64/packetframe_0.2.3_amd64.deb aarch64/packetframe_0.2.3_arm64.deb
```

The published [SHA256SUMS](https://github.com/unredacted/packetframe/releases/download/v0.2.3/SHA256SUMS) already included the correct `.deb` hashes (the build job's `sha256sum *.deb >> "${STEM}.tar.gz.sha256"` step worked correctly), so the manually-attached `.deb`s match what's signed. Verified: downloaded `.deb` hashes match SHA256SUMS exactly. No signing-flow change needed.

## Test plan

- [x] YAML still parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"`)
- [x] `nullglob` is bash-builtin; no new dependencies
- [ ] Next tag (v0.2.4 or v0.2.3-rc1) confirms `.deb` files appear on the release page automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)