### PR TITLE
security: bound listener DoS — read timeout on BMP, faster OPEN, cap UPDATE elems

### DIFF
--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -124,9 +124,25 @@ const INIT_COMPLETE_QUIESCENCE: Duration = Duration::from_secs(5);
 const FRAME_CHANNEL_CAPACITY: usize = 256;
 
 /// Cap on time spent waiting for the peer's OPEN after we send
-/// ours. Real peers respond within milliseconds; 2 minutes is the
-/// RFC 4271 ConnectRetry default and a safe upper bound.
-const OPEN_TIMEOUT: Duration = Duration::from_secs(120);
+/// ours. RFC 4271's 120s ConnectRetry default applies to the
+/// *active* connector waiting for TCP to come up — we're the
+/// passive side with TCP already established, where real peers
+/// send OPEN within milliseconds. 10s is comfortable headroom that
+/// still bounds the slowloris primitive a misconfigured (or
+/// hostile) peer can leverage against the single-connection accept
+/// loop (audit Slice 2).
+const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Cap on iterations through one UPDATE's per-prefix elems. A
+/// single attacker-controlled UPDATE can encode tens of thousands
+/// of NLRI entries that bgpkit-parser's `Elementor` fans out into
+/// `BgpElem`s, each of which `apply_route_event().await`s — a
+/// control-plane amplification primitive flagged by the audit
+/// (Slice 2). 8192 leaves comfortable headroom above any
+/// realistic bird best-path stream (a full v4 table is ~960K
+/// prefixes spread across many UPDATEs) while putting an explicit
+/// ceiling on per-message work.
+const MAX_ELEMS_PER_UPDATE: usize = 8192;
 
 // --- BgpListener ------------------------------------------------------------
 
@@ -499,6 +515,20 @@ impl BgpListener {
                     &peer_asn_for_elems,
                 );
                 let fallback_nh = self.cfg.listen_addr.ip();
+                if elems.len() > MAX_ELEMS_PER_UPDATE {
+                    // Session-fatal: leaving an UPDATE half-applied
+                    // would put the FIB in a torn state across
+                    // peer_id's mirror, and we don't want the next
+                    // attacker-shaped UPDATE to just keep adding to
+                    // the per-message budget. Close, emit Resync,
+                    // let the peer reconnect.
+                    warn!(
+                        elems = elems.len(),
+                        cap = MAX_ELEMS_PER_UPDATE,
+                        "BGP UPDATE elem count exceeds per-message cap; closing session"
+                    );
+                    return;
+                }
                 for elem in elems {
                     let event = match elem_to_route_event(&elem, peer_id, fallback_nh) {
                         Some(e) => e,

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -81,6 +81,23 @@ const INIT_COMPLETE_QUIESCENCE: Duration = Duration::from_secs(5);
 /// second tick wakeups without backpressuring bird.
 const FRAME_CHANNEL_CAPACITY: usize = 256;
 
+/// Per-`read_exact` timeout on the BMP TCP stream. The reader task
+/// otherwise blocks forever on a peer that completed TCP handshake
+/// but never sent bytes (or sent a header but no body) — the
+/// audit-flagged slowloris primitive (Slice 2). 60 s is comfortable
+/// for legitimate bird (which sends initial RIB dumps in < 5 s) and
+/// tight enough to give the operator's stuck-session detection a
+/// chance to recover.
+const BMP_READ_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Cap on per-RouteMonitoring `BgpElem` count. Same rationale as
+/// the matching constant in `route_source_bgp.rs`: a single
+/// RouteMonitoring frame embeds one BGP UPDATE, which `Elementor`
+/// fans out into N elems, each costing one `apply_route_event`
+/// `.await`. 8192 is above any realistic bird best-path dump per
+/// frame.
+const MAX_ELEMS_PER_UPDATE: usize = 8192;
+
 pub struct BmpStation {
     listen_addr: SocketAddr,
     prog_handle: FibProgrammerHandle,
@@ -430,6 +447,13 @@ impl BmpStation {
                     &pph.peer_ip,
                     &pph.peer_asn,
                 );
+                if elems.len() > MAX_ELEMS_PER_UPDATE {
+                    return Err(RouteSourceError::recoverable(format!(
+                        "BMP RouteMonitoring fanned out to {} elems (cap {}); closing session",
+                        elems.len(),
+                        MAX_ELEMS_PER_UPDATE
+                    )));
+                }
                 for elem in elems {
                     let prefix = match network_prefix_to_ip_prefix(&elem.prefix) {
                         Some(p) => p,
@@ -568,14 +592,25 @@ async fn reader_task(
     let mut frames_parsed = 0usize;
     loop {
         let mut header_buf = [0u8; 6];
-        match stream.read_exact(&mut header_buf).await {
-            Ok(_) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
+        // tokio::time::timeout wrapping read_exact bounds the
+        // slowloris primitive: a peer that completes TCP handshake
+        // and stops sending bytes can no longer hold the
+        // single-connection BMP listener idle forever (audit
+        // Slice 2). On timeout we surface a recoverable error so
+        // the accept loop closes the stream and re-listens.
+        match tokio::time::timeout(BMP_READ_TIMEOUT, stream.read_exact(&mut header_buf)).await {
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                 debug!(frames_parsed, "BMP stream EOF (reader)");
                 return Ok(());
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 return Err(RouteSourceError::recoverable(format!("read header: {e}")));
+            }
+            Err(_) => {
+                return Err(RouteSourceError::recoverable(format!(
+                    "BMP read header exceeded {BMP_READ_TIMEOUT:?} (peer stalled)"
+                )));
             }
         }
         // BMP common header: version(1) + msg_len(4) + msg_type(1).
@@ -591,10 +626,17 @@ async fn reader_task(
         let body_len = msg_len - 6;
         let mut body_buf = vec![0u8; body_len];
         if body_len > 0 {
-            stream
-                .read_exact(&mut body_buf)
-                .await
-                .map_err(|e| RouteSourceError::recoverable(format!("read body: {e}")))?;
+            match tokio::time::timeout(BMP_READ_TIMEOUT, stream.read_exact(&mut body_buf)).await {
+                Ok(Ok(_)) => {}
+                Ok(Err(e)) => {
+                    return Err(RouteSourceError::recoverable(format!("read body: {e}")));
+                }
+                Err(_) => {
+                    return Err(RouteSourceError::recoverable(format!(
+                        "BMP read body exceeded {BMP_READ_TIMEOUT:?} (peer stalled mid-frame)"
+                    )));
+                }
+            }
         }
 
         // Reconstruct the full frame. `parse_bmp_msg` expects the


### PR DESCRIPTION
> **Stacked on top of #54 (`security/slice-1-listener-auth`) — merge that first.** The diff below is computed against slice-1; merging into main directly would also pull in slice-1's listener-auth changes.

## Summary

Three audit-flagged DoS primitives on the BGP/BMP listeners. All mechanical.

**1. BMP slowloris fix.** `read_exact` had no timeout; a peer that completed TCP handshake and sent zero bytes pinned the single-connection accept loop indefinitely. The `stall_monitor` task only alerted after 5 minutes, never tore the session down. Wrapped both the header-read and body-read in `tokio::time::timeout` with a 60 s ceiling. Timeout returns a recoverable error so the accept loop closes and re-listens.

**2. BGP `OPEN_TIMEOUT` 120 s → 10 s.** The 120 s default is RFC 4271's *active*-connector ConnectRetry; we're passive with TCP already established, where real peers send OPEN within milliseconds. With the single-connection accept loop, a hostile peer could connect, sit silent for 2 minutes, drop, repeat — locking the legitimate bird side out indefinitely.

**3. `MAX_ELEMS_PER_UPDATE = 8192`.** A single attacker-controlled UPDATE can encode tens of thousands of NLRI entries that bgpkit-parser's `Elementor` fans out into `BgpElem`s, each costing one `apply_route_event().await` against the FibProgrammer — control-plane amplification. Over-cap UPDATEs are session-fatal on both BGP `process_msg` and BMP `RouteMonitoring` paths. 8192 is generous headroom over any realistic bird best-path stream per single UPDATE (full v4 tables spread across many UPDATEs).

## Test plan

- [x] `cargo test --workspace --lib` — all tests pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [ ] Manual: `nc -l` against BGP/BMP port; observe session torn down within 11 s / 61 s respectively (was 121 s / never).
- [ ] Manual: synthesize an UPDATE with > 8192 elems; expect session close + Resync + reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)