### PR TITLE
security: refuse non-loopback BGP/BMP listens by default, gate peer identity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,9 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -701,6 +704,7 @@ version = "0.2.6"
 dependencies = [
  "anyhow",
  "flate2",
+ "ipnet",
  "libc",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,8 +84,11 @@ bgpkit-parser = { version = "0.16", default-features = false, features = ["parse
 bytes = "1.11"
 # ipnet: IPv4/IPv6 prefix types used by bgpkit-parser's NetworkPrefix.
 # We pattern-match on `IpNet::{V4,V6}` directly to extract addr +
-# prefix_len, which requires the type to be in scope.
-ipnet = "2.12"
+# prefix_len, which requires the type to be in scope. The `serde`
+# feature lets `RouteSourceSpec`'s `peer_from: Vec<IpNet>` participate
+# in the workspace-wide `Serialize` derive (used by `packetframe
+# status` config dumps).
+ipnet = { version = "2.12", features = ["serde"] }
 
 [profile.release]
 lto = "thin"

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -110,8 +110,29 @@ module fast-path
   #     hard-rejects pre/post-policy frames so misconfiguration
   #     fails loudly instead of silent wrong-forwarding.
   #
+  # **Listener authorization.** The listener has no protocol-level
+  # auth (no TCP-MD5 / TCP-AO wiring yet). The safe default is a
+  # loopback bind — bird and packetframe must run on the same host
+  # and the iBGP session lives on `127.0.0.1` (or `::1`). For that
+  # topology, no extra keywords are needed.
+  #
+  # Binding a non-loopback address is rejected at config-load unless
+  # the operator opts in with `allow-remote` AND declares a CIDR ACL
+  # via one or more `peer-from <cidr>` entries. The ACL is enforced
+  # at `accept()` time before any BGP/BMP framing runs, so peers
+  # outside the declared sources are dropped at TCP. The BGP variant
+  # additionally accepts `peer-ip <ip>` to pin the configured
+  # `peer-as` to a specific source address; the OPEN's effective
+  # peer-ASN (RFC 6793 four-octet capability when present, else the
+  # 2-byte field) must equal `peer-as` or the session is closed.
+  #
   # route-source bgp 127.0.0.1:1179 local-as 401401 peer-as 401401 router-id 103.17.154.7
   # route-source bmp 127.0.0.1:6543 require-loc-rib
+  #
+  # Non-loopback example (only if the listener is reachable solely
+  # inside a private network, e.g. a netns or VPC the operator owns):
+  # route-source bgp 10.0.0.1:1179 local-as 401401 peer-as 401401 \
+  #   allow-remote peer-from 10.0.0.0/24 peer-ip 10.0.0.5
 
   # ECMP default hash mode (3/4/5-tuple). Applied globally today;
   # per-group overrides could come later if bird ever surfaces a

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -15,5 +15,6 @@ serde_json.workspace = true
 tracing.workspace = true
 libc.workspace = true
 flate2.workspace = true
+ipnet.workspace = true
 
 [dev-dependencies]

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -302,6 +302,16 @@ impl FromStr for ForwardingMode {
 /// implementation lacks RFC 9069 Loc-RIB — see
 /// `route_source_bgp.rs` module docs and
 /// `docs/runbooks/custom-fib.md` for the rationale.
+///
+/// **Authorization.** The listeners are unauthenticated at the
+/// protocol level (no TCP-MD5 wiring). The default posture is
+/// loopback-only: a non-loopback listen address is rejected at
+/// parse time. Operators who genuinely need a routable bind (e.g.,
+/// a netns-segmented deploy where the listener is reachable only
+/// inside a private network) must opt in with `allow-remote` and
+/// declare an `IpNet` ACL via one or more `peer-from <cidr>` sub-
+/// keywords. The BGP variant additionally accepts `peer-ip <ip>`
+/// to pin the configured `peer-as` to a specific source address.
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RouteSourceSpec {
     /// BMP station listen address. Bird dials out to this
@@ -322,6 +332,17 @@ pub enum RouteSourceSpec {
         addr: String,
         port: u16,
         require_loc_rib: bool,
+        /// Operator opt-in for binding a non-loopback listen
+        /// address. False (the safe default) makes a non-loopback
+        /// listen a parse-time error; true requires at least one
+        /// `peer_from` entry.
+        allow_remote: bool,
+        /// CIDR ACL applied at `accept()` time when `allow_remote`
+        /// is true: peers whose source IP doesn't fall in any
+        /// entry are rejected before the BMP framing starts. Empty
+        /// is parse-rejected when `allow_remote` is true; ignored
+        /// (must be empty) when `allow_remote` is false.
+        peer_from: Vec<ipnet::IpNet>,
     },
     /// iBGP listener — packetframe accepts an iBGP session from
     /// bird and ingests UPDATEs as bird's selected best paths.
@@ -333,6 +354,19 @@ pub enum RouteSourceSpec {
         local_as: u32,
         peer_as: u32,
         router_id: Option<std::net::Ipv4Addr>,
+        /// Operator opt-in for binding a non-loopback listen
+        /// address. See [`RouteSourceSpec::Bmp::allow_remote`].
+        allow_remote: bool,
+        /// CIDR ACL on the peer's source IP. See
+        /// [`RouteSourceSpec::Bmp::peer_from`].
+        peer_from: Vec<ipnet::IpNet>,
+        /// Optional pin on the peer's source IP. When set, an
+        /// accepted connection whose source IP differs is closed.
+        /// Combined with the peer-AS check in
+        /// `route_source_bgp::handle_connection`, this is the only
+        /// real identity binding available in the absence of
+        /// TCP-MD5 / TCP-AO.
+        peer_ip: Option<std::net::IpAddr>,
     },
 }
 
@@ -1121,10 +1155,16 @@ where
 }
 
 /// Parse `route-source <kind> <args...>`. Two kinds supported:
-/// - `bmp <addr>:<port>`
-/// - `bgp <addr>:<port> local-as <asn> peer-as <asn> [router-id <ipv4>]`
+/// - `bmp <addr>:<port> [require-loc-rib] [allow-remote peer-from <cidr> ...]`
+/// - `bgp <addr>:<port> local-as <asn> peer-as <asn> [router-id <ipv4>]
+///        [allow-remote peer-from <cidr> ... [peer-ip <ip>]]`
 ///
 /// Unknown kinds become parse errors with an explicit message.
+///
+/// **Listener authorization.** Non-loopback listen addresses require
+/// the explicit `allow-remote` opt-in plus at least one `peer-from
+/// <cidr>` entry. Loopback listens with no extra keywords keep the
+/// pre-existing config compatible. See [`RouteSourceSpec`].
 fn parse_route_source<'a>(
     line: usize,
     mut rest: impl Iterator<Item = &'a str>,
@@ -1141,26 +1181,48 @@ fn parse_route_source<'a>(
                 ConfigError::parse(line, "route-source bmp requires <addr>:<port>")
             })?;
             let (addr, port) = parse_endpoint(line, endpoint, "bmp")?;
-            // Optional trailing `require-loc-rib` flag. Any other
-            // tail token is a parse error.
             let mut require_loc_rib = false;
-            for tok in rest {
+            let mut allow_remote = false;
+            let mut peer_from: Vec<ipnet::IpNet> = Vec::new();
+            // Peek-driven loop: `require-loc-rib` / `allow-remote`
+            // are no-value flags; `peer-from` consumes one trailing
+            // CIDR argument.
+            while let Some(tok) = rest.next() {
                 match tok {
                     "require-loc-rib" => require_loc_rib = true,
+                    "allow-remote" => allow_remote = true,
+                    "peer-from" => {
+                        let cidr_str = rest.next().ok_or_else(|| {
+                            ConfigError::parse(
+                                line,
+                                "route-source bmp: `peer-from` requires a <cidr> argument",
+                            )
+                        })?;
+                        let cidr = cidr_str.parse::<ipnet::IpNet>().map_err(|e| {
+                            ConfigError::parse(
+                                line,
+                                format!("route-source bmp: bad peer-from `{cidr_str}`: {e}"),
+                            )
+                        })?;
+                        peer_from.push(cidr);
+                    }
                     other => {
                         return Err(ConfigError::parse(
                             line,
                             format!(
-                                "route-source bmp: unknown tail flag `{other}` (only `require-loc-rib` is recognized)"
+                                "route-source bmp: unknown tail flag `{other}` (known: require-loc-rib, allow-remote, peer-from <cidr>)"
                             ),
                         ));
                     }
                 }
             }
+            validate_listener_auth(line, "bmp", &addr, allow_remote, !peer_from.is_empty(), false)?;
             Ok(ModuleDirective::RouteSource(RouteSourceSpec::Bmp {
                 addr,
                 port,
                 require_loc_rib,
+                allow_remote,
+                peer_from,
             }))
         }
         "bgp" => {
@@ -1174,7 +1236,16 @@ fn parse_route_source<'a>(
             let mut local_as: Option<u32> = None;
             let mut peer_as: Option<u32> = None;
             let mut router_id: Option<std::net::Ipv4Addr> = None;
+            let mut allow_remote = false;
+            let mut peer_from: Vec<ipnet::IpNet> = Vec::new();
+            let mut peer_ip: Option<std::net::IpAddr> = None;
             while let Some(key) = rest.next() {
+                // `allow-remote` is a no-value flag; everything
+                // else takes one argument.
+                if key == "allow-remote" {
+                    allow_remote = true;
+                    continue;
+                }
                 let value = rest.next().ok_or_else(|| {
                     ConfigError::parse(
                         line,
@@ -1206,11 +1277,29 @@ fn parse_route_source<'a>(
                             )
                         })?);
                     }
+                    "peer-from" => {
+                        let cidr = value.parse::<ipnet::IpNet>().map_err(|e| {
+                            ConfigError::parse(
+                                line,
+                                format!("route-source bgp: bad peer-from `{value}`: {e}"),
+                            )
+                        })?;
+                        peer_from.push(cidr);
+                    }
+                    "peer-ip" => {
+                        let ip = value.parse::<std::net::IpAddr>().map_err(|e| {
+                            ConfigError::parse(
+                                line,
+                                format!("route-source bgp: bad peer-ip `{value}`: {e}"),
+                            )
+                        })?;
+                        peer_ip = Some(ip);
+                    }
                     other => {
                         return Err(ConfigError::parse(
                             line,
                             format!(
-                                "route-source bgp: unknown key `{other}` (known: local-as, peer-as, router-id)"
+                                "route-source bgp: unknown key `{other}` (known: local-as, peer-as, router-id, allow-remote, peer-from, peer-ip)"
                             ),
                         ));
                     }
@@ -1222,12 +1311,23 @@ fn parse_route_source<'a>(
             let peer_as = peer_as.ok_or_else(|| {
                 ConfigError::parse(line, "route-source bgp: missing required `peer-as <asn>`")
             })?;
+            validate_listener_auth(
+                line,
+                "bgp",
+                &addr,
+                allow_remote,
+                !peer_from.is_empty(),
+                peer_ip.is_some(),
+            )?;
             Ok(ModuleDirective::RouteSource(RouteSourceSpec::Bgp {
                 addr,
                 port,
                 local_as,
                 peer_as,
                 router_id,
+                allow_remote,
+                peer_from,
+                peer_ip,
             }))
         }
         other => Err(ConfigError::parse(
@@ -1237,6 +1337,94 @@ fn parse_route_source<'a>(
             ),
         )),
     }
+}
+
+/// Cross-check that the listen address and the authorization opt-in
+/// agree. The rules — same shape for both kinds:
+///
+/// - Loopback address (127.0.0.0/8, ::1): default-allow with no
+///   extra keywords. `allow-remote`, `peer-from`, and `peer-ip` are
+///   parse errors because there's no source IP other than 127.x /
+///   ::1 to gate on.
+/// - Non-loopback address: requires `allow-remote` AND at least one
+///   `peer-from <cidr>`. Without those, the listener would accept
+///   any TCP connection that reaches the port and inject routes —
+///   which the audit (May 2026) flagged as the highest-severity
+///   finding.
+///
+/// `addr` is the literal string from the config so the diagnostic
+/// can interpolate exactly what the operator typed. Parsing it as
+/// an `IpAddr` here is on the hot path of config-load (one call
+/// per route-source directive), so the small cost is fine.
+fn validate_listener_auth(
+    line: usize,
+    kind_label: &str,
+    addr: &str,
+    allow_remote: bool,
+    has_peer_from: bool,
+    has_peer_ip: bool,
+) -> Result<(), ConfigError> {
+    // Strip the brackets bird/operators sometimes use around
+    // IPv6 endpoints (`[::1]`); `parse_endpoint` returns the raw
+    // segment between the brackets unchanged, but a literal `::1`
+    // is what reaches us here.
+    let parsed = addr
+        .trim_start_matches('[')
+        .trim_end_matches(']')
+        .parse::<std::net::IpAddr>()
+        .map_err(|e| {
+            ConfigError::parse(
+                line,
+                format!("route-source {kind_label}: bad listen address `{addr}`: {e}"),
+            )
+        })?;
+    if parsed.is_loopback() {
+        if allow_remote {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: `allow-remote` is only valid with a non-loopback listen address (got loopback `{addr}`)"
+                ),
+            ));
+        }
+        if has_peer_from {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: `peer-from` is only valid with `allow-remote` on a non-loopback listen (got loopback `{addr}`)"
+                ),
+            ));
+        }
+        if has_peer_ip {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: `peer-ip` is only valid with `allow-remote` on a non-loopback listen (got loopback `{addr}`)"
+                ),
+            ));
+        }
+    } else {
+        if !allow_remote {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: listen address `{addr}` is not loopback; \
+                     add `allow-remote peer-from <cidr>` to bind a routable address. \
+                     Without that opt-in the listener has no authentication and would \
+                     accept route injections from any reachable host."
+                ),
+            ));
+        }
+        if !has_peer_from {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: `allow-remote` requires at least one `peer-from <cidr>` to bound which source IPs may complete the handshake"
+                ),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Common `<addr>:<port>` parser, used by both `bmp` and `bgp`
@@ -1865,10 +2053,14 @@ module fast-path
                 addr,
                 port,
                 require_loc_rib,
+                allow_remote,
+                peer_from,
             } => {
                 assert_eq!(addr, "127.0.0.1");
                 assert_eq!(port, 6543);
                 assert!(!require_loc_rib, "default should be off");
+                assert!(!allow_remote, "loopback default does not need opt-in");
+                assert!(peer_from.is_empty());
             }
             other => panic!("expected Bmp, got {other:?}"),
         }
@@ -1938,12 +2130,18 @@ module fast-path
                 local_as,
                 peer_as,
                 router_id,
+                allow_remote,
+                peer_from,
+                peer_ip,
             } => {
                 assert_eq!(addr, "127.0.0.1");
                 assert_eq!(port, 1179);
                 assert_eq!(local_as, 401401);
                 assert_eq!(peer_as, 401401);
                 assert_eq!(router_id, Some("103.17.154.7".parse().unwrap()));
+                assert!(!allow_remote, "loopback default does not need opt-in");
+                assert!(peer_from.is_empty());
+                assert!(peer_ip.is_none());
             }
             other => panic!("expected Bgp, got {other:?}"),
         }
@@ -1998,6 +2196,194 @@ module fast-path
                 assert!(message.contains("router-id"), "msg was: {message}");
             }
             other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    // --- Listener authorization (security audit slice 1) -----------
+
+    #[test]
+    fn route_source_bgp_non_loopback_requires_opt_in() {
+        // Binding 0.0.0.0 without `allow-remote` is the failure mode
+        // the audit (May 2026) flagged as Critical — any TCP-reachable
+        // host could speak iBGP and inject routes. Reject at parse
+        // time so the operator can't silently misconfigure into the
+        // unsafe state.
+        let e = parse_module_body("  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1\n")
+            .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(
+                    message.contains("not loopback") && message.contains("allow-remote"),
+                    "msg was: {message}"
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bmp_non_loopback_requires_opt_in() {
+        let e = parse_module_body("  route-source bmp 192.0.2.5:6543\n").unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(
+                    message.contains("not loopback") && message.contains("allow-remote"),
+                    "msg was: {message}"
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_allow_remote_with_peer_from_parses() {
+        let s = "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 allow-remote peer-from 10.0.0.0/24\n";
+        match extract_route_source(s) {
+            RouteSourceSpec::Bgp {
+                addr,
+                allow_remote,
+                peer_from,
+                peer_ip,
+                ..
+            } => {
+                assert_eq!(addr, "0.0.0.0");
+                assert!(allow_remote);
+                assert_eq!(peer_from.len(), 1);
+                assert_eq!(peer_from[0], "10.0.0.0/24".parse::<ipnet::IpNet>().unwrap());
+                assert!(peer_ip.is_none());
+            }
+            other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_allow_remote_multiple_peer_from_parses() {
+        let s = "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 \
+                 allow-remote peer-from 10.0.0.0/24 peer-from 10.1.0.0/16\n";
+        match extract_route_source(s) {
+            RouteSourceSpec::Bgp { peer_from, .. } => {
+                assert_eq!(peer_from.len(), 2);
+            }
+            other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_allow_remote_without_peer_from_errors() {
+        let e = parse_module_body(
+            "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 allow-remote\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("peer-from"), "msg was: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_peer_from_without_allow_remote_on_loopback_errors() {
+        // Loopback listen + peer-from is a config contradiction — the
+        // ACL has no work to do because all accepted connections come
+        // from 127.x. Catching this at parse-time tells the operator
+        // their intent is unclear before the daemon starts.
+        let e = parse_module_body(
+            "  route-source bgp 127.0.0.1:1179 local-as 1 peer-as 1 peer-from 10.0.0.0/24\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("peer-from"), "msg was: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_allow_remote_on_loopback_errors() {
+        let e = parse_module_body(
+            "  route-source bgp 127.0.0.1:1179 local-as 1 peer-as 1 allow-remote\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("allow-remote"), "msg was: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_peer_ip_pin_parses() {
+        let s = "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 \
+                 allow-remote peer-from 10.0.0.0/24 peer-ip 10.0.0.5\n";
+        match extract_route_source(s) {
+            RouteSourceSpec::Bgp { peer_ip, .. } => {
+                assert_eq!(peer_ip, Some("10.0.0.5".parse().unwrap()));
+            }
+            other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_bad_peer_from_errors() {
+        let e = parse_module_body(
+            "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 \
+             allow-remote peer-from not-a-cidr\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("peer-from"), "msg was: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_bad_peer_ip_errors() {
+        let e = parse_module_body(
+            "  route-source bgp 0.0.0.0:1179 local-as 1 peer-as 1 \
+             allow-remote peer-from 10.0.0.0/24 peer-ip not-an-ip\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("peer-ip"), "msg was: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bmp_allow_remote_with_peer_from_parses() {
+        let s =
+            "  route-source bmp 0.0.0.0:6543 allow-remote peer-from 10.0.0.0/24 require-loc-rib\n";
+        match extract_route_source(s) {
+            RouteSourceSpec::Bmp {
+                addr,
+                require_loc_rib,
+                allow_remote,
+                peer_from,
+                ..
+            } => {
+                assert_eq!(addr, "0.0.0.0");
+                assert!(require_loc_rib);
+                assert!(allow_remote);
+                assert_eq!(peer_from.len(), 1);
+            }
+            other => panic!("expected Bmp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_ipv6_loopback_accepts_default() {
+        // The IPv6 loopback (::1) must round-trip the same as 127.x —
+        // a default-permissive bind that doesn't need allow-remote.
+        match extract_route_source("  route-source bgp [::1]:1179 local-as 1 peer-as 1\n") {
+            RouteSourceSpec::Bgp { addr, .. } => assert_eq!(addr, "[::1]"),
+            other => panic!("expected Bgp, got {other:?}"),
         }
     }
 

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -19,7 +19,7 @@
 
 #![cfg(target_os = "linux")]
 
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
 use std::time::Duration;
 
@@ -40,6 +40,13 @@ use crate::fib::route_source_bmp::BmpStation;
 /// source: operators pick `bmp` or `bgp` via `route-source ...`.
 /// `Bgp` is the recommended choice today because bird lacks RFC 9069
 /// Loc-RIB BMP — see `route_source_bgp.rs` module docs.
+///
+/// The `peer_acl` / `expected_peer_ip` fields carry the
+/// authorization opt-in declared in the operator config. The config
+/// parser already enforces "loopback default-allow, non-loopback
+/// requires opt-in"; the controller passes the parsed ACL into the
+/// listener so the runtime `accept()` filter can reject sources
+/// outside the declared CIDRs before any BMP/BGP framing starts.
 #[derive(Debug, Clone)]
 pub enum RouteSourceConfig {
     Bmp {
@@ -49,12 +56,23 @@ pub enum RouteSourceConfig {
         /// type 3). Required for safe forwarding use against
         /// emitters that send pre/post-policy streams.
         require_loc_rib: bool,
+        /// CIDR ACL applied to the source IP of every accepted TCP
+        /// connection. Empty means "loopback-only" (the config
+        /// parser only permits empty when the listen address is
+        /// itself loopback).
+        peer_acl: Vec<ipnet::IpNet>,
     },
     Bgp {
         listen: SocketAddr,
         local_as: u32,
         peer_as: u32,
         router_id: Ipv4Addr,
+        /// CIDR ACL — same semantics as the BMP variant.
+        peer_acl: Vec<ipnet::IpNet>,
+        /// Optional pin on the peer's source IP. When set, an
+        /// accepted connection whose source IP differs is closed
+        /// before the BGP OPEN exchange.
+        expected_peer_ip: Option<IpAddr>,
     },
 }
 
@@ -185,6 +203,7 @@ impl RouteController {
             Some(RouteSourceConfig::Bmp {
                 listen,
                 require_loc_rib,
+                peer_acl,
             }) => {
                 let snapshot = shared_snapshot();
                 let checker = IntegrityChecker::new(
@@ -206,11 +225,13 @@ impl RouteController {
                 let prog = prog_handle.clone();
                 let shut = shutdown_token.clone();
                 let stall = snapshot.clone();
+                let peer_acl_for_spawn = peer_acl.clone();
                 tasks.push(runtime.spawn(async move {
                     let mut backoff = LISTENER_BACKOFF_INITIAL;
                     loop {
                         let mut station = BmpStation::new(listen, prog.clone(), shut.clone())
-                            .with_stall_gate(stall.clone());
+                            .with_stall_gate(stall.clone())
+                            .with_peer_acl(peer_acl_for_spawn.clone());
                         if require_loc_rib {
                             station = station.with_require_loc_rib();
                         }
@@ -233,9 +254,12 @@ impl RouteController {
                 }));
                 integrity = Some(snapshot);
 
+                let loopback_only = listen.ip().is_loopback() && peer_acl.is_empty();
                 info!(
                     bmp_addr = %listen,
                     require_loc_rib,
+                    peer_acl_entries = peer_acl.len(),
+                    auth_posture = if loopback_only { "loopback-only" } else { "allow-remote (no TCP-MD5)" },
                     "RouteController started: NetlinkNeighborResolver + FibProgrammer + BmpStation + IntegrityChecker"
                 );
             }
@@ -244,6 +268,8 @@ impl RouteController {
                 local_as,
                 peer_as,
                 router_id,
+                peer_acl,
+                expected_peer_ip,
             }) => {
                 let snapshot = shared_snapshot();
                 let checker = IntegrityChecker::new(
@@ -256,7 +282,17 @@ impl RouteController {
 
                 // v0.2.2: same retry-with-backoff pattern as BmpStation
                 // above. See that comment for rationale.
-                let cfg = BgpListenerConfig::new(listen, local_as, peer_as, router_id);
+                let mut cfg = BgpListenerConfig::new(listen, local_as, peer_as, router_id);
+                cfg.peer_acl = peer_acl;
+                cfg.expected_peer_ip = expected_peer_ip;
+                // Capture the auth-posture fields before the spawn
+                // moves `cfg` into the retry loop's coroutine — the
+                // post-spawn `info!` reads them and can't share with
+                // the move.
+                let peer_acl_entries = cfg.peer_acl.len();
+                let peer_ip_log = cfg.expected_peer_ip;
+                let loopback_only =
+                    listen.ip().is_loopback() && peer_acl_entries == 0 && peer_ip_log.is_none();
                 let prog = prog_handle.clone();
                 let shut = shutdown_token.clone();
                 let stall = snapshot.clone();
@@ -288,6 +324,9 @@ impl RouteController {
                     bgp_addr = %listen,
                     local_as,
                     peer_as,
+                    peer_acl_entries,
+                    peer_ip = ?peer_ip_log,
+                    auth_posture = if loopback_only { "loopback-only" } else { "allow-remote (no TCP-MD5)" },
                     "RouteController started: NetlinkNeighborResolver + FibProgrammer + BgpListener + IntegrityChecker"
                 );
             }

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -137,6 +137,20 @@ pub struct BgpListenerConfig {
     pub peer_as: u32,
     pub router_id: Ipv4Addr,
     pub hold_time: u16,
+    /// CIDR ACL applied at `accept()`. Empty means "loopback only" —
+    /// the config parser only permits empty when `listen_addr` is
+    /// loopback. When non-empty, every accepted source IP must fall
+    /// within at least one entry or the connection is dropped before
+    /// the BGP OPEN exchange.
+    pub peer_acl: Vec<ipnet::IpNet>,
+    /// Optional pin on the peer's source IP. When `Some(_)`, an
+    /// accepted connection whose source IP differs is closed
+    /// immediately. The pre-existing `peer_as` cross-check inside
+    /// `handle_connection` then closes any session whose OPEN ASN
+    /// disagrees with the configured value. Together these two
+    /// checks are the only identity binding available in the
+    /// absence of TCP-MD5 / TCP-AO.
+    pub expected_peer_ip: Option<IpAddr>,
 }
 
 impl BgpListenerConfig {
@@ -147,7 +161,24 @@ impl BgpListenerConfig {
             peer_as,
             router_id,
             hold_time: DEFAULT_HOLD_TIME,
+            peer_acl: Vec::new(),
+            expected_peer_ip: None,
         }
+    }
+}
+
+/// Whether `addr` is permitted by the listener's `peer_acl`. An empty
+/// ACL means "loopback only" — the config parser already enforces
+/// that empty + non-loopback listen is rejected, so an empty ACL
+/// implies the listener bound to loopback and only loopback sources
+/// can reach `accept()` in the first place. We still defensively
+/// double-check `is_loopback()` here so a misconstructed in-process
+/// config can't slip past.
+fn source_ip_permitted(addr: IpAddr, peer_acl: &[ipnet::IpNet]) -> bool {
+    if peer_acl.is_empty() {
+        addr.is_loopback()
+    } else {
+        peer_acl.iter().any(|net| net.contains(&addr))
     }
 }
 
@@ -187,7 +218,18 @@ impl BgpListener {
     pub async fn run(self) -> Result<(), RouteSourceError> {
         let listener = bind_with_reuseaddr(self.cfg.listen_addr)
             .map_err(|e| RouteSourceError::fatal(format!("bind {}: {e}", self.cfg.listen_addr)))?;
-        info!(addr = %self.cfg.listen_addr, local_as = self.cfg.local_as, peer_as = self.cfg.peer_as, "BGP listener started");
+        let loopback_only = self.cfg.listen_addr.ip().is_loopback()
+            && self.cfg.peer_acl.is_empty()
+            && self.cfg.expected_peer_ip.is_none();
+        info!(
+            addr = %self.cfg.listen_addr,
+            local_as = self.cfg.local_as,
+            peer_as = self.cfg.peer_as,
+            peer_acl_entries = self.cfg.peer_acl.len(),
+            peer_ip_pin = ?self.cfg.expected_peer_ip,
+            auth_posture = if loopback_only { "loopback-only" } else { "allow-remote (no TCP-MD5)" },
+            "BGP listener started"
+        );
 
         loop {
             tokio::select! {
@@ -198,6 +240,31 @@ impl BgpListener {
                 accept = listener.accept() => {
                     match accept {
                         Ok((stream, addr)) => {
+                            // Source-IP gating runs before any byte is
+                            // read: an unauthorized peer must not reach
+                            // BGP framing because that's the surface the
+                            // audit (May 2026) flagged as the
+                            // arbitrary-route-injection primitive.
+                            if !source_ip_permitted(addr.ip(), &self.cfg.peer_acl) {
+                                warn!(
+                                    %addr,
+                                    peer_acl_entries = self.cfg.peer_acl.len(),
+                                    "BGP accept rejected: source IP outside peer-from ACL"
+                                );
+                                drop(stream);
+                                continue;
+                            }
+                            if let Some(expected) = self.cfg.expected_peer_ip {
+                                if addr.ip() != expected {
+                                    warn!(
+                                        %addr,
+                                        %expected,
+                                        "BGP accept rejected: source IP does not match peer-ip pin"
+                                    );
+                                    drop(stream);
+                                    continue;
+                                }
+                            }
                             info!(%addr, "BGP client connected");
                             if let Err(e) = self.handle_connection(stream).await {
                                 warn!(error = %e, "BGP connection handler exited with error");
@@ -244,25 +311,28 @@ impl BgpListener {
                         o.version
                     )));
                 }
-                let peer_asn = asn_to_u32(o.asn);
-                // bgpkit may decode AS_TRANS (23456) as the 2-byte
-                // ASN when the 4-byte ASN capability is present. The
-                // real ASN comes via the capability. For an iBGP
-                // session with bird, the peer's effective ASN should
-                // match our `peer_as` config; if it doesn't, that's
-                // a misconfiguration worth surfacing.
-                if peer_asn != self.cfg.peer_as && peer_asn != AS_TRANS as u32 {
-                    warn!(
-                        observed = peer_asn,
-                        expected = self.cfg.peer_as,
-                        "peer ASN mismatch in OPEN (continuing — capability ASN may override)"
-                    );
+                let peer_asn_2byte = asn_to_u32(o.asn);
+                let negotiated = walk_open_capabilities(&o.opt_params);
+                // RFC 6793: when the peer supports 4-octet ASNs, the
+                // 2-byte field carries AS_TRANS (23456) and the real
+                // ASN comes via capability 65. Resolve the effective
+                // ASN by preferring the capability when present, then
+                // cross-check against the operator-configured
+                // `peer_as`. Pre-audit this was a soft warning; the
+                // audit (May 2026) flagged it as the second leg of
+                // the "anyone-can-speak-iBGP" Critical finding, so
+                // it's now a session-fatal close.
+                let effective_peer_asn = negotiated.four_octet_asn.unwrap_or(peer_asn_2byte);
+                if effective_peer_asn != self.cfg.peer_as {
+                    return Err(RouteSourceError::recoverable(format!(
+                        "peer ASN mismatch in OPEN: observed {effective_peer_asn} (2-byte field {peer_asn_2byte}, 4-octet cap {:?}), expected {} — closing session",
+                        negotiated.four_octet_asn, self.cfg.peer_as
+                    )));
                 }
                 let effective_hold = self.cfg.hold_time.min(o.hold_time).max(3);
-                let negotiated = walk_open_capabilities(&o.opt_params);
                 let add_path_in_effect = negotiated.add_path_in_effect();
                 info!(
-                    peer_asn = peer_asn,
+                    peer_asn = effective_peer_asn,
                     peer_router_id = %o.bgp_identifier,
                     effective_hold,
                     add_path_in_effect,
@@ -270,7 +340,7 @@ impl BgpListener {
                     add_path_v6 = negotiated.add_path_v6_recv,
                     "received peer OPEN"
                 );
-                (effective_hold, peer_asn, add_path_in_effect)
+                (effective_hold, effective_peer_asn, add_path_in_effect)
             }
             other => {
                 return Err(RouteSourceError::recoverable(format!(
@@ -632,6 +702,12 @@ struct NegotiatedCapabilities {
     add_path_v4_recv: bool,
     /// Peer advertised ADD-PATH Send (or both) for (IPv6, unicast).
     add_path_v6_recv: bool,
+    /// Peer's 4-octet ASN (RFC 6793) if it advertised the capability.
+    /// When `Some(_)`, this is the authoritative ASN — the 2-byte
+    /// `My AS` field in OPEN carries AS_TRANS (23456) and the real
+    /// ASN comes through here. Used by the peer-AS gate in
+    /// `handle_connection` (the audit-flagged identity check).
+    four_octet_asn: Option<u32>,
 }
 
 impl NegotiatedCapabilities {
@@ -665,26 +741,36 @@ fn walk_open_capabilities(
             continue;
         };
         for c in cap_list {
-            let CapabilityValue::AddPath(ap) = &c.value else {
-                continue;
-            };
-            for af in &ap.address_families {
-                // Peer Send => we Receive. Receive-only on the peer
-                // side means the peer wants to receive multipath from
-                // us, which we never originate, so it is not useful
-                // for our decoding state.
-                let peer_sends = matches!(
-                    af.send_receive,
-                    AddPathSendReceive::Send | AddPathSendReceive::SendReceive
-                );
-                if !peer_sends {
-                    continue;
+            match &c.value {
+                CapabilityValue::AddPath(ap) => {
+                    for af in &ap.address_families {
+                        // Peer Send => we Receive. Receive-only on the
+                        // peer side means the peer wants to receive
+                        // multipath from us, which we never originate,
+                        // so it is not useful for our decoding state.
+                        let peer_sends = matches!(
+                            af.send_receive,
+                            AddPathSendReceive::Send | AddPathSendReceive::SendReceive
+                        );
+                        if !peer_sends {
+                            continue;
+                        }
+                        match (af.afi, af.safi) {
+                            (Afi::Ipv4, Safi::Unicast) => caps.add_path_v4_recv = true,
+                            (Afi::Ipv6, Safi::Unicast) => caps.add_path_v6_recv = true,
+                            _ => {}
+                        }
+                    }
                 }
-                match (af.afi, af.safi) {
-                    (Afi::Ipv4, Safi::Unicast) => caps.add_path_v4_recv = true,
-                    (Afi::Ipv6, Safi::Unicast) => caps.add_path_v6_recv = true,
-                    _ => {}
+                CapabilityValue::FourOctetAs(foa) => {
+                    // RFC 6793: when present, this carries the peer's
+                    // real ASN. The 2-byte field in OPEN holds AS_TRANS
+                    // (23456) and the audit-flagged peer-AS check in
+                    // `handle_connection` compares this value against
+                    // the operator-configured `peer_as`.
+                    caps.four_octet_asn = Some(foa.asn);
                 }
+                _ => {}
             }
         }
     }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -45,7 +45,7 @@
 
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicI64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -102,6 +102,12 @@ pub struct BmpStation {
     /// Required for safe forwarding use against bird 2.x / bird 3.x
     /// (which only emit pre/post-policy frames).
     require_loc_rib: bool,
+    /// CIDR ACL applied at `accept()` time. Empty means "loopback
+    /// only" — the config parser only permits empty when
+    /// `listen_addr` is loopback. When non-empty, every accepted
+    /// source IP must fall within at least one entry or the
+    /// connection is dropped before the BMP framing starts.
+    peer_acl: Vec<ipnet::IpNet>,
 }
 
 /// Re-export for callers building the station.
@@ -129,6 +135,7 @@ impl BmpStation {
             last_rm_unix: Arc::new(AtomicI64::new(0)),
             stall_gate: None,
             require_loc_rib: false,
+            peer_acl: Vec::new(),
         }
     }
 
@@ -150,6 +157,16 @@ impl BmpStation {
         self
     }
 
+    /// Set the CIDR ACL applied at `accept()` time. Empty (the
+    /// default) means loopback-only. The config parser enforces the
+    /// "non-loopback listen requires non-empty ACL" invariant; this
+    /// builder is the runtime path the controller uses to thread the
+    /// parsed ACL through.
+    pub fn with_peer_acl(mut self, peer_acl: Vec<ipnet::IpNet>) -> Self {
+        self.peer_acl = peer_acl;
+        self
+    }
+
     /// Main loop: bind, accept, handle one connection at a time.
     /// On disconnect (clean or error), emit Resync so the programmer
     /// marks all mirrored routes unseen — the next `RouteEvent::Add`
@@ -159,7 +176,13 @@ impl BmpStation {
     pub async fn run(self) -> Result<(), RouteSourceError> {
         let listener = bind_with_reuseaddr(self.listen_addr)
             .map_err(|e| RouteSourceError::fatal(format!("bind {}: {e}", self.listen_addr)))?;
-        info!(addr = %self.listen_addr, "BMP station listening");
+        let loopback_only = self.listen_addr.ip().is_loopback() && self.peer_acl.is_empty();
+        info!(
+            addr = %self.listen_addr,
+            peer_acl_entries = self.peer_acl.len(),
+            auth_posture = if loopback_only { "loopback-only" } else { "allow-remote (no TCP-MD5)" },
+            "BMP station listening"
+        );
 
         // Optional stall monitor. Fires a warning log when no ROUTE
         // MONITORING frame arrives for `STALL_THRESHOLD` *and* the
@@ -188,6 +211,19 @@ impl BmpStation {
                 accept = listener.accept() => {
                     match accept {
                         Ok((stream, addr)) => {
+                            // Source-IP gate runs before any BMP byte
+                            // is read. Same audit (May 2026) rationale
+                            // as the matching gate in
+                            // `route_source_bgp::run`.
+                            if !source_ip_permitted(addr.ip(), &self.peer_acl) {
+                                warn!(
+                                    %addr,
+                                    peer_acl_entries = self.peer_acl.len(),
+                                    "BMP accept rejected: source IP outside peer-from ACL"
+                                );
+                                drop(stream);
+                                continue;
+                            }
                             info!(%addr, "BMP client connected");
                             if let Err(e) = self.handle_connection(stream).await {
                                 warn!(error = %e, "BMP connection handler exited with error");
@@ -620,6 +656,19 @@ fn network_prefix_to_ip_prefix(np: &NetworkPrefix) -> Option<IpPrefix> {
 fn asn_to_u32(asn: bgpkit_parser::models::Asn) -> u32 {
     // `Asn` impls `Display` as the decimal integer.
     asn.to_string().parse().unwrap_or(0)
+}
+
+/// Whether `addr` is permitted by the listener's `peer_acl`. Empty
+/// ACL means "loopback only" — the config parser already enforces
+/// that empty + non-loopback listen is rejected, so an empty ACL
+/// implies loopback bind. The defensive `is_loopback()` check covers
+/// a misconstructed in-process config.
+fn source_ip_permitted(addr: IpAddr, peer_acl: &[ipnet::IpNet]) -> bool {
+    if peer_acl.is_empty() {
+        addr.is_loopback()
+    } else {
+        peer_acl.iter().any(|net| net.contains(&addr))
+    }
 }
 
 /// Bind a `TcpListener` with `SO_REUSEADDR` enabled (v0.2.2 fix). See

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -865,12 +865,20 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 addr,
                 port,
                 require_loc_rib,
+                peer_from,
+                // `allow_remote` is informational here — the config
+                // parser already rejected the unsafe shape (non-loopback
+                // bind without opt-in), so by the time we see the spec
+                // the `peer_from` ACL is either non-empty or the listen
+                // is loopback.
+                allow_remote: _,
             }) => format!("{addr}:{port}")
                 .parse::<std::net::SocketAddr>()
                 .ok()
                 .map(|listen| crate::fib::controller::RouteSourceConfig::Bmp {
                     listen,
                     require_loc_rib: *require_loc_rib,
+                    peer_acl: peer_from.clone(),
                 }),
             ModuleDirective::RouteSource(packetframe_common::config::RouteSourceSpec::Bgp {
                 addr,
@@ -878,6 +886,9 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 local_as,
                 peer_as,
                 router_id,
+                peer_from,
+                peer_ip,
+                allow_remote: _,
             }) => {
                 let listen: std::net::SocketAddr = format!("{addr}:{port}").parse().ok()?;
                 // Default router-id: lowest 32 bits of the listen
@@ -893,6 +904,8 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                     local_as: *local_as,
                     peer_as: *peer_as,
                     router_id: rid,
+                    peer_acl: peer_from.clone(),
+                    expected_peer_ip: *peer_ip,
                 })
             }
             _ => None,


### PR DESCRIPTION
## Summary

Closes the **Critical** finding from the May 2026 multi-agent audit: the BGP/BMP listeners are framed as "passive iBGP" but had no in-code authentication. `route-source bgp/bmp <addr>:<port>` passed any address straight to `bind()`, peer-ASN mismatch in OPEN was a soft warning, and there's no TCP-MD5 wiring. Anyone reachable to the listener could speak iBGP and inject arbitrary FIB state into the LPM-trie XDP consults.

- **Config parser** now refuses non-loopback listen addresses unless the operator opts in with `allow-remote` and declares at least one `peer-from <cidr>` ACL entry. BGP additionally accepts `peer-ip <ip>` to pin the configured `peer-as` to a specific source IP. Loopback configs keep working unchanged.
- **Listener accept loops** filter the peer source IP against the parsed ACL/pin *before* any BGP/BMP framing runs.
- **BGP OPEN handler** turns peer-ASN mismatch from `warn!`+continue into a session-fatal close. The effective ASN consults the RFC 6793 four-octet capability before falling back to the 2-byte field, so AS_TRANS doesn't bypass the check.
- **Startup banners** report the auth posture (`loopback-only` vs `allow-remote (no TCP-MD5)`).
- **conf/example.conf** documents the new keywords with a non-loopback example.

Two follow-up PRs build on top of this branch: [`security/slice-2-dos-hardening`](https://github.com/unredacted/packetframe/tree/security/slice-2-dos-hardening) (DoS bounds) and [`security/slice-5-config-validation`](https://github.com/unredacted/packetframe/tree/security/slice-5-config-validation) (defense-in-depth).

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass; 12 new auth tests cover non-loopback rejection, `allow-remote` + `peer-from`, `peer-ip` parse, bad CIDR/IP, IPv6 loopback default.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Manual smoke: start daemon with default loopback-only `route-source bgp 127.0.0.1:1179`, confirm bird connects and UPDATEs land in the FIB.
- [x] Manual smoke: `route-source bgp 192.0.2.1:1179 ...` (no opt-in) → expect config-parse rejection with a clear error.
- [x] CI's qemu-verifier matrix on 5.15 + 6.6 stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)