### PR TITLE
docs: tighten phrasing across CLAUDE.md and runbooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,19 +1,19 @@
 # CLAUDE.md
 
-Project guidance for Claude Code sessions. Keep this file tight — skim it first, then dive in.
+Project guidance for Claude Code sessions. Keep this file tight: skim it first, then dive in.
 
 ## Project overview
 
-PacketFrame is a modular eBPF data plane written in pure Rust (aya + aya-ebpf). The MVP module is **fast-path**, which takes forwarded traffic for allowlisted prefixes off the kernel's conntrack/netfilter path via XDP ingress + `bpf_redirect_map`. Forwarding decisions pick between two modes: `kernel-fib` (`bpf_fib_lookup()`, the default and rollback path) or `custom-fib` (Option F — LPM-trie FIB populated from a userspace route source, with `FibProgrammer` + `NeighborResolver` under a tokio runtime). Two route-source implementations live in tree: `BgpListener` (passive iBGP — the production path, since bird 2.x/3.x does not implement RFC 9069 Loc-RIB BMP) and `BmpStation` (RFC 7854 + 9069, ready for emitters that ship Loc-RIB like FRR). The custom-FIB runbook lives at `docs/runbooks/custom-fib.md`. The design spec (`SPEC.md`) is deliberately **not** in the repo — inline code comments cite section numbers ("SPEC.md §4.2") as breadcrumbs for reviewers who have the spec. Don't re-add `SPEC.md`; it's in `.gitignore`.
+PacketFrame is a modular eBPF data plane written in pure Rust (aya + aya-ebpf). The MVP module is **fast-path**, which takes forwarded traffic for allowlisted prefixes off the kernel's conntrack/netfilter path via XDP ingress + `bpf_redirect_map`. Forwarding decisions pick between two modes: `kernel-fib` (`bpf_fib_lookup()`, the default and rollback path) or `custom-fib` (Option F: LPM-trie FIB populated from a userspace route source, with `FibProgrammer` + `NeighborResolver` under a tokio runtime). Two route-source implementations live in tree: `BgpListener` (passive iBGP, the production path, since bird 2.x/3.x does not implement RFC 9069 Loc-RIB BMP) and `BmpStation` (RFC 7854 + 9069, ready for emitters that ship Loc-RIB like FRR). The custom-FIB runbook lives at `docs/runbooks/custom-fib.md`. The design spec (`SPEC.md`) is deliberately **not** in the repo. Inline code comments cite section numbers ("SPEC.md §4.2") as breadcrumbs for reviewers who have the spec. Don't re-add `SPEC.md`; it's in `.gitignore`.
 
 ## Repo layout
 
-- `crates/common/` — config parser (SPEC.md §6), `Module` trait (§3.2), §2.1 capability probes, custom-FIB trait shapes (`fib/mod.rs`)
-- `crates/cli/` — the `packetframe` binary (clap subcommands: `feasibility`, `run`, `detach`, `status`, `fib`, `probe`)
-- `crates/modules/fast-path/` — fast-path module including the custom-FIB control plane under `src/fib/`
-- `conf/example.conf` — reference config per SPEC.md §4.8
-- `docs/runbooks/custom-fib.md` — Option F operations runbook (healthy state, triage by symptom, cutover + rollback, Phase 4 config snippets)
-- `.github/workflows/` — `ci.yml` (fmt/clippy/test + 4× cross-build), `qemu-verifier.yml` (integration tests on 5.15 + 6.6 kernels), `release.yml` (tag-triggered tarballs)
+- `crates/common/`: config parser (SPEC.md §6), `Module` trait (§3.2), §2.1 capability probes, custom-FIB trait shapes (`fib/mod.rs`)
+- `crates/cli/`: the `packetframe` binary (clap subcommands: `feasibility`, `run`, `detach`, `status`, `fib`, `probe`)
+- `crates/modules/fast-path/`: fast-path module including the custom-FIB control plane under `src/fib/`
+- `conf/example.conf`: reference config per SPEC.md §4.8
+- `docs/runbooks/custom-fib.md`: Option F operations runbook (healthy state, triage by symptom, cutover + rollback, Phase 4 config snippets)
+- `.github/workflows/`: `ci.yml` (fmt/clippy/test + 4× cross-build), `qemu-verifier.yml` (integration tests on 5.15 + 6.6 kernels), `release.yml` (tag-triggered tarballs)
 
 ## Build & test
 
@@ -34,15 +34,15 @@ GPL-3.0-or-later. The three surfaces must agree: `LICENSE` (GPLv3 text), `Cargo.
 
 ## Platform constraints
 
-Linux-only code — BPF syscalls, `/proc/config.gz`, `/proc/sys/...`, bpffs, netlink, custom-FIB control plane — is gated behind `#[cfg(target_os = "linux")]`. Non-Linux hosts get `ENOSYS`-returning stubs so `cargo check`/`cargo test` succeed on macOS dev laptops. On macOS, `packetframe feasibility` correctly reports every BPF capability as **Fail** — that's expected behavior, not a bug to chase. Integration tests (`bpf_prog_test_run` fixtures + netns + pinned-map harnesses) run via the qemu-verifier job on CI; host macOS `cargo check` skips the Linux-only modules, so it's easy to accidentally land code that compiles locally but not on Linux — CI catches these in the cross-build matrix.
+Linux-only code (BPF syscalls, `/proc/config.gz`, `/proc/sys/...`, bpffs, netlink, custom-FIB control plane) is gated behind `#[cfg(target_os = "linux")]`. Non-Linux hosts get `ENOSYS`-returning stubs so `cargo check`/`cargo test` succeed on macOS dev laptops. On macOS, `packetframe feasibility` correctly reports every BPF capability as **Fail**; that's expected behavior, not a bug to chase. Integration tests (`bpf_prog_test_run` fixtures + netns + pinned-map harnesses) run via the qemu-verifier job on CI; host macOS `cargo check` skips the Linux-only modules, so it's easy to accidentally land code that compiles locally but not on Linux. CI catches these in the cross-build matrix.
 
 ## Toolchain
 
-Stable Rust is pinned via root `rust-toolchain.toml`. A second `rust-toolchain.toml` under `crates/modules/fast-path/bpf/` pins nightly for the BPF crate (aya-ebpf needs it). `bpf-linker` is pinned in CI via `cargo install --locked bpf-linker@<version>`. Don't unpin any of these — aya has had breaking API changes across minor versions.
+Stable Rust is pinned via root `rust-toolchain.toml`. A second `rust-toolchain.toml` under `crates/modules/fast-path/bpf/` pins nightly for the BPF crate (aya-ebpf needs it). `bpf-linker` is pinned in CI via `cargo install --locked bpf-linker@<version>`. Don't unpin any of these; aya has had breaking API changes across minor versions.
 
 ## Error handling
 
-Validate at system boundaries (`bpf()` syscall, sysfs/procfs reads, config parse). Trust framework guarantees inside — no fallbacks for conditions that can't occur. No backwards-compat shims for hypothetical future states; change the code directly when requirements change.
+Validate at system boundaries (`bpf()` syscall, sysfs/procfs reads, config parse). Trust framework guarantees inside; no fallbacks for conditions that can't occur. No backwards-compat shims for hypothetical future states; change the code directly when requirements change.
 
 ## Spec tethering
 
@@ -50,16 +50,16 @@ Comments reference spec sections, they don't restate them. Don't paraphrase the 
 
 ## Clippy policy
 
-CI runs `cargo clippy --workspace --all-targets --all-features -- -D warnings`. Cross-platform casts that are no-ops on one target but load-bearing on another (e.g. `statfs.f_type as i64` — `i64` already on glibc Linux x86_64, but `u32` on macOS) need a targeted `#[allow(clippy::unnecessary_cast)]` with a comment explaining *why* the cast stays. The pattern is established in [crates/common/src/probe/mod.rs](crates/common/src/probe/mod.rs) and [crates/common/src/probe/bpf.rs](crates/common/src/probe/bpf.rs).
+CI runs `cargo clippy --workspace --all-targets --all-features -- -D warnings`. Cross-platform casts that are no-ops on one target but load-bearing on another (e.g. `statfs.f_type as i64`: `i64` already on glibc Linux x86_64, but `u32` on macOS) need a targeted `#[allow(clippy::unnecessary_cast)]` with a comment explaining *why* the cast stays. The pattern is established in [crates/common/src/probe/mod.rs](crates/common/src/probe/mod.rs) and [crates/common/src/probe/bpf.rs](crates/common/src/probe/bpf.rs).
 
 ## PR workflow
 
-One feature branch per slice. Commit messages explain **why**, not what the diff already shows. CI must be green before asking for review (seven jobs: fmt+clippy+test, four cross-builds, two qemu kernels). Amending unreviewed commits and `git push --force-with-lease` on a feature branch is fine pre-review — force-push to `main` is never fine. For multi-phase work (e.g. the Option F rollout) the slicing lives in the plan file; keep PRs scoped to a single slice.
+One feature branch per slice. Commit messages explain **why**, not what the diff already shows. CI must be green before asking for review (seven jobs: fmt+clippy+test, four cross-builds, two qemu kernels). Amending unreviewed commits and `git push --force-with-lease` on a feature branch is fine pre-review; force-push to `main` is never fine. For multi-phase work (e.g. the Option F rollout) the slicing lives in the plan file; keep PRs scoped to a single slice.
 
 ## What not to change casually
 
-- `SPEC.md` stays out of the repo — it's in `.gitignore`.
+- `SPEC.md` stays out of the repo; it's in `.gitignore`.
 - License stays GPL-3.0-or-later across `LICENSE`, `Cargo.toml`, and `README.md`.
-- The `Module` trait in [crates/common/src/module.rs](crates/common/src/module.rs) is the public contract for every future module (randomizer, ddos, sampler) — breaking changes need a changelog note and coordinated updates.
-- Counter indices in the `stats` map (§4.6) are append-only once v0.1 ships — renumbering breaks operator dashboards.
+- The `Module` trait in [crates/common/src/module.rs](crates/common/src/module.rs) is the public contract for every future module (randomizer, ddos, sampler); breaking changes need a changelog note and coordinated updates.
+- Counter indices in the `stats` map (§4.6) are append-only once v0.1 ships; renumbering breaks operator dashboards.
 - Platform cfg gates: don't collapse the Linux-only/non-Linux split without also making the macOS dev loop still work.

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -44,7 +44,7 @@ how to roll back to the kernel-FIB path if something goes wrong.
   with bird's chosen nexthop. Translated to
   `RouteEvent::Add`/`Del`. **BmpStation** is also available behind
   the `RouteSource` trait but bird's BMP doesn't ship RFC 9069
-  Loc-RIB — see the section "When to use `route-source bmp`
+  Loc-RIB. See the section "When to use `route-source bmp`
   instead" near the bottom.
 - **FibProgrammer** owns the BPF map write path. Allocates `NexthopId`s
   and `EcmpGroupId`s with refcount + free-list dedup.
@@ -65,7 +65,7 @@ Indicators that the custom-FIB path is working:
 - `custom_fib_hit` counter climbs; `custom_fib_miss` is low relative
   to it (misses indicate prefixes that arrived in XDP before bird
   announced them, or prefixes in the allowlist that bird doesn't cover).
-- `fwd_ok` climbs (the shared success counter — custom and kernel FIB
+- `fwd_ok` climbs (the shared success counter; custom and kernel FIB
   both increment it on redirect).
 - `pass_no_neigh` stays below ~0.01% of matched traffic after the
   first few seconds (first-packet ARP is expected; sustained-high
@@ -91,9 +91,9 @@ sudo packetframe status --config /etc/packetframe/packetframe.conf
 
 Look at:
 
-- `custom-FIB status:` block — `forwarding-mode`, nexthop resolution
+- `custom-FIB status:` block: `forwarding-mode`, nexthop resolution
   counts, ECMP group count.
-- counter block — especially the `custom_fib_*` family.
+- counter block, especially the `custom_fib_*` family.
 
 ### Is the route-source session live?
 
@@ -158,8 +158,8 @@ post-first-update quiescence) or the next Resync.
 
 ### Inspecting the FIB programmatically
 
-The `packetframe fib` subcommand opens the pinned BPF maps directly
-— no daemon IPC. Works as long as the pins exist (i.e., after
+The `packetframe fib` subcommand opens the pinned BPF maps directly.
+No daemon IPC. Works as long as the pins exist (i.e., after
 `systemctl stop packetframe` but before `detach --all`).
 
 ```sh
@@ -169,7 +169,7 @@ sudo packetframe fib lookup 8.8.8.8
 # Walk the whole FIB (O(N); slow on a 1M-route table).
 sudo packetframe fib dump-v4
 
-# Occupancy / mode / hash block only — scriptable.
+# Occupancy / mode / hash block only (scriptable).
 sudo packetframe fib stats
 ```
 
@@ -177,13 +177,13 @@ sudo packetframe fib stats
 
 Alongside the existing counter family, the textfile exporter emits:
 
-- `packetframe_fib_forwarding_mode{mode="kernel-fib|custom-fib|compare"}`
-  — one-hot gauge; alert on unexpected transitions.
-- `packetframe_nexthops{state="resolved|failed|stale|unwritten_or_incomplete"}`
-  — NEXTHOPS state bucket counts.
-- `packetframe_nexthops_max` — configured NEXTHOPS capacity.
+- `packetframe_fib_forwarding_mode{mode="kernel-fib|custom-fib|compare"}`:
+  one-hot gauge; alert on unexpected transitions.
+- `packetframe_nexthops{state="resolved|failed|stale|unwritten_or_incomplete"}`:
+  NEXTHOPS state bucket counts.
+- `packetframe_nexthops_max`: configured NEXTHOPS capacity.
 - `packetframe_ecmp_groups_active`, `packetframe_ecmp_groups_max`.
-- `packetframe_fib_default_hash_mode` — 3/4/5-tuple.
+- `packetframe_fib_default_hash_mode`: 3/4/5-tuple.
 
 Example alerts:
 
@@ -228,13 +228,13 @@ bird outages.
 Bird's iBGP feed gives us the connected /24 (e.g. `23.191.200.0/24`
 on `br1337`) with a self-referential BGP NEXT_HOP (the device's local
 IP). The neighbour resolver can't map that to a useful destination
-MAC — it's our own IP. Without the connected fast-path, the LPM
+MAC: it's our own IP. Without the connected fast-path, the LPM
 lookup hits the /24 with `state=Incomplete` and returns
 `custom_fib_no_neigh` (or, pre-v0.2.1, `custom_fib_miss` because the
 listener silently dropped the announce). Either way, the packet
-falls through XDP_PASS to kernel slow-path — through netfilter,
+falls through XDP_PASS to kernel slow-path: through netfilter,
 conntrack, the FIB walk, and finally out the bridge. That's exactly
-the load fast-path was built to remove.
+the load fast-path exists to remove.
 
 The connected fast-path inverts this: NetlinkNeighborResolver walks
 the kernel ARP table for hosts within an operator-declared CIDR
@@ -269,7 +269,7 @@ hosting the prefix. Validate at startup the same way `attach`
 directives validate (must exist under `/sys/class/net`); a missing
 iface is a startup-fatal error.
 
-The directive set is additive — declare as many as you have
+The directive set is additive. Declare as many as you have
 connected destinations to fast-path. Each adds one hashmap-walk
 of the kernel's neighbour table at startup and one match per
 multicast neighbour event. Match cost is O(N) over the local-prefix
@@ -287,7 +287,7 @@ sudo packetframe fib dump-v4 | grep -E '^10\.88\.1\.[0-9]+/32'   | head
 # host's actual MAC and the iface's ifindex.
 sudo packetframe fib lookup 23.191.200.10
 
-# 3. Watch the resolver stats — `local_arp_routes_added` climbs as
+# 3. Watch the resolver stats. `local_arp_routes_added` climbs as
 # the kernel ARPs new hosts; `_removed` climbs on RTM_DELNEIGH
 # (typical aging churn).
 journalctl -u packetframe -f | grep 'neighbour resolver stats'
@@ -321,23 +321,23 @@ the directive on that prefix and accept the slow-path fallback.
   FIB does nothing if the parent prefix isn't matched. Add the
   customer /24 to `allow-prefix` first.
 - **Tunnels and weirdness.** Don't declare local-prefix on a tunnel
-  iface (WireGuard, GRE, IPSec) — the BPF program can't redirect
+  iface (WireGuard, GRE, IPSec). The BPF program can't redirect
   to non-XDP-capable interfaces, so the /32 just sits unused.
   Stick to physical and bridge interfaces.
 
 ### Disabling
 
 Remove (or comment out) the `local-prefix` lines and restart
-packetframe. SIGHUP doesn't reconcile this directive in v0.2.1
-— a future version may add live add/remove via SIGHUP, but for
+packetframe. SIGHUP doesn't reconcile this directive in v0.2.1.
+A future version may add live add/remove via SIGHUP, but for
 now it's a startup-time-only configuration. The /32 entries get
 flushed on detach and don't reappear at next startup without the
 directive.
 
 ### `arp-scavenge` for quiet LANs (v0.2.1, issue #32)
 
-Some LANs — Ceph clusters, monitoring networks, anything where
-hosts only do intra-/24 L2 traffic — never appear in the kernel's
+Some LANs (Ceph clusters, monitoring networks, anything where
+hosts only do intra-/24 L2 traffic) never appear in the kernel's
 L3 ARP cache. Without entries to feed from, the per-/32 emission
 finds nothing.
 
@@ -353,7 +353,7 @@ multicast event lands the /32. Operator opt-in (default off) because
 it generates noticeable ARP traffic.
 
 **Safety guarantee (v0.2.2+).** ARP probes are issued ONLY on the
-operator-declared `via <iface>` — the resolver does NOT consult the
+operator-declared `via <iface>`. The resolver does NOT consult the
 kernel's routing table when picking the egress iface for the probe.
 This is a deliberate v0.2.2 safety fix: pre-v0.2.2 the code used
 kernel route lookup, which on a multi-VID bridge box (e.g. EFG's
@@ -366,10 +366,10 @@ that iface's L2 broadcast domain.
 **Critical: do NOT declare `arp-scavenge` on an IX-attached iface.**
 Even with the safety scoping, declaring `local-prefix <ix-subnet> via
 <ix-bridge> arp-scavenge` would still broadcast ARP into the IX
-fabric — which violates IX ToS (MANRS, anti-DoS) on most exchanges.
+fabric, which violates IX ToS (MANRS, anti-DoS) on most exchanges.
 `arp-scavenge` is for INTERNAL LANs only (storage, management,
 customer LAN). For IX peer subnets, rely on bird's natural ARP
-behavior — bird already maintains ARP for active BGP peers, so
+behavior: bird already maintains ARP for active BGP peers, so
 their /32s will land via the normal nexthop-resolution path.
 
 ### `fallback-default` synthetic /0 (v0.2.1, issue #31)
@@ -377,7 +377,7 @@ their /32s will land via the normal nexthop-resolution path.
 Custom-FIB only has prefixes bird's iBGP feed advertised. Destinations
 bird doesn't have specific routes for (RFC 1918, CGNAT, test-net,
 anything outside DFZ) miss LPM, fall to kernel slow path through
-netfilter / conntrack, and get dropped upstream anyway — wasting
+netfilter / conntrack, and get dropped upstream anyway, wasting
 kernel CPU + conntrack table capacity.
 
 ```
@@ -386,7 +386,7 @@ fallback-default via eth3 nexthop 194.110.60.50
 
 Injects a `0.0.0.0/0` into FIB_V4 at startup. Every more-specific
 bird-fed route still wins LPM; the /0 catches bogon-bound traffic.
-XDP redirects directly to upstream — same upstream rejection behavior,
+XDP redirects directly to upstream: same upstream rejection behavior,
 just no kernel / conntrack involvement. Measured ~25% reduction in
 steady-state conntrack pressure on a busy Tor exit relay.
 
@@ -407,12 +407,12 @@ fast-path), if dst is in any `block-prefix` the program returns
 `XDP_DROP` and bumps `bogon_dropped`. Saves skb allocation +
 netfilter walk + conntrack entry per dropped packet.
 
-dst-only match — we never block by src, because that would silently
+dst-only match: we never block by src, because that would silently
 drop reply traffic for asymmetric flows where the *peer* happens to
 be in a bogon range.
 
 Refuses to start if a `block-prefix` overlaps any `allow-prefix` or
-`local-prefix` (operator config bug — would silently drop traffic to
+`local-prefix` (operator config bug; would silently drop traffic to
 declared customer prefixes).
 
 ## Cutover and rollback
@@ -431,7 +431,7 @@ declared customer prefixes).
    fast-path` in `/etc/packetframe/packetframe.conf`.
 4. Confirm bird's `kernel.export: false` (or equivalent) so no BGP
    routes flow to the kernel FIB. Customer /32s, connected, static
-   default still flow via non-BGP mechanisms — udapi parses those
+   default still flow via non-BGP mechanisms; udapi parses those
    fine.
 
 **Cutover sequence:**
@@ -478,7 +478,7 @@ sudo sed -i '/^  forwarding-mode /d; /^  route-source bmp /d' \
 sudo systemctl start packetframe
 ```
 
-**Rollback re-exposes the original udapi bug** — BGP routes flow to
+**Rollback re-exposes the original udapi bug.** BGP routes flow to
 the kernel FIB again, udapi parses them, parse-error window opens up.
 Rollback is "restore service now," not a steady state. Follow it with
 same-day diagnosis and a forward-fix plan.
@@ -490,7 +490,7 @@ a feed of bird's selected best paths, and bird's kernel-protocol
 export needs to stay off so udapi never sees BGP routes.
 
 **Why iBGP and not BMP for the forwarding feed.** Bird (2.x and
-3.x master) does not ship RFC 9069 Loc-RIB BMP — only
+3.x master) does not ship RFC 9069 Loc-RIB BMP, only
 `monitoring rib in pre_policy / post_policy`, which deliver
 per-peer Adj-RIB-In streams. That's wrong for forwarding: a
 prefix announced by N peers becomes N RouteMonitoring frames
@@ -501,14 +501,14 @@ one UPDATE per prefix carrying bird's chosen path. See
 `crates/modules/fast-path/src/fib/route_source_bgp.rs` for the
 full design rationale.
 
-**Bird config — inject via pathvector's `global-config`.**
+**Bird config: inject via pathvector's `global-config`.**
 Pathvector ships `global-config` verbatim into the rendered bird
 config (no template fork needed). Add to `pathvector.yml`:
 
 ```yaml
 global-config: |
   # iBGP feed to packetframe's BgpListener. AS 401401 is our own
-  # AS — replace with yours. `passive` ensures bird only initiates;
+  # AS; replace with yours. `passive` ensures bird only initiates;
   # we listen on 1179 (NOT 179, to avoid clashing with anyone else
   # who happens to bind 179 on the loopback).
   protocol bgp packetframe {
@@ -576,7 +576,7 @@ syntax expressed against documentation placeholders; substitute
 your actual peer names and source addresses.
 
 ```
-# Upstream eBGP — keep alternate paths in the local RIB instead of
+# Upstream eBGP: keep alternate paths in the local RIB instead of
 # dropping non-best after best-path selection.
 protocol bgp UPSTREAM_A {
   ipv4 {
@@ -584,7 +584,7 @@ protocol bgp UPSTREAM_A {
   };
 }
 
-# iBGP channel to packetframe — transmit all paths with path_ids.
+# iBGP channel to packetframe: transmit all paths with path_ids.
 protocol bgp packetframe {
   ipv4 { add paths tx; };
   ipv6 { add paths tx; };
@@ -639,7 +639,7 @@ module fast-path
   route-source bgp 127.0.0.1:1179 local-as 401401 peer-as 401401 router-id 103.17.154.7
 ```
 
-`router-id` is optional — defaults to the listen-address (v4) or
+`router-id` is optional; defaults to the listen-address (v4) or
 the local AS (v6 listen).
 
 **Validate after pushing:**
@@ -679,7 +679,7 @@ Wants=bird.service
 ```ini
 [Unit]
 After=packetframe.service
-# Cheap guard against races at boot — wait up to 30 s for the BGP
+# Cheap guard against races at boot: wait up to 30 s for the BGP
 # listener to be reachable before dialing.
 [Service]
 ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do ss -Htnl sport = :1179 | grep -q . && exit 0; sleep 1; done; exit 0'
@@ -698,7 +698,7 @@ The BMP route source is useful when:
 
 - Your routing daemon emits **RFC 9069 Loc-RIB BMP** (peer_type 3).
   FRR has this today; bird does not. Set `require-loc-rib` on the
-  `route-source bmp` line — the BmpStation will refuse any
+  `route-source bmp` line; the BmpStation will refuse any
   non-Loc-RIB frame and tear the session down with an error,
   preventing silent wrong-forwarding from pre/post-policy streams:
 
@@ -709,7 +709,7 @@ The BMP route source is useful when:
 - You want a **pure observability** feed (analytics, anomaly
   detection on per-peer Adj-RIB-In streams) running alongside
   the BGP forwarding feed. This isn't wired into the controller
-  yet — the current build accepts exactly one `route-source`
+  yet; the current build accepts exactly one `route-source`
   per fast-path module.
 
 ## Triage by symptom
@@ -722,12 +722,12 @@ writing), or the allowlist matches traffic bird doesn't cover.
 
 Check:
 
-- `packetframe status` — is `nexthops (resolved)` ≥ your expected
+- `packetframe status`: is `nexthops (resolved)` ≥ your expected
   peer count?
-- `journalctl -u packetframe | grep -iE 'bgp|bmp'` — any errors from
+- `journalctl -u packetframe | grep -iE 'bgp|bmp'`: any errors from
   the route-source handler?
-- `birdc show protocols packetframe` (or your BMP protocol name)
-  — is the session established and propagating routes?
+- `birdc show protocols packetframe` (or your BMP protocol name):
+  is the session established and propagating routes?
 
 ### Symptom: `pass_no_neigh` climbs sustainedly
 
@@ -737,8 +737,8 @@ packet; expected briefly), or the nexthop is genuinely unreachable.
 
 Check:
 
-- `ip neigh show <nexthop-ip>` — what state does the kernel report?
-- `packetframe status` — is `nexthops (failed)` > 0?
+- `ip neigh show <nexthop-ip>`: what state does the kernel report?
+- `packetframe status`: is `nexthops (failed)` > 0?
 - Proactive resolve is currently relying on first-packet kernel ARP
   (Phase 3.5+ adds proactive `RTM_NEWNEIGH NUD_NONE`). If
   `pass_no_neigh` only spikes for a few packets per new destination
@@ -752,8 +752,8 @@ maintenance windows; alarming during stable state.
 
 Check:
 
-- `birdc show protocols | grep -v Established` — what's down?
-- `journalctl | grep bird` — why?
+- `birdc show protocols | grep -v Established`: what's down?
+- `journalctl | grep bird`: why?
 
 ### Symptom: `nexthop_seq_retry` climbs
 
@@ -764,7 +764,7 @@ outside the programmer.
 
 Check:
 
-- `ip monitor neigh` in a separate terminal — is there a neighbor
+- `ip monitor neigh` in a separate terminal: is there a neighbor
   storm?
 - No process other than packetframe should be writing to
   `/sys/fs/bpf/packetframe/fast-path/maps/NEXTHOPS`.
@@ -772,23 +772,23 @@ Check:
 ### Symptom: route-source session stays up but routes stop flowing
 
 What it means: bird is connected and idle. No new BGP churn, no new
-routes. Usually benign — BGP in stable state just doesn't send much.
+routes. Usually benign; BGP in stable state just doesn't send much.
 
 Check:
 
 - `custom_fib_hit` still climbing (existing routes are still
   forwarding). If yes, this is fine.
-- If forwarding has stopped entirely, that's a different problem —
-  look at `fwd_ok`, `pass_not_in_devmap`, `drop_unreachable`.
+- If forwarding has stopped entirely, that's a different problem.
+  Look at `fwd_ok`, `pass_not_in_devmap`, `drop_unreachable`.
 
-### Symptom: Daemon won't start — "LPM trie create failed / ENOMEM"
+### Symptom: Daemon won't start, "LPM trie create failed / ENOMEM"
 
 What it means: kernel rejected a 2M-entry LPM trie allocation. Either
 `rlimit.memlock` is too low, or the kernel has per-map caps.
 
 Check:
 
-- `ulimit -l` — is it `unlimited`? If not, set it in
+- `ulimit -l`: is it `unlimited`? If not, set it in
   `/etc/systemd/system/packetframe.service.d/memlock.conf`:
   `[Service]\nLimitMEMLOCK=infinity`.
 - If `unlimited` and still failing: reduce `FIB_V4_MAX_ENTRIES` in
@@ -820,7 +820,7 @@ landed since the runbook was first written.
   and `packetframe_fib_default_hash_mode` on the usual 15 s cadence.
 - ✅ **Offline comparison harness** (Phase 3.8). `tests/fib_comparison.rs`
   drives a synthetic RIB through the programmer and asserts the LPM
-  lookups resolve correctly — runs in every qemu-verifier CI job.
+  lookups resolve correctly. Runs in every qemu-verifier CI job.
 - ✅ **Integrity check + BmpStalled alert** (Phase 3.8). When BMP is
   configured, the RouteController spawns a 5-minute periodic job
   that cross-checks `birdc show route count` against the mirror size
@@ -841,14 +841,14 @@ landed since the runbook was first written.
   BMP path is for Loc-RIB-emitting daemons (FRR; future bird).
 - ✅ **BgpListener direct-origin fallback + connected fast-path**
   (v0.2.1). Pre-v0.2.1 the BgpListener silently dropped iBGP UPDATEs
-  whose decoded NEXT_HOP was None — exactly what bird emits for
+  whose decoded NEXT_HOP was None: exactly what bird emits for
   `protocol direct` (and static-origin) routes when the BGP block has
   no `next hop self`. Connected /24s never landed in FIB_V4, so every
   inbound packet to a customer host bumped `custom_fib_miss` and fell
   through to slow path. v0.2.1 makes the listener fall back to its
   own listen address; the route lands with `state=Incomplete` so
   counters reflect reality. The `local-prefix <cidr> via <iface>`
-  directive turns those /24s into per-/32 fast-paths — see the
+  directive turns those /24s into per-/32 fast-paths. See the
   [Connected fast-path](#connected-fast-path-v021) section above.
 - ✅ **`fallback-default` synthetic /0** (v0.2.1, issue #31). Inject
   a catch-all default into the custom-FIB so bogon-bound traffic

--- a/docs/runbooks/mss-clamp.md
+++ b/docs/runbooks/mss-clamp.md
@@ -16,7 +16,7 @@ Operator guide for `mss-clamp` directives in `module fast-path`. Closes the [SPE
 Add `mss-clamp` directives if any of these are true on your edge:
 
 - A downstream peer's path MTU is less than the local link MTU (typical: PPPoE, GRE, IPsec, WireGuard, MPLS overlays). Without clamping, large segments arrive at the bottleneck, get fragmented or PMTUD-discovered-then-dropped, and TCP throughput collapses.
-- You currently rely on `iptables -A FORWARD ... TCPMSS --set-mss <N>` rules and one or more of the `-s` / `-d` prefixes overlaps an `allow-prefix`. Those iptables rules do not fire for fast-pathed traffic — adding a matching `mss-clamp` directive moves the mutation into XDP.
+- You currently rely on `iptables -A FORWARD ... TCPMSS --set-mss <N>` rules and one or more of the `-s` / `-d` prefixes overlaps an `allow-prefix`. Those iptables rules do not fire for fast-pathed traffic. Adding a matching `mss-clamp` directive moves the mutation into XDP.
 - You deploy onto a host where you don't control upstream MTU but want to defend against MTU-blackhole-induced TCP stalls.
 
 If none of those apply, you don't need this. PacketFrame doesn't insert any clamp by default.
@@ -42,25 +42,25 @@ mss-clamp 23.191.201.0/24 1360                # customer 23.191.201.0/24, any eg
 
 Prefix matches **src OR dst** (same semantic as `allow-prefix`), so one rule covers both directions of a flow.
 
-CIDR ranges work for both IPv4 and IPv6 — the parser dispatches on the address family. `mss-clamp 2001:db8::/48 1280` is valid.
+CIDR ranges work for both IPv4 and IPv6; the parser dispatches on the address family. `mss-clamp 2001:db8::/48 1280` is valid.
 
-`<mtu>` is the clamp ceiling in bytes. Range: 88–65495. The clamp is **lower-if-higher** — if the SYN's existing MSS is already ≤ the configured value, the packet is left untouched and `mss_clamp_skipped` is bumped instead of `mss_clamp_applied`.
+`<mtu>` is the clamp ceiling in bytes. Range: 88–65495. The clamp is **lower-if-higher**: if the SYN's existing MSS is already ≤ the configured value, the packet is left untouched and `mss_clamp_skipped` is bumped instead of `mss_clamp_applied`.
 
 ## What gets clamped
 
 - Only **matched** traffic (i.e. `allow-prefix` / `allow-prefix6` already hit). Non-matched traffic flows through the kernel where existing iptables `TCPMSS` rules still fire normally.
 - Only **TCP SYN and SYN-ACK** packets. Established-connection packets don't carry an MSS option, so there's nothing to mutate.
-- Both directions: a SYN egressing eth2 from a clamped prefix, AND the responder's SYN-ACK egressing back into the customer LAN. TCP's per-direction MSS is independent — clamping both ensures both endpoints respect the constraint.
+- Both directions: a SYN egressing eth2 from a clamped prefix, AND the responder's SYN-ACK egressing back into the customer LAN. TCP's per-direction MSS is independent; clamping both ensures both endpoints respect the constraint.
 - Only when a clamp value > 0 applies. A packet whose lookup returns no policy is forwarded with no counter activity.
 
-What is **not** touched: the original packet's TCP timestamp, SACK, window-scale, or any other option. Only the MSS option's 2 bytes change. Checksum is recomputed via RFC 1624 incremental update — no full TCP-segment re-fold.
+What is **not** touched: the original packet's TCP timestamp, SACK, window-scale, or any other option. Only the MSS option's 2 bytes change. Checksum is recomputed via RFC 1624 incremental update, with no full TCP-segment re-fold.
 
 ## Troubleshooting
 
 The two relevant counters (SPEC §4.6 indices 33–34, exposed via `packetframe status` and the metrics textfile):
 
-- `mss_clamp_applied` — packets where the MSS option was rewritten. Climbs with new TCP sessions on clamped prefixes; flat means either no SYNs are arriving on those prefixes or your existing SYNs already announce ≤ clamp.
-- `mss_clamp_skipped` — packets matched + with a clamp policy active, but no rewrite. Common reasons:
+- `mss_clamp_applied`: packets where the MSS option was rewritten. Climbs with new TCP sessions on clamped prefixes; flat means either no SYNs are arriving on those prefixes or your existing SYNs already announce ≤ clamp.
+- `mss_clamp_skipped`: packets matched + with a clamp policy active, but no rewrite. Common reasons:
   - Existing MSS already ≤ clamp value (working as intended; you can ignore unless you expect *every* SYN to need adjustment).
   - SYN had no MSS option (rare; some old/embedded stacks).
   - Malformed TCP options block (very rare; would also break the kernel's processing).
@@ -84,11 +84,11 @@ If `mss_clamp_applied` is climbing but downstream still shows MTU-blackhole symp
 
 ## Why no `from <iface>` (ingress) form?
 
-PacketFrame's XDP runs at ingress on attached physical NICs. The directional concept that matters operationally is "what egress will this fast-pathed packet take" — resolved by `bpf_fib_lookup` before redirect. `via <iface>` always means **egress**, matching the `local-prefix via X` and `fallback-default via X` grammar.
+PacketFrame's XDP runs at ingress on attached physical NICs. The directional concept that matters operationally is "what egress will this fast-pathed packet take", resolved by `bpf_fib_lookup` before redirect. `via <iface>` always means **egress**, matching the `local-prefix via X` and `fallback-default via X` grammar.
 
-For the cases where iptables operators reach for `-i <iface>` (e.g. "clamp packets coming in on this tunnel"), the realistic need is "clamp this customer's traffic" — better expressed via prefix scoping. Prefix scoping is route-stable; ingress-iface scoping depends on which physical bridge member happened to receive the packet.
+For the cases where iptables operators reach for `-i <iface>` (e.g. "clamp packets coming in on this tunnel"), the realistic need is "clamp this customer's traffic", better expressed via prefix scoping. Prefix scoping is route-stable; ingress-iface scoping depends on which physical bridge member happened to receive the packet.
 
-If a future use case needs strict ingress scoping, the grammar is append-only — adding `from <iface>` later is straightforward.
+If a future use case needs strict ingress scoping, the grammar is append-only. Adding `from <iface>` later is straightforward.
 
 ## Hot-reload semantics
 
@@ -99,6 +99,6 @@ Changes to `mss-clamp` directives are applied via SIGHUP without re-attaching XD
 sudo packetframe reconfigure       # or `systemctl reload packetframe`
 ```
 
-The reconcile path performs delta updates against the LPM tries (`MSS_CLAMP_V4`, `MSS_CLAMP_V6`) and the per-iface table — adds, removes, and value updates all happen in place. The global `mss-clamp <mtu>` form lives in the `CFG` array and is updated atomically.
+The reconcile path performs delta updates against the LPM tries (`MSS_CLAMP_V4`, `MSS_CLAMP_V6`) and the per-iface table: adds, removes, and value updates all happen in place. The global `mss-clamp <mtu>` form lives in the `CFG` array and is updated atomically.
 
 A bad config (e.g. value out of range, malformed CIDR) is rejected at parse time; the CLI exits non-zero with the parse error, the running daemon keeps the old policy in effect.

--- a/docs/runbooks/reconfigure.md
+++ b/docs/runbooks/reconfigure.md
@@ -1,4 +1,4 @@
-# Reconfigure (SIGHUP) — operator guide (v0.2.4+)
+# Reconfigure (SIGHUP): operator guide (v0.2.4+)
 
 What `packetframe reconfigure` and `systemctl reload packetframe` do, what's hot-reloadable, and what still needs a full restart. The wiring landed in v0.2.4; before that, the README's `systemctl reload packetframe` line was aspirational.
 
@@ -16,13 +16,13 @@ What `packetframe reconfigure` and `systemctl reload packetframe` do, what's hot
 ```sh
 # Edit /etc/packetframe/packetframe.conf, then:
 sudo packetframe reconfigure                # synchronous; exits non-zero on parse error
-sudo systemctl reload packetframe           # equivalent — both end up sending SIGHUP
+sudo systemctl reload packetframe           # equivalent; both end up sending SIGHUP
 
 # Inspect the latest reconfigure result:
 cat /var/lib/packetframe/state/last-reconfigure.timestamp
-# OK <unix_ns>                              — config parsed + every module reconciled
-# ERR parse: <message>                       — config didn't parse; daemon kept old config
-# ERR module: <name>: <message>; ...         — at least one module's reconcile() failed
+# OK <unix_ns>                              : config parsed + every module reconciled
+# ERR parse: <message>                       : config didn't parse; daemon kept old config
+# ERR module: <name>: <message>; ...         : at least one module's reconcile() failed
 ```
 
 The CLI returns immediately on parse failure (exit non-zero, message on stderr). On success it polls the marker file for up to 5s and returns 0 once the daemon has acknowledged.
@@ -34,10 +34,10 @@ These directives can be added, removed, or changed under SIGHUP without re-attac
 | Directive | Map(s) updated | Notes |
 |---|---|---|
 | `allow-prefix`, `allow-prefix6` | `ALLOW_V4`, `ALLOW_V6` | Delta diff vs in-kernel state |
-| `block-prefix` | `BLOCK_V4` | v0.2.4+ — wired up alongside reconfigure |
+| `block-prefix` | `BLOCK_V4` | v0.2.4+; wired up alongside reconfigure |
 | `dry-run on/off` | `CFG.dry_run` | Single-byte write |
 | `forwarding-mode {kernel-fib\|custom-fib\|compare}` | `CFG.flags` bits 3-4 | Atomic |
-| `mss-clamp …` (all four grammars) | `MSS_CLAMP_V4/V6` + `MSS_CLAMP_BY_IFACE` + `CFG.mss_clamp_global` | v0.2.4+ — value changes also pick up |
+| `mss-clamp …` (all four grammars) | `MSS_CLAMP_V4/V6` + `MSS_CLAMP_BY_IFACE` + `CFG.mss_clamp_global` | v0.2.4+; value changes also pick up |
 | (auto) VLAN-subif resolution | `VLAN_RESOLVE` | Re-scanned from `/proc/net/vlan/config` |
 | (auto) Redirect devmap | `REDIRECT_DEVMAP` | Re-scanned from `/sys/class/net` |
 
@@ -47,7 +47,7 @@ Adds-before-removes ordering: a renamed prefix (remove + add of the same value) 
 
 These need `systemctl restart packetframe` (or stop + run):
 
-- **`attach` directives (interface added or removed).** XDP attach mutates kernel-side state and risks brief link bounce on some drivers (SPEC §11.8). The reconcile path explicitly logs a warning and skips attach-set changes — your delta does not silently apply.
+- **`attach` directives (interface added or removed).** XDP attach mutates kernel-side state and risks brief link bounce on some drivers (SPEC §11.8). The reconcile path explicitly logs a warning and skips attach-set changes; your delta does not silently apply.
 - **`route-source` config (custom-FIB only).** The RouteController's runtime is started at attach. Editing the BGP/BMP listener address or peer-AS requires bringing the runtime down and back up.
 - **`circuit-breaker` thresholds.** The breaker sampler thread reads its config at thread start; it doesn't currently observe SIGHUP.
 - **`local-prefix` directives (custom-FIB only).** The connected-fast-path resolver is similarly attach-time-bound.
@@ -60,11 +60,11 @@ If you change one of these in the config and reload, the daemon keeps using the 
 1. The daemon writes `/var/lib/packetframe/state/packetframe.pid` after attach succeeds and removes it on clean exit.
 2. `packetframe reconfigure` (or systemd's `ExecReload=`) reads the PID file and cross-checks `/proc/<pid>/comm == "packetframe"` to defend against stale-PID-after-process-recycle.
 3. The CLI snapshots the mtime of the ack-marker file (`last-reconfigure.timestamp`), then sends SIGHUP via `kill(2)`.
-4. The daemon's signal loop catches SIGHUP, re-parses the config, and calls `Module::reconfigure()` on each loaded module. Per-module errors are logged but not fatal — partial-update state is strictly better than halting mid-reconcile.
+4. The daemon's signal loop catches SIGHUP, re-parses the config, and calls `Module::reconfigure()` on each loaded module. Per-module errors are logged but not fatal. Partial-update state is strictly better than halting mid-reconcile.
 5. The daemon writes `OK <unix_ns>` (or `ERR <reason>`) to the marker file via write-then-rename.
 6. The CLI polls every 100 ms for up to 5s. When the marker's mtime advances, it reads the body and exits accordingly.
 
-If the daemon doesn't ack within 5s, the CLI exits with a "wedged daemon" message. In practice this only fires if the SIGHUP was lost (kernel signal queue full — extremely unlikely) or the reconcile path itself hangs (no observed cases).
+If the daemon doesn't ack within 5s, the CLI exits with a "wedged daemon" message. In practice this only fires if the SIGHUP was lost (kernel signal queue full, extremely unlikely) or the reconcile path itself hangs (no observed cases).
 
 ## Error semantics
 
@@ -87,7 +87,7 @@ sudo systemctl reload packetframe        # equivalent to `packetframe reconfigur
 journalctl -u packetframe --since '5min ago' | grep -i 'sighup\|reconfigure\|reconcile'
 ```
 
-systemd's `reload` is fire-and-forget — it doesn't poll the ack marker. If you want exit-code-on-failure semantics for scripted use, prefer `packetframe reconfigure` directly.
+systemd's `reload` is fire-and-forget; it doesn't poll the ack marker. If you want exit-code-on-failure semantics for scripted use, prefer `packetframe reconfigure` directly.
 
 The unit ships disabled by default (the `.deb` postinst does not auto-enable). After editing the config the first time you'll want:
 

--- a/docs/runbooks/tail-call-architecture.md
+++ b/docs/runbooks/tail-call-architecture.md
@@ -11,7 +11,7 @@ combined stack size of 3 calls is 544. Too large
 stack depth 0+480+0+0
 ```
 
-UniFi's BPF patches plus the aarch64 JIT account stack ~120 bytes higher than vanilla 5.15 on x86_64 — same bytecode, different verifier accounting.
+UniFi's BPF patches plus the aarch64 JIT account stack ~120 bytes higher than vanilla 5.15 on x86_64: same bytecode, different verifier accounting.
 
 Tail-calling into a second program gives that program its own fresh 512-byte stack. Beyond fixing the immediate budget issue, it establishes the pattern for future fast-path stages without re-bisecting stack bytes every time.
 
@@ -47,7 +47,7 @@ This is **not** the multi-module dispatcher (SPEC §3.4 / §5.0). The dispatcher
                       egress NIC TX
 ```
 
-The packet itself is preserved across the tail-call — `bpf_tail_call` doesn't touch `xdp_buff`, so any in-place mutations from fast_path (TTL, L2, etc.) carry over. What does NOT carry are the program's local variables, which is why we need a side channel.
+The packet itself is preserved across the tail-call. `bpf_tail_call` doesn't touch `xdp_buff`, so any in-place mutations from fast_path (TTL, L2, etc.) carry over. What does NOT carry are the program's local variables, which is why we need a side channel.
 
 ## MUTATION_CTX wire format
 
@@ -71,7 +71,7 @@ pub struct MutationCtx {
 
 `MUTATION_PROGS` is a `ProgramArray` sized for 8 slots. Slot 0 holds `finalize`'s file descriptor. Slots 1–7 are reserved for future stages (see "Adding new stages" below).
 
-Userspace populates slot 0 at attach time, in `crates/modules/fast-path/src/linux_impl.rs::populate_mutation_progs`. Order is: load `finalize` → populate slot 0 → load + attach `fast_path` to ifaces. If the order is wrong, fast_path's first packet hits an empty slot, `bpf_tail_call` returns an error, and fast_path falls through to `XDP_PASS` (kernel slow-path) while bumping `ErrTailCall`.
+Userspace populates slot 0 at attach time, in `crates/modules/fast-path/src/linux_impl.rs::populate_mutation_progs`. Order is: load `finalize`, populate slot 0, load + attach `fast_path` to ifaces. If the order is wrong, fast_path's first packet hits an empty slot, `bpf_tail_call` returns an error, and fast_path falls through to `XDP_PASS` (kernel slow-path) while bumping `ErrTailCall`.
 
 ## Diagnostic commands
 
@@ -87,7 +87,7 @@ sudo bpftool map dump name MUTATION_PROGS
 # packetframe status reports the same:
 sudo packetframe status
 # tail-call chain (from /sys/fs/bpf/packetframe):
-#   MUTATION_PROGS[0]: populated (finalize) — confirm prog_id via ...
+#   MUTATION_PROGS[0]: populated (finalize); confirm prog_id via ...
 
 # Watch the diagnostic counters:
 sudo packetframe status | grep -E 'err_tail_call|err_mutation_ctx'
@@ -103,10 +103,10 @@ sudo bpftool map dump name MUTATION_CTX
 
 Two new diagnostic counters at indices 35 and 36:
 
-- `err_tail_call`: fast_path called `MUTATION_PROGS.tail_call(ctx, 0)` and got an error back. Almost always means slot 0 is empty (attach-order bug). fast_path falls through to `XDP_PASS` so traffic still flows via kernel slow-path.
+- `err_tail_call`: fast_path called `MUTATION_PROGS.tail_call(ctx, 0)` and got an error back. Almost always means slot 0 is empty (attach-order bug). fast_path falls through to `XDP_PASS`, so traffic still flows via kernel slow-path.
 - `err_mutation_ctx`: finalize couldn't read `MUTATION_CTX[0]`. Per-CPU array index 0 is always present, so this should be 0; non-zero indicates a kernel/aya bug worth filing.
 
-Both are append-only per CLAUDE.md guardrail — operator dashboards keying on counter index keep working.
+Both are append-only per CLAUDE.md guardrail. Operator dashboards keying on counter index keep working.
 
 ## Pin lifecycle
 
@@ -144,6 +144,6 @@ In both patterns, all stages share the same `MUTATION_CTX` and `STATS` maps (one
 
 ## See also
 
-- [docs/runbooks/mss-clamp.md](mss-clamp.md) — operator guide for the mss-clamp directive (which now lives inside `finalize`)
-- [docs/runbooks/reconfigure.md](reconfigure.md) — SIGHUP / `packetframe reconfigure` semantics; both maps update through the same reconcile path regardless of which program reads them
+- [docs/runbooks/mss-clamp.md](mss-clamp.md): operator guide for the mss-clamp directive (which now lives inside `finalize`)
+- [docs/runbooks/reconfigure.md](reconfigure.md): SIGHUP / `packetframe reconfigure` semantics; both maps update through the same reconcile path regardless of which program reads them
 - SPEC.md §3.2 (priority taxonomy), §3.4 (multi-program composition), §4.x (BPF map layouts), §11.x (kernel compatibility notes)


### PR DESCRIPTION
## Summary
- Copy edits across `CLAUDE.md` and the four runbooks under `docs/runbooks/`. Shorter sentences, less throat-clearing, more direct phrasing.
- No technical content changed. Sections, commands, code blocks, links, kernel/eBPF references, RFC citations, and counter/metric names all preserved.

## Test plan
- [x] Re-read `CLAUDE.md` for project-overview accuracy.
- [x] Re-read each runbook for procedure accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)