### PR TITLE
security: symlink-safe temp writes, /proc/exe PID identity, capped birdc stdout

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -296,8 +296,64 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     Ok(())
 }
 
+/// Open `path` for writing with `O_NOFOLLOW | O_EXCL | O_CREAT | 0600`
+/// — the symlink-safe atomic-write primitive both pidfile / marker
+/// writes (here) and the metrics-textfile writer ([`crate::metrics`])
+/// use for their `.tmp` staging files.
+///
+/// `O_NOFOLLOW` makes the open fail (`ELOOP`) when `path` is a
+/// symlink, so an attacker who can pre-create `<...>.tmp` as a
+/// symlink pointing at e.g. `/etc/passwd` cannot redirect the
+/// privileged daemon's write target. `O_EXCL` makes the open fail
+/// (`EEXIST`) when the path already exists, so a stale `.tmp`
+/// leftover from a crashed run is also surfaced rather than silently
+/// truncated and overwritten — callers handle that one-shot with
+/// `unlink-and-retry`.
+///
+/// The May 2026 audit Slice 4 finding flagged the previous use of
+/// `File::create` (which both follows symlinks and `O_TRUNC`s) on
+/// these temp paths as a privileged-write redirection primitive any
+/// time the parent directory is writable to a non-root user.
+#[cfg(target_os = "linux")]
+pub(crate) fn create_excl_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::unix::fs::OpenOptionsExt;
+    std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .mode(0o600)
+        .open(path)
+}
+
+/// Same shape but with one stale-`.tmp` retry. The retry runs only
+/// when `create_excl_no_follow` returns `AlreadyExists` and the
+/// existing path is a regular file (a leftover from a crashed run);
+/// a `.tmp` that's a symlink hits `ELOOP` on the retried open and
+/// the function gives up. A second `EEXIST` is treated as a real
+/// race between competing writers and errors out.
+#[cfg(target_os = "linux")]
+fn create_excl_no_follow_with_retry(path: &Path) -> std::io::Result<std::fs::File> {
+    match create_excl_no_follow(path) {
+        Ok(f) => Ok(f),
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            // unlink-and-retry, but only if the leftover is a plain
+            // file. symlink_metadata avoids following the symlink so
+            // we don't misclassify an attacker's symlink as a file.
+            let meta = std::fs::symlink_metadata(path)?;
+            if !meta.file_type().is_file() {
+                return Err(e);
+            }
+            std::fs::remove_file(path)?;
+            create_excl_no_follow(path)
+        }
+        Err(e) => Err(e),
+    }
+}
+
 /// Atomically write the current PID to `path`. Uses write-then-rename
-/// so a half-written file is never observed.
+/// so a half-written file is never observed; the temp file is opened
+/// with `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` so a pre-existing
+/// symlink at `<path>.tmp` cannot redirect the write.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn write_pid_file(path: &Path) -> std::io::Result<()> {
     use std::io::Write;
@@ -305,7 +361,7 @@ fn write_pid_file(path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(parent)?;
     let tmp = path.with_extension("pid.tmp");
     {
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut f = create_excl_no_follow_with_retry(&tmp)?;
         writeln!(f, "{}", std::process::id())?;
         f.sync_all()?;
     }
@@ -447,7 +503,7 @@ fn write_reconfigure_marker(path: &Path, status: &str) {
     let tmp = path.with_extension("timestamp.tmp");
     let body = format!("{status} {now_ns}\n");
     let r = (|| -> std::io::Result<()> {
-        let mut f = std::fs::File::create(&tmp)?;
+        let mut f = create_excl_no_follow_with_retry(&tmp)?;
         f.write_all(body.as_bytes())?;
         f.sync_all()?;
         std::fs::rename(&tmp, path)
@@ -477,10 +533,17 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
         _ => ReconfigureError::Io(format!("read PID file {}: {e}", pid_path.display())),
     })?;
 
-    // /proc/<pid>/comm cross-check defends against a stale PID file
-    // pointing at a recycled PID. The kernel truncates `comm` to 15
-    // chars + NUL; "packetframe" fits comfortably.
-    if !proc_comm_matches(pid, "packetframe") {
+    // /proc/<pid>/exe cross-check defends against a stale PID file
+    // pointing at a recycled PID. We previously consulted
+    // /proc/<pid>/comm, but `comm` is user-settable via
+    // `prctl(PR_SET_NAME)` — any local user could rename a process
+    // to "packetframe" and be the target of the SIGHUP a root
+    // reconfigure issues. The kernel publishes /proc/<pid>/exe as a
+    // symlink to the process's executable inode and that link is not
+    // user-writable; readlink-comparing it against our own
+    // current_exe is a real identity check rather than a name match.
+    // See the May 2026 audit Slice 4 finding.
+    if !proc_exe_matches_current(pid) {
         return Err(ReconfigureError::DaemonNotRunning(format!(
             "PID {pid} from {} is not a packetframe process (stale pidfile?)",
             pid_path.display()
@@ -545,16 +608,35 @@ fn read_pid_file(path: &Path) -> std::io::Result<libc::pid_t> {
     })
 }
 
-/// Read /proc/<pid>/comm and check that it matches `expected`.
-/// Returns false on any I/O error or mismatch — caller treats as
-/// "PID is not our process."
+/// Read /proc/<pid>/exe as a symlink and compare against the
+/// canonicalized path of the currently running `packetframe`
+/// executable. The kernel sets /proc/<pid>/exe to point at the
+/// process's executable inode; the link is not writable from
+/// userspace, which makes this a real identity check (unlike
+/// /proc/<pid>/comm which any local user can spoof via
+/// `prctl(PR_SET_NAME)`).
+///
+/// Handles the `(deleted)` suffix the kernel appends when the
+/// executable file has been unlinked after the process started
+/// (rolling upgrade) — we accept the match if the prefix agrees.
+///
+/// Returns false on any I/O error or mismatch — the caller treats
+/// that as "PID is not our process."
 #[cfg(target_os = "linux")]
-fn proc_comm_matches(pid: libc::pid_t, expected: &str) -> bool {
-    let path = format!("/proc/{pid}/comm");
-    match std::fs::read_to_string(&path) {
-        Ok(s) => s.trim() == expected,
-        Err(_) => false,
-    }
+fn proc_exe_matches_current(pid: libc::pid_t) -> bool {
+    let Ok(target) = std::fs::read_link(format!("/proc/{pid}/exe")) else {
+        return false;
+    };
+    let Ok(current) = std::env::current_exe() else {
+        return false;
+    };
+    let current = current.canonicalize().unwrap_or(current);
+    // Strip a trailing ` (deleted)` from the target — the kernel
+    // appends that when the inode has been unlinked since exec, e.g.
+    // during a `cargo install --force` upgrade.
+    let target_str = target.to_string_lossy();
+    let target_clean = target_str.strip_suffix(" (deleted)").unwrap_or(&target_str);
+    Path::new(target_clean) == current.as_path()
 }
 
 /// Modified time of the marker file, in (secs, nanos). `None` if the
@@ -604,19 +686,25 @@ fn daemon_pid() -> Option<u32> {
         if pid == self_pid {
             continue;
         }
-        let comm_path = format!("/proc/{pid}/comm");
-        let comm = match std::fs::read_to_string(&comm_path) {
-            Ok(s) => s,
-            Err(_) => continue,
-        };
-        if comm.trim() == "packetframe" {
-            // Confirm it's actually the `run` subcommand, not e.g.
-            // `packetframe detach` from another shell.
-            let cmdline_path = format!("/proc/{pid}/cmdline");
-            if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
-                if cmdline.split('\0').any(|a| a == "run") {
-                    return Some(pid);
-                }
+        // /proc/<pid>/exe is the kernel-managed identity check (the
+        // May 2026 audit Slice 4 finding). The `comm` field used to
+        // gate this is user-settable via prctl(PR_SET_NAME), so a
+        // local user could rename their own process to "packetframe"
+        // and block the operator's `packetframe detach`. The exe
+        // symlink resolves to the inode the kernel actually exec'd,
+        // and is not user-writable.
+        if !proc_exe_matches_current(pid as libc::pid_t) {
+            continue;
+        }
+        // Confirm it's actually the `run` subcommand, not e.g.
+        // `packetframe detach` from another shell. argv IS still
+        // user-settable, but the exe match above pins identity; a
+        // spoofed argv "run" entry only sources a self-match against
+        // the very same binary.
+        let cmdline_path = format!("/proc/{pid}/cmdline");
+        if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
+            if cmdline.split('\0').any(|a| a == "run") {
+                return Some(pid);
             }
         }
     }

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -92,6 +92,11 @@ fn write_once(textfile_path: &Path, bpffs_root: &Path, uptime_seconds: u64) -> R
 /// Write-then-rename. The rename is atomic on POSIX when source and
 /// dest are on the same filesystem — node_exporter's textfile
 /// collector relies on this to never read a half-written file.
+///
+/// The `.tmp` open uses `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` (see
+/// [`crate::loader::create_excl_no_follow`]) so a pre-existing
+/// symlink at the temp path cannot redirect the privileged write —
+/// the May 2026 audit Slice 4 finding.
 fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     // Use the same filename with `.tmp` appended so we stay on the
     // same filesystem as the target (`with_extension("tmp")` would
@@ -104,6 +109,22 @@ fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
             .unwrap_or("packetframe.prom"),
     ));
     {
+        #[cfg(target_os = "linux")]
+        let mut f = crate::loader::create_excl_no_follow(&tmp).or_else(|e| {
+            // Symmetry with the loader helper's retry path. On a
+            // crashed predecessor, the .tmp leftover is a regular
+            // file — unlink and retry once. A symlink (attacker
+            // pre-creation) trips O_NOFOLLOW on the retry too.
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                let meta = std::fs::symlink_metadata(&tmp)?;
+                if meta.file_type().is_file() {
+                    std::fs::remove_file(&tmp)?;
+                    return crate::loader::create_excl_no_follow(&tmp);
+                }
+            }
+            Err(e)
+        })?;
+        #[cfg(not(target_os = "linux"))]
         let mut f = std::fs::File::create(&tmp)?;
         f.write_all(contents)?;
         f.sync_all()?;

--- a/crates/modules/fast-path/src/fib/integrity.rs
+++ b/crates/modules/fast-path/src/fib/integrity.rs
@@ -279,17 +279,48 @@ async fn run_birdc_protocols(birdc: &std::path::Path) -> Result<usize, String> {
     parse_established_peers(&output)
 }
 
+/// Cap on bytes read from birdc's stdout and stderr. The May 2026
+/// audit Slice 4 finding: `Command::output()` reads stdout into
+/// memory uncapped, so a misbehaving or compromised `birdc` could
+/// emit gigabytes inside the 10s timeout and consume daemon memory.
+/// 1 MiB is two orders of magnitude above legitimate output (`birdc
+/// show route count` is ~100 bytes; `birdc show protocols` on a
+/// 2K-peer router is single-digit KB).
+const BIRDC_OUTPUT_CAP: usize = 1024 * 1024;
+
 async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, String> {
     let birdc = birdc.to_path_buf();
     let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-    // Stringify the args before the blocking task takes ownership; we
-    // still want to name them in the timeout-error message.
     let args_display = format!("{args:?}");
-    let join = tokio::task::spawn_blocking(move || {
-        Command::new(&birdc)
+    let join = tokio::task::spawn_blocking(move || -> Result<BirdcOutput, String> {
+        // `Read` is in scope inside `read_capped` via its `R: Read`
+        // bound — no need to pull it in here.
+        use std::process::Stdio;
+        let mut child = Command::new(&birdc)
             .args(&args)
-            .output()
-            .map_err(|e| format!("spawn {}: {e}", birdc.display()))
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .map_err(|e| format!("spawn {}: {e}", birdc.display()))?;
+        // SAFETY: `stdout`/`stderr` are Some because we configured
+        // both as `Stdio::piped()` above. Unwrap-on-piped is the
+        // standard pattern; the `.take()` removes them from the
+        // child so `wait()` doesn't block on us.
+        let mut stdout = child.stdout.take().expect("piped stdout");
+        let mut stderr = child.stderr.take().expect("piped stderr");
+        let mut stdout_buf = Vec::with_capacity(4096);
+        let mut stderr_buf = Vec::with_capacity(1024);
+        let stdout_truncated = read_capped(&mut stdout, &mut stdout_buf, BIRDC_OUTPUT_CAP)
+            .map_err(|e| format!("read birdc stdout: {e}"))?;
+        let _ = read_capped(&mut stderr, &mut stderr_buf, BIRDC_OUTPUT_CAP);
+        let status = child.wait().map_err(|e| format!("birdc wait: {e}"))?;
+        Ok(BirdcOutput {
+            status,
+            stdout: stdout_buf,
+            stderr: stderr_buf,
+            stdout_truncated,
+        })
     });
     let result = tokio::time::timeout(BIRDC_TIMEOUT, join)
         .await
@@ -302,7 +333,50 @@ async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, Str
             String::from_utf8_lossy(&result.stderr)
         ));
     }
+    if result.stdout_truncated {
+        return Err(format!(
+            "birdc {args_display} stdout exceeded {BIRDC_OUTPUT_CAP} bytes — refusing to parse a runaway response"
+        ));
+    }
     Ok(String::from_utf8_lossy(&result.stdout).into_owned())
+}
+
+/// Spawn result for [`run_birdc`]. Carries the captured streams plus
+/// a flag signalling whether stdout hit the size cap.
+struct BirdcOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+    stderr: Vec<u8>,
+    stdout_truncated: bool,
+}
+
+/// Read from `r` into `buf` up to `cap` bytes. Returns true when the
+/// reader had more data than the cap (the caller surfaces this as a
+/// hard error rather than parsing a runaway stream).
+fn read_capped<R: std::io::Read>(
+    r: &mut R,
+    buf: &mut Vec<u8>,
+    cap: usize,
+) -> std::io::Result<bool> {
+    let mut chunk = [0u8; 4096];
+    loop {
+        let n = match r.read(&mut chunk) {
+            Ok(0) => return Ok(false),
+            Ok(n) => n,
+            Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+            Err(e) => return Err(e),
+        };
+        let allowed = cap.saturating_sub(buf.len());
+        if n > allowed {
+            buf.extend_from_slice(&chunk[..allowed]);
+            // Drain the rest of the reader so the child's write end
+            // doesn't block on a full pipe buffer once we return.
+            let mut sink = [0u8; 4096];
+            while r.read(&mut sink).unwrap_or(0) > 0 {}
+            return Ok(true);
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Three audit-flagged userspace findings, bundled because they all sit inside the CLI / control-plane layer.

**1. Symlink-followable temp writes.** `write_pid_file`, `write_reconfigure_marker`, and `atomic_write` used `File::create(<...>.tmp)` which follows symlinks and `O_TRUNC`s. A non-root user with write access to the parent directory could pre-create the `.tmp` path as a symlink at e.g. `/etc/passwd` and redirect the privileged daemon's write target. Fixed with a shared `create_excl_no_follow` helper (`O_NOFOLLOW | O_EXCL | O_CREAT | 0600`). One-shot stale-`.tmp` retry: regular-file leftover from a crashed run is unlinked and the open retried; a symlink leftover trips `ELOOP` on the retry too.

**2. `/proc/<pid>/comm`-based daemon identity.** Used by both `packetframe reconfigure` (gates SIGHUP) and `packetframe detach` (blocks while a daemon is live). `comm` is settable from userspace via `prctl(PR_SET_NAME)` — any local user could rename their process to `packetframe` and either be the target of a root-issued SIGHUP or block the operator's detach. Switched to `/proc/<pid>/exe`: kernel-managed, not user-writable, compared against canonicalized `current_exe()` and tolerant of the kernel's `(deleted)` suffix after rolling upgrades.

**3. Uncapped birdc subprocess stdout.** `Command::output()` reads stdout into memory unbounded; a misbehaving or compromised `birdc` could emit gigabytes inside the 10 s timeout. Replaced with a manual spawn that caps stdout/stderr at 1 MiB and surfaces overrun as a hard error.

Independent of the other audit slices — branches off main.

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Manual: as root, `ln -s /tmp/poisoned /var/lib/packetframe/state/packetframe.pid.tmp` then start daemon → expect pidfile write fails with `ELOOP` rather than overwriting the target.
- [ ] Manual: spawn a child with `prctl(PR_SET_NAME, "packetframe\0")` and assert `daemon_pid()` does not return its PID.
- [ ] Manual: confirm `packetframe reconfigure` still works against a real daemon (the `/proc/exe` switch should be transparent to legitimate users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)