### PR TITLE
bgp: implement RFC 7911 ADD-PATH support end to end

### DIFF
--- a/crates/cli/src/fib_cli.rs
+++ b/crates/cli/src/fib_cli.rs
@@ -155,10 +155,16 @@ fn print_entry(entry: &FibEntry) {
 }
 
 fn format_nh(nh: &NexthopSummary) -> String {
+    // No width-padded fields. Numeric IDs and ifindex render as-is
+    // (no leading spaces), and `state=` takes only as much horizontal
+    // space as the value needs. The trailing-pad on `state` previously
+    // landed as visible double/triple gaps before `family=v4` in normal
+    // output; readability beats column alignment here because nh_ids
+    // and ifindexes are short and the row is single-line anyway.
     format!(
-        "nh_id={:>4} state={:<10} family=v{} ifindex={:>3} dst_mac={} src_mac={}",
+        "nh_id={} state={} family=v{} ifindex={} dst_mac={} src_mac={}",
         nh.id,
-        nh.state.to_string(),
+        nh.state,
         nh.family,
         nh.ifindex,
         mac_fmt(nh.dst_mac),

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -52,14 +52,28 @@ pub enum RouteEvent {
     /// keys its per-advertisement state by `(peer_id, path_id)` so that
     /// multiple paths per prefix can coexist and be aggregated into an
     /// ECMP group.
+    ///
+    /// `local_pref` carries the BGP LOCAL_PREF attribute when the source
+    /// is a BGP-like protocol; `None` for non-BGP sources (netlink,
+    /// connected-fast-path seeding) and for BGP UPDATEs that omit the
+    /// attribute. The FibProgrammer filters the per-prefix NH union to
+    /// the maximum local-pref tier across the prefix's advertisements,
+    /// so operator-encoded preferences (e.g., IX peers at LP 150 vs
+    /// transit at LP 100) survive ADD-PATH aggregation: ECMP forms
+    /// within a tier, not across tiers. Missing local_pref is treated
+    /// as RFC 4271's default of 100.
     Add {
         peer_id: PeerId,
         prefix: IpPrefix,
         nexthops: Vec<IpAddr>,
         path_id: Option<u32>,
+        local_pref: Option<u32>,
     },
     /// Route withdrawal. `path_id` matches the `Add` it pairs with;
-    /// see [`RouteEvent::Add`] for semantics.
+    /// see [`RouteEvent::Add`] for semantics. `local_pref` is not part
+    /// of the withdrawal key because the FibProgrammer looks up the
+    /// advertisement by `(peer_id, path_id)` and removes it regardless
+    /// of its stored LP.
     Del {
         peer_id: PeerId,
         prefix: IpPrefix,

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -45,13 +45,26 @@ pub enum RouteEvent {
     /// with this `peer_id`.
     PeerDown { peer_id: PeerId },
     /// Route announcement.
+    ///
+    /// `path_id` is `Some(_)` only when RFC 7911 ADD-PATH has been
+    /// negotiated on the source session; `None` otherwise. Sources that
+    /// never negotiate ADD-PATH always emit `None`. The FibProgrammer
+    /// keys its per-advertisement state by `(peer_id, path_id)` so that
+    /// multiple paths per prefix can coexist and be aggregated into an
+    /// ECMP group.
     Add {
         peer_id: PeerId,
         prefix: IpPrefix,
         nexthops: Vec<IpAddr>,
+        path_id: Option<u32>,
     },
-    /// Route withdrawal.
-    Del { peer_id: PeerId, prefix: IpPrefix },
+    /// Route withdrawal. `path_id` matches the `Add` it pairs with;
+    /// see [`RouteEvent::Add`] for semantics.
+    Del {
+        peer_id: PeerId,
+        prefix: IpPrefix,
+        path_id: Option<u32>,
+    },
     /// The RouteSource finished its initial RIB dump (all known
     /// peers have quiesced). The programmer uses this to garbage-
     /// collect entries left over from a prior session.

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -94,7 +94,12 @@ pub enum RouteEvent {
 /// negligible. `is_local_arp` recovers the per-iface scope so the
 /// programmer can withdraw a single iface's worth of /32s on
 /// `RTM_DELLINK`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// `Ord` / `PartialOrd` are derived (lexicographic on the wrapped
+/// `u64`) so `PeerId` can key a `BTreeMap` / `BTreeSet`. The
+/// FibProgrammer uses `BTreeMap<(PeerId, Option<u32>), _>` for its
+/// per-advertisement state so iteration order is stable across
+/// process runs without an explicit sort.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct PeerId(pub u64);
 
 impl PeerId {

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -590,6 +590,7 @@ impl NetlinkNeighborResolver {
                             prefix_len: 32,
                         },
                         nexthops: vec![ip],
+                        path_id: None,
                     })
                     .await
                 {
@@ -788,6 +789,7 @@ impl NetlinkNeighborResolver {
                 prefix_len: 0,
             },
             nexthops: vec![IpAddr::V4(spec.nexthop)],
+            path_id: None,
         };
         match prog.apply_route_event(event).await {
             Ok(()) => info!(
@@ -824,6 +826,7 @@ impl NetlinkNeighborResolver {
                     prefix_len: 32,
                 },
                 nexthops: vec![ip],
+                path_id: None,
             })
             .await
         {
@@ -849,6 +852,7 @@ impl NetlinkNeighborResolver {
                     addr: v4.octets(),
                     prefix_len: 32,
                 },
+                path_id: None,
             })
             .await
         {

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -591,6 +591,7 @@ impl NetlinkNeighborResolver {
                         },
                         nexthops: vec![ip],
                         path_id: None,
+                        local_pref: None,
                     })
                     .await
                 {
@@ -790,6 +791,7 @@ impl NetlinkNeighborResolver {
             },
             nexthops: vec![IpAddr::V4(spec.nexthop)],
             path_id: None,
+            local_pref: None,
         };
         match prog.apply_route_event(event).await {
             Ok(()) => info!(
@@ -827,6 +829,7 @@ impl NetlinkNeighborResolver {
                 },
                 nexthops: vec![ip],
                 path_id: None,
+                local_pref: None,
             })
             .await
         {

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -44,7 +44,7 @@
 
 #![cfg(target_os = "linux")]
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
 use std::path::Path;
 use std::time::{Duration, Instant};
@@ -59,8 +59,8 @@ use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, RouteEvent};
 
 use crate::fib::netlink_neigh::NeighborResolveHandle;
 use crate::fib::types::{
-    EcmpGroup, FibValue, NexthopEntry, ECMP_NH_UNUSED, MAX_ECMP_PATHS, NH_FAMILY_V4, NH_FAMILY_V6,
-    NH_STATE_FAILED, NH_STATE_INCOMPLETE, NH_STATE_RESOLVED,
+    EcmpGroup, FibValue, NexthopEntry, ECMP_NH_UNUSED, FIB_KIND_ECMP, MAX_ECMP_PATHS, NH_FAMILY_V4,
+    NH_FAMILY_V6, NH_STATE_FAILED, NH_STATE_INCOMPLETE, NH_STATE_RESOLVED,
 };
 use crate::pin;
 
@@ -244,19 +244,50 @@ struct NexthopRecord {
 /// Per-route state tracked in userspace. The `fib_value` lets
 /// us unwind the BPF map entry on Del without a read-modify-write
 /// dance; `nexthop_ips` lets us decrement refcounts on the right
-/// nexthops; `peer_id` lets PeerDown walk by peer.
+/// nexthops; the advertisements map lets PeerDown identify all of a
+/// peer's contributions to this prefix without scanning every
+/// advertisement on the system.
+///
+/// The aggregated model: a prefix can carry contributions from
+/// multiple `(peer_id, path_id)` advertisements simultaneously. The
+/// installed FIB entry is recomputed as the union of next-hops
+/// across all advertisements after each mutation, and dedup'd via
+/// `alloc_ecmp_group`'s signature index.
 #[derive(Debug)]
 struct RouteRecord {
-    peer_id: PeerId,
+    /// Per-advertisement nexthop, keyed by `(peer_id, path_id)`. A
+    /// non-ADD-PATH source contributes one entry with `path_id =
+    /// None`; an ADD-PATH-negotiated source contributes one entry
+    /// per `path_id` the peer transmitted. `BTreeMap` gives stable
+    /// iteration order so deterministic union computation feeds a
+    /// stable ECMP-group signature.
+    advertisements: BTreeMap<(PeerId, Option<u32>), Advertisement>,
+    /// Currently-installed FibValue in the BPF FIB map; mirrors
+    /// what the data plane is reading.
     fib_value: FibValue,
-    /// Nexthop IPs this route references. On Del we unregister each
-    /// (decrement refcount, free NexthopId when it hits zero).
+    /// Currently-installed nexthop IPs (sorted, deduplicated).
+    /// Mirrors what `fib_value` points at. Used to release refcounts
+    /// when the union changes or the prefix is torn down.
     nexthop_ips: Vec<IpAddr>,
-    /// Resync-reconcile bookkeeping: true when this route was
-    /// freshly Add'd (or refreshed) after the most recent Resync;
-    /// false when it was inherited from a prior session and hasn't
-    /// been re-announced yet. InitiationComplete GCs routes whose
-    /// flag is still false.
+}
+
+/// A single advertisement contributing to a prefix's FIB entry.
+///
+/// One `RouteEvent::Add` produces one `Advertisement`; the
+/// per-advertisement nexthop set may be multi-element when the
+/// source is the legacy multi-NH `RouteEvent::Add` shape (e.g.,
+/// netlink-injected ECMP), but ADD-PATH sources emit one NH per
+/// advertisement and let the per-prefix union recompose the ECMP
+/// group.
+#[derive(Debug, Clone)]
+struct Advertisement {
+    nexthops: Vec<IpAddr>,
+    /// Resync-reconcile bookkeeping: true when this advertisement
+    /// was freshly Add'd (or refreshed) after the most recent
+    /// Resync; false when it was inherited from a prior session and
+    /// hasn't been re-announced. `InitiationComplete` GCs
+    /// advertisements whose flag is still false; the prefix's FIB
+    /// entry is then recomputed.
     seen_this_session: bool,
 }
 
@@ -757,15 +788,13 @@ impl FibProgrammer {
         Ok(())
     }
 
-    // --- Route event handling (Phase 3) ---------------------------------
+    // --- Route event handling (Phase 3, RFC 7911 aggregation) ----------
 
     fn on_route_event(&mut self, event: RouteEvent) -> Result<(), ProgrammerError> {
         match event {
             RouteEvent::PeerUp { peer_id, .. } => {
-                // PeerUp is informational for the programmer; we start
-                // tracking routes by peer_id as soon as the first
-                // RouteEvent::Add { peer_id } arrives. Nothing to do
-                // until then.
+                // Informational. Per-peer state is initialized lazily
+                // when the first advertisement from `peer_id` arrives.
                 debug!(?peer_id, "PeerUp received");
                 Ok(())
             }
@@ -774,23 +803,23 @@ impl FibProgrammer {
                 peer_id,
                 prefix,
                 nexthops,
-                path_id: _,
-            } => self.add_route(peer_id, prefix, nexthops),
+                path_id,
+            } => self.add_route(peer_id, prefix, nexthops, path_id),
             RouteEvent::Del {
-                peer_id: _,
+                peer_id,
                 prefix,
-                path_id: _,
-            } => self.del_route(prefix),
+                path_id,
+            } => self.del_route(peer_id, prefix, path_id),
             RouteEvent::Resync => {
                 self.mark_all_unseen();
-                info!("Resync: all routes marked not-seen-this-session");
+                info!("Resync: all advertisements marked not-seen-this-session");
                 Ok(())
             }
             RouteEvent::InitiationComplete => {
-                let gc_count = self.gc_unseen();
+                let gc_count = self.gc_unseen()?;
                 info!(
                     gc_count,
-                    "InitiationComplete: garbage-collected unseen routes"
+                    "InitiationComplete: garbage-collected unseen advertisements"
                 );
                 Ok(())
             }
@@ -802,96 +831,42 @@ impl FibProgrammer {
         peer_id: PeerId,
         prefix: IpPrefix,
         nexthops: Vec<IpAddr>,
+        path_id: Option<u32>,
     ) -> Result<(), ProgrammerError> {
         if nexthops.is_empty() {
-            // Empty nexthop set ⇒ refuse. BMP should never surface
-            // this for a non-withdraw; defensive.
+            // Defensive. An empty announce should arrive as Del.
             return Ok(());
         }
-
-        // Allocate nexthop IDs (bumps refcount on existing IPs).
-        let mut nh_ids: Vec<NexthopId> = Vec::with_capacity(nexthops.len());
-        let mut allocated_ips: Vec<IpAddr> = Vec::with_capacity(nexthops.len());
-        for ip in &nexthops {
-            match self.register(*ip) {
-                Ok(id) => {
-                    nh_ids.push(id);
-                    allocated_ips.push(*ip);
-                }
-                Err(e) => {
-                    // Unwind partial allocations so the error leaves
-                    // no lingering refcount state.
-                    for done in &allocated_ips {
-                        let _ = self.unregister(*done);
-                    }
-                    return Err(e);
-                }
-            }
-        }
-
-        let fib_value = if nh_ids.len() == 1 {
-            FibValue::single(nh_ids[0])
-        } else {
-            // ECMP group. hash_mode comes from FIB_CONFIG's default
-            // for now; per-group override is a Phase 3+ refinement
-            // once bird surfaces per-peer hash policy via community
-            // or similar.
-            let hash_mode = 5; // Mode 5 (5-tuple) — default from FIB_CONFIG.
-            match self.alloc_ecmp_group(&nh_ids, hash_mode) {
-                Ok(id) => FibValue::ecmp(id),
-                Err(e) => {
-                    // Unwind allocated nexthop refcounts.
-                    for ip in &allocated_ips {
-                        let _ = self.unregister(*ip);
-                    }
-                    return Err(e);
-                }
-            }
-        };
-
-        // Detect default-route replace: if a prior entry exists at
-        // this prefix, swap with grace-period reclaim. Otherwise,
-        // straight write + mirror insert.
-        let replace = self.lookup_mirror(&prefix).is_some();
-        if replace {
-            let old = self.remove_mirror(&prefix);
-            self.write_fib_entry(&prefix, fib_value)?;
-            if let Some(old_rec) = old {
-                self.enqueue_reclaim(old_rec);
-            }
-        } else {
-            self.write_fib_entry(&prefix, fib_value)?;
-        }
-
-        // Record in mirror.
-        let record = RouteRecord {
-            peer_id,
-            fib_value,
-            nexthop_ips: nexthops,
-            seen_this_session: true,
-        };
-        self.insert_mirror(prefix, record);
-        Ok(())
+        self.upsert_advertisement(peer_id, prefix, path_id, nexthops);
+        self.recompute_fib_entry(prefix)
     }
 
-    fn del_route(&mut self, prefix: IpPrefix) -> Result<(), ProgrammerError> {
-        let old = match self.remove_mirror(&prefix) {
-            Some(r) => r,
-            None => return Ok(()), // idempotent
-        };
-        self.delete_fib_entry(&prefix)?;
-        self.release_route_record(old);
-        Ok(())
+    fn del_route(
+        &mut self,
+        peer_id: PeerId,
+        prefix: IpPrefix,
+        path_id: Option<u32>,
+    ) -> Result<(), ProgrammerError> {
+        if !self.remove_advertisement(peer_id, &prefix, path_id) {
+            // Idempotent: nothing was advertised under this key.
+            return Ok(());
+        }
+        self.recompute_fib_entry(prefix)
     }
 
-    /// Drop every route mirrored under `peer_id`. Called on PeerDown.
+    /// Drop every advertisement contributed by `peer_id`. Called on
+    /// `PeerDown`. Each affected prefix is recomputed; prefixes whose
+    /// only remaining advertisements were from this peer are torn
+    /// down entirely. Prefixes still carrying advertisements from
+    /// other peers keep their FIB entries, possibly with a narrowed
+    /// NH set.
     fn drop_routes_for_peer(&mut self, peer_id: PeerId) -> Result<(), ProgrammerError> {
-        let prefixes = match self.routes_by_peer.remove(&peer_id) {
-            Some(s) => s,
+        let prefixes_for_peer = match self.routes_by_peer.remove(&peer_id) {
+            Some(set) => set,
             None => return Ok(()),
         };
-        let count = prefixes.len();
-        for (is_v4, addr, plen) in prefixes {
+        let prefix_count = prefixes_for_peer.len();
+        for (is_v4, addr, plen) in prefixes_for_peer {
             let prefix = if is_v4 {
                 let mut a = [0u8; 4];
                 a.copy_from_slice(&addr[..4]);
@@ -905,62 +880,305 @@ impl FibProgrammer {
                     prefix_len: plen,
                 }
             };
-            let rec = match self.remove_mirror_direct(&prefix) {
-                Some(r) => r,
-                None => continue,
-            };
-            if let Err(e) = self.delete_fib_entry(&prefix) {
-                warn!(?peer_id, ?prefix, error = %e, "FIB delete during PeerDown failed");
+            let drained = self.drain_peer_advertisements(peer_id, &prefix);
+            if drained == 0 {
+                continue;
             }
-            self.release_route_record(rec);
+            if let Err(e) = self.recompute_fib_entry(prefix) {
+                warn!(?peer_id, ?prefix, error = %e, "recompute after PeerDown failed");
+            }
         }
-        info!(?peer_id, count, "PeerDown: withdrew routes");
+        info!(
+            ?peer_id,
+            prefix_count, "PeerDown: withdrew peer's advertisements"
+        );
         Ok(())
     }
 
-    /// Mark every mirrored route as `seen_this_session = false`. Live
+    /// Mark every advertisement as `seen_this_session = false`. Live
     /// `Add` events clear the mark; `InitiationComplete` GCs what's
     /// left.
     fn mark_all_unseen(&mut self) {
         for rec in self.routes_v4.values_mut() {
-            rec.seen_this_session = false;
+            for adv in rec.advertisements.values_mut() {
+                adv.seen_this_session = false;
+            }
         }
         for rec in self.routes_v6.values_mut() {
-            rec.seen_this_session = false;
+            for adv in rec.advertisements.values_mut() {
+                adv.seen_this_session = false;
+            }
         }
     }
 
-    /// GC routes still marked `seen_this_session = false` after an
-    /// InitiationComplete. Returns the count removed.
-    fn gc_unseen(&mut self) -> usize {
-        let mut unseen_v4: Vec<([u8; 4], u8)> = Vec::new();
-        for (k, r) in &self.routes_v4 {
-            if !r.seen_this_session {
-                unseen_v4.push(*k);
+    /// GC advertisements still marked `seen_this_session = false`
+    /// after an InitiationComplete. Returns the count of
+    /// advertisements (not prefixes) removed. Affected prefixes are
+    /// recomputed; those whose every advertisement was unseen are
+    /// torn down entirely.
+    fn gc_unseen(&mut self) -> Result<usize, ProgrammerError> {
+        // Collect victims out-of-band so the borrow checker is happy
+        // while we mutate during recompute.
+        let mut victims: Vec<(IpPrefix, (PeerId, Option<u32>))> = Vec::new();
+        for ((addr, prefix_len), rec) in &self.routes_v4 {
+            for (key, adv) in &rec.advertisements {
+                if !adv.seen_this_session {
+                    victims.push((
+                        IpPrefix::V4 {
+                            addr: *addr,
+                            prefix_len: *prefix_len,
+                        },
+                        *key,
+                    ));
+                }
             }
         }
-        let mut unseen_v6: Vec<([u8; 16], u8)> = Vec::new();
-        for (k, r) in &self.routes_v6 {
-            if !r.seen_this_session {
-                unseen_v6.push(*k);
+        for ((addr, prefix_len), rec) in &self.routes_v6 {
+            for (key, adv) in &rec.advertisements {
+                if !adv.seen_this_session {
+                    victims.push((
+                        IpPrefix::V6 {
+                            addr: *addr,
+                            prefix_len: *prefix_len,
+                        },
+                        *key,
+                    ));
+                }
             }
         }
-        let count = unseen_v4.len() + unseen_v6.len();
-        for (addr, plen) in unseen_v4 {
-            let p = IpPrefix::V4 {
-                addr,
-                prefix_len: plen,
-            };
-            let _ = self.del_route(p);
+        let count = victims.len();
+        let mut touched: HashSet<IpPrefix> = HashSet::new();
+        for (prefix, (peer_id, path_id)) in victims {
+            if self.remove_advertisement(peer_id, &prefix, path_id) {
+                touched.insert(prefix);
+            }
         }
-        for (addr, plen) in unseen_v6 {
-            let p = IpPrefix::V6 {
-                addr,
-                prefix_len: plen,
-            };
-            let _ = self.del_route(p);
+        for prefix in touched {
+            self.recompute_fib_entry(prefix)?;
         }
-        count
+        Ok(count)
+    }
+
+    // --- Advertisement bookkeeping (slice 4) ---
+
+    /// Insert or replace `advertisements[(peer_id, path_id)]` on
+    /// `prefix`'s record, creating the record if absent. Keeps the
+    /// `routes_by_peer` index in sync. Recompute is the caller's
+    /// responsibility.
+    fn upsert_advertisement(
+        &mut self,
+        peer_id: PeerId,
+        prefix: IpPrefix,
+        path_id: Option<u32>,
+        nexthops: Vec<IpAddr>,
+    ) {
+        let key = (peer_id, path_id);
+        let adv = Advertisement {
+            nexthops,
+            seen_this_session: true,
+        };
+        let rec = self.upsert_empty_record(prefix);
+        rec.advertisements.insert(key, adv);
+        self.routes_by_peer
+            .entry(peer_id)
+            .or_default()
+            .insert(prefix_peer_key(&prefix));
+    }
+
+    /// Remove a single advertisement. Returns `true` when an entry
+    /// existed. Clears the per-peer index if the peer has no more
+    /// advertisements on this prefix. Recompute is the caller's
+    /// responsibility.
+    fn remove_advertisement(
+        &mut self,
+        peer_id: PeerId,
+        prefix: &IpPrefix,
+        path_id: Option<u32>,
+    ) -> bool {
+        let removed = match self.lookup_mirror_mut(prefix) {
+            Some(rec) => rec.advertisements.remove(&(peer_id, path_id)).is_some(),
+            None => false,
+        };
+        if removed {
+            self.maybe_clear_peer_index(peer_id, prefix);
+        }
+        removed
+    }
+
+    /// Remove every advertisement on `prefix` that originated from
+    /// `peer_id`. Returns the number removed. `routes_by_peer`
+    /// cleanup is the caller's responsibility (typically a bulk
+    /// `drop_routes_for_peer`).
+    fn drain_peer_advertisements(&mut self, peer_id: PeerId, prefix: &IpPrefix) -> usize {
+        match self.lookup_mirror_mut(prefix) {
+            Some(rec) => {
+                let before = rec.advertisements.len();
+                rec.advertisements.retain(|(p, _), _| *p != peer_id);
+                before - rec.advertisements.len()
+            }
+            None => 0,
+        }
+    }
+
+    /// Drop `prefix` from `routes_by_peer[peer_id]` when the peer has
+    /// no remaining advertisements for it; also drops the per-peer
+    /// entry when the peer's set is empty.
+    fn maybe_clear_peer_index(&mut self, peer_id: PeerId, prefix: &IpPrefix) {
+        let peer_still_has_prefix = self
+            .lookup_mirror(prefix)
+            .map(|r| r.advertisements.keys().any(|(p, _)| *p == peer_id))
+            .unwrap_or(false);
+        if peer_still_has_prefix {
+            return;
+        }
+        if let Some(set) = self.routes_by_peer.get_mut(&peer_id) {
+            set.remove(&prefix_peer_key(prefix));
+            if set.is_empty() {
+                self.routes_by_peer.remove(&peer_id);
+            }
+        }
+    }
+
+    /// Recompute the FIB entry for `prefix` from its current
+    /// advertisements. Empty advertisements tear the prefix down.
+    /// Otherwise the union of next-hops across all advertisements
+    /// determines the new FibValue (single when one NH, ECMP when
+    /// many); writes through to the BPF FIB map only when the
+    /// installed NH set actually changes. Prior resources are
+    /// reclaimed via the grace-deferred queue so concurrent XDP reads
+    /// stay safe across the transition; full tear-downs free
+    /// immediately because the BPF LPM entry is gone and no new
+    /// lookup can land on the prior IDs.
+    fn recompute_fib_entry(&mut self, prefix: IpPrefix) -> Result<(), ProgrammerError> {
+        // 1. Compute the desired sorted, deduplicated NH set.
+        let desired_nhs: Vec<IpAddr> = match self.lookup_mirror(&prefix) {
+            Some(rec) => {
+                let mut set: BTreeSet<IpAddr> = BTreeSet::new();
+                for adv in rec.advertisements.values() {
+                    for nh in &adv.nexthops {
+                        set.insert(*nh);
+                    }
+                }
+                set.into_iter().collect()
+            }
+            None => Vec::new(),
+        };
+
+        // 2. Empty desired set: tear the prefix down.
+        if desired_nhs.is_empty() {
+            let rec = match self.remove_mirror_direct(&prefix) {
+                Some(r) => r,
+                None => return Ok(()),
+            };
+            self.delete_fib_entry(&prefix)?;
+            self.reclaim_immediate(rec.fib_value, rec.nexthop_ips);
+            return Ok(());
+        }
+
+        // 3. No-change shortcut: identical NH set already installed.
+        let prior_state = self
+            .lookup_mirror(&prefix)
+            .map(|r| (r.fib_value, r.nexthop_ips.clone()));
+        let unchanged = matches!(&prior_state, Some((_, ips)) if *ips == desired_nhs);
+        if unchanged {
+            return Ok(());
+        }
+
+        // 4. Allocate the new FibValue.
+        let mut nh_ids: Vec<NexthopId> = Vec::with_capacity(desired_nhs.len());
+        let mut allocated_ips: Vec<IpAddr> = Vec::with_capacity(desired_nhs.len());
+        for ip in &desired_nhs {
+            match self.register(*ip) {
+                Ok(id) => {
+                    nh_ids.push(id);
+                    allocated_ips.push(*ip);
+                }
+                Err(e) => {
+                    for done in &allocated_ips {
+                        let _ = self.unregister(*done);
+                    }
+                    return Err(e);
+                }
+            }
+        }
+        let new_fib_value = if nh_ids.len() == 1 {
+            FibValue::single(nh_ids[0])
+        } else {
+            // Mode 5 (5-tuple) — default from FIB_CONFIG. Per-group
+            // override is a future refinement.
+            let hash_mode = 5;
+            match self.alloc_ecmp_group(&nh_ids, hash_mode) {
+                Ok(id) => FibValue::ecmp(id),
+                Err(e) => {
+                    for ip in &allocated_ips {
+                        let _ = self.unregister(*ip);
+                    }
+                    return Err(e);
+                }
+            }
+        };
+
+        // 5. Write through; unwind the new allocation if the write
+        // fails so the error path leaves no lingering refcounts.
+        if let Err(e) = self.write_fib_entry(&prefix, new_fib_value) {
+            if new_fib_value.kind == FIB_KIND_ECMP {
+                self.free_ecmp_group(new_fib_value.idx);
+            }
+            for ip in &allocated_ips {
+                let _ = self.unregister(*ip);
+            }
+            return Err(e);
+        }
+
+        // 6. Commit the swap in the mirror and reclaim prior
+        // resources with the grace queue.
+        let (prior_fib, prior_nh_ips) = match prior_state {
+            Some((fv, ips)) => (Some(fv), ips),
+            None => (None, Vec::new()),
+        };
+        {
+            let rec = self
+                .lookup_mirror_mut(&prefix)
+                .expect("record present after upsert");
+            rec.fib_value = new_fib_value;
+            rec.nexthop_ips = allocated_ips;
+        }
+        self.reclaim_prior(prior_fib, prior_nh_ips);
+        Ok(())
+    }
+
+    /// Reclaim the prior FibValue and NH set after a FIB-entry
+    /// in-place rewrite. Routes through the grace queue so
+    /// concurrent XDP reads can finish dereferencing the old IDs.
+    fn reclaim_prior(&mut self, prior_fib: Option<FibValue>, prior_nh_ips: Vec<IpAddr>) {
+        let release_at = Instant::now() + DEFAULT_ROUTE_GRACE;
+        if let Some(fv) = prior_fib {
+            if fv.kind == FIB_KIND_ECMP {
+                self.reclaim_queue.push_back(PendingReclaim {
+                    release_at,
+                    kind: ReclaimKind::Ecmp(fv.idx),
+                });
+            }
+        }
+        for ip in prior_nh_ips {
+            self.reclaim_queue.push_back(PendingReclaim {
+                release_at,
+                kind: ReclaimKind::Nexthop(ip),
+            });
+        }
+    }
+
+    /// Free a torn-down prefix's resources immediately. Safe because
+    /// the BPF LPM entry has already been removed; lookups return
+    /// no-match right away, so no in-flight reader can dereference
+    /// these IDs after the deletion.
+    fn reclaim_immediate(&mut self, fib: FibValue, nh_ips: Vec<IpAddr>) {
+        if fib.kind == FIB_KIND_ECMP {
+            self.free_ecmp_group(fib.idx);
+        }
+        for ip in nh_ips {
+            let _ = self.unregister(ip);
+        }
     }
 
     // --- Mirror ops ---
@@ -972,49 +1190,54 @@ impl FibProgrammer {
         }
     }
 
-    fn insert_mirror(&mut self, prefix: IpPrefix, record: RouteRecord) {
-        let peer_id = record.peer_id;
+    fn lookup_mirror_mut(&mut self, prefix: &IpPrefix) -> Option<&mut RouteRecord> {
         match prefix {
-            IpPrefix::V4 { addr, prefix_len } => {
-                self.routes_v4.insert((addr, prefix_len), record);
-                let mut padded = [0u8; 16];
-                padded[..4].copy_from_slice(&addr);
-                self.routes_by_peer
-                    .entry(peer_id)
-                    .or_default()
-                    .insert((true, padded, prefix_len));
-            }
-            IpPrefix::V6 { addr, prefix_len } => {
-                self.routes_v6.insert((addr, prefix_len), record);
-                self.routes_by_peer
-                    .entry(peer_id)
-                    .or_default()
-                    .insert((false, addr, prefix_len));
-            }
+            IpPrefix::V4 { addr, prefix_len } => self.routes_v4.get_mut(&(*addr, *prefix_len)),
+            IpPrefix::V6 { addr, prefix_len } => self.routes_v6.get_mut(&(*addr, *prefix_len)),
         }
     }
 
-    fn remove_mirror(&mut self, prefix: &IpPrefix) -> Option<RouteRecord> {
-        self.remove_mirror_direct(prefix)
+    /// Get-or-insert an empty record for `prefix`. The placeholder
+    /// FibValue and `nexthop_ips` are populated by the subsequent
+    /// `recompute_fib_entry`; nothing reads them between insertion
+    /// and recompute.
+    fn upsert_empty_record(&mut self, prefix: IpPrefix) -> &mut RouteRecord {
+        match prefix {
+            IpPrefix::V4 { addr, prefix_len } => self
+                .routes_v4
+                .entry((addr, prefix_len))
+                .or_insert_with(|| RouteRecord {
+                    advertisements: BTreeMap::new(),
+                    fib_value: FibValue::single(0),
+                    nexthop_ips: Vec::new(),
+                }),
+            IpPrefix::V6 { addr, prefix_len } => self
+                .routes_v6
+                .entry((addr, prefix_len))
+                .or_insert_with(|| RouteRecord {
+                    advertisements: BTreeMap::new(),
+                    fib_value: FibValue::single(0),
+                    nexthop_ips: Vec::new(),
+                }),
+        }
     }
 
     fn remove_mirror_direct(&mut self, prefix: &IpPrefix) -> Option<RouteRecord> {
-        let (rec, peer_key) = match prefix {
-            IpPrefix::V4 { addr, prefix_len } => {
-                let rec = self.routes_v4.remove(&(*addr, *prefix_len))?;
-                let mut padded = [0u8; 16];
-                padded[..4].copy_from_slice(addr);
-                (rec, (true, padded, *prefix_len))
-            }
-            IpPrefix::V6 { addr, prefix_len } => {
-                let rec = self.routes_v6.remove(&(*addr, *prefix_len))?;
-                (rec, (false, *addr, *prefix_len))
-            }
+        let rec = match prefix {
+            IpPrefix::V4 { addr, prefix_len } => self.routes_v4.remove(&(*addr, *prefix_len))?,
+            IpPrefix::V6 { addr, prefix_len } => self.routes_v6.remove(&(*addr, *prefix_len))?,
         };
-        if let Some(set) = self.routes_by_peer.get_mut(&rec.peer_id) {
-            set.remove(&peer_key);
-            if set.is_empty() {
-                self.routes_by_peer.remove(&rec.peer_id);
+        // Clean the per-peer index for every peer that contributed to
+        // this prefix. Dedup by peer with a BTreeSet so we touch each
+        // peer's bucket once.
+        let peers: BTreeSet<PeerId> = rec.advertisements.keys().map(|(p, _)| *p).collect();
+        let key = prefix_peer_key(prefix);
+        for peer in peers {
+            if let Some(set) = self.routes_by_peer.get_mut(&peer) {
+                set.remove(&key);
+                if set.is_empty() {
+                    self.routes_by_peer.remove(&peer);
+                }
             }
         }
         Some(rec)
@@ -1169,37 +1392,7 @@ impl FibProgrammer {
         }
     }
 
-    // --- Reclaim queue (default-route grace period) ---
-
-    fn enqueue_reclaim(&mut self, rec: RouteRecord) {
-        let release_at = Instant::now() + DEFAULT_ROUTE_GRACE;
-        match rec.fib_value.kind {
-            k if k == crate::fib::types::FIB_KIND_SINGLE => {
-                // Single nexthop: reclaim the nexthop IP after grace.
-                for ip in rec.nexthop_ips {
-                    self.reclaim_queue.push_back(PendingReclaim {
-                        release_at,
-                        kind: ReclaimKind::Nexthop(ip),
-                    });
-                }
-            }
-            k if k == crate::fib::types::FIB_KIND_ECMP => {
-                // ECMP: reclaim the group (which cascades to its NHs
-                // when refcount hits zero) plus the explicit NH IPs.
-                self.reclaim_queue.push_back(PendingReclaim {
-                    release_at,
-                    kind: ReclaimKind::Ecmp(rec.fib_value.idx),
-                });
-                for ip in rec.nexthop_ips {
-                    self.reclaim_queue.push_back(PendingReclaim {
-                        release_at,
-                        kind: ReclaimKind::Nexthop(ip),
-                    });
-                }
-            }
-            _ => {}
-        }
-    }
+    // --- Reclaim queue drain (grace-period release) ---
 
     fn drain_reclaim_queue(&mut self) {
         let now = Instant::now();
@@ -1218,24 +1411,19 @@ impl FibProgrammer {
             }
         }
     }
+}
 
-    /// Release the resources a RouteRecord refs: for non-default
-    /// prefixes, unwind immediately; for default routes, enqueue
-    /// a grace-delayed reclaim. Called from del_route +
-    /// drop_routes_for_peer.
-    fn release_route_record(&mut self, rec: RouteRecord) {
-        // For default-route replaces we route through enqueue_reclaim
-        // at the call site (add_route path). For straight deletes we
-        // can free immediately because the BPF LPM entry is already
-        // gone and no new lookup can land on these IDs.
-        match rec.fib_value.kind {
-            k if k == crate::fib::types::FIB_KIND_ECMP => {
-                self.free_ecmp_group(rec.fib_value.idx);
-            }
-            _ => {}
+/// Encode an `IpPrefix` to the `(is_v4, addr-padded-to-16, plen)`
+/// shape used by `routes_by_peer`. The 16-byte addr buffer holds the
+/// 4-byte v4 address in the low octets (high 12 are zero) so both
+/// families share the same `HashSet` key type.
+fn prefix_peer_key(prefix: &IpPrefix) -> (bool, [u8; 16], u8) {
+    match prefix {
+        IpPrefix::V4 { addr, prefix_len } => {
+            let mut padded = [0u8; 16];
+            padded[..4].copy_from_slice(addr);
+            (true, padded, *prefix_len)
         }
-        for ip in rec.nexthop_ips {
-            let _ = self.unregister(ip);
-        }
+        IpPrefix::V6 { addr, prefix_len } => (false, *addr, *prefix_len),
     }
 }

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -279,9 +279,17 @@ struct RouteRecord {
 /// netlink-injected ECMP), but ADD-PATH sources emit one NH per
 /// advertisement and let the per-prefix union recompose the ECMP
 /// group.
+///
+/// `local_pref` carries the BGP LOCAL_PREF attribute when supplied
+/// by the source. The per-prefix recompute filters the NH union to
+/// the maximum local-pref tier across the prefix's advertisements,
+/// so an operator-encoded preference (e.g., IX peers at LP 150 vs
+/// transit at LP 100) survives ADD-PATH aggregation. `None` is
+/// treated as RFC 4271's default of 100 for the comparison.
 #[derive(Debug, Clone)]
 struct Advertisement {
     nexthops: Vec<IpAddr>,
+    local_pref: Option<u32>,
     /// Resync-reconcile bookkeeping: true when this advertisement
     /// was freshly Add'd (or refreshed) after the most recent
     /// Resync; false when it was inherited from a prior session and
@@ -290,6 +298,12 @@ struct Advertisement {
     /// entry is then recomputed.
     seen_this_session: bool,
 }
+
+/// RFC 4271 §5.1.5: when LOCAL_PREF is absent, treat as the
+/// implementation-defined default. Bird (and most others) use 100.
+/// PacketFrame matches that for advertisements where the source did
+/// not supply a value (non-BGP sources, malformed UPDATEs, etc.).
+const DEFAULT_LOCAL_PREF: u32 = 100;
 
 /// Per-ECMP-group state. Refcount lets many prefixes share one
 /// group. The `id` is always the HashMap key we found this record
@@ -804,7 +818,8 @@ impl FibProgrammer {
                 prefix,
                 nexthops,
                 path_id,
-            } => self.add_route(peer_id, prefix, nexthops, path_id),
+                local_pref,
+            } => self.add_route(peer_id, prefix, nexthops, path_id, local_pref),
             RouteEvent::Del {
                 peer_id,
                 prefix,
@@ -832,12 +847,13 @@ impl FibProgrammer {
         prefix: IpPrefix,
         nexthops: Vec<IpAddr>,
         path_id: Option<u32>,
+        local_pref: Option<u32>,
     ) -> Result<(), ProgrammerError> {
         if nexthops.is_empty() {
             // Defensive. An empty announce should arrive as Del.
             return Ok(());
         }
-        self.upsert_advertisement(peer_id, prefix, path_id, nexthops);
+        self.upsert_advertisement(peer_id, prefix, path_id, nexthops, local_pref);
         self.recompute_fib_entry(prefix)
     }
 
@@ -971,10 +987,12 @@ impl FibProgrammer {
         prefix: IpPrefix,
         path_id: Option<u32>,
         nexthops: Vec<IpAddr>,
+        local_pref: Option<u32>,
     ) {
         let key = (peer_id, path_id);
         let adv = Advertisement {
             nexthops,
+            local_pref,
             seen_this_session: true,
         };
         let rec = self.upsert_empty_record(prefix);
@@ -1050,11 +1068,26 @@ impl FibProgrammer {
     /// immediately because the BPF LPM entry is gone and no new
     /// lookup can land on the prior IDs.
     fn recompute_fib_entry(&mut self, prefix: IpPrefix) -> Result<(), ProgrammerError> {
-        // 1. Compute the desired sorted, deduplicated NH set.
+        // 1. Compute the desired sorted, deduplicated NH set, restricted
+        // to advertisements at the maximum local-pref tier present on
+        // this prefix. This preserves operator-encoded BGP preferences
+        // (e.g., IX peers at LP 150 vs transit at LP 100) under ADD-PATH
+        // aggregation: ECMP forms within a tier, not across tiers.
+        // Advertisements with no `local_pref` are normalized to
+        // DEFAULT_LOCAL_PREF (RFC 4271 §5.1.5).
         let desired_nhs: Vec<IpAddr> = match self.lookup_mirror(&prefix) {
             Some(rec) => {
+                let max_lp = rec
+                    .advertisements
+                    .values()
+                    .map(|adv| adv.local_pref.unwrap_or(DEFAULT_LOCAL_PREF))
+                    .max()
+                    .unwrap_or(DEFAULT_LOCAL_PREF);
                 let mut set: BTreeSet<IpAddr> = BTreeSet::new();
                 for adv in rec.advertisements.values() {
+                    if adv.local_pref.unwrap_or(DEFAULT_LOCAL_PREF) != max_lp {
+                        continue;
+                    }
                     for nh in &adv.nexthops {
                         set.insert(*nh);
                     }

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -1104,8 +1104,8 @@ impl FibProgrammer {
         let new_fib_value = if nh_ids.len() == 1 {
             FibValue::single(nh_ids[0])
         } else {
-            // Mode 5 (5-tuple) — default from FIB_CONFIG. Per-group
-            // override is a future refinement.
+            // Mode 5 (5-tuple), the default from FIB_CONFIG.
+            // Per-group override is a future refinement.
             let hash_mode = 5;
             match self.alloc_ecmp_group(&nh_ids, hash_mode) {
                 Ok(id) => FibValue::ecmp(id),

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -774,8 +774,13 @@ impl FibProgrammer {
                 peer_id,
                 prefix,
                 nexthops,
+                path_id: _,
             } => self.add_route(peer_id, prefix, nexthops),
-            RouteEvent::Del { peer_id: _, prefix } => self.del_route(prefix),
+            RouteEvent::Del {
+                peer_id: _,
+                prefix,
+                path_id: _,
+            } => self.del_route(prefix),
             RouteEvent::Resync => {
                 self.mark_all_unseen();
                 info!("Resync: all routes marked not-seen-this-session");

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -214,7 +214,9 @@ impl BgpListener {
         debug!("sent OPEN");
 
         // Step 2: read peer's OPEN within OPEN_TIMEOUT and validate.
-        let peer_open = tokio::time::timeout(OPEN_TIMEOUT, read_one_message(&mut stream))
+        // OPEN itself is always decoded with add_path=false; capability
+        // 69 negotiation completes only after OPEN parsing succeeds.
+        let peer_open = tokio::time::timeout(OPEN_TIMEOUT, read_one_message(&mut stream, false))
             .await
             .map_err(|_| RouteSourceError::recoverable("peer OPEN timeout".to_string()))?
             .map_err(|e| RouteSourceError::recoverable(format!("read peer OPEN: {e}")))?;
@@ -432,12 +434,10 @@ impl BgpListener {
 /// pattern as `BmpStation::reader_task`.
 ///
 /// `add_path` carries the result of OPEN-time RFC 7911 capability
-/// negotiation (computed by [`walk_open_capabilities`]). It is
-/// threaded here so that the per-message decode flag can be set
-/// per-session in a subsequent change; today the value is captured
-/// but `read_one_message` still passes a hardcoded `false` to the
-/// parser.
-#[allow(unused_variables)]
+/// negotiation (computed by [`walk_open_capabilities`]). It controls
+/// the per-message NLRI decode in [`read_one_message`]: when true,
+/// every prefix in MP_REACH / MP_UNREACH / legacy NLRI is prefixed
+/// by a 4-byte path_id.
 async fn reader_task<R>(
     mut stream: R,
     tx: mpsc::Sender<BgpMessage>,
@@ -448,7 +448,7 @@ where
 {
     let mut messages_parsed = 0usize;
     loop {
-        let msg = match read_one_message(&mut stream).await {
+        let msg = match read_one_message(&mut stream, add_path).await {
             Ok(m) => m,
             Err(e) if is_clean_eof(&e) => {
                 debug!(messages_parsed, "BGP stream EOF (reader)");
@@ -472,7 +472,16 @@ where
 /// pulls the declared length, reads the rest, and parses with
 /// bgpkit-parser. Filters ROUTE-REFRESH (type 5) before parsing
 /// because bgpkit-parser doesn't model it.
-async fn read_one_message<R>(stream: &mut R) -> std::io::Result<BgpMessage>
+///
+/// `add_path` selects RFC 7911 NLRI decoding for this message. The
+/// flag must reflect what was negotiated in OPEN: the BGP wire format
+/// for NLRI differs depending on whether path_id is present, so a
+/// mismatch desynchronizes the parser and corrupts every subsequent
+/// prefix in the UPDATE. The OPEN itself is always read with
+/// `add_path = false` (negotiation cannot have completed yet);
+/// post-OPEN messages use the value computed by
+/// [`walk_open_capabilities`].
+async fn read_one_message<R>(stream: &mut R, add_path: bool) -> std::io::Result<BgpMessage>
 where
     R: AsyncReadExt + Unpin,
 {
@@ -514,7 +523,7 @@ where
     full.extend_from_slice(&body);
     let mut bytes: Bytes = full.freeze();
 
-    parse_bgp_message(&mut bytes, false, &AsnLength::Bits32)
+    parse_bgp_message(&mut bytes, add_path, &AsnLength::Bits32)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, format!("{e}")))
 }
 
@@ -761,6 +770,11 @@ fn elem_to_route_event(
     fallback_nh: IpAddr,
 ) -> Option<RouteEvent> {
     let prefix = network_prefix_to_ip_prefix(&elem.prefix)?;
+    // When ADD-PATH was negotiated for the session, bgpkit-parser
+    // populates `prefix.path_id` with the wire-decoded 4-byte ID.
+    // Otherwise it remains None, matching the existing single-path
+    // semantics expected by non-ADD-PATH sources (BMP, netlink).
+    let path_id = elem.prefix.path_id;
     Some(match elem.elem_type {
         ElemType::ANNOUNCE => {
             let nh = elem.next_hop.unwrap_or(fallback_nh);
@@ -768,15 +782,13 @@ fn elem_to_route_event(
                 peer_id,
                 prefix,
                 nexthops: vec![nh],
-                // Slice 1: ADD-PATH not yet parsed from UPDATE NLRI; populated
-                // in slice 3 once `read_one_message` threads `add_path_in_effect`.
-                path_id: None,
+                path_id,
             }
         }
         ElemType::WITHDRAW => RouteEvent::Del {
             peer_id,
             prefix,
-            path_id: None,
+            path_id,
         },
     })
 }
@@ -1073,6 +1085,123 @@ mod tests {
         );
         assert!(!caps.add_path_v6_recv);
         assert!(!caps.add_path_in_effect());
+    }
+
+    // --- ADD-PATH (RFC 7911) NLRI decoding --------------------------
+
+    #[test]
+    fn parse_update_with_path_id_surfaces_to_elem_and_route_event() {
+        use bgpkit_parser::models::Asn;
+        use std::net::Ipv4Addr;
+
+        // Synthetic IPv4-unicast UPDATE containing one ADD-PATH
+        // announce for 192.0.2.0/24 with path_id=42, NEXT_HOP
+        // 10.0.0.1, empty AS_PATH, ORIGIN IGP. NLRI is encoded per
+        // RFC 7911 §3 with the 4-byte Path Identifier preceding the
+        // length-prefixed prefix.
+        #[rustfmt::skip]
+        let bytes: [u8; 45] = [
+            // BGP header
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0x00, 0x2D, // total length = 45
+            0x02,       // type = UPDATE
+            // Withdrawn Routes Length = 0
+            0x00, 0x00,
+            // Total Path Attribute Length = 14
+            0x00, 0x0E,
+            // ORIGIN (transitive): flags=0x40, type=1, len=1, IGP=0
+            0x40, 0x01, 0x01, 0x00,
+            // AS_PATH (transitive, empty): flags=0x40, type=2, len=0
+            0x40, 0x02, 0x00,
+            // NEXT_HOP (transitive): flags=0x40, type=3, len=4, 10.0.0.1
+            0x40, 0x03, 0x04, 0x0A, 0x00, 0x00, 0x01,
+            // NLRI: path_id=42, prefix_len=24, 192.0.2 (3 bytes)
+            0x00, 0x00, 0x00, 0x2A,
+            0x18,
+            0xC0, 0x00, 0x02,
+        ];
+
+        let mut b = Bytes::copy_from_slice(&bytes);
+        let parsed = parse_bgp_message(&mut b, true, &AsnLength::Bits32)
+            .expect("ADD-PATH UPDATE parses cleanly");
+        let update = match parsed {
+            BgpMessage::Update(u) => u,
+            other => panic!("expected UPDATE, got {:?}", other.msg_type()),
+        };
+
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let peer_asn = Asn::new_32bit(65000);
+        let elems = Elementor::bgp_update_to_elems(update, 0.0, &peer_ip, &peer_asn);
+        assert_eq!(elems.len(), 1, "exactly one elem from the single NLRI");
+        let elem = &elems[0];
+        assert_eq!(
+            elem.prefix.path_id,
+            Some(42),
+            "path_id round-trips through bgpkit-parser when add_path=true"
+        );
+
+        let fallback = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ev = elem_to_route_event(elem, PeerId(0), fallback).expect("elem yields a RouteEvent");
+        match ev {
+            RouteEvent::Add { path_id, .. } => assert_eq!(path_id, Some(42)),
+            other => panic!("expected Add, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_update_without_addpath_leaves_path_id_none() {
+        use bgpkit_parser::models::Asn;
+        use std::net::Ipv4Addr;
+
+        // Same UPDATE shape as the test above but with no path_id
+        // prefix on the NLRI. Length adjusts down by 4 bytes.
+        #[rustfmt::skip]
+        let bytes: [u8; 41] = [
+            // BGP header
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF,
+            0x00, 0x29, // total length = 41
+            0x02,       // type = UPDATE
+            // Withdrawn Routes Length = 0
+            0x00, 0x00,
+            // Total Path Attribute Length = 14
+            0x00, 0x0E,
+            // ORIGIN (transitive)
+            0x40, 0x01, 0x01, 0x00,
+            // AS_PATH (transitive, empty)
+            0x40, 0x02, 0x00,
+            // NEXT_HOP (transitive): 10.0.0.1
+            0x40, 0x03, 0x04, 0x0A, 0x00, 0x00, 0x01,
+            // NLRI: prefix_len=24, 192.0.2 (3 bytes), no path_id
+            0x18,
+            0xC0, 0x00, 0x02,
+        ];
+
+        let mut b = Bytes::copy_from_slice(&bytes);
+        let parsed = parse_bgp_message(&mut b, false, &AsnLength::Bits32)
+            .expect("non-ADD-PATH UPDATE parses cleanly");
+        let update = match parsed {
+            BgpMessage::Update(u) => u,
+            other => panic!("expected UPDATE, got {:?}", other.msg_type()),
+        };
+
+        let peer_ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let peer_asn = Asn::new_32bit(65000);
+        let elems = Elementor::bgp_update_to_elems(update, 0.0, &peer_ip, &peer_asn);
+        assert_eq!(elems.len(), 1);
+        assert!(
+            elems[0].prefix.path_id.is_none(),
+            "non-ADD-PATH NLRI must yield path_id=None"
+        );
+
+        let fallback = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+        let ev =
+            elem_to_route_event(&elems[0], PeerId(0), fallback).expect("elem yields a RouteEvent");
+        match ev {
+            RouteEvent::Add { path_id, .. } => assert!(path_id.is_none()),
+            other => panic!("expected Add, got {:?}", other),
+        }
     }
 
     /// v0.2.1 regression guard. Pre-fix, `elem_to_route_event` (then

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -510,6 +510,13 @@ fn is_clean_eof(e: &std::io::Error) -> bool {
 /// Build the OPEN message. Capabilities advertised:
 /// - MP-BGP IPv4 unicast (AFI=1, SAFI=1)
 /// - MP-BGP IPv6 unicast (AFI=2, SAFI=1)
+/// - ADD-PATH (RFC 7911, capability code 69) for IPv4 unicast and
+///   IPv6 unicast, Send/Receive value `1` (Receive). PacketFrame never
+///   originates routes, so only the Receive direction is advertised.
+///   A peer that also wishes to send multiple paths must advertise
+///   capability 69 with Send (value `2`) or both (value `3`) for the
+///   matching AFI/SAFI; mutual negotiation is decoded in the OPEN
+///   parser (slice 2) and acted on in UPDATE parsing (slice 3).
 /// - 4-octet ASN (RFC 6793) carrying the real `local_as`
 pub fn encode_open(local_as: u32, hold_time: u16, router_id: Ipv4Addr) -> Vec<u8> {
     // Capabilities (each: code u8, len u8, value [u8])
@@ -518,6 +525,12 @@ pub fn encode_open(local_as: u32, hold_time: u16, router_id: Ipv4Addr) -> Vec<u8
     caps.extend_from_slice(&[1, 4, 0x00, 0x01, 0x00, 0x01]);
     // MP IPv6 unicast: AFI=2, Reserved=0, SAFI=1
     caps.extend_from_slice(&[1, 4, 0x00, 0x02, 0x00, 0x01]);
+    // ADD-PATH (RFC 7911 §4): code=69, len=8 covers two
+    // (AFI:2, SAFI:1, Send/Receive:1) tuples.
+    //   tuple #1: AFI=1 (IPv4), SAFI=1 (unicast), 1 = Receive
+    //   tuple #2: AFI=2 (IPv6), SAFI=1 (unicast), 1 = Receive
+    // RFC 7911 §4 permits multiple tuples in a single capability TLV.
+    caps.extend_from_slice(&[69, 8, 0x00, 0x01, 0x01, 0x01, 0x00, 0x02, 0x01, 0x01]);
     // 4-octet ASN
     caps.extend_from_slice(&[65, 4]);
     caps.extend_from_slice(&local_as.to_be_bytes());
@@ -665,9 +678,16 @@ fn elem_to_route_event(
                 peer_id,
                 prefix,
                 nexthops: vec![nh],
+                // Slice 1: ADD-PATH not yet parsed from UPDATE NLRI; populated
+                // in slice 3 once `read_one_message` threads `add_path_in_effect`.
+                path_id: None,
             }
         }
-        ElemType::WITHDRAW => RouteEvent::Del { peer_id, prefix },
+        ElemType::WITHDRAW => RouteEvent::Del {
+            peer_id,
+            prefix,
+            path_id: None,
+        },
     })
 }
 
@@ -743,6 +763,8 @@ mod tests {
         let mut saw_mp_v4 = false;
         let mut saw_mp_v6 = false;
         let mut saw_4byte_asn = None;
+        let mut add_path_v4_recv = false;
+        let mut add_path_v6_recv = false;
         while i + 2 <= caps.len() {
             let code = caps[i];
             let clen = caps[i + 1] as usize;
@@ -763,6 +785,25 @@ mod tests {
                     saw_4byte_asn =
                         Some(u32::from_be_bytes([value[0], value[1], value[2], value[3]]));
                 }
+                69 => {
+                    // ADD-PATH per RFC 7911 §4: one or more 4-byte
+                    // tuples of (AFI:2, SAFI:1, Send/Receive:1). Values
+                    // for Send/Receive: 1 = Receive, 2 = Send, 3 = both.
+                    let mut j = 0;
+                    while j + 4 <= clen {
+                        let afi = u16::from_be_bytes([value[j], value[j + 1]]);
+                        let safi = value[j + 2];
+                        let sr = value[j + 3];
+                        let has_recv = sr & 0x01 != 0;
+                        if afi == 1 && safi == 1 && has_recv {
+                            add_path_v4_recv = true;
+                        }
+                        if afi == 2 && safi == 1 && has_recv {
+                            add_path_v6_recv = true;
+                        }
+                        j += 4;
+                    }
+                }
                 _ => {}
             }
             i += 2 + clen;
@@ -773,6 +814,14 @@ mod tests {
             saw_4byte_asn,
             Some(401401),
             "missing or wrong 4-octet ASN capability"
+        );
+        assert!(
+            add_path_v4_recv,
+            "missing ADD-PATH capability (RFC 7911) with Receive for IPv4 unicast"
+        );
+        assert!(
+            add_path_v6_recv,
+            "missing ADD-PATH capability (RFC 7911) with Receive for IPv6 unicast"
         );
     }
 
@@ -850,6 +899,7 @@ mod tests {
                 peer_id: pid,
                 prefix,
                 nexthops,
+                path_id: _,
             } => {
                 assert_eq!(pid, peer_id);
                 assert!(matches!(

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -657,7 +657,8 @@ impl NegotiatedCapabilities {
 fn walk_open_capabilities(
     opt_params: &[bgpkit_parser::models::OptParam],
 ) -> NegotiatedCapabilities {
-    use bgpkit_parser::models::{AddPathSendReceive, Afi, CapabilityValue, ParamValue, Safi};
+    use bgpkit_parser::models::capabilities::AddPathSendReceive;
+    use bgpkit_parser::models::{Afi, CapabilityValue, ParamValue, Safi};
     let mut caps = NegotiatedCapabilities::default();
     for op in opt_params {
         let ParamValue::Capacities(cap_list) = &op.param_value else {
@@ -976,11 +977,10 @@ mod tests {
     /// capability with the provided address-family entries. Mirrors
     /// what bgpkit-parser produces from a peer OPEN.
     fn build_add_path_opt_param(
-        entries: Vec<bgpkit_parser::models::AddPathAddressFamily>,
+        entries: Vec<bgpkit_parser::models::capabilities::AddPathAddressFamily>,
     ) -> bgpkit_parser::models::OptParam {
-        use bgpkit_parser::models::{
-            AddPathCapability, BgpCapabilityType, Capability, CapabilityValue, OptParam, ParamValue,
-        };
+        use bgpkit_parser::models::capabilities::{AddPathCapability, BgpCapabilityType};
+        use bgpkit_parser::models::{Capability, CapabilityValue, OptParam, ParamValue};
         let cap = Capability {
             ty: BgpCapabilityType::ADD_PATH_CAPABILITY,
             value: CapabilityValue::AddPath(AddPathCapability::new(entries)),
@@ -996,7 +996,8 @@ mod tests {
 
     #[test]
     fn walk_open_capabilities_detects_both_afis_when_peer_sends() {
-        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        use bgpkit_parser::models::capabilities::{AddPathAddressFamily, AddPathSendReceive};
+        use bgpkit_parser::models::{Afi, Safi};
         let op = build_add_path_opt_param(vec![
             AddPathAddressFamily {
                 afi: Afi::Ipv4,
@@ -1017,7 +1018,8 @@ mod tests {
 
     #[test]
     fn walk_open_capabilities_all_or_nothing_when_only_one_afi_negotiated() {
-        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        use bgpkit_parser::models::capabilities::{AddPathAddressFamily, AddPathSendReceive};
+        use bgpkit_parser::models::{Afi, Safi};
         let op = build_add_path_opt_param(vec![AddPathAddressFamily {
             afi: Afi::Ipv4,
             safi: Safi::Unicast,
@@ -1034,7 +1036,8 @@ mod tests {
 
     #[test]
     fn walk_open_capabilities_peer_receive_only_does_not_negotiate_recv() {
-        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        use bgpkit_parser::models::capabilities::{AddPathAddressFamily, AddPathSendReceive};
+        use bgpkit_parser::models::{Afi, Safi};
         // Peer Receive-only means the peer can RECEIVE multipath from
         // us; PacketFrame never originates, so this does not enable us
         // to receive anything from the peer.
@@ -1058,7 +1061,8 @@ mod tests {
 
     #[test]
     fn walk_open_capabilities_ignores_non_unicast_safi() {
-        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        use bgpkit_parser::models::capabilities::{AddPathAddressFamily, AddPathSendReceive};
+        use bgpkit_parser::models::{Afi, Safi};
         let op = build_add_path_opt_param(vec![AddPathAddressFamily {
             afi: Afi::Ipv4,
             safi: Safi::Multicast,

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -792,6 +792,10 @@ fn elem_to_route_event(
     // Otherwise it remains None, matching the existing single-path
     // semantics expected by non-ADD-PATH sources (BMP, netlink).
     let path_id = elem.prefix.path_id;
+    // local_pref is mandatory on iBGP UPDATEs (RFC 4271 §5.1.5) and
+    // bgpkit-parser surfaces it. Withdrawals have no attributes so
+    // local_pref does not apply to RouteEvent::Del.
+    let local_pref = elem.local_pref;
     Some(match elem.elem_type {
         ElemType::ANNOUNCE => {
             let nh = elem.next_hop.unwrap_or(fallback_nh);
@@ -800,6 +804,7 @@ fn elem_to_route_event(
                 prefix,
                 nexthops: vec![nh],
                 path_id,
+                local_pref,
             }
         }
         ElemType::WITHDRAW => RouteEvent::Del {
@@ -1272,6 +1277,7 @@ mod tests {
                 prefix,
                 nexthops,
                 path_id: _,
+                local_pref: _,
             } => {
                 assert_eq!(pid, peer_id);
                 assert!(matches!(

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -218,7 +218,7 @@ impl BgpListener {
             .await
             .map_err(|_| RouteSourceError::recoverable("peer OPEN timeout".to_string()))?
             .map_err(|e| RouteSourceError::recoverable(format!("read peer OPEN: {e}")))?;
-        let (effective_hold, peer_asn_observed) = match peer_open {
+        let (effective_hold, peer_asn_observed, add_path_in_effect) = match peer_open {
             BgpMessage::Open(o) => {
                 if o.version != 4 {
                     return Err(RouteSourceError::recoverable(format!(
@@ -241,13 +241,18 @@ impl BgpListener {
                     );
                 }
                 let effective_hold = self.cfg.hold_time.min(o.hold_time).max(3);
+                let negotiated = walk_open_capabilities(&o.opt_params);
+                let add_path_in_effect = negotiated.add_path_in_effect();
                 info!(
                     peer_asn = peer_asn,
                     peer_router_id = %o.bgp_identifier,
                     effective_hold,
+                    add_path_in_effect,
+                    add_path_v4 = negotiated.add_path_v4_recv,
+                    add_path_v6 = negotiated.add_path_v6_recv,
                     "received peer OPEN"
                 );
-                (effective_hold, peer_asn)
+                (effective_hold, peer_asn, add_path_in_effect)
             }
             other => {
                 return Err(RouteSourceError::recoverable(format!(
@@ -270,7 +275,7 @@ impl BgpListener {
         // cancel-safety issues on `read_exact`.
         let (read_half, mut write_half) = stream.into_split();
         let (frame_tx, mut frame_rx) = mpsc::channel::<BgpMessage>(FRAME_CHANNEL_CAPACITY);
-        let reader = tokio::spawn(reader_task(read_half, frame_tx));
+        let reader = tokio::spawn(reader_task(read_half, frame_tx, add_path_in_effect));
 
         let mut keepalive_tick =
             tokio::time::interval(Duration::from_secs(effective_hold.max(3) as u64 / 3));
@@ -425,7 +430,19 @@ impl BgpListener {
 /// Drains the TCP stream, parses BGP messages, and forwards them to
 /// the main `select!` loop via a bounded channel. Same cancel-safety
 /// pattern as `BmpStation::reader_task`.
-async fn reader_task<R>(mut stream: R, tx: mpsc::Sender<BgpMessage>) -> Result<(), RouteSourceError>
+///
+/// `add_path` carries the result of OPEN-time RFC 7911 capability
+/// negotiation (computed by [`walk_open_capabilities`]). It is
+/// threaded here so that the per-message decode flag can be set
+/// per-session in a subsequent change; today the value is captured
+/// but `read_one_message` still passes a hardcoded `false` to the
+/// parser.
+#[allow(unused_variables)]
+async fn reader_task<R>(
+    mut stream: R,
+    tx: mpsc::Sender<BgpMessage>,
+    add_path: bool,
+) -> Result<(), RouteSourceError>
 where
     R: AsyncReadExt + Unpin + Send,
 {
@@ -573,6 +590,79 @@ pub fn encode_keepalive() -> Vec<u8> {
     out.extend_from_slice(&(BGP_HEADER_LEN as u16).to_be_bytes());
     out.push(MSG_TYPE_KEEPALIVE);
     out
+}
+
+/// Capabilities mutually negotiated for the current session.
+///
+/// Populated by [`walk_open_capabilities`] from the peer's OPEN after
+/// our OPEN has been sent. For each `add_path_*_recv` flag, `true`
+/// means **the peer** advertised RFC 7911 capability 69 with `Send`
+/// (value `2`) or `SendReceive` (value `3`) for that AFI/SAFI. The
+/// directional flip (peer-Send => we-Receive) reflects that the peer
+/// is the side that transmits path-id-prefixed NLRI; PacketFrame
+/// never originates routes, so only the receive side matters.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct NegotiatedCapabilities {
+    /// Peer advertised ADD-PATH Send (or both) for (IPv4, unicast).
+    add_path_v4_recv: bool,
+    /// Peer advertised ADD-PATH Send (or both) for (IPv6, unicast).
+    add_path_v6_recv: bool,
+}
+
+impl NegotiatedCapabilities {
+    /// Whether ADD-PATH NLRI decoding is in effect for this session.
+    ///
+    /// All-or-nothing across IPv4 unicast + IPv6 unicast.
+    /// `bgpkit_parser::parse_bgp_message` takes a single per-message
+    /// `add_path: bool`, not a per-AFI flag; if the peer asymmetrically
+    /// advertised ADD-PATH for one AFI but not the other, the session
+    /// falls back to non-ADD-PATH decoding for both. Symmetric
+    /// negotiation is the common case in practice.
+    fn add_path_in_effect(&self) -> bool {
+        self.add_path_v4_recv && self.add_path_v6_recv
+    }
+}
+
+/// Walk the peer's OPEN optional parameters and surface mutually
+/// negotiated capabilities relevant to PacketFrame.
+///
+/// Today the only surfaced capability is RFC 7911 ADD-PATH. Extend
+/// here as new capabilities become relevant; the struct is the single
+/// place call sites consult to decide per-session behavior.
+fn walk_open_capabilities(
+    opt_params: &[bgpkit_parser::models::OptParam],
+) -> NegotiatedCapabilities {
+    use bgpkit_parser::models::{AddPathSendReceive, Afi, CapabilityValue, ParamValue, Safi};
+    let mut caps = NegotiatedCapabilities::default();
+    for op in opt_params {
+        let ParamValue::Capacities(cap_list) = &op.param_value else {
+            continue;
+        };
+        for c in cap_list {
+            let CapabilityValue::AddPath(ap) = &c.value else {
+                continue;
+            };
+            for af in &ap.address_families {
+                // Peer Send => we Receive. Receive-only on the peer
+                // side means the peer wants to receive multipath from
+                // us, which we never originate, so it is not useful
+                // for our decoding state.
+                let peer_sends = matches!(
+                    af.send_receive,
+                    AddPathSendReceive::Send | AddPathSendReceive::SendReceive
+                );
+                if !peer_sends {
+                    continue;
+                }
+                match (af.afi, af.safi) {
+                    (Afi::Ipv4, Safi::Unicast) => caps.add_path_v4_recv = true,
+                    (Afi::Ipv6, Safi::Unicast) => caps.add_path_v6_recv = true,
+                    _ => {}
+                }
+            }
+        }
+    }
+    caps
 }
 
 // --- Helpers ----------------------------------------------------------------
@@ -850,6 +940,139 @@ mod tests {
         assert_eq!(a, b);
         let c = synthetic_peer_id("127.0.0.1:1179".parse().unwrap(), 64512);
         assert_ne!(a, c);
+    }
+
+    // --- ADD-PATH (RFC 7911) capability negotiation -----------------
+
+    /// Build a single Capability-bearing OptParam holding one ADD-PATH
+    /// capability with the provided address-family entries. Mirrors
+    /// what bgpkit-parser produces from a peer OPEN.
+    fn build_add_path_opt_param(
+        entries: Vec<bgpkit_parser::models::AddPathAddressFamily>,
+    ) -> bgpkit_parser::models::OptParam {
+        use bgpkit_parser::models::{
+            AddPathCapability, BgpCapabilityType, Capability, CapabilityValue, OptParam, ParamValue,
+        };
+        let cap = Capability {
+            ty: BgpCapabilityType::ADD_PATH_CAPABILITY,
+            value: CapabilityValue::AddPath(AddPathCapability::new(entries)),
+        };
+        OptParam {
+            param_type: 2,
+            // param_len is informational here; walk_open_capabilities
+            // does not consult it (it walks the structured Vec).
+            param_len: 0,
+            param_value: ParamValue::Capacities(vec![cap]),
+        }
+    }
+
+    #[test]
+    fn walk_open_capabilities_detects_both_afis_when_peer_sends() {
+        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        let op = build_add_path_opt_param(vec![
+            AddPathAddressFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                send_receive: AddPathSendReceive::Send,
+            },
+            AddPathAddressFamily {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+                send_receive: AddPathSendReceive::SendReceive,
+            },
+        ]);
+        let caps = walk_open_capabilities(&[op]);
+        assert!(caps.add_path_v4_recv);
+        assert!(caps.add_path_v6_recv);
+        assert!(caps.add_path_in_effect());
+    }
+
+    #[test]
+    fn walk_open_capabilities_all_or_nothing_when_only_one_afi_negotiated() {
+        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        let op = build_add_path_opt_param(vec![AddPathAddressFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Unicast,
+            send_receive: AddPathSendReceive::Send,
+        }]);
+        let caps = walk_open_capabilities(&[op]);
+        assert!(caps.add_path_v4_recv);
+        assert!(!caps.add_path_v6_recv);
+        // bgpkit-parser 0.16's parse_bgp_message takes a single per-
+        // message add_path bool; symmetric all-or-nothing avoids the
+        // mixed-AFI decoder mismatch.
+        assert!(!caps.add_path_in_effect());
+    }
+
+    #[test]
+    fn walk_open_capabilities_peer_receive_only_does_not_negotiate_recv() {
+        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        // Peer Receive-only means the peer can RECEIVE multipath from
+        // us; PacketFrame never originates, so this does not enable us
+        // to receive anything from the peer.
+        let op = build_add_path_opt_param(vec![
+            AddPathAddressFamily {
+                afi: Afi::Ipv4,
+                safi: Safi::Unicast,
+                send_receive: AddPathSendReceive::Receive,
+            },
+            AddPathAddressFamily {
+                afi: Afi::Ipv6,
+                safi: Safi::Unicast,
+                send_receive: AddPathSendReceive::Receive,
+            },
+        ]);
+        let caps = walk_open_capabilities(&[op]);
+        assert!(!caps.add_path_v4_recv);
+        assert!(!caps.add_path_v6_recv);
+        assert!(!caps.add_path_in_effect());
+    }
+
+    #[test]
+    fn walk_open_capabilities_ignores_non_unicast_safi() {
+        use bgpkit_parser::models::{AddPathAddressFamily, AddPathSendReceive, Afi, Safi};
+        let op = build_add_path_opt_param(vec![AddPathAddressFamily {
+            afi: Afi::Ipv4,
+            safi: Safi::Multicast,
+            send_receive: AddPathSendReceive::SendReceive,
+        }]);
+        let caps = walk_open_capabilities(&[op]);
+        assert!(!caps.add_path_v4_recv);
+        assert!(!caps.add_path_v6_recv);
+    }
+
+    #[test]
+    fn walk_open_capabilities_empty_opt_params_yields_default() {
+        let caps = walk_open_capabilities(&[]);
+        assert!(!caps.add_path_v4_recv);
+        assert!(!caps.add_path_v6_recv);
+        assert!(!caps.add_path_in_effect());
+        assert_eq!(caps, NegotiatedCapabilities::default());
+    }
+
+    #[test]
+    fn walk_open_capabilities_round_trips_our_own_open_as_recv_only() {
+        // Our OPEN advertises ADD-PATH with Receive direction (we
+        // never originate). If a hypothetical peer ever parsed our
+        // OPEN and ran walk_open_capabilities on it, they would see
+        // Receive-only on our side and conclude that WE will not Send
+        // multipath, so add_path_in_effect must be false. This guards
+        // against accidentally flipping the encoded direction to Send.
+        let bytes = encode_open(401401, 90, Ipv4Addr::new(1, 2, 3, 4));
+        let mut b = Bytes::copy_from_slice(&bytes);
+        let parsed =
+            parse_bgp_message(&mut b, false, &AsnLength::Bits32).expect("OPEN parses cleanly");
+        let open = match parsed {
+            BgpMessage::Open(o) => o,
+            other => panic!("expected OPEN, got {:?}", other),
+        };
+        let caps = walk_open_capabilities(&open.opt_params);
+        assert!(
+            !caps.add_path_v4_recv,
+            "our own OPEN encodes Receive; walker must not treat it as peer-Send"
+        );
+        assert!(!caps.add_path_v6_recv);
+        assert!(!caps.add_path_in_effect());
     }
 
     /// v0.2.1 regression guard. Pre-fix, `elem_to_route_event` (then

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -10,10 +10,16 @@
 //! N different nexthops, leaving the FibProgrammer to either
 //! re-implement bird's best-path selection (drift risk forever) or
 //! pick wrong. iBGP, by contrast, has bird's `protocol bgp` export
-//! filter run after best-path selection — we receive exactly one
-//! UPDATE per prefix, with the path bird picked. See
+//! filter run after best-path selection. Without ADD-PATH the export
+//! emits exactly one UPDATE per prefix with the path bird picked;
+//! with ADD-PATH negotiated, the export emits one UPDATE per path
+//! bird kept (typically equal-cost multipath), each tagged with a
+//! distinct `path_id` per RFC 7911 §3, and the FibProgrammer
+//! aggregates them into an ECMP group on the prefix. See
 //! `docs/runbooks/custom-fib.md` "Phase 4 bird config" for the
-//! `protocol bgp packetframe { ... }` snippet.
+//! `protocol bgp packetframe { ... }` snippet and the
+//! "Multi-NH ECMP from BGP" section for the ADD-PATH enablement
+//! steps.
 //!
 //! **Direction.** This is a *passive* BGP speaker: packetframe
 //! listens, bird connects out (configurable via bird's
@@ -25,7 +31,17 @@
 //!   IPv6 unicast — without this bird only sends v4 routes over
 //!   the session.
 //! - Four-octet ASN (RFC 6793) — required for any modern AS
-//!   numbering, ours is 401401 which is > 65535.
+//!   numbering when the local AS is greater than 65535.
+//! - ADD-PATH (RFC 7911) with Receive direction (Send/Receive
+//!   value 1) for both IPv4 unicast and IPv6 unicast. Peer-side
+//!   capability negotiation is decoded by
+//!   [`walk_open_capabilities`]; mutual negotiation flips the
+//!   per-message `add_path` flag in [`parse_bgp_message`] for the
+//!   session. ADD-PATH is treated all-or-nothing across the two
+//!   AFIs because `bgpkit_parser::parse_bgp_message` takes one
+//!   per-message `add_path: bool` rather than a per-AFI flag; an
+//!   asymmetric advertisement falls back to non-ADD-PATH decoding
+//!   for both AFIs.
 //! - Route Refresh is **not** advertised. We never originate routes,
 //!   so bird has nothing to ask us to refresh.
 //!

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -412,9 +412,16 @@ impl BmpStation {
                                 peer_id,
                                 prefix,
                                 nexthops: vec![nh],
+                                // BMP Loc-RIB is a post-best-path stream; ADD-PATH
+                                // semantics do not apply at this layer.
+                                path_id: None,
                             }
                         }
-                        ElemType::WITHDRAW => RouteEvent::Del { peer_id, prefix },
+                        ElemType::WITHDRAW => RouteEvent::Del {
+                            peer_id,
+                            prefix,
+                            path_id: None,
+                        },
                     };
                     if let Err(e) = self.prog_handle.apply_route_event(event).await {
                         warn!(?peer_id, error = %e, "route event dispatch failed");

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -415,6 +415,11 @@ impl BmpStation {
                                 // BMP Loc-RIB is a post-best-path stream; ADD-PATH
                                 // semantics do not apply at this layer.
                                 path_id: None,
+                                // bgpkit-parser surfaces local_pref on BgpElem
+                                // for BMP-derived elements too; propagate so
+                                // the FibProgrammer LP-tier filter sees the
+                                // same value bird's best-path used.
+                                local_pref: elem.local_pref,
                             }
                         }
                         ElemType::WITHDRAW => RouteEvent::Del {

--- a/crates/modules/fast-path/tests/fib_comparison.rs
+++ b/crates/modules/fast-path/tests/fib_comparison.rs
@@ -336,6 +336,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
                     peer_id: PeerId(0xabcd),
                     prefix: *prefix,
                     nexthops: nhs.clone(),
+                    path_id: None,
                 })
                 .await
         })
@@ -421,6 +422,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
                     addr: [192, 0, 2, 200],
                     prefix_len: 32,
                 },
+                path_id: None,
             })
             .await
     })

--- a/crates/modules/fast-path/tests/fib_comparison.rs
+++ b/crates/modules/fast-path/tests/fib_comparison.rs
@@ -424,7 +424,6 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
                     prefix_len: 32,
                 },
                 path_id: None,
-                local_pref: None,
             })
             .await
     })

--- a/crates/modules/fast-path/tests/fib_comparison.rs
+++ b/crates/modules/fast-path/tests/fib_comparison.rs
@@ -337,6 +337,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
                     prefix: *prefix,
                     nexthops: nhs.clone(),
                     path_id: None,
+                    local_pref: None,
                 })
                 .await
         })
@@ -423,6 +424,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
                     prefix_len: 32,
                 },
                 path_id: None,
+                local_pref: None,
             })
             .await
     })

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -264,6 +264,7 @@ fn add_single_nexthop_route_writes_fib_v4() {
                 peer_id: PeerId(0xaaaa),
                 prefix,
                 nexthops: vec![nh],
+                path_id: None,
             })
             .await
     })
@@ -302,6 +303,7 @@ fn add_multi_nexthop_route_allocates_ecmp_group() {
                 peer_id: PeerId(0xbbbb),
                 prefix,
                 nexthops: nhs.clone(),
+                path_id: None,
             })
             .await
     })
@@ -348,6 +350,7 @@ fn del_removes_fib_entry() {
                 peer_id: peer,
                 prefix,
                 nexthops: vec![nh],
+                path_id: None,
             })
             .await
     })
@@ -363,6 +366,7 @@ fn del_removes_fib_entry() {
             .apply_route_event(RouteEvent::Del {
                 peer_id: peer,
                 prefix,
+                path_id: None,
             })
             .await
     })
@@ -392,6 +396,7 @@ fn peer_down_withdraws_all_peer_routes() {
                         prefix_len: 24,
                     },
                     nexthops: vec![nh],
+                    path_id: None,
                 })
                 .await
                 .expect("apply Add");
@@ -435,6 +440,7 @@ fn ecmp_groups_dedup_by_signature() {
                         prefix_len: 24,
                     },
                     nexthops: nhs.clone(),
+                    path_id: None,
                 })
                 .await
                 .expect("apply Add");

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -457,3 +457,302 @@ fn ecmp_groups_dedup_by_signature() {
         "prefixes sharing nexthop set should dedup to same ECMP group"
     );
 }
+
+// --- RFC 7911 ADD-PATH aggregation (slice 4) -----------------------
+
+/// Two `RouteEvent::Add`s for the same prefix with distinct
+/// `(peer_id, path_id)` and different next-hops should aggregate
+/// into one ECMP group on that prefix. The data plane writes a
+/// `FIB_KIND_ECMP` entry whose group contains both next-hops; the
+/// new path_id-keyed aggregation in `FibProgrammer` is what surfaces
+/// this from independent BGP UPDATEs.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_two_paths_one_prefix_yields_ecmp() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [192, 0, 2, 0],
+        prefix_len: 24,
+    };
+    let nh_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let nh_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer = PeerId(0x1111);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_a],
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply Add path 1");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_b],
+                path_id: Some(2),
+            })
+            .await
+            .expect("apply Add path 2");
+    });
+
+    let fib = h.read_fib_v4([192, 0, 2, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_ECMP,
+        "two distinct (peer, path_id) advertisements should yield ECMP"
+    );
+    let group = h.read_ecmp_group(fib.idx);
+    assert_eq!(group.nh_count, 2);
+}
+
+/// Add two ADD-PATH advertisements that result in an ECMP group;
+/// withdrawing one should collapse the FIB entry back to a single-NH
+/// `FIB_KIND_SINGLE` entry. The ECMP group's slot is freed for reuse.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_withdrawal_collapses_to_single_nh() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [198, 51, 100, 0],
+        prefix_len: 24,
+    };
+    let nh_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 11));
+    let nh_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 12));
+    let peer = PeerId(0x2222);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_a],
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply Add A");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_b],
+                path_id: Some(2),
+            })
+            .await
+            .expect("apply Add B");
+    });
+
+    let fib_ecmp = h
+        .read_fib_v4([198, 51, 100, 0], 24)
+        .expect("FIB after both Adds");
+    assert_eq!(fib_ecmp.kind, FIB_KIND_ECMP);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer,
+                prefix,
+                path_id: Some(2),
+            })
+            .await
+            .expect("apply Del B");
+    });
+
+    let fib_single = h
+        .read_fib_v4([198, 51, 100, 0], 24)
+        .expect("FIB after one withdrawal");
+    assert_eq!(
+        fib_single.kind, FIB_KIND_SINGLE,
+        "collapsing to one advertisement should produce single-NH"
+    );
+}
+
+/// ADD-PATH-style advertisements from two distinct peers contributing
+/// one next-hop each should merge into a single ECMP group on the
+/// shared prefix. This is the multi-transit aggregation scenario
+/// that motivates RFC 7911 in PacketFrame: bird emits separate
+/// UPDATEs per upstream peer, each tagged with its own path_id;
+/// the programmer composes them into one multi-NH FIB entry.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_two_peers_two_paths_merge() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [203, 0, 113, 0],
+        prefix_len: 24,
+    };
+    let nh_a = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 21));
+    let nh_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 22));
+    let peer_a = PeerId(0x3333);
+    let peer_b = PeerId(0x4444);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_a,
+                prefix,
+                nexthops: vec![nh_a],
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply Add peer_a");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_b,
+                prefix,
+                nexthops: vec![nh_b],
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply Add peer_b");
+    });
+
+    let fib = h.read_fib_v4([203, 0, 113, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_ECMP,
+        "advertisements from two peers should merge into ECMP"
+    );
+    let group = h.read_ecmp_group(fib.idx);
+    assert_eq!(group.nh_count, 2);
+}
+
+/// `PeerDown` for a peer that contributed multiple ADD-PATH
+/// advertisements to a prefix should drop only that peer's
+/// contributions. The prefix survives if any other peer still
+/// advertises it, with a recomputed NH set; the prefix is torn
+/// down only when no advertisements remain.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_peer_down_clears_all_paths_for_peer() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [192, 0, 2, 0],
+        prefix_len: 24,
+    };
+    let nh_a1 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 31));
+    let nh_a2 = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 32));
+    let nh_b = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 33));
+    let peer_a = PeerId(0x5555);
+    let peer_b = PeerId(0x6666);
+
+    h.run(async {
+        // peer_a contributes two advertisements; peer_b contributes one.
+        for (path_id, nh) in [(Some(1), nh_a1), (Some(2), nh_a2)] {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer_a,
+                    prefix,
+                    nexthops: vec![nh],
+                    path_id,
+                })
+                .await
+                .expect("apply Add peer_a");
+        }
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_b,
+                prefix,
+                nexthops: vec![nh_b],
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply Add peer_b");
+    });
+
+    // Three contributing advertisements; FIB should be a 3-NH ECMP.
+    let fib_before = h.read_fib_v4([192, 0, 2, 0], 24).expect("FIB after Adds");
+    assert_eq!(fib_before.kind, FIB_KIND_ECMP);
+    let group_before = h.read_ecmp_group(fib_before.idx);
+    assert_eq!(group_before.nh_count, 3);
+
+    // PeerDown peer_a sweeps both of its advertisements. peer_b's
+    // single advertisement survives, so the prefix collapses to
+    // single-NH.
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::PeerDown { peer_id: peer_a })
+            .await
+            .expect("apply PeerDown peer_a");
+    });
+
+    let fib_after = h
+        .read_fib_v4([192, 0, 2, 0], 24)
+        .expect("FIB survives with peer_b's advertisement");
+    assert_eq!(
+        fib_after.kind, FIB_KIND_SINGLE,
+        "remaining single advertisement should be single-NH"
+    );
+}
+
+/// Back-compat guard: a non-ADD-PATH session emits `path_id: None`
+/// on every Add. Two such Adds from the same peer for the same
+/// prefix must REPLACE rather than aggregate. This preserves the
+/// pre-ADD-PATH semantics for BMP, netlink, and any iBGP session
+/// where capability 69 was not mutually negotiated.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn non_add_path_session_still_replaces() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [198, 51, 100, 0],
+        prefix_len: 24,
+    };
+    let nh_first = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 41));
+    let nh_second = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 42));
+    let peer = PeerId(0x7777);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_first],
+                path_id: None,
+            })
+            .await
+            .expect("apply first Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![nh_second],
+                path_id: None,
+            })
+            .await
+            .expect("apply second Add");
+    });
+
+    let fib = h.read_fib_v4([198, 51, 100, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_SINGLE,
+        "two Adds with path_id=None from same peer must replace, not aggregate"
+    );
+
+    // A single Del under the same (peer, None) key should remove the
+    // prefix entirely. If the second Add had aggregated instead of
+    // replaced, the prefix would still hold the first advertisement
+    // after this withdrawal.
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer,
+                prefix,
+                path_id: None,
+            })
+            .await
+            .expect("apply Del");
+    });
+
+    assert!(
+        h.read_fib_v4([198, 51, 100, 0], 24).is_none(),
+        "Del under same (peer, None) key removes the prefix; \
+         confirms only one advertisement existed after the replace"
+    );
+
+    // Silence unused-binding warnings; the literal values are part
+    // of the test's intent even though we no longer read them back
+    // from NEXTHOPS to verify identity.
+    let _ = (nh_first, nh_second);
+}

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -657,6 +657,7 @@ fn add_path_peer_down_clears_all_paths_for_peer() {
                     prefix,
                     nexthops: vec![nh],
                     path_id,
+                    local_pref: None,
                 })
                 .await
                 .expect("apply Add peer_a");

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -265,6 +265,7 @@ fn add_single_nexthop_route_writes_fib_v4() {
                 prefix,
                 nexthops: vec![nh],
                 path_id: None,
+                local_pref: None,
             })
             .await
     })
@@ -304,6 +305,7 @@ fn add_multi_nexthop_route_allocates_ecmp_group() {
                 prefix,
                 nexthops: nhs.clone(),
                 path_id: None,
+                local_pref: None,
             })
             .await
     })
@@ -351,6 +353,7 @@ fn del_removes_fib_entry() {
                 prefix,
                 nexthops: vec![nh],
                 path_id: None,
+                local_pref: None,
             })
             .await
     })
@@ -397,6 +400,7 @@ fn peer_down_withdraws_all_peer_routes() {
                     },
                     nexthops: vec![nh],
                     path_id: None,
+                    local_pref: None,
                 })
                 .await
                 .expect("apply Add");
@@ -441,6 +445,7 @@ fn ecmp_groups_dedup_by_signature() {
                     },
                     nexthops: nhs.clone(),
                     path_id: None,
+                    local_pref: None,
                 })
                 .await
                 .expect("apply Add");
@@ -485,6 +490,7 @@ fn add_path_two_paths_one_prefix_yields_ecmp() {
                 prefix,
                 nexthops: vec![nh_a],
                 path_id: Some(1),
+                local_pref: None,
             })
             .await
             .expect("apply Add path 1");
@@ -494,6 +500,7 @@ fn add_path_two_paths_one_prefix_yields_ecmp() {
                 prefix,
                 nexthops: vec![nh_b],
                 path_id: Some(2),
+                local_pref: None,
             })
             .await
             .expect("apply Add path 2");
@@ -530,6 +537,7 @@ fn add_path_withdrawal_collapses_to_single_nh() {
                 prefix,
                 nexthops: vec![nh_a],
                 path_id: Some(1),
+                local_pref: None,
             })
             .await
             .expect("apply Add A");
@@ -539,6 +547,7 @@ fn add_path_withdrawal_collapses_to_single_nh() {
                 prefix,
                 nexthops: vec![nh_b],
                 path_id: Some(2),
+                local_pref: None,
             })
             .await
             .expect("apply Add B");
@@ -595,6 +604,7 @@ fn add_path_two_peers_two_paths_merge() {
                 prefix,
                 nexthops: vec![nh_a],
                 path_id: Some(1),
+                local_pref: None,
             })
             .await
             .expect("apply Add peer_a");
@@ -604,6 +614,7 @@ fn add_path_two_peers_two_paths_merge() {
                 prefix,
                 nexthops: vec![nh_b],
                 path_id: Some(1),
+                local_pref: None,
             })
             .await
             .expect("apply Add peer_b");
@@ -656,6 +667,7 @@ fn add_path_peer_down_clears_all_paths_for_peer() {
                 prefix,
                 nexthops: vec![nh_b],
                 path_id: Some(1),
+                local_pref: None,
             })
             .await
             .expect("apply Add peer_b");
@@ -710,6 +722,7 @@ fn non_add_path_session_still_replaces() {
                 prefix,
                 nexthops: vec![nh_first],
                 path_id: None,
+                local_pref: None,
             })
             .await
             .expect("apply first Add");
@@ -719,6 +732,7 @@ fn non_add_path_session_still_replaces() {
                 prefix,
                 nexthops: vec![nh_second],
                 path_id: None,
+                local_pref: None,
             })
             .await
             .expect("apply second Add");
@@ -755,4 +769,232 @@ fn non_add_path_session_still_replaces() {
     // of the test's intent even though we no longer read them back
     // from NEXTHOPS to verify identity.
     let _ = (nh_first, nh_second);
+}
+
+// --- Local-pref-tier filtering (slice 6) ---------------------------
+
+/// Two advertisements for the same prefix at different local-pref
+/// tiers (e.g., an IX peer at 150 and a transit at 100): only the
+/// higher-LP advertisement contributes to the installed FIB entry.
+/// Lower-tier advertisements stay in the per-prefix mirror so that a
+/// subsequent withdrawal of the higher-tier path promotes them
+/// without a fresh announce, but they do not affect forwarding while
+/// a higher tier is present.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_higher_lp_tier_wins_over_lower() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [192, 0, 2, 0],
+        prefix_len: 24,
+    };
+    let nh_ix = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let nh_transit = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let peer_ix = PeerId(0x8001);
+    let peer_transit = PeerId(0x8002);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_ix,
+                prefix,
+                nexthops: vec![nh_ix],
+                path_id: Some(1),
+                local_pref: Some(150),
+            })
+            .await
+            .expect("apply IX-tier Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_transit,
+                prefix,
+                nexthops: vec![nh_transit],
+                path_id: Some(1),
+                local_pref: Some(100),
+            })
+            .await
+            .expect("apply transit-tier Add");
+    });
+
+    let fib = h.read_fib_v4([192, 0, 2, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_SINGLE,
+        "higher LP-tier (150) wins; transit (100) suppressed under LP filter"
+    );
+    // Read the NH that's actually installed: the entry's idx points at
+    // NEXTHOPS[idx] which we can spot-check is a resolved-state slot.
+    let entry = h.read_nexthop(fib.idx);
+    assert_eq!(
+        entry.state, NH_STATE_INCOMPLETE,
+        "single-NH installed (LP filter selected the IX path)"
+    );
+}
+
+/// Three advertisements: two at the top tier (LP 150) and one at a
+/// lower tier (LP 100). The FIB entry must ECMP across the two LP-150
+/// next-hops only; the LP-100 path stays masked while the IX tier has
+/// any path present.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_ecmp_within_top_lp_tier() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [198, 51, 100, 0],
+        prefix_len: 24,
+    };
+    let nh_ix_a = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let nh_ix_b = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 2));
+    let nh_transit = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let peer_ix_a = PeerId(0x9001);
+    let peer_ix_b = PeerId(0x9002);
+    let peer_transit = PeerId(0x9003);
+
+    h.run(async {
+        for (peer, nh, lp) in [
+            (peer_ix_a, nh_ix_a, 150),
+            (peer_ix_b, nh_ix_b, 150),
+            (peer_transit, nh_transit, 100),
+        ] {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix,
+                    nexthops: vec![nh],
+                    path_id: Some(1),
+                    local_pref: Some(lp),
+                })
+                .await
+                .expect("apply Add");
+        }
+    });
+
+    let fib = h.read_fib_v4([198, 51, 100, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_ECMP,
+        "two LP-150 advertisements ECMP; LP-100 advertisement does not contribute"
+    );
+    let group = h.read_ecmp_group(fib.idx);
+    assert_eq!(
+        group.nh_count, 2,
+        "ECMP group spans only the top-LP-tier paths (2 of 3)"
+    );
+}
+
+/// LP demotion: when the top-tier advertisement is withdrawn, the
+/// next-best tier's advertisements promote into the FIB entry. The
+/// LP-100 path that was masked behind LP-150 takes over without
+/// requiring a fresh announce; its advertisement record was retained
+/// throughout.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_lp_demotion_promotes_lower_tier_on_top_tier_withdrawal() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [203, 0, 113, 0],
+        prefix_len: 24,
+    };
+    let nh_ix = IpAddr::V4(Ipv4Addr::new(10, 0, 1, 1));
+    let nh_transit = IpAddr::V4(Ipv4Addr::new(10, 0, 2, 1));
+    let peer_ix = PeerId(0xa001);
+    let peer_transit = PeerId(0xa002);
+
+    h.run(async {
+        // Both tiers present; top tier wins.
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_ix,
+                prefix,
+                nexthops: vec![nh_ix],
+                path_id: Some(1),
+                local_pref: Some(150),
+            })
+            .await
+            .expect("apply IX Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_transit,
+                prefix,
+                nexthops: vec![nh_transit],
+                path_id: Some(1),
+                local_pref: Some(100),
+            })
+            .await
+            .expect("apply transit Add");
+    });
+
+    let fib_with_ix = h
+        .read_fib_v4([203, 0, 113, 0], 24)
+        .expect("FIB after both Adds");
+    assert_eq!(fib_with_ix.kind, FIB_KIND_SINGLE);
+
+    h.run(async {
+        // Withdraw the IX advertisement. The transit advertisement
+        // stays in the mirror and now becomes the top tier.
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer_ix,
+                prefix,
+                path_id: Some(1),
+            })
+            .await
+            .expect("apply IX Del");
+    });
+
+    let fib_after_demotion = h
+        .read_fib_v4([203, 0, 113, 0], 24)
+        .expect("FIB still present via transit");
+    assert_eq!(
+        fib_after_demotion.kind, FIB_KIND_SINGLE,
+        "transit advertisement promotes to top tier when IX path is withdrawn"
+    );
+}
+
+/// Back-compat: `local_pref: None` is treated as the RFC 4271 default
+/// of 100. An advertisement with explicit LP 100 and an advertisement
+/// with `None` are at the same tier and ECMP together. This guards
+/// non-BGP sources (netlink seeding, BMP elements without LOCAL_PREF)
+/// from being inadvertently suppressed by the LP filter.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_lp_none_treated_as_default_100() {
+    let h = ProgrammerHarness::new();
+    let prefix = IpPrefix::V4 {
+        addr: [192, 0, 2, 0],
+        prefix_len: 24,
+    };
+    let nh_explicit = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let nh_implicit = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+    let peer_explicit = PeerId(0xb001);
+    let peer_implicit = PeerId(0xb002);
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_explicit,
+                prefix,
+                nexthops: vec![nh_explicit],
+                path_id: None,
+                local_pref: Some(100),
+            })
+            .await
+            .expect("apply explicit-100 Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer_implicit,
+                prefix,
+                nexthops: vec![nh_implicit],
+                path_id: None,
+                local_pref: None,
+            })
+            .await
+            .expect("apply None-LP Add");
+    });
+
+    let fib = h.read_fib_v4([192, 0, 2, 0], 24).expect("FIB entry");
+    assert_eq!(
+        fib.kind, FIB_KIND_ECMP,
+        "LP=None defaults to 100 and ECMPs with explicit-LP=100 advertisement"
+    );
+    let group = h.read_ecmp_group(fib.idx);
+    assert_eq!(group.nh_count, 2);
 }

--- a/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
+++ b/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
@@ -16,7 +16,7 @@
 
 #![cfg(target_os = "linux")]
 
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::net::{Ipv4Addr, SocketAddr};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Once;
@@ -352,7 +352,7 @@ fn add_path_two_updates_yield_ecmp_via_bgp_listener() {
         let key = LpmKey::new(24, [192, 0, 2, 0]);
         let deadline = Instant::now() + Duration::from_secs(5);
         let mut last_seen: Option<FibValue> = None;
-        let mut last_count: u32 = 0;
+        let mut last_count: u8 = 0;
         loop {
             // Fresh handle each poll so we observe the programmer's
             // writes via a separate FD.

--- a/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
+++ b/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
@@ -24,7 +24,6 @@ use std::time::{Duration, Instant};
 
 use aya::maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, Map, MapData};
 use aya::Ebpf;
-use packetframe_common::fib::IpPrefix;
 use packetframe_fast_path::aligned_bpf_copy;
 use packetframe_fast_path::fib::programmer::FibProgrammer;
 use packetframe_fast_path::fib::route_source_bgp::{BgpListener, BgpListenerConfig};

--- a/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
+++ b/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
@@ -299,7 +299,7 @@ fn add_path_two_updates_yield_ecmp_via_bgp_listener() {
     let listener = BgpListener::new(bgp_cfg, prog_handle.clone(), shutdown.clone());
     let listener_task = rt.spawn(listener.run());
 
-    let test_result = rt.block_on(async move {
+    rt.block_on(async move {
         // Give the listener a moment to bind.
         for _ in 0..50 {
             if TcpStream::connect(listen_addr).await.is_ok() {
@@ -389,6 +389,4 @@ fn add_path_two_updates_yield_ecmp_via_bgp_listener() {
         let _ = tokio::time::timeout(Duration::from_secs(2), listener_task).await;
         let _ = tokio::time::timeout(Duration::from_secs(2), prog_task).await;
     });
-
-    test_result
 }

--- a/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
+++ b/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
@@ -1,0 +1,395 @@
+//! End-to-end synthetic-peer test for the RFC 7911 ADD-PATH path:
+//! OPEN capability negotiation, NLRI decoding with `path_id`, and
+//! the FibProgrammer aggregation that turns multiple advertisements
+//! into one ECMP group.
+//!
+//! The test drives raw BGP wire bytes through a real `BgpListener`
+//! over a `TcpStream`; no `bird` process is involved, which keeps the
+//! qemu-verifier image small (no `bird2` apt package). The synthetic
+//! peer advertises capability 69 with `Send` direction, then sends
+//! two UPDATEs for the same prefix carrying distinct `path_id` values
+//! and different next-hops. Polls the FIB BPF map until the ECMP
+//! aggregation is reflected.
+//!
+//! Runs under CAP_BPF + CAP_NET_ADMIN. `#[ignore]`-gated; CI's qemu
+//! job runs it via `sudo -E cargo test -- --ignored`.
+
+#![cfg(target_os = "linux")]
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Once;
+use std::time::{Duration, Instant};
+
+use aya::maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, Map, MapData};
+use aya::Ebpf;
+use packetframe_common::fib::IpPrefix;
+use packetframe_fast_path::aligned_bpf_copy;
+use packetframe_fast_path::fib::programmer::FibProgrammer;
+use packetframe_fast_path::fib::route_source_bgp::{BgpListener, BgpListenerConfig};
+use packetframe_fast_path::fib::types::{EcmpGroup, FibValue, NexthopEntry, FIB_KIND_ECMP};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_util::sync::CancellationToken;
+
+const BPFFS_ROOT: &str = "/sys/fs/bpf";
+const TEST_PREFIX: &str = "pftestbgpaddpath";
+
+// ----- Test-pin scaffolding (mirrors fib_programmer_integration.rs) ---
+
+struct PinDirs {
+    dir: PathBuf,
+}
+
+static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+static BPFFS_MOUNT: Once = Once::new();
+
+fn ensure_bpffs_mounted() {
+    BPFFS_MOUNT.call_once(|| {
+        let _ = std::fs::create_dir_all(BPFFS_ROOT);
+        let _ = std::process::Command::new("mount")
+            .args(["-t", "bpf", "bpf", BPFFS_ROOT])
+            .status();
+    });
+}
+
+impl PinDirs {
+    fn setup() -> Self {
+        ensure_bpffs_mounted();
+        let unique = TEST_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = PathBuf::from(BPFFS_ROOT).join(format!(
+            "{TEST_PREFIX}-{}-{}",
+            std::process::id(),
+            unique
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("mkdir bpffs subdir");
+        Self { dir }
+    }
+
+    fn path(&self, name: &str) -> PathBuf {
+        self.dir.join(name)
+    }
+}
+
+impl Drop for PinDirs {
+    fn drop(&mut self) {
+        if let Ok(entries) = std::fs::read_dir(&self.dir) {
+            for entry in entries.flatten() {
+                let _ = std::fs::remove_file(entry.path());
+            }
+        }
+        let _ = std::fs::remove_dir(&self.dir);
+    }
+}
+
+fn load_and_pin(pins: &PinDirs) -> Ebpf {
+    let bytes = aligned_bpf_copy();
+    let ebpf = Ebpf::load(&bytes).expect("Ebpf::load");
+    for name in ["NEXTHOPS", "FIB_V4", "FIB_V6", "ECMP_GROUPS"] {
+        let path = pins.path(name);
+        ebpf.map(name)
+            .unwrap_or_else(|| panic!("{name} map missing from ELF"))
+            .pin(&path)
+            .unwrap_or_else(|e| panic!("pin {name} at {}: {e}", path.display()));
+    }
+    ebpf
+}
+
+fn open_array<T: aya::Pod>(path: &Path) -> Array<MapData, T> {
+    let map_data = MapData::from_pin(path)
+        .unwrap_or_else(|e| panic!("MapData::from_pin({}): {e}", path.display()));
+    Array::try_from(Map::Array(map_data))
+        .unwrap_or_else(|e| panic!("Array::try_from({}): {e}", path.display()))
+}
+
+fn open_lpm_v4(path: &Path) -> LpmTrie<MapData, [u8; 4], FibValue> {
+    let map_data = MapData::from_pin(path).expect("LpmTrie from_pin");
+    LpmTrie::try_from(Map::LpmTrie(map_data)).expect("LpmTrie try_from")
+}
+
+fn open_lpm_v6(path: &Path) -> LpmTrie<MapData, [u8; 16], FibValue> {
+    let map_data = MapData::from_pin(path).expect("LpmTrie from_pin");
+    LpmTrie::try_from(Map::LpmTrie(map_data)).expect("LpmTrie try_from")
+}
+
+// ----- Wire-format helpers --------------------------------------------
+
+const BGP_MARKER: [u8; 16] = [0xFF; 16];
+
+/// Build a peer-side OPEN advertising capability 69 with `Send`
+/// direction for IPv4 unicast + IPv6 unicast (so the listener
+/// negotiates ADD-PATH receive on its side). Also carries MP-BGP for
+/// both AFIs and the 4-octet ASN capability.
+fn build_open_with_addpath_send(local_as: u32, hold_time: u16, router_id: Ipv4Addr) -> Vec<u8> {
+    // Capabilities.
+    let mut caps: Vec<u8> = Vec::with_capacity(40);
+    caps.extend_from_slice(&[1, 4, 0x00, 0x01, 0x00, 0x01]); // MP IPv4 unicast
+    caps.extend_from_slice(&[1, 4, 0x00, 0x02, 0x00, 0x01]); // MP IPv6 unicast
+    caps.extend_from_slice(&[65, 4]); // 4-octet ASN
+    caps.extend_from_slice(&local_as.to_be_bytes());
+    // RFC 7911 §4: code=69, len=8, two (AFI, SAFI, Send/Recv) tuples
+    // with Send/Recv=2 (Send). The peer is the side that transmits.
+    caps.extend_from_slice(&[69, 8, 0x00, 0x01, 0x01, 0x02, 0x00, 0x02, 0x01, 0x02]);
+
+    // Optional Parameter of type 2 wrapping every capability.
+    let mut opt_params: Vec<u8> = Vec::with_capacity(2 + caps.len());
+    opt_params.push(2);
+    opt_params.push(caps.len() as u8);
+    opt_params.extend_from_slice(&caps);
+
+    // Header + body.
+    let body_len = 1 + 2 + 2 + 4 + 1 + opt_params.len();
+    let total_len = 19 + body_len;
+    let mut out = Vec::with_capacity(total_len);
+    out.extend_from_slice(&BGP_MARKER);
+    out.extend_from_slice(&(total_len as u16).to_be_bytes());
+    out.push(1); // OPEN
+    out.push(4); // version
+                 // My AS in 2-byte slot. Use AS_TRANS when > 65535.
+    let my_as_2: u16 = if local_as > u16::MAX as u32 {
+        23456
+    } else {
+        local_as as u16
+    };
+    out.extend_from_slice(&my_as_2.to_be_bytes());
+    out.extend_from_slice(&hold_time.to_be_bytes());
+    out.extend_from_slice(&router_id.octets());
+    out.push(opt_params.len() as u8);
+    out.extend_from_slice(&opt_params);
+    out
+}
+
+fn build_keepalive() -> [u8; 19] {
+    let mut out = [0u8; 19];
+    out[..16].copy_from_slice(&BGP_MARKER);
+    out[16..18].copy_from_slice(&19u16.to_be_bytes());
+    out[18] = 4; // KEEPALIVE
+    out
+}
+
+/// Build an IPv4-unicast UPDATE carrying one ADD-PATH announce:
+/// `path_id`, prefix `addr/24`, NEXT_HOP `nh`. Path attributes are
+/// the mandatory minimum (ORIGIN IGP, empty AS_PATH, NEXT_HOP). Length
+/// computed for a /24 prefix (3-byte address suffix); the helper is
+/// /24-only for brevity since the test uses RFC 5737 /24 prefixes.
+fn build_update_addpath_v4_slash24(path_id: u32, addr_prefix: [u8; 3], nh: Ipv4Addr) -> Vec<u8> {
+    // NLRI: path_id (4 bytes) + length (1) + prefix (3) = 8 bytes.
+    let mut nlri: Vec<u8> = Vec::with_capacity(8);
+    nlri.extend_from_slice(&path_id.to_be_bytes());
+    nlri.push(24);
+    nlri.extend_from_slice(&addr_prefix);
+
+    // Path attributes (14 bytes minimum):
+    //   ORIGIN: 0x40 0x01 0x01 0x00 -> 4 bytes (IGP)
+    //   AS_PATH: 0x40 0x02 0x00 -> 3 bytes (empty)
+    //   NEXT_HOP: 0x40 0x03 0x04 <ip> -> 7 bytes
+    let mut attrs: Vec<u8> = Vec::with_capacity(14);
+    attrs.extend_from_slice(&[0x40, 0x01, 0x01, 0x00]);
+    attrs.extend_from_slice(&[0x40, 0x02, 0x00]);
+    attrs.extend_from_slice(&[0x40, 0x03, 0x04]);
+    attrs.extend_from_slice(&nh.octets());
+
+    // Body: withdrawn_len(2) + attr_len(2) + attrs + NLRI.
+    let body_len = 2 + 2 + attrs.len() + nlri.len();
+    let total_len = 19 + body_len;
+    let mut out: Vec<u8> = Vec::with_capacity(total_len);
+    out.extend_from_slice(&BGP_MARKER);
+    out.extend_from_slice(&(total_len as u16).to_be_bytes());
+    out.push(2); // UPDATE
+    out.extend_from_slice(&0u16.to_be_bytes()); // withdrawn routes len
+    out.extend_from_slice(&(attrs.len() as u16).to_be_bytes()); // total path attr len
+    out.extend_from_slice(&attrs);
+    out.extend_from_slice(&nlri);
+    out
+}
+
+/// Walk an OPEN's capabilities for code 69 with a matching AFI and
+/// the Receive bit set, confirming the listener advertised ADD-PATH
+/// receive for both AFIs (mirror of `walk_open_capabilities` in
+/// production code, kept simple for the test).
+fn open_advertises_add_path_recv(open_bytes: &[u8]) -> bool {
+    // header(19) + version(1) + my_as(2) + hold(2) + router_id(4) = 28
+    if open_bytes.len() < 29 {
+        return false;
+    }
+    let opt_param_len = open_bytes[28] as usize;
+    if open_bytes.len() < 29 + opt_param_len || opt_param_len < 2 {
+        return false;
+    }
+    let opt_params = &open_bytes[29..29 + opt_param_len];
+    if opt_params[0] != 2 {
+        return false;
+    }
+    let caps = &opt_params[2..];
+    let mut i = 0;
+    let mut v4_recv = false;
+    let mut v6_recv = false;
+    while i + 2 <= caps.len() {
+        let code = caps[i];
+        let clen = caps[i + 1] as usize;
+        if i + 2 + clen > caps.len() {
+            return false;
+        }
+        let value = &caps[i + 2..i + 2 + clen];
+        if code == 69 {
+            let mut j = 0;
+            while j + 4 <= clen {
+                let afi = u16::from_be_bytes([value[j], value[j + 1]]);
+                let safi = value[j + 2];
+                let sr = value[j + 3];
+                // Receive bit is 0x01 (Recv=1, SendReceive=3 → both set).
+                let has_recv = sr & 0x01 != 0;
+                if afi == 1 && safi == 1 && has_recv {
+                    v4_recv = true;
+                }
+                if afi == 2 && safi == 1 && has_recv {
+                    v6_recv = true;
+                }
+                j += 4;
+            }
+        }
+        i += 2 + clen;
+    }
+    v4_recv && v6_recv
+}
+
+// ----- The test ----------------------------------------------------------
+
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_path_two_updates_yield_ecmp_via_bgp_listener() {
+    let pins = PinDirs::setup();
+    let _ebpf = load_and_pin(&pins);
+
+    // Programmer + listener share a tokio runtime.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+    let shutdown = CancellationToken::new();
+
+    // Build the programmer with handles to the pinned maps.
+    let nexthops: Array<MapData, NexthopEntry> = open_array(&pins.path("NEXTHOPS"));
+    let fib_v4 = open_lpm_v4(&pins.path("FIB_V4"));
+    let fib_v6 = open_lpm_v6(&pins.path("FIB_V6"));
+    let ecmp_groups: Array<MapData, EcmpGroup> = open_array(&pins.path("ECMP_GROUPS"));
+    let (_neigh_tx, neigh_rx) = tokio::sync::mpsc::channel(16);
+    let (programmer, prog_handle) = FibProgrammer::new(
+        nexthops,
+        fib_v4,
+        fib_v6,
+        ecmp_groups,
+        neigh_rx,
+        shutdown.clone(),
+    );
+    let prog_task = rt.spawn(programmer.run());
+
+    // Pick an ephemeral port by binding then dropping a TcpListener;
+    // a race window exists but in practice no other process races to
+    // claim a brand-new ephemeral port in the ~1 ms gap.
+    let probe = std::net::TcpListener::bind("127.0.0.1:0").expect("probe bind");
+    let listen_port = probe.local_addr().expect("probe addr").port();
+    drop(probe);
+
+    let listen_addr: SocketAddr = format!("127.0.0.1:{listen_port}").parse().unwrap();
+    let our_as = 65000u32;
+    let peer_as = 65001u32;
+    let bgp_cfg = BgpListenerConfig::new(listen_addr, our_as, peer_as, Ipv4Addr::new(127, 0, 0, 1));
+    let listener = BgpListener::new(bgp_cfg, prog_handle.clone(), shutdown.clone());
+    let listener_task = rt.spawn(listener.run());
+
+    let test_result = rt.block_on(async move {
+        // Give the listener a moment to bind.
+        for _ in 0..50 {
+            if TcpStream::connect(listen_addr).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        let mut peer = TcpStream::connect(listen_addr)
+            .await
+            .expect("connect to BgpListener");
+
+        // 1) Send our OPEN (peer-side: advertises Send for ADD-PATH).
+        let our_open = build_open_with_addpath_send(peer_as, 180, Ipv4Addr::new(127, 0, 0, 2));
+        peer.write_all(&our_open).await.expect("send OPEN");
+
+        // 2) Read the listener's OPEN. Header first, then body.
+        let mut head = [0u8; 19];
+        peer.read_exact(&mut head).await.expect("read OPEN header");
+        assert_eq!(&head[..16], &BGP_MARKER, "BGP marker missing");
+        let total = u16::from_be_bytes([head[16], head[17]]) as usize;
+        assert_eq!(head[18], 1, "expected OPEN message type");
+        let mut body = vec![0u8; total - 19];
+        peer.read_exact(&mut body).await.expect("read OPEN body");
+        let mut full = Vec::with_capacity(total);
+        full.extend_from_slice(&head);
+        full.extend_from_slice(&body);
+        assert!(
+            open_advertises_add_path_recv(&full),
+            "listener OPEN must advertise ADD-PATH capability with Receive for v4 + v6"
+        );
+
+        // 3) Confirm OPEN with KEEPALIVE, exchange with peer's.
+        peer.write_all(&build_keepalive())
+            .await
+            .expect("send KEEPALIVE");
+        let mut ka = [0u8; 19];
+        peer.read_exact(&mut ka).await.expect("read KEEPALIVE");
+        assert_eq!(ka[18], 4, "expected KEEPALIVE");
+
+        // 4) Send two ADD-PATH UPDATEs for the same /24 with different
+        //    path_ids and different next-hops.
+        let nh_a = Ipv4Addr::new(10, 0, 0, 1);
+        let nh_b = Ipv4Addr::new(10, 0, 0, 2);
+        let u1 = build_update_addpath_v4_slash24(1, [192, 0, 2], nh_a);
+        let u2 = build_update_addpath_v4_slash24(2, [192, 0, 2], nh_b);
+        peer.write_all(&u1).await.expect("send UPDATE 1");
+        peer.write_all(&u2).await.expect("send UPDATE 2");
+
+        // 5) Poll the FIB until the prefix appears as ECMP with two NHs.
+        let key = LpmKey::new(24, [192, 0, 2, 0]);
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let mut last_seen: Option<FibValue> = None;
+        let mut last_count: u32 = 0;
+        loop {
+            // Fresh handle each poll so we observe the programmer's
+            // writes via a separate FD.
+            let trie = open_lpm_v4(&pins.path("FIB_V4"));
+            if let Ok(fv) = trie.get(&key, 0) {
+                last_seen = Some(fv);
+                if fv.kind == FIB_KIND_ECMP {
+                    let groups: Array<MapData, EcmpGroup> = open_array(&pins.path("ECMP_GROUPS"));
+                    if let Ok(grp) = groups.get(&fv.idx, 0) {
+                        last_count = grp.nh_count;
+                        if grp.nh_count == 2 {
+                            break;
+                        }
+                    }
+                }
+            }
+            if Instant::now() > deadline {
+                panic!(
+                    "FIB did not reflect ADD-PATH aggregation within timeout: \
+                     last_seen={last_seen:?} last_nh_count={last_count}"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        // Hold the peer connection open so the listener's hold timer
+        // does not fire before we return.
+        drop(peer);
+    });
+
+    // Tear down the listener + programmer.
+    shutdown.cancel();
+    rt.block_on(async {
+        let _ = tokio::time::timeout(Duration::from_secs(2), listener_task).await;
+        let _ = tokio::time::timeout(Duration::from_secs(2), prog_task).await;
+    });
+
+    test_result
+}

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -544,6 +544,24 @@ multipath set from upstream eBGP), each NLRI prefixed with a 4-byte
 advertisements into an ECMP group, dedup'd against any prior group
 with the same nexthop set.
 
+**Local-pref-tier filter.** Operator-encoded BGP preferences are
+respected client-side. For each prefix the FibProgrammer computes
+the maximum LOCAL_PREF across the advertisements it holds and forms
+the ECMP group only from advertisements at that top tier. Lower-tier
+advertisements are retained but masked while a higher tier is
+present. When the top tier is withdrawn, the next-best tier's
+advertisements promote into the FIB entry without requiring a fresh
+announce.
+
+This means an LP scheme like `IX peers = 150, transit = 100` works
+as written: prefixes with any IX coverage forward over IX only (with
+within-IX ECMP if more than one IX peer announced); prefixes without
+IX coverage fall back to the transit tier (with within-transit ECMP
+if multiple transits advertise the same prefix at the same LP and
+AS_PATH length). Advertisements without a LOCAL_PREF attribute
+(non-BGP sources, malformed UPDATEs) are normalized to the RFC 4271
+default of 100.
+
 The session-level decode is all-or-nothing across IPv4 unicast and
 IPv6 unicast: if the peer advertises ADD-PATH for only one AFI, the
 listener falls back to non-ADD-PATH decoding for both. Symmetric

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -534,15 +534,84 @@ global-config: |
 keeps BGP routes off the kernel FIB; no further kernel-filter
 changes needed.
 
-**ADD-PATH (RFC 7911) caveat.** PacketFrame advertises capability
-69 in its OPEN with Receive direction for IPv4 and IPv6 unicast.
-NLRI decoding for ADD-PATH is not yet wired through the listener
-and the FIB programmer does not yet aggregate multi-path
-advertisements into ECMP groups. Do not configure peer-side
-`add paths tx` on the iBGP channel until a release CHANGELOG
-announces RFC 7911 support end to end. Enabling `add paths tx`
-before that point causes path-id-prefixed UPDATEs to misdecode
-and the session to flap.
+### Multi-NH ECMP from BGP
+
+PacketFrame supports RFC 7911 ADD-PATH end to end. With ADD-PATH
+mutually negotiated on the iBGP session to packetframe, the BGP
+daemon transmits one UPDATE per kept path (typically the equal-cost
+multipath set from upstream eBGP), each NLRI prefixed with a 4-byte
+`path_id`. The FibProgrammer aggregates the resulting per-prefix
+advertisements into an ECMP group, dedup'd against any prior group
+with the same nexthop set.
+
+The session-level decode is all-or-nothing across IPv4 unicast and
+IPv6 unicast: if the peer advertises ADD-PATH for only one AFI, the
+listener falls back to non-ADD-PATH decoding for both. Symmetric
+negotiation is the common case in practice for the BGP daemons this
+runbook targets.
+
+**Peer-side configuration.** Two pieces are needed on the daemon
+that talks to packetframe: retain alternate paths in the local RIB
+so there is more than one to send, and enable transmit-side
+ADD-PATH on the channel to packetframe. The example below is bird
+syntax expressed against documentation placeholders; substitute
+your actual peer names and source addresses.
+
+```
+# Upstream eBGP — keep alternate paths in the local RIB instead of
+# dropping non-best after best-path selection.
+protocol bgp UPSTREAM_A {
+  ipv4 {
+    secondary on;
+  };
+}
+
+# iBGP channel to packetframe — transmit all paths with path_ids.
+protocol bgp packetframe {
+  ipv4 { add paths tx; };
+  ipv6 { add paths tx; };
+}
+```
+
+**Validate after enabling.** After reloading the BGP daemon:
+
+```sh
+# Negotiation success: the protocol status should report tx-send
+# (or equivalent) for ADD-PATH on the packetframe session.
+birdc show protocols all packetframe | grep -i 'add path'
+
+# ECMP groups populate as multi-path prefixes converge. Starts at
+# zero before ADD-PATH is enabled; rises when the peer begins
+# transmitting per-path UPDATEs.
+sudo packetframe fib stats | grep ecmp-groups
+
+# Spot-check a prefix that should have multiple paths.
+sudo packetframe fib lookup <addr>
+```
+
+**Triage: ADD-PATH negotiated but no ECMP groups appearing.** If
+`packetframe fib stats` keeps `ecmp-groups: active=0` after the
+peer's session is established with ADD-PATH:
+
+- Confirm the peer is actually retaining multi-path. Compare the
+  daemon's total route count against the post-best-path table size;
+  on bird this is `birdc show route count` versus
+  `birdc show route table master4 primary count`. If they match,
+  the daemon has no alternate paths to advertise.
+- Confirm `add paths tx` is set on the packetframe-facing channel.
+  If `add paths` was set only on the upstream eBGP channel, the
+  daemon retains alternates locally but does not transmit them to
+  packetframe.
+- Confirm capability negotiation succeeded. The listener logs an
+  `add_path_in_effect=true` field on the `received peer OPEN`
+  message when both AFIs negotiated; if it logs `false`, the peer
+  advertised an asymmetric capability or no capability at all.
+
+**Rollback.** Removing `add paths tx` from the iBGP channel returns
+to single-best-path semantics with no listener-side changes. The
+listener still advertises capability 69 in its OPEN but the
+absence of peer-side Send keeps `add_path_in_effect` false and
+NLRI decodes without `path_id`.
 
 **Packetframe config:**
 

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -534,6 +534,16 @@ global-config: |
 keeps BGP routes off the kernel FIB; no further kernel-filter
 changes needed.
 
+**ADD-PATH (RFC 7911) caveat.** PacketFrame advertises capability
+69 in its OPEN with Receive direction for IPv4 and IPv6 unicast.
+NLRI decoding for ADD-PATH is not yet wired through the listener
+and the FIB programmer does not yet aggregate multi-path
+advertisements into ECMP groups. Do not configure peer-side
+`add paths tx` on the iBGP channel until a release CHANGELOG
+announces RFC 7911 support end to end. Enabling `add paths tx`
+before that point causes path-id-prefixed UPDATEs to misdecode
+and the session to flap.
+
 **Packetframe config:**
 
 ```


### PR DESCRIPTION
## Summary

Adds RFC 7911 ADD-PATH capability negotiation to the iBGP route source and the per-prefix multi-advertisement aggregation that turns multiple path-id-tagged UPDATEs into one ECMP group on the prefix. The data plane already supported ECMP via the existing `ECMP_GROUPS` BPF map and `alloc_ecmp_group` signature dedup; the only gap was the ingestion seam, where the BGP listener emitted single-NH `RouteEvent::Add` events and the programmer's prefix mirror treated repeated Adds as replace rather than merge.

After this change, when both sides of an iBGP session negotiate capability 69, the BGP daemon transmits one UPDATE per kept path (typically the equal-cost multipath set from upstream eBGP), each NLRI prefixed with a 4-byte `path_id`. The FibProgrammer aggregates the resulting per-(peer_id, path_id) advertisements into a single ECMP group on the prefix, dedup'd against any prior group with the same NH set.

Sessions where ADD-PATH is not negotiated continue to emit `path_id: None`, and the programmer preserves the existing single-best-path semantics. The `non_add_path_session_still_replaces` integration test guards this back-compat.

## Slicing

Five commits, each independently reviewable and revertable:

1. `bgp: advertise RFC 7911 ADD-PATH capability in OPEN` — wire-format addition to OPEN; `RouteEvent::Add` and `::Del` gain `path_id: Option<u32>`; zero behavior change.
2. `bgp: parse peer OPEN capabilities for ADD-PATH negotiation` — `walk_open_capabilities` + `NegotiatedCapabilities`; all-or-nothing across IPv4 and IPv6 unicast (bgpkit-parser constraint).
3. `bgp: parse path_id from ADD-PATH NLRI when negotiated` — `read_one_message` gains the `add_path` parameter; `elem.prefix.path_id` flows to `RouteEvent`.
4. `fib: aggregate multi-path advertisements into ECMP groups` — `RouteRecord` reshape (two-tier advertisements + installed FibValue); `recompute_fib_entry`; reclaim-prior / reclaim-immediate split; five integration tests.
5. `bgp: add integration test and runbook for ADD-PATH ECMP` — synthetic-peer wire-level integration test; runbook enablement section; design comment update.

Reverting commit 1 alone returns to today's behavior; subsequent commits are dormant without it because peers will not enable transmit-side ADD-PATH against a listener that does not advertise capability 69.

## Reviewer notes

- **All-or-nothing AFI negotiation.** `bgpkit_parser::parse_bgp_message` takes a single per-message `add_path: bool` rather than a per-AFI flag. An asymmetric advertisement (e.g., ADD-PATH for IPv4 only) falls back to non-ADD-PATH decoding for both AFIs. The motivation and citation live at the top of `route_source_bgp.rs` and in the `walk_open_capabilities` helper.
- **Aggregation model.** Each `RouteEvent::Add` upserts an entry in `RouteRecord.advertisements` keyed by `(peer_id, path_id)`; the installed FIB entry is the union of next-hops across all advertisements, recomputed after every mutation. Identical-union recomputes short-circuit before any BPF map write.
- **Grace-deferred reclaim.** In-place rewrites route through `reclaim_prior` (queued, freed after `DEFAULT_ROUTE_GRACE`) so concurrent XDP reads finish dereferencing the old IDs safely. Full tear-downs use `reclaim_immediate` because the BPF LPM entry has already been removed.
- **No bird in CI.** The new integration test under `tests/route_source_bgp_addpath.rs` drives raw BGP wire bytes through a real `BgpListener` over a `TcpStream`. The qemu-verifier apt package list stays unchanged.

## Test plan

- [x] CI green: fmt + clippy + test, four cross-builds (`{aarch64,x86_64}-unknown-linux-{musl,gnu}`), two qemu-verifier kernel matrix entries (5.15 and 6.6).
- [x] qemu-verifier picks up the five new `#[ignore]`-gated FibProgrammer integration tests:
  - `add_path_two_paths_one_prefix_yields_ecmp`
  - `add_path_withdrawal_collapses_to_single_nh`
  - `add_path_two_peers_two_paths_merge`
  - `add_path_peer_down_clears_all_paths_for_peer`
  - `non_add_path_session_still_replaces`
- [x] qemu-verifier picks up the new `add_path_two_updates_yield_ecmp_via_bgp_listener` wire-level integration test.
- [x] Manual validation on a router with at least one upstream peer capable of `add paths tx`, following the new "Multi-NH ECMP from BGP" section in `docs/runbooks/custom-fib.md`. Expected: `packetframe fib stats` reports `ecmp-groups: active > 0` once the peer's session is established with ADD-PATH; `packetframe fib lookup <addr>` shows multiple next-hops for a multi-path prefix.