### PR TITLE
fast-path: structural fix — per-CPU scratch map for bpf_fib_lookup, kill MutationCtx padding

### DIFF
--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -35,9 +35,9 @@ mod finalize;
 mod maps;
 
 use maps::{
-    bump_stat, StatIdx, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG, FP_CFG_FLAG_COMPARE_MODE,
-    FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_HEAD_SHIFT_128, MUTATION_CTX, MUTATION_PROGS,
-    REDIRECT_DEVMAP, VLAN_RESOLVE,
+    bump_stat, StatIdx, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG, FIB_LOOKUP_SCRATCH,
+    FP_CFG_FLAG_COMPARE_MODE, FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_HEAD_SHIFT_128, MUTATION_CTX,
+    MUTATION_PROGS, REDIRECT_DEVMAP, VLAN_RESOLVE,
 };
 
 const AF_INET: u8 = 2;
@@ -250,66 +250,56 @@ fn handle_ipv4(
         return dispatch_custom_fib(custom, ctx, eth, ip as *mut u8, true, ingress_vid);
     }
 
-    // Build `bpf_fib_lookup` via `MaybeUninit` + selective field
-    // writes — NEVER as a struct literal with zero-padded arrays
-    // ([0; 6], [val, 0, 0, 0], etc.) and NEVER with `mem::zeroed()`.
-    //
-    // Why: LLVM's "merge stores" pass recognizes any run of adjacent
-    // zero stores and lowers them into a `memset` libcall. The BPF
-    // backend has no libc to link against, so memset becomes a
-    // separate BPF function — a bpf-to-bpf subprogram call. That
-    // combined with `bpf_tail_call` (which fast_path uses to enter
-    // finalize) trips the kernel verifier's
-    //     "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
-    // guard on kernels whose JIT returns false from
-    // `bpf_jit_supports_subprog_tailcalls()` (UniFi 5.15-ui-cn9670
-    // aarch64 is the canonical hit).
-    //
-    // We can't fix this with `#[no_mangle] #[inline(always)]` shim
-    // functions either: rustc warns "`#[inline]` is ignored on
-    // externally exported functions" and refuses to inline at the
-    // libcall site.
-    //
-    // The only reliable mitigation is to never produce the merge-able
-    // pattern in the first place. So: write each input field
-    // individually via raw pointer; leave smac/dmac uninit (kernel
-    // writes them as outputs); leave the unread union bytes uninit
-    // (kernel doesn't read offsets 13-15 of __bindgen_anon_2 or
-    // 20-31/36-47 of __bindgen_anon_3/4 in the IPv4 path).
-    let mut fib_uninit: core::mem::MaybeUninit<bpf_fib_lookup> =
-        core::mem::MaybeUninit::uninit();
-    let p = fib_uninit.as_mut_ptr();
+    // Use the per-CPU `FIB_LOOKUP_SCRATCH` map for the bpf_fib_lookup
+    // struct rather than allocating it on the stack. Per-CPU array
+    // elements are pre-zeroed at map creation by the kernel; we only
+    // ever write the input fields the kernel reads. This sidesteps
+    // LLVM's stack zero-init optimization that lowers adjacent zero
+    // stores into `memset` libcalls — those become bpf-to-bpf
+    // subprogram calls, which combined with `bpf_tail_call` violates
+    // the kernel verifier's
+    //   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
+    // guard on UniFi-style kernels (`bpf_jit_supports_subprog_tailcalls()`
+    // returns false). See SPEC §11.x and the v0.2.6 post-mortem in
+    // tail-call-architecture.md.
+    let fib_ptr = match FIB_LOOKUP_SCRATCH.get_ptr_mut(0) {
+        Some(p) => p,
+        None => {
+            // Per-CPU array index 0 is always present; this branch is
+            // unreachable in practice. Fail-safe XDP_PASS so traffic
+            // falls to kernel slow-path rather than getting dropped.
+            bump_stat(StatIdx::ErrFibOther);
+            return Ok(xdp_action::XDP_PASS);
+        }
+    };
     unsafe {
-        (*p).family = AF_INET;
-        (*p).l4_protocol = proto;
-        (*p).sport = sport;
-        (*p).dport = dport;
-        (*p).__bindgen_anon_1.tot_len = u16::from_be_bytes((*ip).tot_len);
-        (*p).ifindex = (*ctx.ctx).ingress_ifindex;
-        (*p).__bindgen_anon_2.tos = (*ip).tos;
-        (*p).__bindgen_anon_3.ipv4_src = u32::from_ne_bytes(src_bytes);
-        (*p).__bindgen_anon_4.ipv4_dst = u32::from_ne_bytes(dst_bytes);
-        // tbid: routing table ID. 0 = main table. Single u32 store —
-        // no merge with other zero stores because adjacent fields are
-        // either non-zero (the writes above) or kernel-output (smac
-        // immediately follows tbid at offset 52).
-        (*p).__bindgen_anon_5.tbid = 0;
+        (*fib_ptr).family = AF_INET;
+        (*fib_ptr).l4_protocol = proto;
+        (*fib_ptr).sport = sport;
+        (*fib_ptr).dport = dport;
+        (*fib_ptr).__bindgen_anon_1.tot_len = u16::from_be_bytes((*ip).tot_len);
+        (*fib_ptr).ifindex = (*ctx.ctx).ingress_ifindex;
+        (*fib_ptr).__bindgen_anon_2.tos = (*ip).tos;
+        (*fib_ptr).__bindgen_anon_3.ipv4_src = u32::from_ne_bytes(src_bytes);
+        (*fib_ptr).__bindgen_anon_4.ipv4_dst = u32::from_ne_bytes(dst_bytes);
+        // tbid (off 48), smac (off 52), dmac (off 58): we never write
+        // these. tbid stays 0 from initial map zero-init. smac/dmac
+        // are kernel outputs; on success the helper fills them.
     }
 
     let ret = unsafe {
         fib_lookup_helper(
             ctx.ctx as *mut _,
-            p as *mut _,
+            fib_ptr as *mut _,
             mem::size_of::<bpf_fib_lookup>() as i32,
             0,
         )
     };
 
-    // Borrow from the raw pointer for the rest of the function.
+    // Borrow from the per-CPU map pointer for the rest of the function.
     // After fib_lookup_helper, the kernel has written smac/dmac on
-    // success; on failure, dispatch_fib doesn't read them. Other
-    // unread union bytes stay uninit but aren't observed.
-    let fib_ref = unsafe { &*p };
+    // success; on failure, dispatch_fib doesn't read them.
+    let fib_ref = unsafe { &*fib_ptr };
 
     if compare {
         // Compare mode: we also ran above iff `use_custom`; but since
@@ -390,37 +380,39 @@ fn handle_ipv6(
         return dispatch_custom_fib(custom, ctx, eth, ip as *mut u8, false, ingress_vid);
     }
 
-    // See handle_ipv4 for the rationale behind the MaybeUninit
-    // pattern (avoids the LLVM-emitted memset bpf-to-bpf subprogram
-    // that conflicts with bpf_tail_call on non-JITed kernels).
-    let mut fib_uninit: core::mem::MaybeUninit<bpf_fib_lookup> =
-        core::mem::MaybeUninit::uninit();
-    let p = fib_uninit.as_mut_ptr();
+    // See handle_ipv4 for the rationale behind using FIB_LOOKUP_SCRATCH
+    // (per-CPU map) instead of stack-allocated bpf_fib_lookup.
+    let fib_ptr = match FIB_LOOKUP_SCRATCH.get_ptr_mut(0) {
+        Some(p) => p,
+        None => {
+            bump_stat(StatIdx::ErrFibOther);
+            return Ok(xdp_action::XDP_PASS);
+        }
+    };
     unsafe {
-        (*p).family = AF_INET6;
-        (*p).l4_protocol = next;
-        (*p).sport = sport;
-        (*p).dport = dport;
-        (*p).__bindgen_anon_1.tot_len =
+        (*fib_ptr).family = AF_INET6;
+        (*fib_ptr).l4_protocol = next;
+        (*fib_ptr).sport = sport;
+        (*fib_ptr).dport = dport;
+        (*fib_ptr).__bindgen_anon_1.tot_len =
             u16::from_be_bytes((*ip).payload_len) + Ipv6Hdr::LEN as u16;
-        (*p).ifindex = (*ctx.ctx).ingress_ifindex;
-        (*p).__bindgen_anon_2.flowinfo = u32::from_be_bytes((*ip).vcf);
-        (*p).__bindgen_anon_3.ipv6_src = bytes_to_u32x4(&src_bytes);
-        (*p).__bindgen_anon_4.ipv6_dst = bytes_to_u32x4(&dst_bytes);
-        (*p).__bindgen_anon_5.tbid = 0;
-        // smac, dmac: kernel-output, leave uninit.
+        (*fib_ptr).ifindex = (*ctx.ctx).ingress_ifindex;
+        (*fib_ptr).__bindgen_anon_2.flowinfo = u32::from_be_bytes((*ip).vcf);
+        (*fib_ptr).__bindgen_anon_3.ipv6_src = bytes_to_u32x4(&src_bytes);
+        (*fib_ptr).__bindgen_anon_4.ipv6_dst = bytes_to_u32x4(&dst_bytes);
+        // tbid, smac, dmac: see handle_ipv4 commentary.
     }
 
     let ret = unsafe {
         fib_lookup_helper(
             ctx.ctx as *mut _,
-            p as *mut _,
+            fib_ptr as *mut _,
             mem::size_of::<bpf_fib_lookup>() as i32,
             0,
         )
     };
 
-    let fib_ref = unsafe { &*p };
+    let fib_ref = unsafe { &*fib_ptr };
 
     if compare {
         let custom = fib::lookup_v6(src_bytes, dst_bytes, next, sport_h, dport_h);
@@ -536,12 +528,10 @@ fn forward_success(
             (*mctx_ptr).egress_vid = egress_vid;
             (*mctx_ptr).ingress_vid = ingress_vid;
             (*mctx_ptr).ip_offset = ip_offset as u32;
-            (*mctx_ptr).is_v4 = u8::from(is_v4);
-            // _pad: per-CPU array elements are zero-initialized at map
-            // creation and we never write the padding region — leaving
-            // it as the residual zeros saves a memset libcall (now
-            // inlined via libcalls.rs anyway, but the moot store is
-            // still worth eliding).
+            // is_v4 is u32 (no padding); low byte holds the bool.
+            // Single u32 store — LLVM has no adjacent zero stores to
+            // merge into a memset libcall.
+            (*mctx_ptr).is_v4 = u32::from(u8::from(is_v4));
         }
     } else {
         // Per-CPU array index 0 is always present; this branch should

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -7,6 +7,7 @@
 //! `size_of`-asserting test to catch layout drift.
 
 use aya_ebpf::{
+    bindings::bpf_fib_lookup,
     macros::map,
     maps::{Array, DevMapHash, HashMap, LpmTrie, PerCpuArray, ProgramArray, RingBuf},
 };
@@ -297,8 +298,18 @@ pub struct MutationCtx {
     pub ip_offset: u32,
     /// 1 = IPv4 packet, 0 = IPv6. Determines which IP-header struct
     /// finalize casts to and which MSS_CLAMP map to consult.
-    pub is_v4: u8,
-    pub _pad: [u8; 3],
+    ///
+    /// Stored as `u32` (not `u8`) so the struct has no padding bytes.
+    /// With padding, LLVM's "merge stores" optimization recognizes the
+    /// 3 unwritten bytes between `is_v4: u8` and the end of the struct
+    /// as a zero-init block and lowers them into a `memset` libcall —
+    /// emitted by the BPF backend as a separate bpf-to-bpf subprogram,
+    /// which then trips the kernel verifier's
+    ///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
+    /// guard on UniFi-style kernels (5.15-ui-cn9670 aarch64). Single
+    /// `u32` field = single store, no padding, no merge-able zero
+    /// pattern. Low byte holds the boolean.
+    pub is_v4: u32,
 }
 
 // --- Custom FIB value layouts (Option F) -------------------------------
@@ -510,6 +521,30 @@ pub static MSS_CLAMP_BY_IFACE: HashMap<u32, u16> =
 /// most recent write.
 #[map]
 pub static MUTATION_CTX: PerCpuArray<MutationCtx> = PerCpuArray::with_max_entries(1, 0);
+
+/// Per-CPU scratch buffer for `bpf_fib_lookup` calls. Per-CPU array
+/// elements are pre-zeroed at map creation by the kernel and remain
+/// accessible at a stable address — fast_path writes the input fields
+/// (family, l4_protocol, sport/dport, addrs, etc.), the kernel helper
+/// fills `smac`/`dmac` on success, and the value persists per-CPU
+/// between calls.
+///
+/// Why per-CPU map instead of stack: a stack-allocated `bpf_fib_lookup`
+/// triggers LLVM's "merge stores" optimization on the unwritten union
+/// trailing bytes (`__bindgen_anon_3.ipv6_src[1..4]` in the IPv4 path,
+/// `__bindgen_anon_5.tbid`, etc.), which then lowers into a `memset`
+/// libcall — emitted by the BPF backend as a separate bpf-to-bpf
+/// subprogram. Combined with `bpf_tail_call`, that violates the kernel
+/// verifier's
+///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
+/// guard on UniFi-style kernels (5.15-ui-cn9670 aarch64) where
+/// `bpf_jit_supports_subprog_tailcalls()` returns false. Moving the
+/// scratch struct to a per-CPU map sidesteps stack init entirely:
+/// fast_path's only writes are to fields the kernel reads (family,
+/// addrs, etc.), with no zero-padded blocks for LLVM to coalesce.
+#[map]
+pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> =
+    PerCpuArray::with_max_entries(1, 0);
 
 /// Tail-call jump table (v0.2.5+). fast_path tail_calls into slot 0 after
 /// classification + L2/TTL mutations. Slot 0 holds `finalize` today.

--- a/crates/modules/fast-path/src/pin.rs
+++ b/crates/modules/fast-path/src/pin.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use crate::MODULE_NAME;
 
 /// Every §4.5 map that gets pinned. Order is not significant.
-pub const MAP_NAMES: [&str; 19] = [
+pub const MAP_NAMES: [&str; 20] = [
     "ALLOW_V4",
     "ALLOW_V6",
     "CFG",
@@ -51,6 +51,9 @@ pub const MAP_NAMES: [&str; 19] = [
     // --- v0.2.5: two-stage datapath ---
     "MUTATION_CTX",
     "MUTATION_PROGS",
+    // --- v0.2.7: per-CPU scratch for bpf_fib_lookup (replaces the
+    // stack-allocated struct that was triggering memset libcalls).
+    "FIB_LOOKUP_SCRATCH",
 ];
 
 /// The fast-path XDP program's pinned basename (attached per-iface).


### PR DESCRIPTION
## Stop iterating on source patterns; use the right BPF idiom

The post-PR-#49 install on UniFi still trips the verifier. Verifier dump still shows three bpf-to-bpf memset subprogram calls (3 / 6 / 22 bytes) — LLVM keeps finding patterns to merge regardless of how I write the source. We need to stop fighting LLVM and use the canonical BPF design pattern.

## Two structural changes

**1. \`bpf_fib_lookup\` → per-CPU scratch map.** Stack-allocated bpf_fib_lookup is what LLVM was zero-coalescing into memsets. Per-CPU array elements are pre-zeroed at map creation by the kernel and remain accessible at a stable address — fast_path writes only the input fields, the kernel helper fills smac/dmac on success, and the value persists per-CPU between calls. This is the textbook BPF pattern for scratch buffers (libbpf's CO-RE projects all do this; it shows up in cilium, sysdig, etc.).

\`\`\`rust
#[map]
pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> =
    PerCpuArray::with_max_entries(1, 0);
\`\`\`

**2. \`MutationCtx { is_v4: u8, _pad: [u8; 3] }\` → \`is_v4: u32\`.** The padding bytes were what LLVM was alignment-completing into a 3-byte memset (visible at instruction 4410 in every dump). Collapsing to a single u32 field eliminates the padding entirely. Single store, no merge-able pattern. \`finalize\` reads \`mctx.is_v4 != 0\` which works identically for u8 and u32 low-byte semantics.

## What this is not

Not a band-aid. Not "remove this one zero store and hope LLVM stops." Both changes are how BPF programs are *supposed* to be written:

- Per-CPU maps for scratch buffers larger than ~32 bytes (avoids stack budget pressure AND zero-init issues).
- Repr-C structs without padding bytes (avoids alignment-completion stores).

## Test plan

- [ ] CI green.
- [ ] Verifier dump on UniFi: zero \`(85) call pc+N\` instructions in fast_path or finalize.
- [ ] \`sudo bpftool prog show name fast_path\` reports \`jited:\` non-zero.
- [ ] \`sudo packetframe feasibility --human\`: all xdp.attach.ethN PASS.
- [ ] Forwarding works (IPv4 + IPv6 + per-prefix mss-clamp).

## Wire-format note

\`MutationCtx\` size is unchanged (16 bytes both before and after). Field offsets through \`ip_offset\` are unchanged. Only the trailing 4 bytes' interpretation changes (\`is_v4: u8 + _pad: [u8; 3]\` → \`is_v4: u32\`). No userspace mirror struct exists to keep in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)