### PR TITLE
probe: zero ringbuf tail padding so reservation doesn't leak kernel memory

### DIFF
--- a/crates/modules/probe/bpf/src/main.rs
+++ b/crates/modules/probe/bpf/src/main.rs
@@ -30,22 +30,36 @@ use core::mem;
 /// One sample published per packet. `#[repr(C)]` so the userspace
 /// reader can cast incoming ringbuf bytes directly into this layout;
 /// changing the layout requires bumping a version field and updating
-/// the userspace `ProbeEvent` in sync. Tail-padded by the compiler to
-/// 8-byte alignment (8 + 4 + 16 = 28 → 32 bytes) — the kernel also
-/// insists `align_of::<T>() ≤ 8` for `RingBuf::reserve`, which this
-/// struct satisfies.
+/// the userspace `ProbeEvent` in sync. `u64 + u32 + [u8;16] + [u8;4]`
+/// packs to a flat 32 bytes with no compiler-inserted padding — the
+/// kernel insists `align_of::<T>() ≤ 8` for `RingBuf::reserve`, which
+/// this struct satisfies.
 ///
 /// `pkt_len` is the on-the-wire packet length as observed by the XDP
 /// hook (`data_end - data`); useful for distinguishing truncated
 /// frames from full ones, and for confirming that a non-conformant
 /// head prefix is correlated with a suspicious total length.
+///
+/// `_pad` exists so the trailing 4 bytes of the 32-byte slot are an
+/// explicit, addressable field that the BPF program zeros before
+/// submit. Without it, the layout would have compiler-inserted tail
+/// padding that `RingBuf::reserve` (returning `MaybeUninit<T>` over
+/// a kernel-allocated slot that the kernel does NOT zero) would
+/// publish to userspace carrying whatever the ringbuf cell last
+/// held — a 4-byte information leak per sample. See SPEC.md §11.1(c)
+/// + the May 2026 audit Slice 3 fix for the longer rationale.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct ProbeEvent {
     pub ts_ns: u64,
     pub pkt_len: u32,
     pub head: [u8; 16],
+    pub _pad: [u8; 4],
 }
+
+// Pin the layout: any change here must update the userspace mirror
+// in `crates/modules/probe/src/lib.rs` in lockstep.
+const _: () = assert!(core::mem::size_of::<ProbeEvent>() == 32);
 
 /// 256 KiB works across 4-KiB and 16-KiB page hosts (some ARM
 /// kernels use 16K pages; ringbuf size must be a power-of-two page
@@ -125,9 +139,14 @@ pub fn probe(ctx: XdpContext) -> u32 {
     let ts = unsafe { bpf_ktime_get_ns() };
 
     // SAFETY: `RingBufEntry::as_mut_ptr` gives a valid, 8-aligned,
-    // `mem::size_of::<ProbeEvent>()`-sized slot that the kernel has
-    // reserved for us. We write every field before calling `submit`;
-    // the tail padding stays at whatever the kernel zeroed it to.
+    // `mem::size_of::<ProbeEvent>()`-sized slot. **The kernel does
+    // NOT zero the reservation** — `RingBuf::reserve` returns
+    // `MaybeUninit<T>` over whatever bytes the ringbuf cell last
+    // held. Every byte of the slot must be written before `submit`
+    // or the leftover content goes out to userspace as kernel-memory
+    // leakage. We write each named field below; `_pad` is the
+    // explicit zero-fill of the trailing 4 bytes that closes the
+    // padding-leak path the May 2026 audit (Slice 3) flagged.
     unsafe {
         let e = entry.as_mut_ptr();
         (*e).ts_ns = ts;
@@ -138,6 +157,7 @@ pub fn probe(ctx: XdpContext) -> u32 {
         // well-defined in-range pointer.
         let p = (start + offset) as *const [u8; 16];
         (*e).head = core::ptr::read_unaligned(p);
+        (*e)._pad = [0u8; 4];
     }
 
     entry.submit(0);

--- a/crates/modules/probe/src/lib.rs
+++ b/crates/modules/probe/src/lib.rs
@@ -44,7 +44,8 @@ pub fn aligned_bpf_copy() -> Vec<u8> {
 /// One packet sample. `#[repr(C)]` and layout-identical to the BPF
 /// program's `ProbeEvent` struct — the ringbuf delivers these bytes
 /// unchanged. Changing the layout here requires the BPF side to
-/// change in lockstep (and vice versa).
+/// change in lockstep (and vice versa). The pinned size (32 bytes)
+/// is asserted at compile time below.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct ProbeEvent {
@@ -58,7 +59,17 @@ pub struct ProbeEvent {
     /// rvu-nicpf native, §11.1(c)), this is what actually lands and
     /// is the evidence for what to do about it.
     pub head: [u8; 16],
+    /// Explicit trailing pad that the BPF side zeros before
+    /// `submit`. Closes the May 2026 audit Slice 3 finding: without
+    /// an explicit field here the compiler-inserted tail padding
+    /// would be `RingBuf::reserve`'s uninitialized bytes, publishing
+    /// 4 bytes of kernel memory per sample to userspace.
+    pub _pad: [u8; 4],
 }
+
+// Pin the layout: any change to ProbeEvent here must keep the
+// BPF-side struct in `bpf/src/main.rs` in lockstep.
+const _: () = assert!(std::mem::size_of::<ProbeEvent>() == 32);
 
 #[cfg(target_os = "linux")]
 pub use linux_impl::run;


### PR DESCRIPTION
## Summary

Closes the May 2026 audit Slice 3 finding: the probe BPF program publishes 4 bytes of uninitialized kernel memory per sample via `RingBuf::reserve`'s `MaybeUninit<T>` slot. The kernel does NOT zero ringbuf reservations, and the compiler-inserted tail padding (from `u64 + u32 + [u8;16]` rounding up to 32-byte 8-aligned) goes out untouched. A reader with `CAP_BPF + CAP_NET_ADMIN` sees those bytes via `bpftool map dump`.

The SAFETY comment on the unsafe block claimed the kernel zeroed the slot — wrong.

- Make the trailing 4 bytes an explicit `pub _pad: [u8; 4]` field on both the BPF-side and userspace-mirror `ProbeEvent`.
- Zero `_pad` before `submit()` along with the other fields.
- Fix the SAFETY comment.
- Pin the 32-byte layout with `const _: () = assert!(size_of::<ProbeEvent>() == 32)` on each side so any future layout drift fails at compile time on the side that breaks.

Independent of the other audit slices — branches off main.

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] On a Linux host with `CAP_BPF`: `packetframe probe <iface>` for 1 second; `bpftool map dump pinned /sys/fs/bpf/packetframe/probe-events`; assert the 4 tail bytes are 0x00 (was random).
- [ ] CI's qemu-verifier matrix stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)