### PR TITLE
docs: documentation pass across README, runbooks, and rustdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PacketFrame
 
-**eBPF/XDP fast-path for Linux packet forwarding.** Pure Rust, pluggable, attaches per-interface. Forwards allowlisted traffic directly between NICs at the driver level — bypassing iptables, conntrack, and the kernel routing stack — and falls back to normal kernel forwarding for everything else.
+**eBPF/XDP fast-path for Linux packet forwarding.** Pure Rust, pluggable, attaches per-interface. Forwards allowlisted traffic directly between NICs at the driver level (bypassing iptables, conntrack, and the kernel routing stack), and falls back to normal kernel forwarding for everything else.
 
 Production-tested on edge routers with full-table BGP feeds. **~98% of allowlisted flows fast-path** in measured deployments, with conntrack table size and customer-facing latency both reduced significantly versus stock kernel forwarding.
 
@@ -11,7 +11,7 @@ GPL-3.0-or-later. Linux ≥ 5.15. Single static binary; no separate libbpf, bpft
 For each interface you attach it to, PacketFrame runs an eBPF program at XDP ingress that:
 
 1. **Filters** by your declared `allow-prefix` / `allow-prefix6` lists. Non-matching packets fall through to the kernel unchanged.
-2. **Forwards** matched packets directly to the egress NIC via `bpf_redirect_map` — no `nf_hook_slow`, no conntrack, no iptables walk, no kernel skb allocation in native XDP mode.
+2. **Forwards** matched packets directly to the egress NIC via `bpf_redirect_map`: no `nf_hook_slow`, no conntrack, no iptables walk, no kernel skb allocation in native XDP mode.
 3. **Resolves the egress** via either the kernel FIB (`bpf_fib_lookup`) or PacketFrame's own LPM trie populated from a BGP feed (your choice via `forwarding-mode`).
 
 Optional layered features:
@@ -26,8 +26,8 @@ Optional layered features:
 
 | Concern | Stock kernel forwarding | PacketFrame fast-path |
 |---|---|---|
-| Per-packet conntrack lookup | yes — every packet | bypassed for allowlisted flows |
-| iptables FORWARD chain walk | yes — every packet, every rule | bypassed |
+| Per-packet conntrack lookup | yes, every packet | bypassed for allowlisted flows |
+| iptables FORWARD chain walk | yes, every packet, every rule | bypassed |
 | skb allocation cost (native XDP) | yes | bypassed |
 | BGP route source | netlink from a routing daemon | direct iBGP/BMP, no netlink coupling |
 | Kernel features still work | yes | yes (slow path is unchanged) |
@@ -52,8 +52,8 @@ Actual results depend on workload mix, NIC, kernel version, and deployment topol
 |---|---|---|---|---|
 | Bypasses kernel | partially (XDP) | fully (userspace) | no | no |
 | Dedicated cores required | no | yes | no | no |
-| Kernel features still work | yes | no — replaces stack | yes | yes |
-| Has its own BGP daemon | no — pairs with bird | typically not | yes | n/a |
+| Kernel features still work | yes | no, replaces stack | yes | yes |
+| Has its own BGP daemon | no, pairs with bird | typically not | yes | n/a |
 | Memory model | kernel-managed BPF maps | hugepages | kernel | kernel |
 | Deploy disruption | per-iface attach, opt-in | replaces network stack | runs alongside | default |
 
@@ -63,7 +63,7 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 
 | Component | State |
 |---|---|
-| `fast-path` module — XDP ingress, allowlist, redirect | Production |
+| `fast-path` module (XDP ingress, allowlist, redirect) | Production |
 | `kernel-fib` forwarding mode (default) | Production |
 | `custom-fib` forwarding mode (BGP-fed LPM) | Production (v0.2.0+) |
 | iBGP route source (`route-source bgp`) | Production (v0.2.0+) |
@@ -73,12 +73,12 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 | `block-prefix` XDP-time drop | Production (v0.2.1+) |
 | `mss-clamp` directive (fast-path) | Production (v0.2.4+; per-prefix loads on stricter kernels in v0.2.5+) |
 | `packetframe reconfigure` / `systemctl reload packetframe` | Production (v0.2.4+) |
-| Two-stage BPF datapath (`fast_path` + `finalize` via `bpf_tail_call`) | Production (v0.2.5+) — see [docs/runbooks/tail-call-architecture.md](docs/runbooks/tail-call-architecture.md) |
-| `probe` module — diagnostic XDP | Production |
-| `ddos` module — XDP-time SYN-flood + amplification filter | Future — sketched in SPEC §5.2 (priority 0–999, security/admission) |
-| `sampler` module — per-flow ringbuf observability | Future — sketched in SPEC §5.3 (priority 2000–2999, observation) |
-| `randomizer` module — TC egress jitter for NoiseNet anti-correlation | Future — sketched in SPEC §5.1 (priority ~3000, egress) |
-| Multi-module dispatcher (prerequisite for any second module on the same hook) | Future — module trait already shaped for it (SPEC §3.2 / §3.4) |
+| Two-stage BPF datapath (`fast_path` + `finalize` via `bpf_tail_call`) | Production (v0.2.5+); see [docs/runbooks/tail-call-architecture.md](docs/runbooks/tail-call-architecture.md) |
+| `probe` module (diagnostic XDP) | Production |
+| `ddos` module (XDP-time SYN-flood + amplification filter) | Future; sketched in SPEC §5.2 (priority 0–999, security/admission) |
+| `sampler` module (per-flow ringbuf observability) | Future; sketched in SPEC §5.3 (priority 2000–2999, observation) |
+| `randomizer` module (TC egress jitter for NoiseNet anti-correlation) | Future; sketched in SPEC §5.1 (priority ~3000, egress) |
+| Multi-module dispatcher (prerequisite for any second module on the same hook) | Future; module trait already shaped for it (SPEC §3.2 / §3.4) |
 
 ## Install
 
@@ -97,7 +97,7 @@ sha256sum -c SHA256SUMS --ignore-missing
 sudo apt-get install ./packetframe_${VERSION#v}_${ARCH}.deb
 ```
 
-Installs `/usr/bin/packetframe`, the systemd unit at `/lib/systemd/system/packetframe.service`, and an example config at `/etc/packetframe/example.conf`. The service is **not** auto-started — copy the example to `/etc/packetframe/packetframe.conf`, edit per the [Quickstart](#quickstart), then `sudo systemctl enable --now packetframe`. Requires glibc ≥ 2.31 (Debian 11+ / Ubuntu 20.04+).
+Installs `/usr/bin/packetframe`, the systemd unit at `/lib/systemd/system/packetframe.service`, and an example config at `/etc/packetframe/example.conf`. The service is **not** auto-started. Copy the example to `/etc/packetframe/packetframe.conf`, edit per the [Quickstart](#quickstart), then `sudo systemctl enable --now packetframe`. Requires glibc ≥ 2.31 (Debian 11+ / Ubuntu 20.04+).
 
 ### Tarball (any Linux)
 
@@ -144,14 +144,14 @@ module fast-path
   attach eth0 auto
   allow-prefix 192.0.2.0/24       # your customer / forwarding scope
   allow-prefix6 2001:db8::/48
-  dry-run on                       # observe-only — no redirects yet
+  dry-run on                       # observe-only, no redirects yet
   circuit-breaker drop-ratio 0.01 of matched window 5s threshold 5
-  # mss-clamp via eth0 1360       # optional — clamp TCP MSS for fast-pathed
+  # mss-clamp via eth0 1360       # optional, clamp TCP MSS for fast-pathed
                                    # traffic egressing eth0 (closes the
                                    # iptables-bypass MSS gap; v0.2.4+)
 ```
 
-`dry-run on` makes the program count matched packets but always return `XDP_PASS` — the kernel handles forwarding as if PacketFrame weren't there. Counters tell you whether your allowlist matches the right traffic before you flip the switch.
+`dry-run on` makes the program count matched packets but always return `XDP_PASS`. The kernel handles forwarding as if PacketFrame weren't there. Counters tell you whether your allowlist matches the right traffic before you flip the switch.
 
 ### 3. Validate against the host
 
@@ -165,7 +165,7 @@ Now also runs a per-interface trial XDP attach to catch driver compatibility iss
 
 ```sh
 sudo packetframe run                 # foreground; --config defaults to /etc/...
-sudo packetframe status              # in another shell — live counters
+sudo packetframe status              # in another shell, live counters
 ```
 
 ### 5. Flip dry-run off when match ratios look right
@@ -174,7 +174,7 @@ Edit the config, change `dry-run on` to `dry-run off`, then trigger a reload (v0
 
 ```sh
 sudo packetframe reconfigure                # synchronous; exits non-zero on parse error
-sudo systemctl reload packetframe           # equivalent under systemd — both end up sending SIGHUP
+sudo systemctl reload packetframe           # equivalent under systemd; both end up sending SIGHUP
 ```
 
 What's hot-reloadable: `allow-prefix*`, `block-prefix`, `dry-run`, `forwarding-mode`, `mss-clamp`, VLAN-subif resolution, and the redirect devmap. Attach-set changes (interfaces added/removed), `route-source` config, `circuit-breaker` thresholds, and `local-prefix` still require a full restart. See [docs/runbooks/reconfigure.md](docs/runbooks/reconfigure.md).
@@ -189,9 +189,9 @@ sudo packetframe detach --all        # removes pins, detaches XDP
 
 `forwarding-mode` selects how PacketFrame resolves the egress for a matched packet:
 
-- **`kernel-fib`** (default) — uses `bpf_fib_lookup()` against the kernel's routing table. Same routing decisions as plain Linux. The permanent rollback path.
-- **`custom-fib`** — uses PacketFrame's own LPM trie, populated from a BGP feed. Lets daemons that consume the kernel route table work in parallel without racing on BGP attribute updates from the routing daemon.
-- **`compare`** — runs both lookups, forwards via the kernel result, bumps a disagreement counter. Pre-cutover validation only.
+- **`kernel-fib`** (default): uses `bpf_fib_lookup()` against the kernel's routing table. Same routing decisions as plain Linux. The permanent rollback path.
+- **`custom-fib`**: uses PacketFrame's own LPM trie, populated from a BGP feed. Lets daemons that consume the kernel route table work in parallel without racing on BGP attribute updates from the routing daemon.
+- **`compare`**: runs both lookups, forwards via the kernel result, bumps a disagreement counter. Pre-cutover validation only.
 
 Custom-fib mode requires a `route-source` directive:
 
@@ -217,21 +217,21 @@ Each `attach <iface> <mode>` directive picks how XDP binds to the interface:
 
 | Mode | Cost | Use when |
 |---|---|---|
-| `native` | Lowest — runs in NIC driver before skb alloc | Driver supports native XDP and delivers Ethernet-shaped frames |
-| `generic` | Higher — runs after skb alloc | Driver doesn't support native XDP, or has known native-mode bugs |
+| `native` | Lowest; runs in NIC driver before skb alloc | Driver supports native XDP and delivers Ethernet-shaped frames |
+| `generic` | Higher; runs after skb alloc | Driver doesn't support native XDP, or has known native-mode bugs |
 | `auto` | tries native, falls back to generic | Most cases; downgraded automatically on drivers with known bugs |
 
 ### Driver caveats
 
 PacketFrame refuses configurations it has empirical evidence are unsafe:
 
-**Marvell `rvu-nicpf` on kernels < v6.8** — native XDP attach leaks a kernel resource counter (`non_qos_queues`) on every detach. After a handful of attach/detach cycles the kernel page allocator can corrupt. PacketFrame hard-refuses explicit `attach <iface> native` here and downgrades `auto` to `generic`. Fixed upstream in commit `04f647c8e456`; operators with the backport can opt out via `driver-workaround rvu-nicpf-head-shift off`.
+**Marvell `rvu-nicpf` on kernels < v6.8:** native XDP attach leaks a kernel resource counter (`non_qos_queues`) on every detach. After a handful of attach/detach cycles the kernel page allocator can corrupt. PacketFrame hard-refuses explicit `attach <iface> native` here and downgrades `auto` to `generic`. Fixed upstream in commit `04f647c8e456`; operators with the backport can opt out via `driver-workaround rvu-nicpf-head-shift off`.
 
-**Marvell `rvu-nicpf` on multi-member bridges** — XDP attach AND detach briefly bounce the link, which the bridge stack treats as a port-state change. Two ports flapping inside one STP/RSTP window has caused L2 loops and kernel panics. PacketFrame paces both attach and detach via `attach-settle-time` (default 2 s, raise on slow-converging bridges) when ≥ 2 attached ifaces share a `/sys/class/net/<iface>/master`.
+**Marvell `rvu-nicpf` on multi-member bridges:** XDP attach AND detach briefly bounce the link, which the bridge stack treats as a port-state change. Two ports flapping inside one STP/RSTP window has caused L2 loops and kernel panics. PacketFrame paces both attach and detach via `attach-settle-time` (default 2 s, raise on slow-converging bridges) when ≥ 2 attached ifaces share a `/sys/class/net/<iface>/master`.
 
 ### Diagnosing driver-specific issues
 
-If `packetframe status` shows `rx_total` climbing in lockstep with `pass_not_ip` while `matched_*` stays at zero, the program is running but not parsing frames it receives — usually a driver-specific native-mode delivery quirk. Use `packetframe probe` to inspect what the driver actually hands to XDP:
+If `packetframe status` shows `rx_total` climbing in lockstep with `pass_not_ip` while `matched_*` stays at zero, the program is running but not parsing frames it receives. That usually points to a driver-specific native-mode delivery quirk. Use `packetframe probe` to inspect what the driver actually hands to XDP:
 
 ```sh
 sudo packetframe probe --iface eth0 --mode native --duration 2s
@@ -250,28 +250,28 @@ Quick directive index:
 **Global**
 - `bpffs-root`, `state-dir`, `metrics-textfile`, `log-level`, `attach-settle-time`
 
-**Module fast-path — attach + allowlist**
+**Module fast-path: attach + allowlist**
 - `attach <iface> {native|generic|auto}`
-- `allow-prefix <ipv4-cidr>`, `allow-prefix6 <ipv6-cidr>` — src-or-dst match
+- `allow-prefix <ipv4-cidr>`, `allow-prefix6 <ipv6-cidr>`: src-or-dst match
 - `dry-run {on|off}`
 - `circuit-breaker drop-ratio X of matched window Ys threshold N`
 
-**Module fast-path — forwarding mode**
+**Module fast-path: forwarding mode**
 - `forwarding-mode {kernel-fib|custom-fib|compare}`
 - `route-source bgp <addr>:<port> local-as <asn> peer-as <asn> [router-id <ipv4>]`
 - `route-source bmp <addr>:<port> [require-loc-rib]`
-- `local-prefix <cidr> via <iface> [arp-scavenge]` — per-host fast-path for connected destinations
-- `fallback-default via <iface> nexthop <ipv4>` — synthetic 0.0.0.0/0 catch-all
-- `block-prefix <cidr>` — XDP-time drop for unrouteable destinations
-- `ecmp-default-hash-mode {3|4|5}` — tuple width for ECMP hashing
+- `local-prefix <cidr> via <iface> [arp-scavenge]`: per-host fast-path for connected destinations
+- `fallback-default via <iface> nexthop <ipv4>`: synthetic 0.0.0.0/0 catch-all
+- `block-prefix <cidr>`: XDP-time drop for unrouteable destinations
+- `ecmp-default-hash-mode {3|4|5}`: tuple width for ECMP hashing
 
-**Module fast-path — TCP transforms (v0.2.4+)**
-- `mss-clamp <mtu>` — global clamp ceiling for matched TCP SYN/SYN-ACK
-- `mss-clamp via <iface> <mtu>` — per-egress-iface
-- `mss-clamp <cidr> <mtu>` — per-src-or-dst-prefix (any egress)
-- `mss-clamp <cidr> via <iface> <mtu>` — most specific (precedence: prefix+iface > prefix > iface > global)
+**Module fast-path: TCP transforms (v0.2.4+)**
+- `mss-clamp <mtu>`: global clamp ceiling for matched TCP SYN/SYN-ACK
+- `mss-clamp via <iface> <mtu>`: per-egress-iface
+- `mss-clamp <cidr> <mtu>`: per-src-or-dst-prefix (any egress)
+- `mss-clamp <cidr> via <iface> <mtu>`: most specific (precedence: prefix+iface > prefix > iface > global)
 
-**Module fast-path — driver opt-ins**
+**Module fast-path: driver opt-ins**
 - `driver-workaround rvu-nicpf-head-shift {auto|on|off}`
 
 `SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, and forwarding-mode bits. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, or editing `local-prefix` requires a restart.
@@ -290,8 +290,8 @@ Counters export as Prometheus textfile every 15 s when `metrics-textfile` is set
 
 ## Documentation
 
-- [`conf/example.conf`](conf/example.conf) — annotated reference config
-- [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md) — operational runbook for custom-FIB mode (cutover, rollback, integrity checks, triage by symptom)
+- [`conf/example.conf`](conf/example.conf): annotated reference config
+- [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md): operational runbook for custom-FIB mode (cutover, rollback, integrity checks, triage by symptom)
 
 ## Build from source
 

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -1,11 +1,10 @@
 # PacketFrame example config.
 #
-# Interface names, VLAN IDs, and prefixes in this file are illustrative —
-# they match the reference EFG deployment in SPEC.md and will not apply
-# verbatim to any other host. Substitute your own.
+# Interface names, VLAN IDs, and prefixes in this file are illustrative.
+# They will not apply verbatim to any other host; substitute your own.
 #
-# Grammar is documented in SPEC.md §6. Unknown directives are fatal;
-# every interface in an `attach` directive must exist at startup.
+# The grammar is line-based. Unknown directives are fatal; every interface
+# named in an `attach` directive must exist at startup.
 
 global
   metrics-textfile /var/lib/node_exporter/textfile/packetframe.prom
@@ -14,42 +13,42 @@ global
   state-dir /var/lib/packetframe/state
 
   # Pause between per-iface attaches so each link settles before the
-  # next attach touches the driver. SPEC.md §11.8 — on some drivers
-  # XDP attach briefly bounces the link; if multiple attach ifaces
-  # share a bridge master, bouncing two ports inside one STP
-  # reconvergence window has been observed to trigger L2 loops. 0s
-  # disables; recommended >=2s whenever multiple ifaces share a bridge.
+  # next attach touches the driver. On some drivers XDP attach briefly
+  # bounces the link; if multiple attach ifaces share a bridge master,
+  # bouncing two ports inside one STP reconvergence window has been
+  # observed to trigger L2 loops. 0s disables; recommended >=2s
+  # whenever multiple ifaces share a bridge.
   attach-settle-time 2s
 
 module fast-path
   # Attach native XDP to every interface carrying forwarded traffic we want
   # on the fast path. Omit HA links, out-of-band management, and anything
-  # terminating tunnels locally. See SPEC.md §4.3.
+  # terminating tunnels locally.
   attach eth0 native
   attach eth2 native
   attach eth3 native
   attach eth4 native
   attach eth5 native
 
-  # Allowlist: matches if src OR dst falls in any prefix (SPEC.md §4.2).
+  # Allowlist: matches if src OR dst falls in any prefix.
   # Asymmetric (dst-only) would leave reply traffic on conntrack.
   allow-prefix  23.191.200.0/24
   allow-prefix6 2001:db8::/48
 
-  # Dry-run mode: program counts but does not redirect. Live-updatable via
-  # `packetframe reconfigure` once v0.1 ships reconfigure.
+  # Dry-run mode: program counts but does not redirect. Live-updatable
+  # via `packetframe reconfigure`.
   dry-run on
 
-  # Circuit breaker: denominator is matched traffic, not rx_total
-  # (SPEC.md §4.9). Trips when drop_unreachable + err_fib_other exceeds
-  # 1% of matched over 5 consecutive 5-second samples.
+  # Circuit breaker: denominator is matched traffic, not rx_total.
+  # Trips when drop_unreachable + err_fib_other exceeds 1% of matched
+  # over 5 consecutive 5-second samples.
   circuit-breaker drop-ratio 0.01 of matched window 5s threshold 5
 
-  # MSS clamping for fast-pathed TCP SYN/SYN-ACK packets (v0.2.4+,
-  # SPEC.md §4.x — closes the §11.4 iptables-bypass gap). Standard
-  # iptables `-A FORWARD ... TCPMSS --set-mss N` rules don't fire on
-  # XDP-redirected traffic because bpf_redirect_map skips netfilter;
-  # this directive runs the equivalent mutation inline before the
+  # MSS clamping for fast-pathed TCP SYN/SYN-ACK packets (v0.2.4+).
+  # Closes the iptables-bypass MSS gap: standard iptables
+  # `-A FORWARD ... TCPMSS --set-mss N` rules don't fire on
+  # XDP-redirected traffic because bpf_redirect_map skips netfilter,
+  # so this directive runs the equivalent mutation inline before the
   # redirect.
   #
   # Lookup precedence (most specific wins, lower-if-higher policy):
@@ -68,43 +67,43 @@ module fast-path
   # mss-clamp 1360                           # global fallback for all matched
 
   # Driver workaround for the pre-Linux-v6.8 rvu-nicpf native XDP bug
-  # (SPEC.md §11.1(c); upstream fix is commit 04f647c8e456). Values:
-  #   auto — detect rvu-nicpf via /sys and apply only on native attaches
+  # (upstream fix is commit 04f647c8e456). Values:
+  #   auto:  detect rvu-nicpf via /sys and apply only on native attaches
   #          (default; safe across driver families).
-  #   on   — force-apply regardless of driver.
-  #   off  — never apply (set this after upgrading to Linux v6.8+ or a
+  #   on:    force-apply regardless of driver.
+  #   off:   never apply (set this after upgrading to Linux v6.8+ or a
   #          kernel with the fix backported).
   # driver-workaround rvu-nicpf-head-shift auto
 
   # --- Option F custom FIB. Cutting over to `custom-fib` requires
   # bird's BMP protocol dialing this station AND bird's kernel
   # export dropping BGP routes. See docs/runbooks/custom-fib.md for
-  # the full cutover sequence and rollback procedure — do not flip
+  # the full cutover sequence and rollback procedure. Do not flip
   # this in production without validating on staging first.
 
   # Forwarding path selector. Values:
-  #   kernel-fib — (default) use bpf_fib_lookup() against the kernel
-  #                FIB. Today's behavior; the permanent rollback
-  #                option.
-  #   custom-fib — consult the module's own LPM-trie FIB populated
-  #                from BMP. Requires `route-source bmp ...`.
-  #   compare    — run both lookups, forward via kernel result, bump
-  #                disagreement counters. Pre-cutover validation
-  #                mode; expect 2× the per-packet FIB cost. Temporary.
+  #   kernel-fib: (default) use bpf_fib_lookup() against the kernel
+  #               FIB. Today's behavior; the permanent rollback
+  #               option.
+  #   custom-fib: consult the module's own LPM-trie FIB populated
+  #               from BMP. Requires `route-source bmp ...`.
+  #   compare:    run both lookups, forward via kernel result, bump
+  #               disagreement counters. Pre-cutover validation
+  #               mode; expect 2× the per-packet FIB cost. Temporary.
   # forwarding-mode kernel-fib
 
   # Route-source feed for the custom FIB. Pick exactly one when
   # forwarding-mode is `custom-fib` or `compare`. Two kinds:
   #
   #   bgp <addr>:<port> local-as <asn> peer-as <asn> [router-id <ipv4>]
-  #     iBGP listener — bird dials in via `protocol bgp packetframe
+  #     iBGP listener. Bird dials in via `protocol bgp packetframe
   #     { neighbor <addr> port <port> as <asn>; ... }`. Bird's
   #     export filter runs after best-path so we get bird's selected
   #     paths verbatim. Recommended for production today (bird 2.x /
   #     3.x master don't ship RFC 9069 Loc-RIB BMP).
   #
   #   bmp <addr>:<port> [require-loc-rib]
-  #     BMP station — only safe to drive forwarding from if the
+  #     BMP station. Only safe to drive forwarding from if the
   #     emitter sends RFC 9069 Loc-RIB peer_type=3 frames (FRR has
   #     this; bird 2.x/3.x does not). The `require-loc-rib` flag
   #     hard-rejects pre/post-policy frames so misconfiguration
@@ -112,7 +111,7 @@ module fast-path
   #
   # **Listener authorization.** The listener has no protocol-level
   # auth (no TCP-MD5 / TCP-AO wiring yet). The safe default is a
-  # loopback bind — bird and packetframe must run on the same host
+  # loopback bind: bird and packetframe must run on the same host
   # and the iBGP session lives on `127.0.0.1` (or `::1`). For that
   # topology, no extra keywords are needed.
   #
@@ -139,19 +138,18 @@ module fast-path
   # hint via BMP. Rarely needs changing from the default 5.
   # ecmp-default-hash-mode 5
 
-  # Custom-FIB map sizes. **Parsed but not yet runtime-applied** —
-  # aya and the kernel allocate BPF maps at compile-time sizes set
-  # in crates/modules/fast-path/bpf/src/maps.rs. Changing these in
-  # the config has no effect until the BPF ELF is rebuilt with the
-  # matching constant. Defaults (2²¹ v4 / 2²⁰ v6) comfortably cover
-  # the current DFZ.
+  # Custom-FIB map sizes. **Parsed but not yet runtime-applied.**
+  # aya and the kernel allocate BPF maps at compile-time sizes baked
+  # into the BPF program. Changing these in the config has no effect
+  # until the BPF ELF is rebuilt with the matching constant.
+  # Defaults (2²¹ v4 / 2²⁰ v6) comfortably cover the current DFZ.
   # fib-v4-max-entries 2097152
   # fib-v6-max-entries 1048576
   # nexthops-max-entries 8192
   # ecmp-groups-max-entries 1024
 
   # Connected fast-path (v0.2.1+). Declare connected/local prefixes
-  # that bird sees as `direct1`-origin — the ones under `birdc show
+  # that bird sees as `direct1`-origin, the ones under `birdc show
   # route protocol direct1`. Without these, custom-fib mode falls
   # through to kernel slow path for every inbound packet to a
   # connected destination because the iBGP-supplied NEXT_HOP for a
@@ -178,7 +176,7 @@ module fast-path
   # SAFETY (v0.2.2+): probes go ONLY on the operator-declared `via
   # <iface>`, never through kernel route lookup. ARP traffic cannot
   # escape that iface's L2 broadcast domain. **Do NOT declare
-  # arp-scavenge on an IX-attached iface** — broadcasting ARP onto
+  # arp-scavenge on an IX-attached iface.** Broadcasting ARP onto
   # an IX violates IX ToS (MANRS, anti-DoS rules). For internal LANs
   # only (storage, management, customer LANs).
   # local-prefix 10.88.1.0/24 via br88 arp-scavenge
@@ -196,7 +194,7 @@ module fast-path
   #
   # `<iface>` must match the iface carrying default-route traffic
   # (typically the upstream/transit peer's iface). `<ipv4>` is the
-  # peer's IP — must already be a known kernel ARP entry (or be
+  # peer's IP; it must already be a known kernel ARP entry (or be
   # one of the BGP nexthops the resolver already knows about).
   #
   # fallback-default via eth3 nexthop 194.110.60.50
@@ -205,13 +203,13 @@ module fast-path
   # falls in any `block-prefix` AND the packet is otherwise allowlist-
   # matched, the program returns XDP_DROP rather than XDP_PASS-to-
   # kernel. Drops bogon-bound traffic (RFC 1918, CGNAT, test-net) at
-  # the earliest possible point — saves the skb allocation, netfilter
+  # the earliest possible point. Saves the skb allocation, netfilter
   # walk, and conntrack capacity that would otherwise be burned on
   # packets that just get RST'd upstream anyway. Empty list = no
   # behavior change. Operator opts in.
   #
   # Refusing to start when a `block-prefix` overlaps an `allow-prefix`
-  # or `local-prefix` (config bug — would silently drop traffic to
+  # or `local-prefix` (config bug, would silently drop traffic to
   # declared customer prefixes).
   #
   # block-prefix 10.0.0.0/8       # RFC 1918

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -50,7 +50,7 @@ section = "net"
 priority = "optional"
 # Workspace `[profile.release]` already strips, and the host's `strip`
 # can't read cross-built arm64 ELFs anyway. Skipping is handled at the
-# cargo-deb invocation site via the `--no-strip` CLI flag — there's no
+# cargo-deb invocation site via the `--no-strip` CLI flag, there's no
 # `strip` key in [package.metadata.deb]; cargo-deb 2.7 rejects it.
 # dpkg-shlibdeps doesn't work cross-arch on the Ubuntu CI runner, so
 # pin the glibc dependency floor explicitly. 2.31 = Ubuntu 20.04 /

--- a/crates/cli/src/breaker.rs
+++ b/crates/cli/src/breaker.rs
@@ -24,7 +24,7 @@ use std::time::{Duration, Instant};
 use packetframe_common::config::CircuitBreakerSpec;
 use packetframe_fast_path::breaker::{CircuitBreaker, Decision};
 
-/// Shutdown-check granularity — how often the sampler wakes between
+/// Shutdown-check granularity, how often the sampler wakes between
 /// window ticks to check for shutdown.
 const POLL: Duration = Duration::from_millis(250);
 

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -1,7 +1,8 @@
 //! Feasibility subcommand glue: run SPEC.md §2.1 probes and render the
-//! report either as JSON (default) or as a human table. PR #4 adds the
-//! per-interface XDP trial-attach probe (§2.3) for each `attach`ed iface
-//! in the config — graduates from Deferred to a real check.
+//! report either as JSON (default) or as a human table. A per-interface
+//! XDP trial-attach probe (§2.3) runs for each `attach`ed iface in the
+//! config; it graduates the per-iface attach feasibility from Deferred
+//! to a real pass/fail check.
 
 use std::path::Path;
 
@@ -32,7 +33,7 @@ pub fn attach_ifaces_from_config(config: &Config) -> Vec<String> {
 pub fn probe_and_render(bpffs_root: &Path, attach_ifaces: &[String], human: bool) -> Rendered {
     let mut report = run_probes(bpffs_root);
 
-    // Graduate §2.3 per-interface trial-attach probe from Deferred —
+    // Graduate §2.3 per-interface trial-attach probe from Deferred
     // remove the placeholder entry and replace with real per-iface
     // verdicts.
     report
@@ -176,7 +177,7 @@ fn print_human(report: &FeasibilityReport) {
 
     println!();
     if report.passed {
-        println!("Result: PASS — all required capabilities present.");
+        println!("Result: PASS, all required capabilities present.");
     } else {
         let failing: Vec<&Capability> = report
             .capabilities
@@ -184,7 +185,7 @@ fn print_human(report: &FeasibilityReport) {
             .filter(|c| c.required && c.status != CapabilityStatus::Pass)
             .collect();
         println!(
-            "Result: FAIL — {} required capabilit{} missing or unknown:",
+            "Result: FAIL, {} required capabilit{} missing or unknown:",
             failing.len(),
             if failing.len() == 1 { "y" } else { "ies" },
         );

--- a/crates/cli/src/fib_cli.rs
+++ b/crates/cli/src/fib_cli.rs
@@ -7,7 +7,7 @@
 //!
 //! All operations open the bpffs pins directly via
 //! `packetframe_fast_path::fib::inspect`; no daemon IPC, no pin-
-//! registry dependency. Works as long as the pins are alive —
+//! registry dependency. Works as long as the pins are alive
 //! after `systemctl stop packetframe` but before `detach --all`.
 
 #![cfg(all(target_os = "linux", feature = "fast-path"))]
@@ -46,7 +46,7 @@ pub enum FibOp {
         ip: IpAddr,
     },
     /// Print just the FIB occupancy / hash-mode / forwarding-mode
-    /// block from `packetframe status` — useful for scripting.
+    /// block from `packetframe status`, useful for scripting.
     Stats {
         #[arg(long)]
         config: Option<PathBuf>,
@@ -83,7 +83,7 @@ pub fn run(op: FibOp) -> ExitCode {
                     ExitCode::from(EXIT_OK)
                 }
                 Ok(None) => {
-                    println!("NO MATCH — {ip} has no covering prefix in FIB");
+                    println!("NO MATCH, {ip} has no covering prefix in FIB");
                     ExitCode::from(EXIT_OK)
                 }
                 Err(e) => {

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -4,7 +4,7 @@
 //!   persist the pin registry, block on SIGTERM/SIGINT (SPEC.md §7.3).
 //! - `detach`: read the pin registry and report what's recorded.
 //!   Actual in-kernel detach without an active loader requires pinning,
-//!   which lands with PR #6 — this subcommand graduates then.
+//!   which lands with PR #6, this subcommand graduates then.
 //! - `status`: read the pin registry and (when a loader is running with
 //!   a pinned stats map) the counter values. v0.1 reports the registry
 //!   alone.
@@ -27,10 +27,10 @@ use packetframe_fast_path::registry::HookTypeRecord;
 
 #[derive(Debug, thiserror::Error)]
 pub enum RunError {
-    /// Config parse / interface-missing / capability fail — exit 1.
+    /// Config parse / interface-missing / capability fail, exit 1.
     #[error("{0}")]
     Startup(String),
-    /// Post-attach errors or unexpected runtime failures — exit 2.
+    /// Post-attach errors or unexpected runtime failures, exit 2.
     /// Only constructed on Linux (the non-Linux path returns Startup
     /// immediately), so non-Linux builds flag this as dead code.
     #[cfg_attr(not(all(target_os = "linux", feature = "fast-path")), allow(dead_code))]
@@ -40,17 +40,17 @@ pub enum RunError {
 
 /// Errors from `packetframe reconfigure`. Kept separate from
 /// [`RunError`] because the CLI maps each variant to a different exit
-/// code + log message — distinguishing "no daemon" from "daemon
+/// code + log message, distinguishing "no daemon" from "daemon
 /// rejected the new config" matters for operator scripts. Most
 /// variants are Linux-only since the underlying signal/PID-file flow
 /// is Linux-only; the macOS dev build gates them behind a generic
 /// stub.
 #[derive(Debug, thiserror::Error)]
 pub enum ReconfigureError {
-    /// Config / pidfile / proc IO error — exit 2 (runtime).
+    /// Config / pidfile / proc IO error, exit 2 (runtime).
     #[error("{0}")]
     Io(String),
-    /// PID file absent or stale — exit 1 (startup-style).
+    /// PID file absent or stale, exit 1 (startup-style).
     #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
     #[error("{0}")]
     DaemonNotRunning(String),
@@ -96,7 +96,7 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
         .validate_interfaces()
         .map_err(|e| RunError::Startup(e.to_string()))?;
 
-    // Fail fast if metrics-textfile can't be written — the exporter
+    // Fail fast if metrics-textfile can't be written, the exporter
     // would retry silently every 15s otherwise.
     if let Some(path) = &config.global.metrics_textfile {
         let parent = path.parent().unwrap_or_else(|| Path::new("."));
@@ -110,7 +110,7 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
 
     // Refuse startup if a circuit-breaker trip flag from a prior
     // invocation is still present. The flag is sticky across kernel
-    // reboots — SPEC §8.3 — and must be cleared by an operator.
+    // reboots, SPEC §8.3, and must be cleared by an operator.
     #[cfg(feature = "fast-path")]
     {
         let flag_path = packetframe_fast_path::breaker::trip_flag_path(&config.global.state_dir);
@@ -125,7 +125,7 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
 
     // Feasibility gate: refuse to attach if any required capability is
     // missing. The per-interface trial-attach probe (§2.3) runs here
-    // too — if a specific iface can't receive an XDP program at all,
+    // too, if a specific iface can't receive an XDP program at all,
     // the user finds out before we try to actually attach.
     let attach_ifaces = crate::feasibility::attach_ifaces_from_config(&config);
     let report = run_probes(&config.global.bpffs_root);
@@ -246,7 +246,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         );
     }
 
-    tracing::info!("fast-path running — SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
+    tracing::info!("fast-path running, SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
 
     let termination = drive_signal_loop(config_path, &config.global.state_dir, &mut modules)
         .map_err(RunError::Runtime)?;
@@ -273,7 +273,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
             // Breaker fired (SIGUSR1). Tear down pins so the kernel
             // detaches; the sticky trip flag is already on disk so
             // subsequent `run` invocations refuse to re-attach.
-            tracing::error!("circuit breaker tripped — detaching every module");
+            tracing::error!("circuit breaker tripped, detaching every module");
             for (name, module) in modules.iter_mut() {
                 if let Err(e) = module.detach() {
                     tracing::error!(module = %name, error = %e, "detach failed");
@@ -282,7 +282,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
             drop(modules);
         }
     }
-    // Best-effort PID file cleanup. Non-fatal — the file is harmless
+    // Best-effort PID file cleanup. Non-fatal, the file is harmless
     // if left behind (PID will be unrecognized on re-validate).
     if let Err(e) = std::fs::remove_file(&pid_file_path) {
         if e.kind() != std::io::ErrorKind::NotFound {
@@ -297,7 +297,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 }
 
 /// Open `path` for writing with `O_NOFOLLOW | O_EXCL | O_CREAT | 0600`
-/// — the symlink-safe atomic-write primitive both pidfile / marker
+/// the symlink-safe atomic-write primitive both pidfile / marker
 /// writes (here) and the metrics-textfile writer ([`crate::metrics`])
 /// use for their `.tmp` staging files.
 ///
@@ -307,7 +307,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 /// privileged daemon's write target. `O_EXCL` makes the open fail
 /// (`EEXIST`) when the path already exists, so a stale `.tmp`
 /// leftover from a crashed run is also surfaced rather than silently
-/// truncated and overwritten — callers handle that one-shot with
+/// truncated and overwritten, callers handle that one-shot with
 /// `unlink-and-retry`.
 ///
 /// The May 2026 audit Slice 4 finding flagged the previous use of
@@ -370,7 +370,7 @@ fn write_pid_file(path: &Path) -> std::io::Result<()> {
 
 /// Look through a module section's directives and return its
 /// `CircuitBreakerSpec`, if present. Multiple directives of the same
-/// kind aren't rejected by the parser — take the last one if so.
+/// kind aren't rejected by the parser, take the last one if so.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn extract_breaker_spec(
     section: &packetframe_common::config::ModuleSection,
@@ -419,7 +419,7 @@ fn drive_signal_loop(
                 return Ok(Termination::ExitPreserveAttach);
             }
             SIGUSR1 => {
-                tracing::warn!("SIGUSR1 received — breaker-triggered shutdown");
+                tracing::warn!("SIGUSR1 received, breaker-triggered shutdown");
                 return Ok(Termination::BreakerTrip);
             }
             _ => {}
@@ -430,7 +430,7 @@ fn drive_signal_loop(
 
 /// SIGHUP handler. Re-parses the config from `config_path` and calls
 /// `Module::reconfigure` on each loaded module. Parse failures and
-/// per-module reconfigure errors are logged and swallowed — a bad
+/// per-module reconfigure errors are logged and swallowed, a bad
 /// SIGHUP never kills the running data plane. Writes an ack marker
 /// to `state_dir/last-reconfigure.timestamp` for the
 /// `packetframe reconfigure` CLI to poll.
@@ -508,7 +508,7 @@ fn scrub_control_chars(s: &str) -> String {
 }
 
 /// Append a timestamp + status line to the reconfigure marker file.
-/// Non-fatal on I/O error — the SIGHUP handler still completed its
+/// Non-fatal on I/O error, the SIGHUP handler still completed its
 /// real work; the marker is just a hint to the CLI ack-poller.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn write_reconfigure_marker(path: &Path, status: &str) {
@@ -549,7 +549,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
 
     let pid = read_pid_file(&pid_path).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => ReconfigureError::DaemonNotRunning(format!(
-            "PID file not found at {} — daemon doesn't appear to be running",
+            "PID file not found at {}, daemon doesn't appear to be running",
             pid_path.display()
         )),
         _ => ReconfigureError::Io(format!("read PID file {}: {e}", pid_path.display())),
@@ -558,7 +558,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     // /proc/<pid>/exe cross-check defends against a stale PID file
     // pointing at a recycled PID. We previously consulted
     // /proc/<pid>/comm, but `comm` is user-settable via
-    // `prctl(PR_SET_NAME)` — any local user could rename a process
+    // `prctl(PR_SET_NAME)`, any local user could rename a process
     // to "packetframe" and be the target of the SIGHUP a root
     // reconfigure issues. The kernel publishes /proc/<pid>/exe as a
     // symlink to the process's executable inode and that link is not
@@ -615,7 +615,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
 #[cfg(not(target_os = "linux"))]
 pub fn reconfigure(_config_path: &Path) -> Result<(), ReconfigureError> {
     Err(ReconfigureError::Io(
-        "reconfigure is Linux-only — the daemon cannot run on this host".into(),
+        "reconfigure is Linux-only, the daemon cannot run on this host".into(),
     ))
 }
 
@@ -640,9 +640,9 @@ fn read_pid_file(path: &Path) -> std::io::Result<libc::pid_t> {
 ///
 /// Handles the `(deleted)` suffix the kernel appends when the
 /// executable file has been unlinked after the process started
-/// (rolling upgrade) — we accept the match if the prefix agrees.
+/// (rolling upgrade), we accept the match if the prefix agrees.
 ///
-/// Returns false on any I/O error or mismatch — the caller treats
+/// Returns false on any I/O error or mismatch, the caller treats
 /// that as "PID is not our process."
 #[cfg(target_os = "linux")]
 fn proc_exe_matches_current(pid: libc::pid_t) -> bool {
@@ -653,7 +653,7 @@ fn proc_exe_matches_current(pid: libc::pid_t) -> bool {
         return false;
     };
     let current = current.canonicalize().unwrap_or(current);
-    // Strip a trailing ` (deleted)` from the target — the kernel
+    // Strip a trailing ` (deleted)` from the target, the kernel
     // appends that when the inode has been unlinked since exec, e.g.
     // during a `cargo install --force` upgrade.
     let target_str = target.to_string_lossy();
@@ -662,7 +662,7 @@ fn proc_exe_matches_current(pid: libc::pid_t) -> bool {
 }
 
 /// Modified time of the marker file, in (secs, nanos). `None` if the
-/// file doesn't exist — used to detect "freshly written since
+/// file doesn't exist, used to detect "freshly written since
 /// SIGHUP." Any non-NotFound error is treated as "no observation,"
 /// which causes the poller to keep waiting until timeout.
 #[cfg(target_os = "linux")]
@@ -673,7 +673,7 @@ fn marker_mtime(path: &Path) -> Option<(i64, u32)> {
     Some((dur.as_secs() as i64, dur.subsec_nanos()))
 }
 
-/// Parse the marker body — `OK <ns>` or `ERR <category>: <message>`.
+/// Parse the marker body, `OK <ns>` or `ERR <category>: <message>`.
 #[cfg(target_os = "linux")]
 fn parse_reconfigure_marker(body: &str) -> Result<(), ReconfigureError> {
     let trimmed = body.trim();
@@ -744,7 +744,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // paths alone doesn't drop the kernel-side bpf_link refcount, so
     // the XDP program stays attached even after `detach` claims
     // success. The operator needs to SIGTERM/kill the daemon first.
-    // Confirmed outage-adjacent on the reference EFG 2026-04-21 — the
+    // Confirmed outage-adjacent on the reference EFG 2026-04-21, the
     // detach ran, reported clean, but `ip link show` still had
     // `xdpgeneric` attached.
     if let Some(pid) = daemon_pid() {
@@ -752,7 +752,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
             "a `packetframe run` daemon is still running (pid {pid}); \
              stop it first (e.g. `kill {pid}`) before detaching. \
              Detach unlinks bpffs pins, but the kernel-side bpf_link \
-             holds refs through the daemon's open FDs — both have to \
+             holds refs through the daemon's open FDs, both have to \
              be released for the iface to actually detach."
         ));
     }
@@ -774,7 +774,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     };
 
     // v0.1 has one module (fast-path), so `--all` and the default case
-    // behave identically — both tear down every pin under the module's
+    // behave identically, both tear down every pin under the module's
     // pin root. `--all` becomes meaningful once a second module ships.
     let _ = all;
 
@@ -798,7 +798,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
                 }
             }
             Ok(None) => {
-                tracing::info!("no pin registry found — sweeping bpffs pin root anyway");
+                tracing::info!("no pin registry found, sweeping bpffs pin root anyway");
             }
             Err(e) => return Err(format!("registry read: {e}")),
         }
@@ -806,7 +806,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         // Unlink every pin under `<bpffs-root>/fast-path/`. Removing
         // link pins triggers the kernel-side XDP detach (§8.5). Pace
         // by `attach_settle_time` so bridge-member detaches don't
-        // pile up inside one STP reconvergence window — that's the
+        // pile up inside one STP reconvergence window, that's the
         // post-rc5 fix for the EFG kernel-panic-on-detach observed
         // during Phase 4 cutover testing. Map + program pins are
         // housekeeping with no kernel-link side effects, no pacing.
@@ -866,7 +866,7 @@ pub fn status(config_path: &Path) -> Result<(), String> {
         print_tail_call_chain(&config.global.bpffs_root);
 
         // Live counter readback from the pinned STATS map. Works
-        // whether or not the loader is running — the pin survives
+        // whether or not the loader is running, the pin survives
         // process exit (§8.5).
         #[cfg(target_os = "linux")]
         print_stats(&config.global.bpffs_root);
@@ -882,11 +882,11 @@ fn print_tail_call_chain(bpffs_root: &Path) {
     println!("tail-call chain (from {}):", bpffs_root.display());
     match tail_call_chain_from_pin(bpffs_root) {
         Ok(true) => println!(
-            "  MUTATION_PROGS[0]: populated (finalize) — \
+            "  MUTATION_PROGS[0]: populated (finalize), \
              confirm prog_id via `bpftool prog show name finalize`"
         ),
         Ok(false) => println!(
-            "  MUTATION_PROGS[0]: <EMPTY> — fast_path's tail_call will fail; traffic \
+            "  MUTATION_PROGS[0]: <EMPTY>, fast_path's tail_call will fail; traffic \
              falls to kernel slow-path. Restart packetframe to repopulate."
         ),
         Err(e) => eprintln!("  MUTATION_PROGS pin unavailable ({e}); loader may not be attached"),
@@ -897,7 +897,7 @@ fn print_tail_call_chain(bpffs_root: &Path) {
 fn print_stats(bpffs_root: &Path) {
     // §4.6 counter names, indexed by `StatIdx` discriminants. Order
     // matches `crates/modules/fast-path/bpf/src/maps.rs::StatIdx`.
-    // Append-only — adding new entries at the end is fine; renumbering
+    // Append-only, adding new entries at the end is fine; renumbering
     // breaks dashboards. Indices 0-19 are the kernel-fib counter set;
     // 20-31 were appended in the Option F custom-FIB rollout (§4.11).
     const NAMES: [&str; 37] = [
@@ -960,7 +960,7 @@ fn print_stats(bpffs_root: &Path) {
     }
 }
 
-/// Print the Option F custom-FIB status — map occupancies, nexthop
+/// Print the Option F custom-FIB status, map occupancies, nexthop
 /// state distribution, default hash mode. Best-effort: prints
 /// whatever readable slice of the FIB pins returns. Runs regardless
 /// of forwarding-mode so operators can verify pins exist and the

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,11 @@
-//! `packetframe` — PacketFrame CLI.
+//! `packetframe`, PacketFrame CLI.
 //!
 //! See SPEC.md §7.4 for the subcommand surface. `run` loads + attaches
 //! the fast-path module via aya, persists the pin registry, and blocks
 //! on SIGTERM/SIGINT for graceful exit. `detach` and `status` read the
 //! pin registry and the live stats map respectively. SIGHUP triggers a
 //! delta-only reconcile (allowlists, VLAN-resolve, devmap) without
-//! detaching. `fib` (Option F, Phase 3.8 — see SPEC.md §4.11) opens
+//! detaching. `fib` (Option F, Phase 3.8, see SPEC.md §4.11) opens
 //! the pinned custom-FIB maps directly for inspection.
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
@@ -39,7 +39,7 @@ pub(crate) const DEFAULT_CONFIG_PATH: &str = "/etc/packetframe/packetframe.conf"
 
 /// Resolve a caller-supplied `Option<PathBuf>` against the default.
 /// Returns the caller's value if `Some`; otherwise returns the default
-/// path unchanged. We deliberately don't stat the path here — the
+/// path unchanged. We deliberately don't stat the path here, the
 /// config parser emits a clear "I/O error reading {path}" if the
 /// default file is missing, which is a more actionable error than a
 /// generic "provide --config".
@@ -51,7 +51,7 @@ pub(crate) fn config_path_or_default(caller: Option<PathBuf>) -> PathBuf {
 #[command(
     name = "packetframe",
     version,
-    about = "Modular eBPF data plane (see SPEC.md for the full spec).",
+    about = "Modular eBPF data plane.",
     long_about = None,
 )]
 struct Cli {
@@ -61,12 +61,12 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Command {
-    /// Probe the host kernel for PacketFrame's capability requirements (SPEC.md §2.1).
+    /// Probe the host kernel for PacketFrame's capability requirements.
     Feasibility {
         /// Optional config path. When supplied, `bpffs-root` from config is
         /// probed instead of the default, and configured interfaces are
         /// checked against /sys/class/net. Also enables the per-interface
-        /// XDP trial-attach probe (SPEC.md §2.3) for every `attach`ed iface.
+        /// XDP trial-attach probe for every `attach`ed iface.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Emit a human-readable table instead of JSON.
@@ -84,16 +84,15 @@ enum Command {
 
     /// Detach attached programs by removing every pin under the
     /// module's bpffs pin root. Removing a link pin triggers the
-    /// kernel-side XDP detach (SPEC.md §8.5); removing map + program
-    /// pins is housekeeping.
+    /// kernel-side XDP detach; removing map and program pins is
+    /// housekeeping.
     Detach {
         /// Path to the config file. Defaults to
         /// `/etc/packetframe/packetframe.conf`.
         #[arg(long)]
         config: Option<PathBuf>,
         /// Tear down every PacketFrame pin across every module, not
-        /// just the one in the supplied config. v0.1 has one module
-        /// so this is equivalent to the default.
+        /// just the one in the supplied config.
         #[arg(long)]
         all: bool,
     },
@@ -113,8 +112,8 @@ enum Command {
     /// `last-reconfigure.timestamp` marker for confirmation.
     /// Equivalent to `systemctl reload packetframe` under systemd.
     /// Attach-set changes (interfaces added/removed) require a full
-    /// restart and are silently skipped — `packetframe status` after
-    /// the reload shows what's currently attached.
+    /// restart and are silently skipped; run `packetframe status`
+    /// after the reload to see what's currently attached.
     Reconfigure {
         /// Path to the config file. Defaults to
         /// `/etc/packetframe/packetframe.conf`. Used to discover the
@@ -123,8 +122,9 @@ enum Command {
         config: Option<PathBuf>,
     },
 
-    /// Direct BPF map ops for debugging. Lands in PR #6 alongside
-    /// reconfigure (both need live map handles from the running loader).
+    /// Direct BPF map ops for debugging. Not yet implemented; both
+    /// this and `reconfigure` need live map handles from the running
+    /// loader.
     Map {
         module: String,
         map: String,
@@ -132,9 +132,8 @@ enum Command {
         args: Vec<String>,
     },
 
-    /// Inspect the custom-FIB maps (Option F, Phase 3.8). Opens the
-    /// pinned LPM tries / nexthop arrays directly — works without the
-    /// daemon running.
+    /// Inspect the custom-FIB maps. Opens the pinned LPM tries and
+    /// nexthop arrays directly; works without the daemon running.
     #[cfg(all(target_os = "linux", feature = "fast-path"))]
     Fib {
         #[command(subcommand)]
@@ -143,8 +142,9 @@ enum Command {
 
     /// Attach a diagnostic XDP program, dump the first 16 bytes of a
     /// sample of incoming packets, detach. Built to answer "what does
-    /// this driver hand to XDP?" — see SPEC.md §11.1(c) for the
-    /// rvu-nicpf native-delivery investigation that motivated it.
+    /// this driver hand to XDP?" when an interface's counters suggest
+    /// the driver is delivering something other than Ethernet-shaped
+    /// frames to native XDP.
     #[cfg(feature = "probe")]
     Probe {
         /// Interface to probe.
@@ -165,7 +165,7 @@ enum Command {
         /// Byte offset at which the BPF program samples each packet's
         /// head. Default `0` (start of `xdp->data`). Non-zero values
         /// are for diagnosing drivers that point `xdp->data` into
-        /// headroom instead of at the packet — e.g. `--offset 128`
+        /// headroom instead of at the packet, e.g. `--offset 128`
         /// on rvu-nicpf pre-Linux-v6.8 to see the real Ethernet
         /// header. Capped at 512.
         #[arg(long, default_value_t = 0)]
@@ -175,7 +175,7 @@ enum Command {
 
 #[cfg(feature = "probe")]
 fn parse_duration(s: &str) -> Result<Duration, String> {
-    // Unit suffixes: `ms`, `s`, `m` — parsed in longest-match order so
+    // Unit suffixes: `ms`, `s`, `m`, parsed in longest-match order so
     // `ms` wins over `s`. Bare integers are treated as seconds, which
     // matches the feel of most "how long" CLI flags.
     if let Some(num) = s.strip_suffix("ms") {
@@ -214,7 +214,7 @@ fn main() -> ExitCode {
         // Default: info from our crates, plus suppress one upstream
         // noise source. `bgpkit_parser::parser::bgp::messages`
         // emits a `WARN seeing strange one-byte NLRI field` whenever
-        // a BGP UPDATE arrives with a 1-byte NLRI section — which is
+        // a BGP UPDATE arrives with a 1-byte NLRI section, which is
         // the valid wire encoding of a default route (`0.0.0.0/0`:
         // prefix-length byte = 0, zero prefix bytes follow).
         // bgpkit-parser conservatively treats it as malformed and
@@ -301,7 +301,7 @@ fn main() -> ExitCode {
                 }
                 Err(loader::ReconfigureError::Timeout) => {
                     tracing::error!(
-                        "reconfigure: no acknowledgment from the daemon within 5s — \
+                        "reconfigure: no acknowledgment from the daemon within 5s, \
                          daemon may be wedged. Check `journalctl -u packetframe`."
                     );
                     ExitCode::from(EXIT_RUNTIME_ERROR)
@@ -357,7 +357,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
 fn not_implemented(name: &str) -> ExitCode {
     tracing::warn!(
         subcommand = name,
-        "not implemented in this release — tracked in the v0.1 plan"
+        "not implemented in this release, tracked in the v0.1 plan"
     );
     ExitCode::from(EXIT_RUNTIME_ERROR)
 }

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -90,13 +90,13 @@ fn write_once(textfile_path: &Path, bpffs_root: &Path, uptime_seconds: u64) -> R
 }
 
 /// Write-then-rename. The rename is atomic on POSIX when source and
-/// dest are on the same filesystem — node_exporter's textfile
+/// dest are on the same filesystem, node_exporter's textfile
 /// collector relies on this to never read a half-written file.
 ///
 /// The `.tmp` open uses `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` (see
 /// [`crate::loader::create_excl_no_follow`]) so a pre-existing
-/// symlink at the temp path cannot redirect the privileged write —
-/// the May 2026 audit Slice 4 finding.
+/// symlink at the temp path cannot redirect the privileged write.
+/// This was the May 2026 audit Slice 4 finding.
 fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     // Use the same filename with `.tmp` appended so we stay on the
     // same filesystem as the target (`with_extension("tmp")` would
@@ -113,7 +113,7 @@ fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         let mut f = crate::loader::create_excl_no_follow(&tmp).or_else(|e| {
             // Symmetry with the loader helper's retry path. On a
             // crashed predecessor, the .tmp leftover is a regular
-            // file — unlink and retry once. A symlink (attacker
+            // file, unlink and retry once. A symlink (attacker
             // pre-creation) trips O_NOFOLLOW on the retry too.
             if e.kind() == std::io::ErrorKind::AlreadyExists {
                 let meta = std::fs::symlink_metadata(&tmp)?;

--- a/crates/cli/src/probe.rs
+++ b/crates/cli/src/probe.rs
@@ -1,4 +1,4 @@
-//! `packetframe probe` subcommand — one-shot XDP diagnostic.
+//! `packetframe probe` subcommand, one-shot XDP diagnostic.
 //!
 //! Purpose per SPEC.md §11.1(c): let operators answer "what does this
 //! driver actually hand to XDP?" without editing and redeploying a
@@ -7,7 +7,7 @@
 //! and prints the collected samples.
 //!
 //! The formatted output is deliberately plain text keyed on the first
-//! 16 bytes of each sample — an operator scanning for `01 23 45 67 89
+//! 16 bytes of each sample, an operator scanning for `01 23 45 67 89
 //! ab 0b 16 17 c8 52 01 08 00` (six dst MAC, six src MAC, Ethernet
 //! type = IPv4) is the happy path; seeing a consistent 16-byte header
 //! that doesn't match that shape is the §11.1(c) smoking gun.
@@ -71,7 +71,7 @@ fn print_report(iface: &str, duration: Duration, out: &ProbeOutput) {
         return;
     }
     if !out.saw_traffic {
-        println!("(ringbuf was empty throughout — duration exceeded packet arrival)");
+        println!("(ringbuf was empty throughout, duration exceeded packet arrival)");
     }
 
     println!();
@@ -112,9 +112,9 @@ fn format_head_hex(head: &[u8; 16]) -> String {
 
 /// Heuristic summary: tries to tell the operator in one line whether
 /// the head bytes look like a standard Ethernet frame. False positives
-/// are fine — the operator still has the raw bytes above to inspect.
+/// are fine, the operator still has the raw bytes above to inspect.
 /// False negatives would be worse, but given we only flag "definitely
-/// looks like Ethernet" positively, the fallback is just "unknown" —
+/// looks like Ethernet" positively, the fallback is just "unknown"
 /// which is the honest thing to say on a non-conformant driver.
 fn summarize(samples: &[ProbeEvent]) -> String {
     if samples.is_empty() {
@@ -124,11 +124,11 @@ fn summarize(samples: &[ProbeEvent]) -> String {
     let n = samples.len();
 
     // Count how many samples have a plausible Ethernet ethertype at
-    // bytes 12..14 — 0x0800 (IPv4), 0x86dd (IPv6), 0x8100 (802.1Q),
+    // bytes 12..14, 0x0800 (IPv4), 0x86dd (IPv6), 0x8100 (802.1Q),
     // 0x88a8 (802.1ad), 0x0806 (ARP). If most samples match, the
     // driver is probably conformant. If almost none match, the first
     // 16 bytes likely include a descriptor prefix rather than the
-    // Ethernet header — the §11.1(c) signature.
+    // Ethernet header, the §11.1(c) signature.
     let ethertype_plausible = samples
         .iter()
         .filter(|s| {
@@ -142,7 +142,7 @@ fn summarize(samples: &[ProbeEvent]) -> String {
 
     // Check for a common-prefix signature: if all N samples share a
     // fixed first-k-bytes prefix, that prefix is almost certainly a
-    // driver descriptor and not a variable MAC address — which would
+    // driver descriptor and not a variable MAC address, which would
     // differ per-flow. k of 8 is enough to distinguish (two hosts
     // rarely share the whole first 8 bytes of an Ethernet frame).
     let common_prefix_len = common_prefix_len(samples);
@@ -179,7 +179,7 @@ fn summarize(samples: &[ProbeEvent]) -> String {
             .join(" ");
         lines.push(format!(
             "  Common {common_prefix_len}-byte prefix across all {n} samples: {prefix} \
-             — unusual for real Ethernet (MACs would vary); suggests a driver descriptor."
+            , unusual for real Ethernet (MACs would vary); suggests a driver descriptor."
         ));
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -6,7 +6,7 @@
 //! section until the next section header. Unknown directives are fatal.
 //!
 //! Interface-existence checks for `attach` directives are performed by
-//! [`Config::validate_interfaces`] rather than the parser — the parser stays
+//! [`Config::validate_interfaces`] rather than the parser, the parser stays
 //! pure so it can run in contexts without `/sys/class/net` (tests, non-root,
 //! cross-host audit).
 
@@ -70,7 +70,7 @@ pub struct GlobalConfig {
     pub state_dir: PathBuf,
     /// Pause between per-iface attaches during `packetframe run` to let
     /// each link settle before the next attach touches the driver. See
-    /// SPEC.md §11.8 — on some drivers (rvu-nicpf observed) XDP attach
+    /// SPEC.md §11.8, on some drivers (rvu-nicpf observed) XDP attach
     /// briefly bounces the link, and attaching two bridge slaves of the
     /// same bridge inside one STP reconvergence window can trigger an
     /// L2 loop. Default 2s. `0s` disables.
@@ -151,14 +151,14 @@ pub enum ModuleDirective {
     /// /24 with an unresolvable next-hop (a self-IP for direct-origin
     /// routes), so without per-host /32 entries the LPM lookup hits
     /// the /24 with `state=Incomplete` and bumps `custom_fib_no_neigh`
-    /// — XDP_PASS to kernel for every packet. With a `local-prefix`
+    /// XDP_PASS to kernel for every packet. With a `local-prefix`
     /// directive, [`NetlinkNeighborResolver`] walks the kernel's
     /// neighbour table for IPs within `cidr` reachable via `iface`
     /// and synthesizes per-/32 `RouteEvent::Add { peer_id: LocalArp,
     /// prefix: /32, nexthops: [host_ip] }` events into FibProgrammer.
     /// The host's own MAC (already in the kernel ARP cache) is what
     /// `state=Resolved` writes into `NEXTHOPS[id].dst_mac`, and the
-    /// /32 wins in the LPM walk over the /24 from the BGP feed —
+    /// /32 wins in the LPM walk over the /24 from the BGP feed
     /// inbound packets to that customer fast-path via `bpf_redirect_map`.
     /// New in v0.2.1; complements the BgpListener fallback fix.
     LocalPrefix {
@@ -186,7 +186,7 @@ pub enum ModuleDirective {
     /// know (RFC 1918, CGNAT, test-net, anything outside DFZ) misses
     /// LPM, falls to slow path, and clogs conntrack with flows that
     /// just get dropped upstream anyway. With this fallback, those
-    /// packets XDP-redirect to upstream — same upstream behavior,
+    /// packets XDP-redirect to upstream, same upstream behavior,
     /// but conntrack stays out of it.
     FallbackDefault {
         iface: String,
@@ -197,7 +197,7 @@ pub enum ModuleDirective {
     /// falls in `block-prefix <cidr>` AND the packet is otherwise
     /// allowlist-matched, the program returns `XDP_DROP` rather than
     /// XDP_PASS-to-kernel. Used to drop traffic toward bogons /
-    /// RFC 1918 / CGNAT — destinations that would just get RST'd
+    /// RFC 1918 / CGNAT, destinations that would just get RST'd
     /// upstream anyway, but currently waste skb allocation +
     /// netfilter walk + conntrack capacity. Operator opt-in: empty
     /// list = no behavior change.
@@ -210,15 +210,15 @@ pub enum ModuleDirective {
     /// fire on fast-pathed flows because XDP redirect bypasses
     /// netfilter. Four grammars:
     ///
-    /// - `mss-clamp <mtu>` — global default for all matched TCP SYNs
-    /// - `mss-clamp via <iface> <mtu>` — per-egress-iface
-    /// - `mss-clamp <cidr> <mtu>` — per-src-or-dst-prefix (any egress)
-    /// - `mss-clamp <cidr> via <iface> <mtu>` — most specific
+    /// - `mss-clamp <mtu>`, global default for all matched TCP SYNs
+    /// - `mss-clamp via <iface> <mtu>`, per-egress-iface
+    /// - `mss-clamp <cidr> <mtu>`, per-src-or-dst-prefix (any egress)
+    /// - `mss-clamp <cidr> via <iface> <mtu>`, most specific
     ///
     /// Lookup precedence at XDP runtime, most specific wins:
     /// `(prefix + iface)` then `prefix` then `iface` then `global`.
     /// Prefix matches on src OR dst (mirrors `allow-prefix`).
-    /// Lower-if-higher policy — only rewrites when the SYN's existing
+    /// Lower-if-higher policy, only rewrites when the SYN's existing
     /// MSS is greater than the configured clamp (matches iptables
     /// `TCPMSS --set-mss` semantics).
     MssClamp {
@@ -231,7 +231,7 @@ pub enum ModuleDirective {
     CircuitBreaker(CircuitBreakerSpec),
     /// Operator override for a driver-specific workaround. Currently
     /// the only defined knob is `rvu-nicpf-head-shift` (SPEC
-    /// §11.1(c)) — see [`DriverWorkaround`] for the axes.
+    /// §11.1(c)), see [`DriverWorkaround`] for the axes.
     DriverWorkaround(DriverWorkaround),
     // --- Custom FIB (Option F, Phase 1) ---
     /// Selects the forwarding lookup path. `kernel-fib` (default)
@@ -240,14 +240,14 @@ pub enum ModuleDirective {
     /// runs both and bumps CompareAgree/CompareDisagree (pre-cutover
     /// validation, temporary).
     ForwardingMode(ForwardingMode),
-    /// RouteSource configuration — where the custom FIB gets its
+    /// RouteSource configuration, where the custom FIB gets its
     /// routes. Two kinds: `bmp <addr>:<port>` and `bgp <addr>:<port>
     /// local-as <asn> peer-as <asn>`. Spawned by the RouteController
     /// when this is set and `forwarding-mode` is `custom-fib` or
     /// `compare`. See [`RouteSourceSpec`] for the per-kind shape.
     RouteSource(RouteSourceSpec),
     /// Max entries for the custom-FIB LPM tries and side arrays.
-    /// Accepted but **not yet runtime-applied** — aya / kernel
+    /// Accepted but **not yet runtime-applied**, aya / kernel
     /// allocate maps at compile-time sizes set in
     /// `crates/modules/fast-path/bpf/src/maps.rs`. The directive is
     /// preserved for operator config forward-compatibility; actual
@@ -259,7 +259,7 @@ pub enum ModuleDirective {
     EcmpDefaultHashMode(EcmpHashMode),
 }
 
-/// One side of the [`ModuleDirective::MssClamp`] discriminator —
+/// One side of the [`ModuleDirective::MssClamp`] discriminator
 /// either an IPv4 or IPv6 prefix. Userspace dispatches on this when
 /// populating the `MSS_CLAMP_V4` / `MSS_CLAMP_V6` LPM tries.
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
@@ -269,7 +269,7 @@ pub enum MssClampPrefix {
     V6(Ipv6Prefix),
 }
 
-/// Forwarding-path selector. `KernelFib` keeps today's behavior —
+/// Forwarding-path selector. `KernelFib` keeps today's behavior
 /// bpf_fib_lookup() and the legacy success path. `CustomFib` routes
 /// through the Option-F LPM trie + nexthop cache. `Compare` runs
 /// both and bumps disagreement counters; the kernel result is
@@ -299,7 +299,7 @@ impl FromStr for ForwardingMode {
 
 /// RouteSource configuration. Two impls today: BMP and iBGP. BGP
 /// is the recommended forwarding feed because bird's BMP
-/// implementation lacks RFC 9069 Loc-RIB — see
+/// implementation lacks RFC 9069 Loc-RIB, see
 /// `route_source_bgp.rs` module docs and
 /// `docs/runbooks/custom-fib.md` for the rationale.
 ///
@@ -323,7 +323,7 @@ pub enum RouteSourceSpec {
     /// with peer_type = 3 (RFC 9069 Loc-RIB Instance Peer) are
     /// accepted; pre/post-policy frames cause the session to be
     /// torn down with an error. **This is required for safe use
-    /// against pre/post-policy emitters** like bird 2.x — without
+    /// against pre/post-policy emitters** like bird 2.x, without
     /// it, multiple peers' Adj-RIB-In streams would race-overwrite
     /// per-prefix nexthops in the FIB and produce silent
     /// wrong-forwarding. See module docs in
@@ -344,7 +344,7 @@ pub enum RouteSourceSpec {
         /// (must be empty) when `allow_remote` is false.
         peer_from: Vec<ipnet::IpNet>,
     },
-    /// iBGP listener — packetframe accepts an iBGP session from
+    /// iBGP listener, packetframe accepts an iBGP session from
     /// bird and ingests UPDATEs as bird's selected best paths.
     /// `local_as`/`peer_as` are typically equal (iBGP within one AS);
     /// `router_id` defaults to `addr` when not specified.
@@ -371,7 +371,7 @@ pub enum RouteSourceSpec {
 }
 
 /// One `fib-*-max-entries` directive. Parsed but not runtime-applied
-/// — see the doc on [`ModuleDirective::FibSize`].
+/// see the doc on [`ModuleDirective::FibSize`].
 #[derive(Debug, Clone, Copy, Serialize, PartialEq, Eq)]
 pub enum FibSizeDirective {
     FibV4MaxEntries(u32),
@@ -540,7 +540,7 @@ pub struct CircuitBreakerSpec {
     pub threshold: u32,
 }
 
-// CircuitBreakerSpec is Eq-by-bit-pattern if you squint at the f64 — but we
+// CircuitBreakerSpec is Eq-by-bit-pattern if you squint at the f64, but we
 // don't rely on it. Implement a tolerant Eq for tests without going through
 // f64::total_cmp.
 impl Eq for CircuitBreakerSpec {}
@@ -549,7 +549,7 @@ impl Eq for CircuitBreakerSpec {}
 #[serde(rename_all = "lowercase")]
 pub enum CircuitBreakerDenominator {
     Matched,
-    // Rx — reserved, parser rejects with a clear error in v0.0.1.
+    // Rx, reserved, parser rejects with a clear error in v0.0.1.
 }
 
 /// Minimal humantime-like serializer for Duration, so the report JSON shows
@@ -580,8 +580,8 @@ impl Config {
     pub fn from_file(path: impl AsRef<Path>) -> Result<Self, ConfigError> {
         let path = path.as_ref();
         // Pre-flight size check via metadata so we never `read_to_string`
-        // a runaway file. Symlinks are followed deliberately — operators
-        // do symlink configs in deploy layouts — but a deeply nested
+        // a runaway file. Symlinks are followed deliberately, operators
+        // do symlink configs in deploy layouts, but a deeply nested
         // attacker-pointed symlink chain bottoms out at a real file
         // whose size we can still measure here.
         if let Ok(meta) = fs::metadata(path) {
@@ -654,7 +654,7 @@ fn parse(input: &str) -> Result<Config, ConfigError> {
     // `global` and `module` are reserved keywords: they are always parsed as
     // section headers regardless of indentation. Per SPEC.md §6, leading
     // whitespace is ignored, so we can't use indent to disambiguate. Module
-    // directives must therefore never be named "global" or "module" — fine,
+    // directives must therefore never be named "global" or "module", fine,
     // since the grammar enumerates them and does neither.
     for (idx, raw_line) in input.lines().enumerate() {
         let line = idx + 1;
@@ -1079,7 +1079,7 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             Ok(ModuleDirective::BlockPrefix { cidr: p, line })
         }
         "mss-clamp" => {
-            // v0.2.4+ — four grammars accepted:
+            // v0.2.4+, four grammars accepted:
             //   mss-clamp <mtu>
             //   mss-clamp via <iface> <mtu>
             //   mss-clamp <cidr> <mtu>
@@ -1154,7 +1154,7 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             let mss: u16 = mss_tok.parse().map_err(|e| {
                 ConfigError::parse(line, format!("mss-clamp: bad MTU `{mss_tok}`: {e}"))
             })?;
-            // 88 = TCP/IP minimum (RFC 879/1122 — 40-byte v4+TCP
+            // 88 = TCP/IP minimum (RFC 879/1122, 40-byte v4+TCP
             // header on a 128-byte frame, less than 88 starts breaking
             // assumptions). 65495 = max ethernet payload minus a v4 +
             // TCP header (65535 - 40). Outside this range is almost
@@ -1463,7 +1463,7 @@ fn parse_route_source<'a>(
 }
 
 /// Cross-check that the listen address and the authorization opt-in
-/// agree. The rules — same shape for both kinds:
+/// agree. The rules, same shape for both kinds:
 ///
 /// - Loopback address (127.0.0.0/8, ::1): default-allow with no
 ///   extra keywords. `allow-remote`, `peer-from`, and `peer-ip` are
@@ -1471,7 +1471,7 @@ fn parse_route_source<'a>(
 ///   ::1 to gate on.
 /// - Non-loopback address: requires `allow-remote` AND at least one
 ///   `peer-from <cidr>`. Without those, the listener would accept
-///   any TCP connection that reaches the port and inject routes —
+///   any TCP connection that reaches the port and inject routes
 ///   which the audit (May 2026) flagged as the highest-severity
 ///   finding.
 ///
@@ -2327,7 +2327,7 @@ module fast-path
     #[test]
     fn route_source_bgp_non_loopback_requires_opt_in() {
         // Binding 0.0.0.0 without `allow-remote` is the failure mode
-        // the audit (May 2026) flagged as Critical — any TCP-reachable
+        // the audit (May 2026) flagged as Critical, any TCP-reachable
         // host could speak iBGP and inject routes. Reject at parse
         // time so the operator can't silently misconfigure into the
         // unsafe state.
@@ -2407,7 +2407,7 @@ module fast-path
 
     #[test]
     fn route_source_bgp_peer_from_without_allow_remote_on_loopback_errors() {
-        // Loopback listen + peer-from is a config contradiction — the
+        // Loopback listen + peer-from is a config contradiction, the
         // ACL has no work to do because all accepted connections come
         // from 127.x. Catching this at parse-time tells the operator
         // their intent is unclear before the daemon starts.
@@ -2502,7 +2502,7 @@ module fast-path
 
     #[test]
     fn route_source_ipv6_loopback_accepts_default() {
-        // The IPv6 loopback (::1) must round-trip the same as 127.x —
+        // The IPv6 loopback (::1) must round-trip the same as 127.x
         // a default-permissive bind that doesn't need allow-remote.
         match extract_route_source("  route-source bgp [::1]:1179 local-as 1 peer-as 1\n") {
             RouteSourceSpec::Bgp { addr, .. } => assert_eq!(addr, "[::1]"),
@@ -2582,7 +2582,7 @@ module fast-path
         let e = parse_module_body("  local-prefix 10.0.0.0/24 via has space\n").unwrap_err();
         match e {
             ConfigError::Parse { message, .. } => {
-                // "has space" — the parser splits on whitespace so the
+                // "has space", the parser splits on whitespace so the
                 // second token is `space`. Either error is acceptable;
                 // they both flag a problem.
                 assert!(
@@ -2777,7 +2777,7 @@ module fast-path
 
     #[test]
     fn local_prefix_arp_scavenge_accepts_slash22_boundary() {
-        // /22 = 1024 hosts is the boundary — should be allowed.
+        // /22 = 1024 hosts is the boundary, should be allowed.
         let m =
             parse_module_body("  local-prefix 10.0.0.0/22 via br0 arp-scavenge\n").expect("parse");
         assert_eq!(m.directives.len(), 1);

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! Phase 1 defines only the trait surfaces so Phase 2-3 can land
 //! concrete implementations (BMP station, netlink neighbor listener,
-//! FibProgrammer) without churning the shape. No impls here — the
+//! FibProgrammer) without churning the shape. No impls here, the
 //! fast-path module owns its own concrete impls under
 //! `crates/modules/fast-path/src/fib/`.
 
@@ -23,7 +23,7 @@ pub trait RouteSource: Send {
     /// shutdown.
     ///
     /// Phase 1 sink / shutdown types are intentionally unspecified
-    /// at the trait level — Phase 3 lands a concrete channel pair
+    /// at the trait level, Phase 3 lands a concrete channel pair
     /// under `crates/modules/fast-path/src/fib/` along with the
     /// BMP station impl.
     fn run(&mut self) -> Result<(), RouteSourceError>;
@@ -245,7 +245,7 @@ pub enum NeighEvent {
     /// redirected frames). Added in Phase 3.6; pre-3.6 the programmer
     /// wrote `0x00…00` here, which works on most switches but breaks
     /// policy tools that inspect src_mac. `[0; 6]` is still a valid
-    /// value when the resolver couldn't look up the egress MAC — the
+    /// value when the resolver couldn't look up the egress MAC, the
     /// programmer writes whatever's provided.
     Learned {
         ip: IpAddr,

--- a/crates/common/src/module.rs
+++ b/crates/common/src/module.rs
@@ -47,7 +47,7 @@ pub enum HookType {
 
 /// A single hook use declared by a module. Priority ordering per SPEC.md §3.2
 /// (lower = runs earlier under the future dispatcher). In v0.0.1 with a
-/// single-module deployment, priorities are recorded but not consulted —
+/// single-module deployment, priorities are recorded but not consulted
 /// SPEC.md §3.4.
 #[derive(Debug, Clone, Copy)]
 pub struct HookUse {
@@ -91,7 +91,7 @@ pub struct LoaderCtx<'a> {
 }
 
 /// Context supplied to `Module::health_check` when circuit breakers evaluate.
-/// v0.0.1 is empty — populated with per-counter deltas in v0.1.
+/// v0.0.1 is empty, populated with per-counter deltas in v0.1.
 #[derive(Debug, Default)]
 pub struct HealthCtx {
     // Deliberately empty until v0.1 wires in counter samples.
@@ -142,7 +142,7 @@ pub struct SubsystemHealth {
 /// Structured health report returned by `Module::health_check`.
 ///
 /// Carries an overall state plus a `Vec<SubsystemHealth>` for
-/// modules with internal subsystems — e.g. fast-path's
+/// modules with internal subsystems, e.g. fast-path's
 /// RouteController, which can report BMP + netlink + FibProgrammer
 /// freshness independently. Modules without subsystems return
 /// `HealthReport::default()` (an empty, healthy report).
@@ -157,7 +157,7 @@ pub struct HealthReport {
 }
 
 impl HealthReport {
-    /// An empty, healthy report — the default any module with no
+    /// An empty, healthy report, the default any module with no
     /// subsystems to report on can return.
     pub fn healthy() -> Self {
         Self::default()
@@ -183,7 +183,7 @@ impl<'a> MetricsWriter<'a> {
 /// Every PacketFrame module implements this. The shape is stable across
 /// modules so the loader can drive them polymorphically; see SPEC.md §3.2 for
 /// the per-method contract (notably: `detach` must complete in under 1s, and
-/// `reconfigure` must not reload programs — only mutate maps).
+/// `reconfigure` must not reload programs, only mutate maps).
 pub trait Module: Send + Sync {
     fn name(&self) -> &'static str;
 

--- a/crates/common/src/probe/bpf.rs
+++ b/crates/common/src/probe/bpf.rs
@@ -214,7 +214,7 @@ pub unsafe fn bpf_syscall(cmd: u32, attr: *const u8, size: u32) -> io::Result<i6
 /// host as unsupported without a build failure on dev laptops.
 ///
 /// # Safety
-/// Trivially safe — ignores all arguments.
+/// Trivially safe, ignores all arguments.
 #[cfg(not(target_os = "linux"))]
 #[allow(unused_unsafe)]
 pub unsafe fn bpf_syscall(_cmd: u32, _attr: *const u8, _size: u32) -> io::Result<i64> {
@@ -259,7 +259,7 @@ pub struct ProgLoadOutcome {
 }
 
 /// Attempt to load a BPF program with a verifier log buffer. Returns outcome
-/// including the log content regardless of success — callers use the log to
+/// including the log content regardless of success, callers use the log to
 /// distinguish "helper unknown" vs "other verifier rejection".
 pub fn prog_load(prog_type: u32, insns: &[BpfInsn], license: &str) -> io::Result<ProgLoadOutcome> {
     let license_c = CString::new(license).expect("license has no NUL");
@@ -278,7 +278,7 @@ pub fn prog_load(prog_type: u32, insns: &[BpfInsn], license: &str) -> io::Result
     attr.insn_cnt = insns.len() as u32;
     attr.insns = insns.as_ptr() as u64;
     attr.license = license_c.as_ptr() as u64;
-    attr.log_level = 1; // BPF_LOG_LEVEL1 — emit verifier log
+    attr.log_level = 1; // BPF_LOG_LEVEL1, emit verifier log
     attr.log_size = log_buf.len() as u32;
     attr.log_buf = log_buf.as_mut_ptr() as u64;
 

--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -3,7 +3,7 @@
 //! The loader refuses to start if any *required* capability is missing; the
 //! feasibility subcommand (`packetframe feasibility`) renders the full
 //! report. Per-interface native-XDP trial-attach (§2.3) is deferred to v0.1,
-//! since it requires a real program to attach — reported here as Deferred.
+//! since it requires a real program to attach, reported here as Deferred.
 
 pub mod bpf;
 
@@ -112,7 +112,7 @@ impl FeasibilityReport {
 /// will use for pins (matches the `bpffs-root` config directive, default
 /// `/sys/fs/bpf/packetframe`).
 pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
-    // Helpers — probed by loading minimal XDP programs and inspecting the
+    // Helpers, probed by loading minimal XDP programs and inspecting the
     // verifier log. Any log substring matching "unknown func" /
     // "unrecognized bpf_func_id" / "invalid func" means the helper is not
     // compiled into this kernel.
@@ -164,7 +164,7 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
     ));
     caps.push(probe_memlock());
 
-    // §2.3 per-interface native-XDP trial-attach — deferred. The probe needs
+    // §2.3 per-interface native-XDP trial-attach, deferred. The probe needs
     // a real attachable program, which doesn't exist in v0.0.1.
     caps.push(Capability::deferred(
         "xdp.per_interface_attach_probe",
@@ -270,29 +270,29 @@ fn probe_bpf_syscall_available() -> Capability {
         ),
         BpfSyscallStatus::NotImplemented => Capability::fail(
             "syscall.bpf",
-            "bpf() syscall not implemented (ENOSYS) — kernel lacks BPF support",
+            "bpf() syscall not implemented (ENOSYS), kernel lacks BPF support",
             true,
         ),
         BpfSyscallStatus::Permission => Capability::fail(
             "syscall.bpf",
-            "bpf() returned EPERM — run as root (kernel.unprivileged_bpf_disabled likely set)",
+            "bpf() returned EPERM, run as root (kernel.unprivileged_bpf_disabled likely set)",
             true,
         ),
         BpfSyscallStatus::UnexpectedOk => Capability::unknown(
             "syscall.bpf",
-            "bpf() returned OK for a bogus cmd — unexpected, kernel version mismatch?",
+            "bpf() returned OK for a bogus cmd, unexpected, kernel version mismatch?",
             true,
         ),
         BpfSyscallStatus::UnknownError => Capability::unknown(
             "syscall.bpf",
-            "bpf() returned an error without errno — unexpected",
+            "bpf() returned an error without errno, unexpected",
             true,
         ),
     }
 }
 
 fn probe_prog_type(name: &str, prog_type: u32, required: bool) -> Capability {
-    // mov r0, 0; exit — a valid trivial program for any prog_type we care
+    // mov r0, 0; exit, a valid trivial program for any prog_type we care
     // about (XDP returns XDP_ABORTED=0, sched_cls returns TC_ACT_OK=0).
     let insns = [mov64_imm(0, 0), exit_insn()];
     match prog_load(prog_type, &insns, "GPL") {
@@ -323,25 +323,25 @@ fn probe_helper(name: &str, helper_id: i32, required: bool) -> Capability {
             if out.fd.is_some() {
                 return Capability::pass(name, "helper present (program accepted)", required);
             }
-            // ENOSYS means the bpf() syscall itself is unavailable — not a
+            // ENOSYS means the bpf() syscall itself is unavailable, not a
             // helper verdict. Without a verifier run we can't say anything
             // about helper presence; defer to the syscall.bpf cap for the
             // real signal.
             if out.errno == Some(libc::ENOSYS) {
                 return Capability::fail(
                     name,
-                    "bpf() syscall unavailable (ENOSYS) — see syscall.bpf",
+                    "bpf() syscall unavailable (ENOSYS), see syscall.bpf",
                     required,
                 );
             }
             // EPERM typically means we're not root and the kernel is
             // hardened (SPEC.md §2.2 on `unprivileged_bpf_disabled=2`). The
-            // verifier doesn't run, so there's no log — we can't tell
+            // verifier doesn't run, so there's no log, we can't tell
             // whether the helper exists or not.
             if out.errno == Some(libc::EPERM) {
                 return Capability::unknown(
                     name,
-                    "prog_load returned EPERM — run as root to probe helpers",
+                    "prog_load returned EPERM, run as root to probe helpers",
                     required,
                 );
             }
@@ -459,8 +459,8 @@ fn map_probe(
         Ok(_fd) => Capability::pass(name, "map_create succeeded", required),
         Err(e) => {
             let hint = match e.raw_os_error() {
-                Some(libc::EPERM) => " (EPERM — run as root)",
-                Some(libc::EINVAL) => " (EINVAL — map type likely unsupported)",
+                Some(libc::EPERM) => " (EPERM, run as root)",
+                Some(libc::EINVAL) => " (EINVAL, map type likely unsupported)",
                 _ => "",
             };
             Capability::fail(name, format!("map_create failed: {e}{hint}"), required)
@@ -512,7 +512,7 @@ fn probe_bpffs(path: &Path) -> Capability {
     // `statfs.f_type` varies by platform/libc: `i64` on glibc Linux x86_64,
     // `u32` on macOS, `u64` on some musl configs. Normalize to `i64` for
     // the comparison; clippy will call this unnecessary on whichever
-    // platform already has `i64` — the cast is still correct on every other.
+    // platform already has `i64`, the cast is still correct on every other.
     #[allow(clippy::unnecessary_cast)]
     let f_type = statfs.f_type as i64;
     if f_type == BPF_FS_MAGIC {

--- a/crates/modules/fast-path/bpf/Cargo.toml
+++ b/crates/modules/fast-path/bpf/Cargo.toml
@@ -13,7 +13,7 @@ publish = false
 # An empty `[workspace]` table makes this crate its own workspace root
 # so a nested `cargo build` (invoked from our parent's build.rs) does
 # not walk up and find the outer workspace. Without this, cargo errors
-# "current package believes it's in a workspace when it's not" — the
+# "current package believes it's in a workspace when it's not", the
 # outer `workspace.exclude` list alone is not sufficient when cargo is
 # invoked from within the excluded directory. See the companion note
 # in the root Cargo.toml's `[workspace].exclude`.
@@ -28,7 +28,7 @@ aya-ebpf = "=0.1.1"
 network-types = "=0.2.0"
 
 [profile.release]
-# BPF programs typically only pass the verifier in release mode — dev-mode
+# BPF programs typically only pass the verifier in release mode, dev-mode
 # debuginfo and lack of optimization produce instruction sequences the
 # verifier rejects as too long / loopy.
 opt-level = 3

--- a/crates/modules/fast-path/bpf/rust-toolchain.toml
+++ b/crates/modules/fast-path/bpf/rust-toolchain.toml
@@ -4,7 +4,7 @@
 # reviewed PR rather than `nightly` unqualified.
 #
 # `bpfel-unknown-none` is a tier-3 target with no precompiled `rust-std`
-# — we build `core` from source via `[unstable] build-std = ["core"]`
+#, we build `core` from source via `[unstable] build-std = ["core"]`
 # in `.cargo/config.toml`, which only needs `rust-src`. Do NOT list
 # `targets = ["bpfel-unknown-none"]` here; rustup would try to download
 # a nonexistent `rust-std` component.

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -130,7 +130,7 @@ pub fn lookup_v4(
     }
 }
 
-/// IPv6 custom-FIB lookup. See [`lookup_v4`] — same byte-order
+/// IPv6 custom-FIB lookup. See [`lookup_v4`], same byte-order
 /// contract on `sport` / `dport`.
 #[inline(always)]
 pub fn lookup_v6(
@@ -221,7 +221,7 @@ fn resolve_fib_value_v6(
 ///
 /// If the starting slot is resolved, returns immediately (the common
 /// case). If we walked past the starting slot, bump
-/// `EcmpDeadLegFallback` — that's diagnostic signal that a leg is
+/// `EcmpDeadLegFallback`, that's diagnostic signal that a leg is
 /// down and we're compensating.
 #[inline(always)]
 fn pick_ecmp_leg(group: &EcmpGroup, hash: u32) -> Option<u32> {
@@ -353,7 +353,7 @@ const JHASH_INITVAL: u32 = 0xdeadbeef;
 
 /// Jenkins 3-word mix (the `__jhash_mix` primitive). Six rounds of
 /// sub / xor / rot / add on three u32 lanes. Verifier-cost is 18
-/// integer ops + register pressure for 3 live values — comfortably
+/// integer ops + register pressure for 3 live values, comfortably
 /// under any realistic BPF instruction budget.
 #[inline(always)]
 fn jhash_mix(mut a: u32, mut b: u32, mut c: u32) -> (u32, u32, u32) {
@@ -408,7 +408,7 @@ fn jhash_final(mut a: u32, mut b: u32, mut c: u32) -> u32 {
 /// - mode 5 (L4): proto + sport + dport fully mixed.
 ///
 /// Fragmented / ICMP / non-TCP-UDP callers pass `sport = dport = 0`,
-/// which collapses mode 5 to effectively mode 3 for those packets —
+/// which collapses mode 5 to effectively mode 3 for those packets
 /// no port bits to distinguish. The layer above (main.rs) is what
 /// actually ensures the ports-zero case for non-L4 packets.
 #[inline(always)]

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -11,7 +11,7 @@
 //! Communication from `fast_path` is via two side channels:
 //! - The packet itself (preserved across `bpf_tail_call`).
 //! - `MUTATION_CTX` per-CPU scratch (egress info, ingress VID, IP offset,
-//!   v4/v6 discriminator) — written by fast_path, read here.
+//!   v4/v6 discriminator), written by fast_path, read here.
 //!
 //! See SPEC.md §4.x "Two-stage BPF datapath" and
 //! `docs/runbooks/tail-call-architecture.md`.
@@ -34,7 +34,7 @@ use crate::maps::{
 /// is self-contained.
 const TPID_8021Q: u16 = 0x8100;
 
-/// Sentinel for "no VLAN" — mirror of `main::VLAN_NONE`.
+/// Sentinel for "no VLAN", mirror of `main::VLAN_NONE`.
 const VLAN_NONE: u16 = 0;
 
 /// SYN flag in TCP byte 13.
@@ -46,7 +46,7 @@ const PROTO_TCP: u8 = IpProto::Tcp as u8;
 
 /// Upper bound on `ip_offset` post-VLAN-parse. Used to give the BPF
 /// verifier a tight `umax` so range propagation through packet-pointer
-/// arithmetic works — see commentary on the `ip_offset > MAX_IP_OFFSET`
+/// arithmetic works, see commentary on the `ip_offset > MAX_IP_OFFSET`
 /// check in `finalize`.
 const MAX_IP_OFFSET: usize = 64;
 
@@ -72,7 +72,7 @@ pub fn finalize(ctx: XdpContext) -> u32 {
     // Clamp ip_offset to MAX_IP_OFFSET (64). The BPF verifier's
     // `find_good_pkt_pointers` refuses to propagate range information
     // through packet-pointer arithmetic when the scalar offset's
-    // umax_value exceeds MAX_PACKET_OFF (0xffff) — which is the case
+    // umax_value exceeds MAX_PACKET_OFF (0xffff), which is the case
     // for `mctx.ip_offset` since it's read from a map and the verifier
     // sees its full u32 range. Capping the offset gives the verifier
     // a tight umax it can reason about, so the subsequent
@@ -89,7 +89,7 @@ pub fn finalize(ctx: XdpContext) -> u32 {
 
     // mss-clamp first, then VLAN choreography (which can shift bytes
     // via bpf_xdp_adjust_head). mss-clamp's TCP-options walk relies on
-    // ip_offset being valid relative to ctx.data() — true until VLAN
+    // ip_offset being valid relative to ctx.data(), true until VLAN
     // push/pop changes the layout.
     mss_clamp_inline(&ctx, ip_offset, is_v4, egress_ifindex);
 
@@ -114,13 +114,13 @@ pub fn finalize(ctx: XdpContext) -> u32 {
 
 /// Top-level entry: dispatch into the v4 or v6 path with a constant-sized
 /// bounds check. Splitting upfront (rather than threading `is_v4` through
-/// a single function) is what satisfies the BPF verifier — the bounds
+/// a single function) is what satisfies the BPF verifier, the bounds
 /// check needs to use a compile-time-known size so the verifier can
 /// track that subsequent reads via `*const Ipv4Hdr` / `*const Ipv6Hdr`
 /// stay within the checked region.
 ///
-/// The ergonomic alternative — `let size = if is_v4 { 20 } else { 40 };
-/// if start + offset + size > end { ... }; ip_addr as *const Ipv4Hdr` —
+/// The ergonomic alternative, `let size = if is_v4 { 20 } else { 40 };
+/// if start + offset + size > end { ... }; ip_addr as *const Ipv4Hdr`
 /// loses the verifier's bound-tracking when the cast is reached: see
 /// `R9 offset is outside of the packet` from the v0.2.5 prerelease build.
 #[inline(always)]
@@ -228,7 +228,7 @@ fn mss_clamp_tcp(ctx: &XdpContext, ip_ptr: *const u8, ip_hdr_size: usize, clamp:
         return;
     }
 
-    // Walk options. Cap at 8 — real SYN packets put MSS in the first
+    // Walk options. Cap at 8, real SYN packets put MSS in the first
     // 1-4 options (Linux's tcp_options_write emits MSS very early); 8
     // is comfortable headroom while keeping verifier state-space bounded.
     let opts_start_off = tcp_offset + 20;
@@ -392,7 +392,7 @@ fn apply_vlan_egress(ctx: &XdpContext, ingress_vid: u16, egress_vid: u16) -> Res
 /// rejects programs that combine tail-calls with bpf-to-bpf calls.
 /// Reading all 12 source bytes into local variables before any store
 /// also handles the source/destination overlap that `core::ptr::copy`
-/// (memmove) handles for us — without the libcall.
+/// (memmove) handles for us, without the libcall.
 #[inline(always)]
 fn vlan_push(ctx: &XdpContext, vid: u16) -> Result<(), ()> {
     let rc = unsafe { bpf_xdp_adjust_head(ctx.ctx as *mut _, -4) };
@@ -406,9 +406,9 @@ fn vlan_push(ctx: &XdpContext, vid: u16) -> Result<(), ()> {
     }
     unsafe {
         let base = start as *mut u8;
-        // Read all 12 source bytes (offsets 4..16 — the original MAC
+        // Read all 12 source bytes (offsets 4..16, the original MAC
         // pair, now shifted right by 4 from adjust_head) before writing
-        // anything. Then write to offsets 0..12. No overlap concern —
+        // anything. Then write to offsets 0..12. No overlap concern
         // source and dest don't co-exist in memory at the same time.
         let m0 = *base.add(4);
         let m1 = *base.add(5);
@@ -446,7 +446,7 @@ fn vlan_push(ctx: &XdpContext, vid: u16) -> Result<(), ()> {
 
 /// Tagged → untagged. Shifts the MAC pair right by 4 over the about-to-
 /// be-discarded TPID+TCI slot, then shrinks headroom by 4. Same
-/// byte-by-byte pattern as `vlan_push` — see commentary there for the
+/// byte-by-byte pattern as `vlan_push`, see commentary there for the
 /// `core::ptr::copy` libcall avoidance rationale.
 #[inline(always)]
 fn vlan_pop(ctx: &XdpContext) -> Result<(), ()> {
@@ -457,7 +457,7 @@ fn vlan_pop(ctx: &XdpContext) -> Result<(), ()> {
     }
     unsafe {
         let base = start as *mut u8;
-        // Read all 12 source bytes (offsets 0..12 — the MAC pair before
+        // Read all 12 source bytes (offsets 0..12, the MAC pair before
         // the 4-byte VLAN tag at offsets 12..16) before writing.
         let m0 = *base;
         let m1 = *base.add(1);

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -55,7 +55,7 @@ const PROTO_ICMPV6: u8 = IpProto::Ipv6Icmp as u8;
 /// 802.1Q reserves VID 0 for priority-only tagging, so `vid == 0`
 /// means absent from the fast-path's perspective. Using a single u16
 /// instead of `Option<u16>` keeps the value in one register across
-/// function-call boundaries — the verifier chokes on Option<u16>
+/// function-call boundaries, the verifier chokes on Option<u16>
 /// because the inner-value register is uninitialized on the None
 /// branch, failing with `Rn !read_ok` after argument spills.
 const VLAN_NONE: u16 = 0;
@@ -79,7 +79,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     // bug (SPEC §11.1(c)). The driver passes
     // `xdp_prepare_buff(&xdp, hard_start, data - hard_start, seg_size, false)`
     // with `data` pointing at `buffer_start`, 128 bytes before the
-    // actual packet — so `xdp->data` is headroom and `xdp->data_end`
+    // actual packet, so `xdp->data` is headroom and `xdp->data_end`
     // is `seg_size` bytes past `buffer_start`, which cuts off the
     // last 128 bytes of the frame. Rebalance both pointers: skip 128
     // bytes of leading headroom and extend the tail 128 bytes to
@@ -97,7 +97,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
             return xdp_action::XDP_PASS;
         }
         // `adjust_tail(+128)` can fail if the current frame is close
-        // to `xdp->frame_sz` — unlikely on rvu-nicpf (rbsize is 2048+)
+        // to `xdp->frame_sz`, unlikely on rvu-nicpf (rbsize is 2048+)
         // for MTU-sized traffic. `XDP_PASS` on failure preserves the
         // invariant that the kernel never sees a frame the fast path
         // has half-mutated (SPEC §11.13).
@@ -119,7 +119,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
 
 /// Read the `FpCfg.flags` byte via the CFG array map and check
 /// whether `bit` is set. Returns `false` if the map is somehow empty
-/// (shouldn't happen — userspace always populates it before attach).
+/// (shouldn't happen, userspace always populates it before attach).
 #[inline(always)]
 unsafe fn cfg_has_flag(bit: u8) -> bool {
     CFG.get(0).map(|c| c.flags & bit != 0).unwrap_or(false)
@@ -144,7 +144,7 @@ fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
         // Low 12 bits are the VID. Legal VIDs are 1..4094; 0 and 4095
         // are reserved. A VID of 0 here would collide with VLAN_NONE,
         // so treat it as absent (matches 802.1Q's "priority-only" tag
-        // semantics — we don't fast-path those either).
+        // semantics, we don't fast-path those either).
         let vid = tci & 0x0fff;
         let inner = unsafe { (*vlan).inner_ether_type };
         (inner, EthHdr::LEN + VLAN_HDR_LEN, vid)
@@ -210,7 +210,7 @@ fn handle_ipv4(
 
     // v0.2.1 issue #33: bogon block. After allowlist match (so we only
     // affect traffic we'd otherwise touch), check if dst falls in any
-    // operator-declared `block-prefix`. If so, drop here — saves the
+    // operator-declared `block-prefix`. If so, drop here, saves the
     // skb allocation, netfilter walk, and conntrack entry that this
     // packet would otherwise burn just to be RST'd by upstream. Empty
     // map (default config) → LPM lookup misses cheaply, no perf impact.
@@ -255,7 +255,7 @@ fn handle_ipv4(
     // elements are pre-zeroed at map creation by the kernel; we only
     // ever write the input fields the kernel reads. This sidesteps
     // LLVM's stack zero-init optimization that lowers adjacent zero
-    // stores into `memset` libcalls — those become bpf-to-bpf
+    // stores into `memset` libcalls, those become bpf-to-bpf
     // subprogram calls, which combined with `bpf_tail_call` violates
     // the kernel verifier's
     //   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
@@ -368,7 +368,7 @@ fn handle_ipv6(
 
     let (sport, dport) = l4_ports(ctx, ip_offset + Ipv6Hdr::LEN, next);
 
-    // Option F dispatch — see handle_ipv4 for commentary, including the
+    // Option F dispatch, see handle_ipv4 for commentary, including the
     // port byte-swap rationale.
     let use_custom = unsafe { cfg_has_flag(FP_CFG_FLAG_CUSTOM_FIB) };
     let compare = unsafe { cfg_has_flag(FP_CFG_FLAG_COMPARE_MODE) };
@@ -480,7 +480,7 @@ fn forward_success(
     ingress_vid: u16,
 ) -> Result<u32, ()> {
     // Resolve the egress port's expected tagging. If `ifindex` is
-    // recorded in `vlan_resolve`, it's a VLAN subif — redirect to the
+    // recorded in `vlan_resolve`, it's a VLAN subif, redirect to the
     // physical parent and push/rewrite to the recorded VID. Otherwise
     // the target is physical/untagged.
     let (egress_ifindex, egress_vid) = match unsafe { VLAN_RESOLVE.get(&ifindex) } {
@@ -488,7 +488,7 @@ fn forward_success(
         None => (ifindex, VLAN_NONE),
     };
 
-    // Defensive devmap pre-check (§4.4 step 9d) — **before any packet
+    // Defensive devmap pre-check (§4.4 step 9d), **before any packet
     // mutation**. A prior version rewrote L2 + ran VLAN choreography
     // first, then decided to XDP_PASS when the egress ifindex wasn't
     // in REDIRECT_DEVMAP. That handed the kernel a mangled packet
@@ -501,7 +501,7 @@ fn forward_success(
         return Ok(xdp_action::XDP_PASS);
     }
 
-    // TTL/hop_limit + csum — IP header's position in memory doesn't
+    // TTL/hop_limit + csum, IP header's position in memory doesn't
     // change with adjust_head, only its offset from `data`. Safe to do
     // before VLAN choreography (which lives in finalize).
     if is_v4 {
@@ -529,7 +529,7 @@ fn forward_success(
             (*mctx_ptr).ingress_vid = ingress_vid;
             (*mctx_ptr).ip_offset = ip_offset as u32;
             // is_v4 is u32 (no padding); low byte holds the bool.
-            // Single u32 store — LLVM has no adjacent zero stores to
+            // Single u32 store, LLVM has no adjacent zero stores to
             // merge into a memset libcall.
             (*mctx_ptr).is_v4 = u32::from(u8::from(is_v4));
         }
@@ -543,7 +543,7 @@ fn forward_success(
 
     // tail_call returns Err on slot-empty / invalid; on success it
     // doesn't return at all (control transfers to finalize). The Err
-    // branch is fail-safe — if userspace's populate_mutation_progs
+    // branch is fail-safe, if userspace's populate_mutation_progs
     // somehow skipped slot 0, traffic falls through to kernel rather
     // than getting silently dropped.
     let _ = unsafe { MUTATION_PROGS.tail_call(ctx, 0) };
@@ -553,7 +553,7 @@ fn forward_success(
 
 /// Dispatch on a [`fib::CustomFibResult`] returned by the custom-FIB
 /// path. Maps the four action codes into the same XDP verdicts
-/// `dispatch_fib` returns for the equivalent kernel-FIB outcomes —
+/// `dispatch_fib` returns for the equivalent kernel-FIB outcomes
 /// so the allowlist / dry-run / VLAN-resolve plumbing upstream and
 /// downstream is unchanged whether we took the kernel or custom path.
 #[inline(always)]
@@ -604,11 +604,11 @@ fn compare_and_bump(
     let kernel_forwards = kernel_ret == BPF_FIB_LKUP_RET_SUCCESS;
     let custom_forwards = custom.action == fib::FIB_ACTION_FORWARD;
     let agree = if kernel_forwards && custom_forwards {
-        // Both forward — compare the decision tuple.
+        // Both forward, compare the decision tuple.
         kernel_fib.ifindex == custom.egress_ifindex && kernel_fib.dmac == custom.dmac
     } else {
         // Both non-forward is "agree" (both defer upstream). Any
-        // mix — one forwards while the other doesn't — is disagree.
+        // mix, one forwards while the other doesn't, is disagree.
         !kernel_forwards && !custom_forwards
     };
     if agree {

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -15,7 +15,7 @@ use aya_ebpf::{
 /// Runtime flags poked by userspace via the `cfg` map. `version` is a
 /// reserved byte carved out now so future fields can be added without
 /// breaking userspace reads of older-layout BPF objects (SPEC §4.5 note:
-/// the `fp_cfg` struct has `...` — we enumerate exactly the fields
+/// the `fp_cfg` struct has `...`, we enumerate exactly the fields
 /// plus a version discriminator).
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -48,7 +48,7 @@ impl FpCfg {
     }
 }
 
-/// §4.6 counters. Discriminants are wire format — they are **append-only**
+/// §4.6 counters. Discriminants are wire format, they are **append-only**
 /// once v0.1 ships, since operator dashboards consume them by index. Do
 /// not renumber; add new counters to the end.
 #[repr(u32)]
@@ -76,7 +76,7 @@ pub enum StatIdx {
     /// `bpf_xdp_adjust_head` or `bpf_xdp_adjust_tail` failed while
     /// applying the `FP_CFG_FLAG_HEAD_SHIFT_128` workaround (SPEC
     /// §11.1(c)). Typically means the ingress frame is smaller than
-    /// the 128-byte shift — e.g. a 64-byte TCP ACK on a buggy-kernel
+    /// the 128-byte shift, e.g. a 64-byte TCP ACK on a buggy-kernel
     /// rvu-nicpf iface, which the workaround can't expose in full
     /// because the driver's `data_end` is 128 bytes short. The packet
     /// returns `XDP_PASS` unmodified; the counter tells operators how
@@ -125,11 +125,11 @@ pub enum StatIdx {
     /// the bogon-block is catching.
     BogonDropped = 32,
     /// v0.2.4: matched TCP SYN/SYN-ACK whose MSS option was rewritten
-    /// down to the configured clamp value (SPEC §4.x — closes §11.4
+    /// down to the configured clamp value (SPEC §4.x, closes §11.4
     /// gap). Bumped per packet, not per flow.
     MssClampApplied = 33,
     /// v0.2.4: matched TCP SYN/SYN-ACK that hit a clamp lookup but was
-    /// NOT rewritten — either the existing MSS option was already ≤ the
+    /// NOT rewritten, either the existing MSS option was already ≤ the
     /// clamp value (no-op), there was no MSS option in the SYN, or the
     /// TCP-options walk hit its bounded cap before finding one. Useful
     /// to gauge how often clamps are firing vs being skipped on existing
@@ -139,10 +139,10 @@ pub enum StatIdx {
     /// returned an error (slot empty / invalid). Should be 0 in steady
     /// state; non-zero means `populate_mutation_progs` failed at attach
     /// time. fast_path falls back to XDP_PASS so traffic still flows
-    /// (kernel slow path) — the chain is fail-safe.
+    /// (kernel slow path), the chain is fail-safe.
     ErrTailCall = 35,
     /// v0.2.5: finalize couldn't read the per-CPU `MUTATION_CTX`
-    /// scratch slot. Shouldn't happen — fast_path always writes before
+    /// scratch slot. Shouldn't happen, fast_path always writes before
     /// tail_call. Diagnostic; finalize XDP_PASSes on this error.
     ErrMutationCtx = 36,
 }
@@ -187,14 +187,14 @@ const REDIRECT_DEVMAP_MAX_ENTRIES: u32 = 64;
 const LOG_RINGBUF_BYTES: u32 = 256 * 1024;
 
 /// Max VLAN-subif entries. The reference EFG's agg-switch trunk carries
-/// VIDs 1/66/88/99/1337 + 3996..4040 — ~50. 256 is headroom.
+/// VIDs 1/66/88/99/1337 + 3996..4040, ~50. 256 is headroom.
 const VLAN_RESOLVE_MAX_ENTRIES: u32 = 256;
 
 /// Max prefixes per mss-clamp LPM trie. Sized like the allowlist; each
 /// `mss-clamp <cidr> [via <iface>] <mtu>` directive becomes one entry.
 const MSS_CLAMP_PREFIX_MAX_ENTRIES: u32 = 1024;
 
-/// Max per-egress mss-clamp entries. Sized like the redirect devmap —
+/// Max per-egress mss-clamp entries. Sized like the redirect devmap
 /// one entry per attached egress iface that has a `mss-clamp via X N`
 /// rule. 64 is comfortable for any non-container deployment.
 const MSS_CLAMP_IFACE_MAX_ENTRIES: u32 = 64;
@@ -203,13 +203,13 @@ const MSS_CLAMP_IFACE_MAX_ENTRIES: u32 = 64;
 //
 // Sized to accommodate the full IPv4 + IPv6 BGP tables plus headroom.
 // Kernel allocates at load time regardless of whether `forwarding-mode
-// custom-fib` is selected — the maps live in the same ELF. Approximate
+// custom-fib` is selected, the maps live in the same ELF. Approximate
 // memory cost at defaults: ~50-80 MB v4 + ~40-50 MB v6 + small NH + ECMP.
 // Changing `max_entries` requires an ELF rebuild (aya/kernel limitation);
 // config-level `fib-v4-max-entries` directives are accepted but documented
 // as "rebuild required" in Phase 1.
 //
-// Phase 1 keeps these empty — the BPF program never reads them while
+// Phase 1 keeps these empty, the BPF program never reads them while
 // `FP_CFG_FLAG_CUSTOM_FIB` is clear, so the allocation is all the load
 // cost. Phase 3's FibProgrammer populates them.
 
@@ -248,7 +248,7 @@ pub struct VlanResolve {
 /// explicit padding so userspace layout matches byte-for-byte.
 ///
 /// Why a struct rather than a bare u16: lets a single LPM lookup
-/// answer both "prefix only" and "prefix + via iface" queries — the
+/// answer both "prefix only" and "prefix + via iface" queries, the
 /// XDP path checks `iface_filter == 0 || iface_filter == egress_ifindex`
 /// without needing two separate tries. Userspace splats one entry per
 /// `mss-clamp <cidr> [via <iface>] <mtu>` directive.
@@ -302,7 +302,7 @@ pub struct MutationCtx {
     /// Stored as `u32` (not `u8`) so the struct has no padding bytes.
     /// With padding, LLVM's "merge stores" optimization recognizes the
     /// 3 unwritten bytes between `is_v4: u8` and the end of the struct
-    /// as a zero-init block and lowers them into a `memset` libcall —
+    /// as a zero-init block and lowers them into a `memset` libcall
     /// emitted by the BPF backend as a separate bpf-to-bpf subprogram,
     /// which then trips the kernel verifier's
     ///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
@@ -328,7 +328,7 @@ pub const FIB_KIND_ECMP: u8 = 1;
 
 /// Value stored in `FIB_V4` / `FIB_V6` LPM tries. Points at either
 /// a single nexthop (`NEXTHOPS[idx]`) or an ECMP group
-/// (`ECMP_GROUPS[idx]`). 8 bytes — single aligned write from
+/// (`ECMP_GROUPS[idx]`). 8 bytes, single aligned write from
 /// userspace is torn-read-free.
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -389,7 +389,7 @@ pub struct NexthopEntry {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct EcmpGroup {
-    /// `3`, `4`, or `5` — the tuple width the XDP program hashes on
+    /// `3`, `4`, or `5`, the tuple width the XDP program hashes on
     /// for this group. 3 = (src IP, dst IP, proto); 4 = + one port;
     /// 5 = + src port + dst port. Non-TCP/UDP + ICMP + fragments
     /// fall back to 3 regardless.
@@ -446,7 +446,7 @@ pub static ALLOW_V6: LpmTrie<[u8; 16], u8> =
 
 /// v0.2.1 issue #33: IPv4 destination block list. Matched packets
 /// whose dst falls in this LPM trie return `XDP_DROP` (counter
-/// `BogonDropped` bumped). Empty by default — operator opts in by
+/// `BogonDropped` bumped). Empty by default, operator opts in by
 /// declaring `block-prefix <cidr>` lines in config. Sized the same
 /// as the allowlist; expected entries are a handful of bogon ranges
 /// (RFC 1918, CGNAT, test-net) so 1024 is generous.
@@ -475,7 +475,7 @@ pub static STATS: PerCpuArray<u64> = PerCpuArray::with_max_entries(STATS_COUNT, 
 pub static LOG: RingBuf = RingBuf::with_byte_size(LOG_RINGBUF_BYTES, 0);
 
 /// Redirect target devmap (SPEC §4.5). Hash-keyed by ifindex so size
-/// doesn't scale with the host's highest ifindex — matters on container
+/// doesn't scale with the host's highest ifindex, matters on container
 /// hosts with sparse, high ifindex numbers.
 #[map]
 pub static REDIRECT_DEVMAP: DevMapHash =
@@ -524,7 +524,7 @@ pub static MUTATION_CTX: PerCpuArray<MutationCtx> = PerCpuArray::with_max_entrie
 
 /// Per-CPU scratch buffer for `bpf_fib_lookup` calls. Per-CPU array
 /// elements are pre-zeroed at map creation by the kernel and remain
-/// accessible at a stable address — fast_path writes the input fields
+/// accessible at a stable address, fast_path writes the input fields
 /// (family, l4_protocol, sport/dport, addrs, etc.), the kernel helper
 /// fills `smac`/`dmac` on success, and the value persists per-CPU
 /// between calls.
@@ -533,7 +533,7 @@ pub static MUTATION_CTX: PerCpuArray<MutationCtx> = PerCpuArray::with_max_entrie
 /// triggers LLVM's "merge stores" optimization on the unwritten union
 /// trailing bytes (`__bindgen_anon_3.ipv6_src[1..4]` in the IPv4 path,
 /// `__bindgen_anon_5.tbid`, etc.), which then lowers into a `memset`
-/// libcall — emitted by the BPF backend as a separate bpf-to-bpf
+/// libcall, emitted by the BPF backend as a separate bpf-to-bpf
 /// subprogram. Combined with `bpf_tail_call`, that violates the kernel
 /// verifier's
 ///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
@@ -549,7 +549,7 @@ pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> =
 /// Tail-call jump table (v0.2.5+). fast_path tail_calls into slot 0 after
 /// classification + L2/TTL mutations. Slot 0 holds `finalize` today.
 /// Sized for 8 future stages (chained finalizers, alternate clamp
-/// strategies, future packet transforms) — slot count is BPF-load-time-
+/// strategies, future packet transforms), slot count is BPF-load-time-
 /// fixed, so headroom here is cheap.
 ///
 /// Tail-call into an empty slot returns an error to the caller; fast_path
@@ -596,7 +596,7 @@ pub static FIB_CONFIG: Array<FpFibCfg> = Array::with_max_entries(1, 0);
 
 // --- Stat increment helper ---------------------------------------------
 
-/// Bump the per-CPU counter at `idx` by 1. Safe on the hot path — the
+/// Bump the per-CPU counter at `idx` by 1. Safe on the hot path, the
 /// verifier tolerates the single get_ptr_mut + deref, and on miss we
 /// simply skip the increment (a map hit is guaranteed iff `idx <
 /// STATS_COUNT`, which we enforce via the [`StatIdx`] enum).

--- a/crates/modules/fast-path/build.rs
+++ b/crates/modules/fast-path/build.rs
@@ -6,8 +6,8 @@
 //! `.github/workflows/ci.yml`); local dev on macOS typically has none of
 //! them and that is deliberate per the PR #3 plan ("CI-only BPF builds").
 //!
-//! If the nested build fails for any reason — no rustup, no nightly, no
-//! bpf-linker, missing target, or a real compile error — we emit an
+//! If the nested build fails for any reason, no rustup, no nightly, no
+//! bpf-linker, missing target, or a real compile error, we emit an
 //! empty stub ELF and skip setting the `packetframe_bpf_built` cfg.
 //! Userspace code uses that cfg to gate tests and error clearly at
 //! runtime if someone tries to load the empty object.
@@ -29,7 +29,7 @@ fn main() {
     let obj_out = out_dir.join("fast-path.bpf.o");
 
     // Rerun triggers. `src/**/*.rs` is covered by `rerun-if-changed` on
-    // the directory — cargo walks it recursively.
+    // the directory, cargo walks it recursively.
     for rel in [
         "src",
         "Cargo.toml",
@@ -52,7 +52,7 @@ fn main() {
         );
     }
 
-    // Pre-built ELF override — used by release.yml to build BPF once on
+    // Pre-built ELF override, used by release.yml to build BPF once on
     // the host runner (where nightly + bpf-linker exist), upload as an
     // artifact, and hand the path to every cross-build job. Cross
     // containers lack rustup entirely, so nested cargo would fail and
@@ -102,7 +102,7 @@ fn main() {
     // will fail and we fall through to the stub path.
     //
     // Capture stderr + stdout so we can re-emit the real cargo error
-    // as cargo:warning lines on failure — otherwise the outer cargo
+    // as cargo:warning lines on failure, otherwise the outer cargo
     // swallows this build.rs process's output and users see only our
     // opaque "BPF build failed (exit N)" warning, which is useless
     // for diagnosing toolchain or compile errors in the BPF crate.
@@ -116,7 +116,7 @@ fn main() {
     // only activates under nightly.
     // Build with `--message-format=json` so we can parse cargo's
     // structured output and locate the compiler-artifact filename.
-    // That's more robust than hardcoding the target/ path — cargo and
+    // That's more robust than hardcoding the target/ path, cargo and
     // bpf-linker have both moved artifact locations across versions.
     let output = Command::new("cargo")
         .current_dir(&bpf_dir)
@@ -185,7 +185,7 @@ fn main() {
             forward_rendered_diagnostics(&out.stdout);
             forward_output(&[], &out.stderr);
             let msg = format!(
-                "BPF build failed (exit {}) — see cargo:warning lines above for the real error, or run `(cd crates/modules/fast-path/bpf && cargo build --release)` directly",
+                "BPF build failed (exit {}), see cargo:warning lines above for the real error, or run `(cd crates/modules/fast-path/bpf && cargo build --release)` directly",
                 out.status.code().unwrap_or(-1)
             );
             fail_or_stub(&obj_out, bpf_required, &msg);
@@ -232,7 +232,7 @@ fn find_artifact(stdout: &[u8]) -> Option<PathBuf> {
 fn fail_or_stub(obj_out: &std::path::Path, required: bool, msg: &str) {
     if required {
         panic!(
-            "PACKETFRAME_BPF_REQUIRED is set but {msg}. Refusing to stub the ELF — that would make every BPF-dependent test a silent no-op."
+            "PACKETFRAME_BPF_REQUIRED is set but {msg}. Refusing to stub the ELF, that would make every BPF-dependent test a silent no-op."
         );
     }
     println!(
@@ -243,7 +243,7 @@ fn fail_or_stub(obj_out: &std::path::Path, required: bool, msg: &str) {
 
 /// Re-emit the nested cargo's stdout + stderr as `cargo:warning` lines
 /// so the outer cargo shows them. Each source line becomes a separate
-/// warning — cargo prints one warning per line anyway, and this way
+/// warning, cargo prints one warning per line anyway, and this way
 /// the user doesn't have to `cargo build -vv` to diagnose a BPF build
 /// failure.
 fn forward_output(stdout: &[u8], stderr: &[u8]) {
@@ -265,7 +265,7 @@ fn write_stub(path: &std::path::Path) {
 /// Walk cargo's `--message-format=json` stdout, find each
 /// `"reason":"compiler-message"` line, and forward its rendered
 /// diagnostic body. This is what makes BPF compile errors visible in
-/// the parent cargo's warning stream — they're emitted as JSON on
+/// the parent cargo's warning stream, they're emitted as JSON on
 /// stdout (not stderr), so without this they're invisible when
 /// `forward_output(&[], ...)` is called.
 fn forward_rendered_diagnostics(stdout: &[u8]) {

--- a/crates/modules/fast-path/examples/bmp_probe.rs
+++ b/crates/modules/fast-path/examples/bmp_probe.rs
@@ -2,7 +2,7 @@
 //!
 //! Reads a captured BMP byte stream (file or stdin), parses each
 //! message via `bgpkit-parser`, and prints a structured summary.
-//! This is the **Phase 1 deferred deliverable** — it proves the
+//! This is the **Phase 1 deferred deliverable**, it proves the
 //! library handles bird's wire format (especially RFC 9069 Loc-RIB /
 //! peer type 3) before the real RouteSource in Slice 3C builds on it.
 //!
@@ -17,7 +17,7 @@
 //!
 //! Output is plain text, one line per message. A closing summary
 //! prints message-type counts, per-peer-type counts, and per-peer
-//! route-monitoring counts — enough to spot a library regression
+//! route-monitoring counts, enough to spot a library regression
 //! (e.g., Loc-RIB frames silently misparsed as something else).
 //!
 //! Not a production binary; not shipped in the release tarball.
@@ -65,7 +65,7 @@ fn main() {
 
     while !bytes.is_empty() {
         // `parse_bmp_msg` advances `bytes` past the message on success.
-        // On error we bail — a malformed frame past this point means
+        // On error we bail, a malformed frame past this point means
         // we've lost sync with the stream framing and further parsing
         // would produce garbage.
         match parse_bmp_msg(&mut bytes) {

--- a/crates/modules/fast-path/src/breaker.rs
+++ b/crates/modules/fast-path/src/breaker.rs
@@ -8,7 +8,7 @@
 //! breaker trips: writes a sticky flag under the state directory and
 //! raises SIGUSR1 so the main loop can detach the module.
 //!
-//! The state-dir flag survives a kernel reboot — that's deliberate.
+//! The state-dir flag survives a kernel reboot, that's deliberate.
 //! A tripped breaker refuses to re-attach on subsequent `packetframe
 //! run` invocations until an operator clears it. This matches SPEC
 //! §8.3's "sticky detach" requirement.
@@ -38,7 +38,7 @@ pub fn is_tripped(state_dir: &Path) -> bool {
 /// Write the sticky trip flag. Best-effort: if the write fails,
 /// the main-loop detach still proceeds; the worst case is that the
 /// next restart re-attaches a breaker whose condition may have
-/// cleared — operator sees the same trip again.
+/// cleared, operator sees the same trip again.
 pub fn write_trip_flag(
     state_dir: &Path,
     ratio: f64,
@@ -65,13 +65,13 @@ pub fn write_trip_flag(
 /// What the sampler observed, minus I/O on STATS itself.
 #[derive(Debug)]
 pub enum Decision {
-    /// No matched traffic since last sample — can't divide.
+    /// No matched traffic since last sample, can't divide.
     NoData,
     /// Under threshold.
     Ok { ratio: f64 },
     /// Over threshold but streak hasn't reached `threshold` samples yet.
     Bad { ratio: f64, streak: u32 },
-    /// Streak reached `threshold` — trip.
+    /// Streak reached `threshold`, trip.
     Trip {
         ratio: f64,
         window_drops: u64,
@@ -168,7 +168,7 @@ mod tests {
 
     fn stats(matched_v4: u64, drops: u64) -> Vec<u64> {
         // Matches STATS_COUNT in bpf/src/maps.rs (32 after the Option F
-        // Phase 1 additions). Was 19 pre-Phase-1 — that was already
+        // Phase 1 additions). Was 19 pre-Phase-1, that was already
         // off-by-one against the 20-variant StatIdx enum; fixed in
         // passing by the custom-FIB work that bumped STATS_COUNT.
         let mut s = vec![0u64; crate::metrics::COUNTER_NAMES.len()];

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -1,4 +1,4 @@
-//! RouteController — owns the tokio runtime, spawns the
+//! RouteController, owns the tokio runtime, spawns the
 //! NeighborResolver and FibProgrammer tasks, and exposes a clean
 //! `start()` / `shutdown()` lifecycle that mirrors the
 //! `BreakerSampler` and `MetricsExporter` pattern in
@@ -6,7 +6,7 @@
 //!
 //! **Phase 2 scope.** Starts the netlink resolver + the programmer
 //! (neigh-side). The RouteSource (BMP station) and its integration
-//! into this controller land in Phase 3 — the tokio runtime shape
+//! into this controller land in Phase 3, the tokio runtime shape
 //! here accommodates that expansion without rework: spawning a
 //! third long-lived task is an additive change.
 //!
@@ -39,7 +39,7 @@ use crate::fib::route_source_bmp::BmpStation;
 /// Forwarding-feed source. The controller spawns at most one route
 /// source: operators pick `bmp` or `bgp` via `route-source ...`.
 /// `Bgp` is the recommended choice today because bird lacks RFC 9069
-/// Loc-RIB BMP — see `route_source_bgp.rs` module docs.
+/// Loc-RIB BMP, see `route_source_bgp.rs` module docs.
 ///
 /// The `peer_acl` / `expected_peer_ip` fields carry the
 /// authorization opt-in declared in the operator config. The config
@@ -67,7 +67,7 @@ pub enum RouteSourceConfig {
         local_as: u32,
         peer_as: u32,
         router_id: Ipv4Addr,
-        /// CIDR ACL — same semantics as the BMP variant.
+        /// CIDR ACL, same semantics as the BMP variant.
         peer_acl: Vec<ipnet::IpNet>,
         /// Optional pin on the peer's source IP. When set, an
         /// accepted connection whose source IP differs is closed
@@ -87,7 +87,7 @@ const LISTENER_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
 /// v0.2.2: ceiling on the listener restart backoff. After a transient
 /// bind failure (TIME_WAIT, port held by orphan, etc.), we want to
 /// retry promptly. After a sustained failure (real port conflict), we
-/// don't want to spam the kernel — 60 s is operator-readable in the
+/// don't want to spam the kernel, 60 s is operator-readable in the
 /// log without being too loud.
 const LISTENER_BACKOFF_MAX: Duration = Duration::from_secs(60);
 
@@ -124,7 +124,7 @@ impl RouteController {
     /// `route-source bmp ...` or `route-source bgp ...`; the
     /// controller then spawns the matching listener as a third task
     /// alongside the resolver + programmer. `None` runs without a
-    /// live route source — useful for test harnesses that drive the
+    /// live route source, useful for test harnesses that drive the
     /// programmer directly via its `FibProgrammerHandle`.
     pub fn start(
         bpffs_root: &Path,
@@ -286,7 +286,7 @@ impl RouteController {
                 cfg.peer_acl = peer_acl;
                 cfg.expected_peer_ip = expected_peer_ip;
                 // Capture the auth-posture fields before the spawn
-                // moves `cfg` into the retry loop's coroutine — the
+                // moves `cfg` into the retry loop's coroutine, the
                 // post-spawn `info!` reads them and can't share with
                 // the move.
                 let peer_acl_entries = cfg.peer_acl.len();
@@ -333,7 +333,7 @@ impl RouteController {
             None => {
                 info!(
                     "RouteController started: NetlinkNeighborResolver + FibProgrammer \
-                     (no route source — `route-source` not configured)"
+                     (no route source, `route-source` not configured)"
                 );
             }
         }
@@ -358,7 +358,7 @@ impl RouteController {
 
     /// Cooperative shutdown. Signals the cancellation token, awaits
     /// each task up to [`SHUTDOWN_TIMEOUT`], then tears down the
-    /// runtime. Drops any tasks that blow past the timeout — they'd
+    /// runtime. Drops any tasks that blow past the timeout, they'd
     /// leak otherwise when the runtime finalizes.
     pub fn shutdown(mut self) {
         self.shutdown_token.cancel();

--- a/crates/modules/fast-path/src/fib/hash.rs
+++ b/crates/modules/fast-path/src/fib/hash.rs
@@ -145,7 +145,7 @@ mod tests {
     #[test]
     fn hash_v4_distribution_is_nontrivial() {
         // Ten distinct src IPs into the same dst should produce at
-        // least 8 unique hashes — guard against "hash returns same
+        // least 8 unique hashes, guard against "hash returns same
         // value for all inputs" regressions. Not a statistical test;
         // just a sanity check.
         let mut hashes = std::collections::HashSet::new();

--- a/crates/modules/fast-path/src/fib/inspect.rs
+++ b/crates/modules/fast-path/src/fib/inspect.rs
@@ -2,7 +2,7 @@
 //! Powers `packetframe fib dump / lookup / stats`.
 //!
 //! All functions open the bpffs pins directly so they work
-//! without the daemon running — an operator can query the FIB
+//! without the daemon running, an operator can query the FIB
 //! state any time the pins are alive, including after `systemctl
 //! stop packetframe` as long as `detach --all` hasn't removed
 //! them.
@@ -140,7 +140,7 @@ pub fn dump_v6(bpffs_root: &Path) -> Result<Vec<FibEntry>, String> {
 }
 
 /// LPM-lookup a single IP. `Ok(None)` means the trie is open and
-/// readable but has no covering prefix — i.e., the data plane
+/// readable but has no covering prefix, i.e., the data plane
 /// would have XDP_PASS'd this address.
 pub fn lookup(bpffs_root: &Path, ip: IpAddr) -> Result<Option<FibEntry>, String> {
     let nexthops = FibProgrammer::open_nexthops(bpffs_root).map_err(|e| e.to_string())?;

--- a/crates/modules/fast-path/src/fib/integrity.rs
+++ b/crates/modules/fast-path/src/fib/integrity.rs
@@ -6,7 +6,7 @@
 //! peers in `Established` state so the BMP stall detector can gate
 //! its alert on "bird says there are peers to hear from."
 //!
-//! Scope: diagnostic safety net. Not on the feed path — if this
+//! Scope: diagnostic safety net. Not on the feed path, if this
 //! crashes or `birdc` is uninstallable, forwarding is unaffected;
 //! only the integrity alert goes dark. The 5-minute cadence is
 //! deliberately slow because this is a drift-catch job, not a
@@ -14,7 +14,7 @@
 //!
 //! Parsing bird's text output is inherently brittle; version drift
 //! can break the parser. Treating that as "integrity check stops
-//! working" is fine — forwarding keeps going, the operator gets a
+//! working" is fine, forwarding keeps going, the operator gets a
 //! warning log, and we update the parser. The plan explicitly
 //! accepts this fragility as the price of having the check at all.
 
@@ -69,8 +69,8 @@ impl Default for IntegrityConfig {
     }
 }
 
-/// Snapshot of the most recent integrity-check result. Readers —
-/// specifically the BmpStalled gate — consult this to decide whether
+/// Snapshot of the most recent integrity-check result. Readers
+/// specifically the BmpStalled gate, consult this to decide whether
 /// a stall warrants an alert.
 #[derive(Debug, Clone, Default)]
 pub struct IntegritySnapshot {
@@ -111,7 +111,7 @@ impl IntegrityChecker {
     }
 
     /// Main loop. Sleeps `config.interval`, runs one check, repeats.
-    /// Each tick is independent — a failure writes `last_error` into
+    /// Each tick is independent, a failure writes `last_error` into
     /// the snapshot and continues.
     pub async fn run(self) {
         info!(
@@ -200,21 +200,21 @@ impl IntegrityChecker {
 /// followed by a `Total: ...` summary across ALL tables in
 /// multi-table outputs. The `Total:` line includes RPKI tables (and
 /// any other custom tables operators have configured), which is NOT
-/// what we want — packetframe's mirror only ever holds master4/master6
+/// what we want, packetframe's mirror only ever holds master4/master6
 /// content.
 ///
 /// **v0.2.2 fix.** The rc5 fix preferred the `Total:` line over per-
 /// table sums to avoid double-counting when bird emitted both. But
 /// on operators with RPKI enabled (including the reference EFG via
 /// pathvector's `rtr-server` directive), the Total includes the
-/// RPKI tables — observed `bird_routes = 2,120,822` (sum of master4
+/// RPKI tables, observed `bird_routes = 2,120,822` (sum of master4
 /// 1.04M, master6 0.24M, rpki4 0.66M, rpki6 0.19M) where the operator
 /// expected 1.27M (master4 plus master6). The drift warning fired
 /// every 5 minutes for a non-existent drift.
 ///
 /// Now we explicitly filter for `in table master4` / `in table master6`
 /// per-table lines and sum those, ignoring `Total:` and any other
-/// table names. Single-table outputs (just `master4`) still work — we
+/// table names. Single-table outputs (just `master4`) still work, we
 /// pick up that one line.
 ///
 /// **rc5 fix retained**: pre-rc5 we summed every line containing
@@ -294,7 +294,7 @@ async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, Str
     let args_display = format!("{args:?}");
     let join = tokio::task::spawn_blocking(move || -> Result<BirdcOutput, String> {
         // `Read` is in scope inside `read_capped` via its `R: Read`
-        // bound — no need to pull it in here.
+        // bound, no need to pull it in here.
         use std::process::Stdio;
         let mut child = Command::new(&birdc)
             .args(&args)
@@ -335,7 +335,7 @@ async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, Str
     }
     if result.stdout_truncated {
         return Err(format!(
-            "birdc {args_display} stdout exceeded {BIRDC_OUTPUT_CAP} bytes — refusing to parse a runaway response"
+            "birdc {args_display} stdout exceeded {BIRDC_OUTPUT_CAP} bytes, refusing to parse a runaway response"
         ));
     }
     Ok(String::from_utf8_lossy(&result.stdout).into_owned())

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -18,9 +18,9 @@
 //! ifindex for a given nexthop IP, which couples this module to
 //! `rtnetlink::RouteHandle`. First-packet kernel ARP/ND already
 //! triggers resolution on its own, so skipping proactive kicks only
-//! adds a single-packet latency — not a correctness concern.
+//! adds a single-packet latency, not a correctness concern.
 //!
-//! No direct BPF-map writes happen here — the
+//! No direct BPF-map writes happen here, the
 //! [`FibProgrammer`](super::programmer) consumes `NeighEvent` and
 //! owns the `NEXTHOPS` seqlock write path.
 
@@ -73,7 +73,7 @@ pub struct LocalPrefixSpec {
     /// avoid kernel `gc_thresh3` overflow + ARP storms). Useful for
     /// quiet LANs (storage networks like Ceph) where hosts don't
     /// communicate L3 with the gateway and therefore never appear in
-    /// `ip neigh show <iface>`. Off by default — generates noticeable
+    /// `ip neigh show <iface>`. Off by default, generates noticeable
     /// ARP traffic during startup.
     pub arp_scavenge: bool,
 }
@@ -85,7 +85,7 @@ pub struct LocalPrefixSpec {
 /// CGNAT, test-net, anything not in DFZ). Otherwise those packets
 /// miss LPM, fall to slow-path through netfilter / conntrack, and
 /// get dropped upstream anyway. With this directive they XDP-redirect
-/// to upstream — same upstream behavior, conntrack stays out of it.
+/// to upstream, same upstream behavior, conntrack stays out of it.
 ///
 /// `iface` is validated at startup against `/sys/class/net` (same
 /// as `attach`/`local-prefix`); `nexthop` is the IPv4 address of an
@@ -112,7 +112,7 @@ impl LocalPrefixSpec {
 /// Outbound `NeighEvent` queue capacity. Sized to absorb a full-table
 /// neighbor-churn storm without blocking the netlink reader. If the
 /// programmer can't drain fast enough we apply backpressure, which is
-/// fine — the kernel re-broadcasts neighbor state on the next event
+/// fine, the kernel re-broadcasts neighbor state on the next event
 /// and the programmer catches up.
 const EVENTS_CAPACITY: usize = 8192;
 
@@ -178,7 +178,7 @@ pub struct NetlinkNeighborResolver {
     /// **Why we need this** (Phase 3.9 fix): if the kernel already
     /// has a stable `REACHABLE` entry for a BGP nexthop when
     /// packetframe starts, the multicast subscription will never see
-    /// it — multicast only fires on state *transitions*. Without this
+    /// it, multicast only fires on state *transitions*. Without this
     /// cache, `request_resolve(ip)` would issue an `RTM_NEWNEIGH
     /// NUD_NONE` probe for an entry the kernel already has, which
     /// the kernel correctly treats as a no-op and produces no event,
@@ -197,7 +197,7 @@ pub struct NetlinkNeighborResolver {
     /// v0.2.1: handle to the FibProgrammer for local-prefix /32
     /// emission. `None` when no local-prefix is configured (or when
     /// running under a test harness that doesn't drive a programmer
-    /// — e.g., the existing netns ARP-walk tests).
+    /// e.g., the existing netns ARP-walk tests).
     prog_handle: Option<FibProgrammerHandle>,
     /// v0.2.1 issue #31: optional synthetic 0.0.0.0/0 catch-all.
     /// `None` = no fallback (default). `Some(spec)` = inject a /0
@@ -323,7 +323,7 @@ impl NetlinkNeighborResolver {
                 warn!(
                     error = %e,
                     "RTM_GETNEIGH dump failed; pre-existing kernel neighbour entries \
-                     won't be visible until they transition (degraded perf only — first-packet \
+                     won't be visible until they transition (degraded perf only, first-packet \
                      ARP is the fallback)"
                 );
             }
@@ -361,7 +361,7 @@ impl NetlinkNeighborResolver {
                 local_prefixes = self.local_prefixes.len(),
                 has_fallback = self.fallback_default.is_some(),
                 "v0.2.1 directives configured but no FibProgrammer handle wired through; \
-                 fast-path features will not be enabled — file a bug if you see this on a \
+                 fast-path features will not be enabled, file a bug if you see this on a \
                  production deploy"
             );
         }
@@ -427,7 +427,7 @@ impl NetlinkNeighborResolver {
                             } else {
                                 self.cache_misses += 1;
                                 if self.cache_misses <= 20 {
-                                    // First few misses — log explicitly so
+                                    // First few misses, log explicitly so
                                     // the operator can see *which* IPs the
                                     // dump didn't capture.
                                     info!(?ip, "neighbour cache miss; proactive probe");
@@ -448,7 +448,7 @@ impl NetlinkNeighborResolver {
                 _ = stats_tick.tick() => {
                     // Periodic resolver stats. Helps diagnose whether
                     // register_nexthop calls are landing on cache hits
-                    // (good — synthetic Learned fired) or misses (kernel
+                    // (good, synthetic Learned fired) or misses (kernel
                     // didn't have an ARP entry; relying on proactive
                     // probe).
                     info!(
@@ -484,7 +484,7 @@ impl NetlinkNeighborResolver {
                     // Mirror Learned events into the local cache so
                     // a later request_resolve for the same IP hits
                     // synchronously (Phase 3.9 fix). Cache misses on
-                    // Failed/Gone — those don't carry a usable MAC.
+                    // Failed/Gone, those don't carry a usable MAC.
                     if let NeighEvent::Learned {
                         ip, mac, ifindex, ..
                     } = &evt
@@ -494,7 +494,7 @@ impl NetlinkNeighborResolver {
                         // local-prefix and is reachable via the matching
                         // iface, emit a /32 RouteEvent::Add. The
                         // FibProgrammer takes it from there; we don't
-                        // need to track per-/32 state ourselves —
+                        // need to track per-/32 state ourselves
                         // RouteEvent::Del on RTM_DELNEIGH is the symmetric
                         // cleanup, and PeerDown on RTM_DELLINK handles
                         // the iface-disappears case.
@@ -537,8 +537,8 @@ impl NetlinkNeighborResolver {
                     }
                 }
                 // v0.2.1: keep iface_to_ifindex current. An iface that
-                // came up after packetframe started — covered by a
-                // local-prefix that the operator staged in config —
+                // came up after packetframe started, covered by a
+                // local-prefix that the operator staged in config
                 // becomes resolvable now.
                 if let Some(name) = extract_link_name(&msg) {
                     self.iface_to_ifindex.insert(name, ifindex);
@@ -611,7 +611,7 @@ impl NetlinkNeighborResolver {
         // v0.2.1 issue #32: ARP-scavenge any prefix the operator
         // flagged. For each IP in the CIDR (excluding network and
         // broadcast), call NeighborResolveHandle::request_resolve via
-        // the resolve_tx channel — the proactive-resolve path then
+        // the resolve_tx channel, the proactive-resolve path then
         // issues an RTM_NEWNEIGH NUD_NONE which the kernel turns into
         // an ARP request. Hosts that respond land in the L3 ARP cache,
         // RTM_NEWNEIGH multicasts back to us, and our existing
@@ -628,7 +628,7 @@ impl NetlinkNeighborResolver {
     /// v0.2.1 issue #32, with v0.2.2 broadcast-storm safety (#34).
     /// For every `local-prefix` flagged with `arp-scavenge`, ARP-probe
     /// every host IP in the CIDR via the **operator-declared iface**
-    /// (NOT the kernel's routing-table OIF — see safety rationale below).
+    /// (NOT the kernel's routing-table OIF, see safety rationale below).
     /// Capped at /22 (1024 hosts) per config-parse validation.
     ///
     /// **Safety: why we use the operator's declared iface, not the
@@ -653,7 +653,7 @@ impl NetlinkNeighborResolver {
     async fn scavenge_local_prefix_arp(&mut self) {
         // Snapshot the specs (filter to arp-scavenge enabled) AND
         // resolve each spec's iface to ifindex up-front. If an iface
-        // doesn't resolve, we refuse the sweep entirely — that's
+        // doesn't resolve, we refuse the sweep entirely, that's
         // safer than falling back to kernel-OIF behavior.
         let specs: Vec<(LocalPrefixSpec, u32)> = self
             .local_prefixes
@@ -687,7 +687,7 @@ impl NetlinkNeighborResolver {
                 1u32 << host_bits
             };
             // Mask off any host bits the operator left set in the
-            // declared CIDR — treat 23.191.200.5/24 as 23.191.200.0/24.
+            // declared CIDR, treat 23.191.200.5/24 as 23.191.200.0/24.
             let mask: u32 = if plen == 0 {
                 0
             } else {
@@ -710,7 +710,7 @@ impl NetlinkNeighborResolver {
                 probed += 1;
                 // Rate-limit at ~500 probes/sec (50 per 100ms). Without
                 // pacing, a /22 sweep (1024 hosts) issues 1024 ARP
-                // requests in milliseconds — saturates the kernel
+                // requests in milliseconds, saturates the kernel
                 // neighbour queue and triggers `Neighbour table
                 // overflow` warnings. 500/s is comfortably under the
                 // default `gc_thresh3` (1024) replenishment rate and
@@ -805,7 +805,7 @@ impl NetlinkNeighborResolver {
     }
 
     /// Same as [`Self::seed_local_prefix_routes`] but for a single
-    /// (ip, ifindex) pair — called from the multicast event handler
+    /// (ip, ifindex) pair, called from the multicast event handler
     /// on RTM_NEWNEIGH. Idempotent against the FibProgrammer side
     /// (multiple Adds for the same /32 just bump a refcount).
     async fn maybe_emit_local_arp_add(&mut self, ip: IpAddr, ifindex: u32) {
@@ -814,7 +814,7 @@ impl NetlinkNeighborResolver {
             return;
         };
         // Clone to release the &self borrow on prog_handle before the
-        // mutable counter update below — same pattern as
+        // mutable counter update below, same pattern as
         // seed_local_prefix_routes. FibProgrammerHandle is cheap to
         // clone (mpsc Sender wrapper).
         let Some(prog) = self.prog_handle.clone() else {
@@ -879,10 +879,10 @@ impl NetlinkNeighborResolver {
                 .unwrap_or(false)
         });
         // After the iface_to_ifindex purge above, we may have already
-        // lost the entry — fall back to comparing against any cached
+        // lost the entry, fall back to comparing against any cached
         // matching done in seed time. For now the simpler heuristic is
         // "always emit a PeerDown if local-prefixes are configured at
-        // all" — wasteful for ifaces that weren't local-prefix targets,
+        // all", wasteful for ifaces that weren't local-prefix targets,
         // but safe (programmer's PeerDown handler is a HashMap walk
         // that does nothing for an unknown peer_id).
         if !was_local && self.local_prefixes.is_empty() {
@@ -931,7 +931,7 @@ impl NetlinkNeighborResolver {
 /// message shape), or the neighbor add fails (EEXIST because the
 /// neighbor already exists, permission issues, etc.), we log at debug
 /// and return. The fallback is "kernel resolves when real traffic
-/// arrives" — exactly what we'd get without proactive resolve, so
+/// arrives", exactly what we'd get without proactive resolve, so
 /// the only cost of a proactive-resolve failure is one-packet latency
 /// on first forward.
 async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
@@ -964,7 +964,7 @@ async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
     };
     // Issue the RTM_NEWNEIGH with NUD_NONE. The kernel interprets
     // "state NONE + no lladdr" as "initialize this neighbor and start
-    // resolving." Replace lets the call be idempotent — if the
+    // resolving." Replace lets the call be idempotent, if the
     // neighbor already exists, we quietly succeed.
     match handle
         .neighbours()
@@ -981,7 +981,7 @@ async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
 
 /// Query the main routing table for `msg`, return the OIF of the
 /// first route returned. Kernel answers via a stream; we only care
-/// about the first entry — subsequent entries for multipath routes
+/// about the first entry, subsequent entries for multipath routes
 /// are handled at the programmer level via ECMP groups.
 async fn lookup_oif(
     handle: &Handle,
@@ -1003,7 +1003,7 @@ async fn lookup_oif(
 
 /// Dump every link on the box via a single RTM_GETLINK-dump request;
 /// return both an `ifindex → MAC` map and a `name → ifindex` map.
-/// Uses a dedicated unicast netlink connection — the main multicast
+/// Uses a dedicated unicast netlink connection, the main multicast
 /// one is owned by the select! loop.
 ///
 /// Links without a usable MAC (e.g., tunnels, loopback, bridge masters
@@ -1037,7 +1037,7 @@ async fn dump_link_info() -> Result<(HashMap<u32, [u8; 6]>, HashMap<String, u32>
 }
 
 /// Pull the `IfName` (IFLA_IFNAME) attribute out of a `LinkMessage`.
-/// Returns `None` if the attribute is absent (rare — the kernel sets
+/// Returns `None` if the attribute is absent (rare, the kernel sets
 /// it on every iface) or non-UTF-8 (effectively never on Linux).
 fn extract_link_name(msg: &LinkMessage) -> Option<String> {
     for attr in &msg.attributes {
@@ -1054,14 +1054,14 @@ fn extract_link_name(msg: &LinkMessage) -> Option<String> {
 /// **Why this exists** (Phase 3.9): the multicast subscription only
 /// observes neighbour state *transitions*, not the steady state at
 /// the moment we subscribe. If the kernel already has REACHABLE
-/// entries for BGP peers when packetframe starts (typical — bird's
+/// entries for BGP peers when packetframe starts (typical, bird's
 /// been ARPing them for hours), we'd never see them. This dump
 /// gives us a one-time snapshot to seed the cache, and the
 /// multicast subscription keeps it current from then on.
 ///
 /// Skips entries whose state isn't usable for forwarding
 /// (Incomplete/None/Failed) and entries without a Link-Layer
-/// Address attribute. STALE/DELAY/PROBE are kept — same policy as
+/// Address attribute. STALE/DELAY/PROBE are kept, same policy as
 /// `parse_neighbour_add` for the multicast path.
 async fn dump_neighbours() -> Result<HashMap<IpAddr, (u32, [u8; 6])>, NeighError> {
     let (connection, handle, _) =
@@ -1091,7 +1091,7 @@ async fn dump_neighbours() -> Result<HashMap<IpAddr, (u32, [u8; 6])>, NeighError
 
 /// Pull the `Address` (IFLA_ADDRESS) attribute out of a LinkMessage
 /// if it's a plausible Ethernet MAC. Returns None for non-Ethernet
-/// links — tunnels encode the peer address in `Address` with varying
+/// links, tunnels encode the peer address in `Address` with varying
 /// widths, and a 6-byte address on a tunnel isn't semantically what
 /// we want as src_mac anyway.
 fn extract_link_mac(msg: &LinkMessage) -> Option<[u8; 6]> {
@@ -1101,7 +1101,7 @@ fn extract_link_mac(msg: &LinkMessage) -> Option<[u8; 6]> {
                 let mut mac = [0u8; 6];
                 mac.copy_from_slice(bytes);
                 // Skip the all-zero MAC some virtual ifaces present
-                // before they're configured — that would be worse than
+                // before they're configured, that would be worse than
                 // not providing one (looks like a real address).
                 if mac != [0; 6] {
                     return Some(mac);
@@ -1114,7 +1114,7 @@ fn extract_link_mac(msg: &LinkMessage) -> Option<[u8; 6]> {
 
 /// Build a [`NeighEvent`] from an RTM_NEWNEIGH message. Returns
 /// `None` for transient or uninteresting states (`Incomplete` / `None`
-/// — no MAC yet; `Other` — unknown variant). `src_mac` is the cached
+/// no MAC yet; `Other`, unknown variant). `src_mac` is the cached
 /// egress iface MAC (Phase 3.6); `[0; 6]` when the cache hasn't been
 /// populated for this ifindex yet.
 fn parse_neighbour_add(msg: &NeighbourMessage, src_mac: [u8; 6]) -> Option<NeighEvent> {
@@ -1319,7 +1319,7 @@ mod tests {
     #[test]
     fn local_prefix_contains_misalignment_is_treated_as_aligned() {
         // Operator wrote `local-prefix 23.191.200.5/24` (host bits
-        // set). The mask logic ignores host bits when comparing —
+        // set). The mask logic ignores host bits when comparing
         // semantically the prefix is still 23.191.200.0/24.
         let spec = LocalPrefixSpec {
             addr: "23.191.200.5".parse().unwrap(),

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -1,4 +1,4 @@
-//! FibProgrammer — owns the BPF FIB write path (NEXTHOPS seqlock,
+//! FibProgrammer, owns the BPF FIB write path (NEXTHOPS seqlock,
 //! FIB_V4 / FIB_V6 LPM tries, ECMP_GROUPS dedup) and the userspace
 //! mirror state.
 //!
@@ -38,7 +38,7 @@
 //!      NeighEvents, Commands, the default-route reclaim tick, and
 //!      shutdown.
 //!
-//! All mirror state lives inside the run task — no mutex on the hot
+//! All mirror state lives inside the run task, no mutex on the hot
 //! path. Commands are serialized through a command mpsc; replies
 //! travel back via oneshot channels.
 
@@ -158,7 +158,7 @@ impl FibProgrammerHandle {
 
     /// Blocking variant for callers not already on the tokio runtime
     /// (e.g., integration tests driving the programmer from a sync
-    /// thread). Panics if called from within a tokio context — use
+    /// thread). Panics if called from within a tokio context, use
     /// `register_nexthop` there instead.
     pub fn register_nexthop_blocking(&self, ip: IpAddr) -> Result<NexthopId, ProgrammerError> {
         let (tx, rx) = oneshot::channel();
@@ -195,7 +195,7 @@ impl FibProgrammerHandle {
 
     /// Return the current `(v4, v6)` route mirror counts. Used by the
     /// integrity checker to diff against bird's `show route count`.
-    /// Reads the programmer's in-memory mirror, not the BPF maps —
+    /// Reads the programmer's in-memory mirror, not the BPF maps
     /// the mirror is the authoritative record of what the programmer
     /// believes it has written.
     pub async fn mirror_counts(&self) -> Result<(usize, usize), ProgrammerError> {
@@ -329,7 +329,7 @@ struct EcmpSignature {
 
 /// Reclaim queue entry for the default-route replace-by-swap path.
 /// `release_at` is the earliest instant at which it's safe to free
-/// the ID — an in-flight XDP program invocation may have read the
+/// the ID, an in-flight XDP program invocation may have read the
 /// old FibValue and be about to dereference this nexthop / group.
 #[derive(Debug)]
 struct PendingReclaim {
@@ -375,7 +375,7 @@ pub struct FibProgrammer {
     routes_v4: HashMap<([u8; 4], u8), RouteRecord>,
     routes_v6: HashMap<([u8; 16], u8), RouteRecord>,
     /// Per-peer index for O(1) PeerDown traversal. Values are keys
-    /// into `routes_v4` / `routes_v6` — the bool discriminates.
+    /// into `routes_v4` / `routes_v6`, the bool discriminates.
     /// `true` = v4, `false` = v6.
     routes_by_peer: HashMap<PeerId, HashSet<(bool, [u8; 16], u8)>>,
 
@@ -638,7 +638,7 @@ impl FibProgrammer {
         // Resolved. On miss it falls back to RTM_NEWNEIGH NUD_NONE
         // (proactive probe). Without this call, the only thing that
         // resolves a nexthop is a kernel ARP state-transition
-        // multicast — which never fires for entries that are
+        // multicast, which never fires for entries that are
         // already-stable REACHABLE. Pre-fix, ~95 % of BGP nexthops
         // stayed `incomplete` forever and forwarding silently fell
         // back to XDP_PASS for those routes.
@@ -1396,7 +1396,7 @@ impl FibProgrammer {
         if rec.refcount > 0 {
             return;
         }
-        // Fully freed — remove from mirror, push ID to free-list,
+        // Fully freed, remove from mirror, push ID to free-list,
         // tombstone the BPF slot.
         let signature = EcmpSignature {
             nh_ids_sorted: rec.nh_ids_sorted.clone(),

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -1,10 +1,10 @@
-//! BGP route source — receives bird's selected best paths over an
+//! BGP route source, receives bird's selected best paths over an
 //! iBGP session and translates UPDATEs into [`RouteEvent`]s for the
 //! FibProgrammer.
 //!
 //! **Why BGP and not BMP for the forwarding feed.** Bird's BMP
 //! implementation (as of bird master, April 2026) does not implement
-//! RFC 9069 Loc-RIB — only `monitoring rib in pre_policy` /
+//! RFC 9069 Loc-RIB, only `monitoring rib in pre_policy` /
 //! `post_policy`, which deliver per-peer Adj-RIB-In streams. For a
 //! prefix announced by N peers, that's N RouteMonitoring frames with
 //! N different nexthops, leaving the FibProgrammer to either
@@ -28,9 +28,9 @@
 //!
 //! **Capabilities advertised in OPEN.**
 //! - Multi-Protocol Extensions (RFC 4760) for IPv4 unicast and
-//!   IPv6 unicast — without this bird only sends v4 routes over
+//!   IPv6 unicast, without this bird only sends v4 routes over
 //!   the session.
-//! - Four-octet ASN (RFC 6793) — required for any modern AS
+//! - Four-octet ASN (RFC 6793), required for any modern AS
 //!   numbering when the local AS is greater than 65535.
 //! - ADD-PATH (RFC 7911) with Receive direction (Send/Receive
 //!   value 1) for both IPv4 unicast and IPv6 unicast. Peer-side
@@ -50,7 +50,7 @@
 //! KEEPALIVEs are sent at `effective_hold / 3`.
 //!
 //! **What we never send.** No UPDATE, no NOTIFICATION (we close on
-//! protocol error rather than send a structured NOTIFICATION — bird
+//! protocol error rather than send a structured NOTIFICATION, bird
 //! reconnects either way), no ROUTE-REFRESH (we don't advertise the
 //! capability).
 //!
@@ -82,7 +82,7 @@ use crate::fib::route_source_bmp::SharedIntegritySnapshot;
 
 // --- Wire constants ---------------------------------------------------------
 
-/// BGP message marker — 16 bytes of 0xFF per RFC 4271 §4.1.
+/// BGP message marker, 16 bytes of 0xFF per RFC 4271 §4.1.
 const BGP_MARKER: [u8; 16] = [0xFF; 16];
 
 /// Minimum BGP message length (header only, KEEPALIVE).
@@ -125,7 +125,7 @@ const FRAME_CHANNEL_CAPACITY: usize = 256;
 
 /// Cap on time spent waiting for the peer's OPEN after we send
 /// ours. RFC 4271's 120s ConnectRetry default applies to the
-/// *active* connector waiting for TCP to come up — we're the
+/// *active* connector waiting for TCP to come up, we're the
 /// passive side with TCP already established, where real peers
 /// send OPEN within milliseconds. 10s is comfortable headroom that
 /// still bounds the slowloris primitive a misconfigured (or
@@ -136,7 +136,7 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// Cap on iterations through one UPDATE's per-prefix elems. A
 /// single attacker-controlled UPDATE can encode tens of thousands
 /// of NLRI entries that bgpkit-parser's `Elementor` fans out into
-/// `BgpElem`s, each of which `apply_route_event().await`s — a
+/// `BgpElem`s, each of which `apply_route_event().await`s, a
 /// control-plane amplification primitive flagged by the audit
 /// (Slice 2). 8192 leaves comfortable headroom above any
 /// realistic bird best-path stream (a full v4 table is ~960K
@@ -153,7 +153,7 @@ pub struct BgpListenerConfig {
     pub peer_as: u32,
     pub router_id: Ipv4Addr,
     pub hold_time: u16,
-    /// CIDR ACL applied at `accept()`. Empty means "loopback only" —
+    /// CIDR ACL applied at `accept()`. Empty means "loopback only"
     /// the config parser only permits empty when `listen_addr` is
     /// loopback. When non-empty, every accepted source IP must fall
     /// within at least one entry or the connection is dropped before
@@ -184,7 +184,7 @@ impl BgpListenerConfig {
 }
 
 /// Whether `addr` is permitted by the listener's `peer_acl`. An empty
-/// ACL means "loopback only" — the config parser already enforces
+/// ACL means "loopback only", the config parser already enforces
 /// that empty + non-loopback listen is rejected, so an empty ACL
 /// implies the listener bound to loopback and only loopback sources
 /// can reach `accept()` in the first place. We still defensively
@@ -204,7 +204,7 @@ pub struct BgpListener {
     shutdown: CancellationToken,
     /// Shared atomic updated on each UPDATE frame. Unix seconds; 0 =
     /// none seen since process start. Read by the same stall monitor
-    /// that BmpStation uses — both feeds publish to the same signal.
+    /// that BmpStation uses, both feeds publish to the same signal.
     last_update_unix: Arc<AtomicI64>,
     stall_gate: Option<SharedIntegritySnapshot>,
 }
@@ -341,7 +341,7 @@ impl BgpListener {
                 let effective_peer_asn = negotiated.four_octet_asn.unwrap_or(peer_asn_2byte);
                 if effective_peer_asn != self.cfg.peer_as {
                     return Err(RouteSourceError::recoverable(format!(
-                        "peer ASN mismatch in OPEN: observed {effective_peer_asn} (2-byte field {peer_asn_2byte}, 4-octet cap {:?}), expected {} — closing session",
+                        "peer ASN mismatch in OPEN: observed {effective_peer_asn} (2-byte field {peer_asn_2byte}, 4-octet cap {:?}), expected {}, closing session",
                         negotiated.four_octet_asn, self.cfg.peer_as
                     )));
                 }
@@ -373,7 +373,7 @@ impl BgpListener {
             .await
             .map_err(|e| RouteSourceError::recoverable(format!("send KEEPALIVE: {e}")))?;
 
-        // Step 4: established — drain UPDATEs, send periodic
+        // Step 4: established, drain UPDATEs, send periodic
         // KEEPALIVEs, watch hold timer. Reader/writer split so the
         // main `select!` can interleave the keepalive timer without
         // cancel-safety issues on `read_exact`.
@@ -410,7 +410,7 @@ impl BgpListener {
                             self.process_msg(m, peer_id, peer_asn_observed, &mut last_update, &mut updates_seen).await;
                         }
                         None => {
-                            // Reader exited — surface the result.
+                            // Reader exited, surface the result.
                             return match reader.await {
                                 Ok(Ok(())) => {
                                     debug!(updates_seen, "BGP stream done");
@@ -433,7 +433,7 @@ impl BgpListener {
                 }
                 _ = quiescence_tick.tick() => {
                     // Hold-timer expiry → tear down. RFC 4271: peer
-                    // dead, send NOTIFICATION (we skip — close
+                    // dead, send NOTIFICATION (we skip, close
                     // suffices; bird reconnects).
                     if Instant::now() >= hold_deadline {
                         return Err(RouteSourceError::recoverable(format!(
@@ -476,7 +476,7 @@ impl BgpListener {
     ) {
         match msg {
             BgpMessage::Open(_) => {
-                // Spurious post-handshake OPEN — bird shouldn't do
+                // Spurious post-handshake OPEN, bird shouldn't do
                 // this. Log + ignore.
                 warn!("unexpected OPEN after handshake");
             }
@@ -486,7 +486,7 @@ impl BgpListener {
             BgpMessage::Notification(n) => {
                 // BgpError is a typed enum (MessageHeaderError,
                 // OpenError, UpdateError, HoldTimerExpired, Cease, ...);
-                // log the Debug repr — operator can grep on it.
+                // log the Debug repr, operator can grep on it.
                 warn!(error = ?n.error, "received NOTIFICATION; closing session");
                 // Reader will see EOF after bird closes; that path
                 // emits Resync via the accept loop.
@@ -502,7 +502,7 @@ impl BgpListener {
 
                 // Pretend the peer-IP for Elementor is the listen
                 // address (bird-side IP isn't carried in BGP UPDATE
-                // — we know it from the connection, but Elementor
+                // we know it from the connection, but Elementor
                 // doesn't need an accurate value, just something
                 // stable for elem.peer_ip). For peer_asn we pass
                 // bird's observed ASN.
@@ -626,7 +626,7 @@ where
     }
 
     // ROUTE-REFRESH (type 5) is RFC 2918, optional. bgpkit-parser
-    // doesn't model it; skip silently — bird shouldn't send refresh
+    // doesn't model it; skip silently, bird shouldn't send refresh
     // requests to us anyway since we don't advertise the capability.
     if msg_type == MSG_TYPE_ROUTE_REFRESH {
         debug!("ignoring ROUTE-REFRESH");
@@ -720,7 +720,7 @@ pub fn encode_open(local_as: u32, hold_time: u16, router_id: Ipv4Addr) -> Vec<u8
     out
 }
 
-/// Build a KEEPALIVE — header only, 19 bytes.
+/// Build a KEEPALIVE, header only, 19 bytes.
 pub fn encode_keepalive() -> Vec<u8> {
     let mut out = Vec::with_capacity(BGP_HEADER_LEN);
     out.extend_from_slice(&BGP_MARKER);
@@ -745,7 +745,7 @@ struct NegotiatedCapabilities {
     /// Peer advertised ADD-PATH Send (or both) for (IPv6, unicast).
     add_path_v6_recv: bool,
     /// Peer's 4-octet ASN (RFC 6793) if it advertised the capability.
-    /// When `Some(_)`, this is the authoritative ASN — the 2-byte
+    /// When `Some(_)`, this is the authoritative ASN, the 2-byte
     /// `My AS` field in OPEN carries AS_TRANS (23456) and the real
     /// ASN comes through here. Used by the peer-AS gate in
     /// `handle_connection` (the audit-flagged identity check).
@@ -840,7 +840,7 @@ fn synthetic_peer_id(listen: SocketAddr, peer_asn: u32) -> PeerId {
 /// in `TIME_WAIT` for ~60 s, and the default `tokio::net::TcpListener::bind`
 /// fails the new bind during that window. The error currently propagates
 /// out of `BgpListener::run` and the controller's `JoinHandle` swallows
-/// it — leaving the rest of packetframe running with a dead BGP feed
+/// it, leaving the rest of packetframe running with a dead BGP feed
 /// and no operator-visible signal short of bird's "Connection refused"
 /// state. `SO_REUSEADDR` lets the new bind succeed even with lingering
 /// TIME_WAIT state.
@@ -880,7 +880,7 @@ fn asn_to_u32(asn: Asn) -> u32 {
 /// Translate one parsed BGP element (announce or withdraw of a single
 /// prefix) into a [`RouteEvent`] for the FibProgrammer. Returns `None`
 /// when the element's prefix can't be represented in our [`IpPrefix`]
-/// type — graceful skip; bgpkit-parser's [`Elementor`] occasionally
+/// type, graceful skip; bgpkit-parser's [`Elementor`] occasionally
 /// emits malformed prefixes from withdraw NLRIs and we don't want
 /// those to crash the session.
 ///
@@ -888,13 +888,13 @@ fn asn_to_u32(asn: Asn) -> u32 {
 /// dropping bird's `protocol direct` exports. Direct-origin (and
 /// static-origin) routes go out via iBGP without an explicit BGP
 /// NEXT_HOP attribute when the bird-side BGP block has no
-/// `next hop self` directive — there's no upstream eBGP next-hop
+/// `next hop self` directive, there's no upstream eBGP next-hop
 /// to preserve, and bird doesn't synthesize one. bgpkit-parser's
 /// `Elementor::bgp_update_to_elems` returns `next_hop = None` for
 /// those announces.
 ///
 /// Pre-v0.2.1 we silently `continue`d on `None`, so connected /24s
-/// bird was correctly exporting never landed in `FIB_V4` at all —
+/// bird was correctly exporting never landed in `FIB_V4` at all
 /// the prefix wasn't present for XDP to LPM-match. Operator-visible
 /// symptom: `matched_dst_only` inbound to customer /24s all bumped
 /// `custom_fib_miss` instead of `custom_fib_no_neigh`, and the FIB
@@ -904,7 +904,7 @@ fn asn_to_u32(asn: Asn) -> u32 {
 /// The chosen fallback is the BGP session's listen address (typically
 /// `127.0.0.1` for the loopback iBGP setup). The neighbor resolver
 /// can't get a useful MAC for loopback, so the route lands with
-/// `state=Incomplete` — operationally the same XDP_PASS-to-kernel as
+/// `state=Incomplete`, operationally the same XDP_PASS-to-kernel as
 /// the silent-drop, but now the prefix exists in `FIB_V4`, the
 /// nexthop counter (`custom_fib_no_neigh`) reflects reality, and
 /// integrity drift goes away. Phase B (`local-prefix` ARP-walk)

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -1,4 +1,4 @@
-//! BMP station — the concrete `RouteSource` that receives bird's
+//! BMP station, the concrete `RouteSource` that receives bird's
 //! Loc-RIB (RFC 9069) over a BMP session and translates it into
 //! [`RouteEvent`]s delivered to the FibProgrammer.
 //!
@@ -19,7 +19,7 @@
 //! `length - 6` bytes of body, hand the whole frame to
 //! `parse_bmp_msg`. Framing runs in a dedicated task so the main
 //! event loop's `select!` can interleave a quiescence timer without
-//! cancel-safety issues — `read_exact` isn't cancel-safe, so running
+//! cancel-safety issues, `read_exact` isn't cancel-safe, so running
 //! it under a `select!` arm would desync the stream whenever the
 //! timer arm fired mid-read.
 //!
@@ -38,7 +38,7 @@
 //! False-positive risk: if bird is dumping so slowly that individual
 //! peers quiesce for > 5 s between batches, we fire early and GC
 //! mid-dump routes. Mitigation: the next Add events after InitComplete
-//! simply re-populate them — the programmer mirror gets rewritten.
+//! simply re-populate them, the programmer mirror gets rewritten.
 //! Operationally benign.
 
 #![cfg(target_os = "linux")]
@@ -83,7 +83,7 @@ const FRAME_CHANNEL_CAPACITY: usize = 256;
 
 /// Per-`read_exact` timeout on the BMP TCP stream. The reader task
 /// otherwise blocks forever on a peer that completed TCP handshake
-/// but never sent bytes (or sent a header but no body) — the
+/// but never sent bytes (or sent a header but no body), the
 /// audit-flagged slowloris primitive (Slice 2). 60 s is comfortable
 /// for legitimate bird (which sends initial RIB dumps in < 5 s) and
 /// tight enough to give the operator's stuck-session detection a
@@ -120,7 +120,7 @@ pub struct BmpStation {
     /// (which only emit pre/post-policy frames).
     require_loc_rib: bool,
     /// CIDR ACL applied at `accept()` time. Empty means "loopback
-    /// only" — the config parser only permits empty when
+    /// only", the config parser only permits empty when
     /// `listen_addr` is loopback. When non-empty, every accepted
     /// source IP must fall within at least one entry or the
     /// connection is dropped before the BMP framing starts.
@@ -158,7 +158,7 @@ impl BmpStation {
 
     /// Attach the integrity checker's snapshot so `run()` spawns a
     /// stall monitor alongside the accept loop. Without this, stall
-    /// detection is silent — appropriate for test harnesses that
+    /// detection is silent, appropriate for test harnesses that
     /// don't care about the alert path.
     pub fn with_stall_gate(mut self, snapshot: SharedIntegritySnapshot) -> Self {
         self.stall_gate = Some(snapshot);
@@ -168,7 +168,7 @@ impl BmpStation {
     /// Enable Loc-RIB-only safety mode: any RouteMonitoring frame
     /// with `peer_type != LocalRib` tears the session down with an
     /// error. Required when running against pre/post-policy emitters
-    /// like bird 2.x — see the `require_loc_rib` field doc.
+    /// like bird 2.x, see the `require_loc_rib` field doc.
     pub fn with_require_loc_rib(mut self) -> Self {
         self.require_loc_rib = true;
         self
@@ -186,7 +186,7 @@ impl BmpStation {
 
     /// Main loop: bind, accept, handle one connection at a time.
     /// On disconnect (clean or error), emit Resync so the programmer
-    /// marks all mirrored routes unseen — the next `RouteEvent::Add`
+    /// marks all mirrored routes unseen, the next `RouteEvent::Add`
     /// storm from the reconnect clears the marks; InitiationComplete
     /// (emitted by a quiescence timer inside `handle_connection`)
     /// GCs whatever never reappeared.
@@ -319,7 +319,7 @@ impl BmpStation {
                             }
                         }
                         None => {
-                            // Reader task exited — EOF or error. Join it
+                            // Reader task exited, EOF or error. Join it
                             // to surface any error, then return.
                             match reader.await {
                                 Ok(Ok(())) => {
@@ -364,11 +364,11 @@ impl BmpStation {
     }
 
     /// Dispatch on the BMP message body and fan out the appropriate
-    /// RouteEvents. Programmer errors are logged but not propagated —
+    /// RouteEvents. Programmer errors are logged but not propagated
     /// a single bad map write shouldn't kill the BMP connection when
     /// the next route might succeed.
     ///
-    /// **Returns Err only on session-fatal protocol violations** —
+    /// **Returns Err only on session-fatal protocol violations**
     /// today that's a RouteMonitoring frame whose peer_type isn't
     /// `LocalRib` while `require_loc_rib` is set. The caller closes
     /// the session and lets the peer reconnect.
@@ -464,7 +464,7 @@ impl BmpStation {
                             let nh = match elem.next_hop {
                                 Some(h) => h,
                                 None => {
-                                    debug!(?prefix, "announce without next_hop — skipping");
+                                    debug!(?prefix, "announce without next_hop, skipping");
                                     continue;
                                 }
                             };
@@ -508,7 +508,7 @@ impl BmpStation {
 /// Stall monitor: fires a warning log if no ROUTE MONITORING frame
 /// has arrived for [`STALL_THRESHOLD`] *and* the integrity check
 /// reports ≥1 Established BGP peer. The cross-check avoids a
-/// false-positive during a global bird outage — in that case the
+/// false-positive during a global bird outage, in that case the
 /// alert we'd actually want is "bird down," not "BMP stalled."
 ///
 /// Startup suppression: first [`STALL_STARTUP_SUPPRESSION`] of
@@ -517,7 +517,7 @@ impl BmpStation {
 /// here (and because the function has no other access to a clock
 /// reference point).
 ///
-/// Evaluation cadence is [`STALL_TICK`] — a real stall sits long
+/// Evaluation cadence is [`STALL_TICK`], a real stall sits long
 /// enough for any reasonable poll interval.
 async fn stall_monitor(
     last_rm_unix: Arc<AtomicI64>,
@@ -559,13 +559,13 @@ async fn stall_monitor(
                         // false-positives during bird downtime.
                         debug!(
                             quiet_seconds,
-                            "BMP quiet but integrity cache is cold — stall alert suppressed"
+                            "BMP quiet but integrity cache is cold, stall alert suppressed"
                         );
                     }
                     Some(0) => {
                         debug!(
                             quiet_seconds,
-                            "BMP quiet but bird reports zero Established peers — stall alert suppressed"
+                            "BMP quiet but bird reports zero Established peers, stall alert suppressed"
                         );
                     }
                     Some(n) => {
@@ -640,7 +640,7 @@ async fn reader_task(
         }
 
         // Reconstruct the full frame. `parse_bmp_msg` expects the
-        // header bytes at the front of the buffer — it re-reads
+        // header bytes at the front of the buffer, it re-reads
         // them to validate the version / type.
         let mut full = Vec::with_capacity(msg_len);
         full.extend_from_slice(&header_buf);
@@ -651,7 +651,7 @@ async fn reader_task(
             Ok(msg) => {
                 frames_parsed += 1;
                 if tx.send(msg).await.is_err() {
-                    // Main loop dropped the receiver — shutdown.
+                    // Main loop dropped the receiver, shutdown.
                     debug!(frames_parsed, "frame receiver closed; reader exiting");
                     return Ok(());
                 }
@@ -667,7 +667,7 @@ async fn reader_task(
 
 /// Derive a stable [`PeerId`] from a BMP per-peer header.
 /// `peer_ip + peer_distinguisher + peer_type` together uniquely
-/// identify one peer — two BGP sessions to the same peer IP that
+/// identify one peer, two BGP sessions to the same peer IP that
 /// differ in RD or peer-type hash to distinct IDs.
 fn peer_id_from_header(pph: &BmpPerPeerHeader) -> PeerId {
     let mut hasher = DefaultHasher::new();
@@ -701,7 +701,7 @@ fn asn_to_u32(asn: bgpkit_parser::models::Asn) -> u32 {
 }
 
 /// Whether `addr` is permitted by the listener's `peer_acl`. Empty
-/// ACL means "loopback only" — the config parser already enforces
+/// ACL means "loopback only", the config parser already enforces
 /// that empty + non-loopback listen is rejected, so an empty ACL
 /// implies loopback bind. The defensive `is_loopback()` check covers
 /// a misconstructed in-process config.
@@ -715,7 +715,7 @@ fn source_ip_permitted(addr: IpAddr, peer_acl: &[ipnet::IpNet]) -> bool {
 
 /// Bind a `TcpListener` with `SO_REUSEADDR` enabled (v0.2.2 fix). See
 /// the `bind_with_reuseaddr` doc in `route_source_bgp.rs` for the
-/// rationale — same problem class on both listeners.
+/// rationale, same problem class on both listeners.
 fn bind_with_reuseaddr(addr: SocketAddr) -> std::io::Result<TcpListener> {
     let socket = match addr {
         SocketAddr::V4(_) => TcpSocket::new_v4()?,

--- a/crates/modules/fast-path/src/fib/types.rs
+++ b/crates/modules/fast-path/src/fib/types.rs
@@ -172,7 +172,7 @@ unsafe impl aya::Pod for FpFibCfg {}
 // --- Layout assertions -------------------------------------------------
 //
 // These match the layouts declared in `bpf/src/maps.rs`. Any drift on
-// either side breaks the build — safer than waiting for a field
+// either side breaks the build, safer than waiting for a field
 // misalignment to cause an XDP map write to corrupt the wrong bytes.
 
 const _: () = assert!(core::mem::size_of::<FibValue>() == 8);

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -7,7 +7,7 @@
 //! with the trial-attach fallback behavior from SPEC.md §2.3, `detach`
 //! tears everything down. The real logic lives in [`linux_impl`] and
 //! is cfg-gated to `target_os = "linux"` so macOS dev loops still
-//! compile — non-Linux builds return [`ModuleError::NotImplemented`]
+//! compile, non-Linux builds return [`ModuleError::NotImplemented`]
 //! from every lifecycle method.
 
 use packetframe_common::module::{
@@ -41,13 +41,13 @@ pub const FAST_PATH_PRIORITY: u16 = 1000;
 
 /// The compiled fast-path BPF ELF, staged by `build.rs` and embedded at
 /// crate-compile time. Empty (zero bytes) when the BPF toolchain isn't
-/// available — see [`FAST_PATH_BPF_AVAILABLE`].
+/// available, see [`FAST_PATH_BPF_AVAILABLE`].
 ///
 /// Note: `include_bytes!` returns a 1-byte-aligned slice. Passing it
 /// directly to `aya::Ebpf::load` fails with "Invalid ELF header size
 /// or alignment" because the `object` crate's ELF parser does
 /// unaligned u32/u64 reads into the header. Callers must copy to an
-/// aligned buffer — use [`FastPathModule::new`] + `Module::load`,
+/// aligned buffer, use [`FastPathModule::new`] + `Module::load`,
 /// which handles this internally, or call [`aligned_bpf_copy`] to
 /// get a heap-allocated 16-byte-aligned `Vec<u8>` suitable for
 /// `aya::Ebpf::load`.
@@ -193,7 +193,7 @@ impl Module for FastPathModule {
 
     fn health_check(&self, _ctx: &HealthCtx) -> ModuleResult<HealthReport> {
         // Phase 1 (Option F): structured health reporting is now the
-        // trait surface, but fast-path has no live subsystems yet —
+        // trait surface, but fast-path has no live subsystems yet
         // RouteController / BmpStation / NeighborResolver land in
         // Phase 2-3 and will populate `subsystems`. For now, always
         // report healthy with no subsystems. Circuit-breaker wiring
@@ -224,7 +224,7 @@ mod tests {
     #[test]
     fn lifecycle_stubs_safe_to_call() {
         let mut m = FastPathModule::new();
-        // detach on an unloaded module must succeed — teardown paths
+        // detach on an unloaded module must succeed, teardown paths
         // call it unconditionally.
         assert!(m.detach().is_ok());
         let mut buf = String::new();

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -29,11 +29,11 @@ use crate::{aligned_bpf_copy, pin, FAST_PATH_BPF_AVAILABLE, MODULE_NAME};
 
 /// Layout mirror of `FpCfg` in `bpf/src/maps.rs` (PR #3). `#[repr(C)]`
 /// with all-bit-patterns-valid primitive fields, so `aya::Pod` is safe
-/// to impl — the marker tells aya the struct is safe to byte-copy into
+/// to impl, the marker tells aya the struct is safe to byte-copy into
 /// the kernel's map buffer. Bytes-for-bytes match the BPF-side struct.
 ///
 /// Layout V2 (v0.2.4): the formerly-`_reserved [u8; 2]` slot is now
-/// `mss_clamp_global: u16` — a global MSS clamp ceiling for matched
+/// `mss_clamp_global: u16`, a global MSS clamp ceiling for matched
 /// TCP SYN/SYN-ACK packets. 0 = unset. Per-prefix and per-iface clamp
 /// maps take precedence over this fallback.
 #[repr(C)]
@@ -61,7 +61,7 @@ pub(crate) const FP_CFG_FLAG_HEAD_SHIFT_128: u8 = 0b0000_0100;
 /// Mirror of `bpf/src/maps.rs::FP_CFG_FLAG_CUSTOM_FIB` (Option F).
 /// Set when `forwarding-mode` is `custom-fib` or `compare`; routes
 /// the XDP program to consult `FIB_V4`/`FIB_V6` instead of
-/// `bpf_fib_lookup()`. Not yet read from the XDP program — Phase 1
+/// `bpf_fib_lookup()`. Not yet read from the XDP program, Phase 1
 /// Slice 1B lands the dispatch gate. Kept in lockstep with the BPF
 /// side so userspace writes the right bit.
 #[allow(dead_code)]
@@ -85,11 +85,11 @@ const RVU_NICPF_FIXED_IN_KERNEL: (u32, u32) = (6, 8);
 
 /// Kernel driver names that trigger the head-shift workaround.
 /// `/sys/class/net/<iface>/device/driver` is a symlink into
-/// `/sys/bus/pci/drivers/<module_name>` — for this driver the kernel
+/// `/sys/bus/pci/drivers/<module_name>`, for this driver the kernel
 /// module is `rvu_nicpf.ko`, so the sysfs leaf is `rvu_nicpf` (with
 /// an underscore). `ethtool -i` happens to print the pci_driver's
 /// `name` field as `rvu-nicpf` (with a hyphen) on the reference
-/// hardware, which had us matching the wrong spelling in v0.1.3 —
+/// hardware, which had us matching the wrong spelling in v0.1.3
 /// confirmed empirically via `readlink /sys/class/net/ethN/device/driver`
 /// on 5.15.72-ui-cn9670. Accepting both spellings is cheap and keeps
 /// us correct even if a distro one day canonicalises differently.
@@ -132,7 +132,7 @@ unsafe impl aya::Pod for MssClampValue {}
 /// After `attach`, the XDP program, every §4.5 map, and each per-iface
 /// link is pinned under `<bpffs-root>/fast-path/`. Dropping
 /// `ActiveState` closes our userspace FDs but the bpffs inodes hold
-/// the kernel references — SPEC.md §8.5 "exit without detach" works as
+/// the kernel references, SPEC.md §8.5 "exit without detach" works as
 /// soon as pinning is in place. `Module::detach` unlinks the pins,
 /// which is when the kernel actually tears everything down.
 pub struct ActiveState {
@@ -149,18 +149,18 @@ pub struct ActiveState {
     /// `detach` so we can pace link-pin removals symmetrically with
     /// the attach path. Removing all link pins inside one STP
     /// reconvergence window has been observed to wedge the bridge
-    /// stack on rvu-nicpf hardware (kernel panic, full reboot)
-    /// — the same class of bug §11.8 calls out for attach.
+    /// stack on rvu-nicpf hardware (kernel panic, full reboot);
+    /// this is the same class of bug §11.8 calls out for attach.
     pub attach_settle_time: std::time::Duration,
 }
 
 /// One XDP attach. `effective_mode` records what actually stuck in
 /// `Auto` mode so `status` can report it. `link` is either:
 ///
-/// - `Pinned(PinnedLink)` — the happy path; dropping closes the
+/// - `Pinned(PinnedLink)`, the happy path; dropping closes the
 ///   userspace FD but leaves the bpffs inode, so the kernel attach
 ///   survives process exit (§8.5).
-/// - `Transient(FdLink)` — pin syscall was rejected (e.g. EPERM on
+/// - `Transient(FdLink)`, pin syscall was rejected (e.g. EPERM on
 ///   generic-mode XDP links on some kernels). The attach still works,
 ///   but dropping the FdLink detaches the kernel-side XDP program.
 ///   SIGTERM will detach these interfaces; native-mode ones persist.
@@ -186,20 +186,20 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
     if !FAST_PATH_BPF_AVAILABLE {
         return Err(ModuleError::other(
             MODULE_NAME,
-            "no BPF ELF embedded in the binary — build with rustup + nightly + bpf-linker (see CLAUDE.md)",
+            "no BPF ELF embedded in the binary, build with rustup + nightly + bpf-linker (see CLAUDE.md)",
         ));
     }
 
     // Refuse startup when pins from a prior invocation survive.
     // SPEC.md §8.5 "exit without detach" leaves pins in bpffs after
-    // SIGTERM; v0.1 does not adopt those — operator must run
+    // SIGTERM; v0.1 does not adopt those, operator must run
     // `packetframe detach --all` first. Full adoption (zero-disruption
     // restart) is deferred.
     if pin::has_existing_pins(ctx.bpffs_root) {
         return Err(ModuleError::other(
             MODULE_NAME,
             format!(
-                "existing pins under {} from a prior invocation — \
+                "existing pins under {} from a prior invocation, \
                  run `packetframe detach --all` before restarting \
                  (v0.1 does not yet adopt in-place)",
                 pin::module_root(ctx.bpffs_root).display()
@@ -212,7 +212,7 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
 
     // aya doesn't expose an `Ebpf::load_with_options` that'd let us
     // skip BTF lookup; on the reference EFG (§2.2) BTF is absent but
-    // aya handles that path internally. Use an aligned copy — the
+    // aya handles that path internally. Use an aligned copy, the
     // embedded `include_bytes!` slice is 1-byte-aligned which the
     // object crate's ELF parser rejects.
     let bytes = aligned_bpf_copy();
@@ -313,7 +313,7 @@ fn populate_cfg(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<()> {
 /// mode so the XDP program reads consistent config even if an
 /// operator flips to `custom-fib` via `packetframe reconfigure`
 /// later. Fail-soft: if the map is missing from the ELF (older build
-/// during development), log and continue — the BPF program reads the
+/// during development), log and continue, the BPF program reads the
 /// map defensively and falls back to built-in defaults.
 fn populate_fib_config(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<()> {
     let hash_mode = mcfg
@@ -335,7 +335,7 @@ fn populate_fib_config(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult
     let map = match ebpf.map_mut("FIB_CONFIG") {
         Some(m) => m,
         None => {
-            info!("FIB_CONFIG map missing from ELF — skipping (older build?)");
+            info!("FIB_CONFIG map missing from ELF, skipping (older build?)");
             return Ok(());
         }
     };
@@ -424,7 +424,7 @@ fn populate_blocklists(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult
         return Ok(());
     }
     // Sanity-guard: refuse to start if a block-prefix overlaps an
-    // allow-prefix or local-prefix. Operator config bug — they almost
+    // allow-prefix or local-prefix. Operator config bug, they almost
     // certainly didn't mean to block traffic to their own customer
     // /24.
     let allow_v4: Vec<Ipv4Prefix> = mcfg
@@ -452,7 +452,7 @@ fn populate_blocklists(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult
                     MODULE_NAME,
                     format!(
                         "block-prefix {}/{} overlaps with allow-prefix or local-prefix \
-                         {}/{} — refusing to start (operator config bug; would silently \
+                         {}/{}, refusing to start (operator config bug; would silently \
                          drop traffic to declared customer prefixes)",
                         b.addr, b.prefix_len, a.addr, a.prefix_len
                     ),
@@ -518,7 +518,7 @@ pub(crate) fn mss_clamp_global_value(directives: &[ModuleDirective]) -> Option<u
 /// from any `mss-clamp` directives in the module config. The global
 /// (`mss-clamp <mtu>`) form is handled in `populate_cfg` via the
 /// `FpCfg.mss_clamp_global` field; this function handles the three
-/// scoped forms — per-prefix, per-iface, and per-prefix-+-iface.
+/// scoped forms, per-prefix, per-iface, and per-prefix-+-iface.
 /// Empty / no directives → all maps stay empty (LPM lookups miss
 /// cheaply, no per-packet overhead).
 fn populate_mss_clamp(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<()> {
@@ -540,7 +540,7 @@ fn populate_mss_clamp(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<
             continue;
         };
         // Resolve `via <iface>` to ifindex if present. Missing ifaces
-        // are fatal at load — the operator declared a clamp on an
+        // are fatal at load, the operator declared a clamp on an
         // iface that doesn't exist, which is almost certainly a typo.
         let iface_filter: u32 = match iface {
             Some(name) => if_nametoindex(name).map_err(|e| {
@@ -562,7 +562,7 @@ fn populate_mss_clamp(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<
                 iface_entries.push((name.clone(), *mss));
             }
             (None, None) => {
-                // Global — handled by populate_cfg; skip here.
+                // Global, handled by populate_cfg; skip here.
             }
         }
     }
@@ -725,7 +725,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // fixes two bugs in one patch: (1) the xdp.data_hard_start offset
     // bug that v0.1.3 worked around via head-shift; (2) a
     // `non_qos_queues` leak at `otx2_xdp_setup` that is *not* fixable
-    // from userspace — every native XDP attach leaks the count, and
+    // from userspace, every native XDP attach leaks the count, and
     // after enough attach/detach cycles the driver's queue sizing
     // drifts and the page allocator's freelist gets a NULL write,
     // producing the `get_page_from_freelist` NULL deref crash signature
@@ -749,7 +749,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // (e.g. EPERM on some kernels for generic-XDP links) the attach
     // still succeeds but that specific link won't outlive the process.
     //
-    // SPEC.md §11.8 — XDP attach on some drivers (rvu-nicpf observed)
+    // SPEC.md §11.8, XDP attach on some drivers (rvu-nicpf observed)
     // briefly bounces the link. If multiple attach ifaces share a
     // bridge master, attaching them inside one STP reconvergence
     // window risks an L2 loop and packet storm. Sleep
@@ -796,7 +796,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // defensive devmap pre-check in the BPF program (§4.4 step 9d)
     // recognizes them as valid redirect targets. The value ifindex
     // matches the key ifindex for a simple "redirect back to the
-    // physical port the FIB resolved to" — aya accepts this.
+    // physical port the FIB resolved to", aya accepts this.
     let devmap_map = state
         .ebpf
         .map_mut("REDIRECT_DEVMAP")
@@ -805,13 +805,13 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("REDIRECT_DEVMAP try_from: {e}")))?;
 
     // Populate REDIRECT_DEVMAP with every UP Ethernet-type iface on the
-    // host, not just the attach ifaces. The FIB lookup is dynamic — on
+    // host, not just the attach ifaces. The FIB lookup is dynamic, on
     // a BGP edge, routes change and the egress iface for any given
     // packet is determined at lookup time. Hardcoding the attach list
     // as the egress allowlist breaks any topology where ingress ≠
     // egress (classic edge router: trunks in, WAN out).
     //
-    // Filter: `/sys/class/net/<iface>/type == 1` (ARPHRD_ETHER — covers
+    // Filter: `/sys/class/net/<iface>/type == 1` (ARPHRD_ETHER, covers
     // physical NICs, bridges, VLAN subifs, veth) AND operstate is `up`
     // or `unknown` (some virtual ifaces never report operstate). Skip
     // loopback (type 772) + tunnels (various non-1 types).
@@ -866,7 +866,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 port,
                 require_loc_rib,
                 peer_from,
-                // `allow_remote` is informational here — the config
+                // `allow_remote` is informational here, the config
                 // parser already rejected the unsafe shape (non-loopback
                 // bind without opt-in), so by the time we see the spec
                 // the `peer_from` ACL is either non-empty or the listen
@@ -979,7 +979,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     }
 
     // Build Attachment records for the pin registry. `pinned_path`
-    // points at the real link pin — when `packetframe detach` runs,
+    // points at the real link pin, when `packetframe detach` runs,
     // it unlinks this path, which is how the kernel-side attach tears
     // down.
     Ok(state
@@ -1006,7 +1006,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
 /// hits the rvu-nicpf native-mode delivery bug (SPEC §11.1(c),
 /// upstream-fixed in Linux v6.8 commit `04f647c8e456` but absent
 /// from many downstream kernels). Safe and idempotent on fixed
-/// kernels — set `off` via config override once the operator
+/// kernels, set `off` via config override once the operator
 /// confirms the backport (future PR; for v0.1.3 the detection is
 /// purely driver-name-based).
 ///
@@ -1044,14 +1044,14 @@ fn apply_driver_quirks_cfg(state: &mut ActiveState, mcfg: &ModuleConfig<'_>) -> 
         if matches!(toggle, ToggleAutoOnOff::Off) {
             info!(
                 "rvu-nicpf head-shift workaround disabled by config (`driver-workaround \
-                 rvu-nicpf-head-shift off`) — assuming Linux v6.8+ or backported fix"
+                 rvu-nicpf-head-shift off`), assuming Linux v6.8+ or backported fix"
             );
         }
         return Ok(());
     }
 
-    // Read current FpCfg, OR in the flag, write back. We only set —
-    // never clear — so we don't clobber the IPv4/IPv6 enable bits
+    // Read current FpCfg, OR in the flag, write back. We only set
+    // never clear, so we don't clobber the IPv4/IPv6 enable bits
     // that `populate_cfg` wrote at load time.
     let map = state
         .ebpf
@@ -1082,7 +1082,7 @@ fn apply_driver_quirks_cfg(state: &mut ActiveState, mcfg: &ModuleConfig<'_>) -> 
         ifaces = ?affected,
         upstream_fix_commit = "04f647c8e456",
         fixed_in_kernel = "v6.8",
-        "enabling pre-v6.8 rvu-nicpf head-shift workaround (SPEC §11.1(c)) — fast-path will \
+        "enabling pre-v6.8 rvu-nicpf head-shift workaround (SPEC §11.1(c)), fast-path will \
          bpf_xdp_adjust_head(+128) + bpf_xdp_adjust_tail(+128) on every packet to expose the \
          real frame. Set `driver-workaround rvu-nicpf-head-shift off` in the config once the \
          kernel backport lands."
@@ -1092,7 +1092,7 @@ fn apply_driver_quirks_cfg(state: &mut ActiveState, mcfg: &ModuleConfig<'_>) -> 
 
 /// Read `/proc/sys/kernel/osrelease` (= `uname -r`) and parse the
 /// leading `major.minor`. Returns `None` if the file is unreadable
-/// or the format is unrecognizable — callers treat that as "can't
+/// or the format is unrecognizable, callers treat that as "can't
 /// prove the fix is present", i.e. the conservative path.
 fn kernel_version() -> Option<(u32, u32)> {
     let osrelease = std::fs::read_to_string("/proc/sys/kernel/osrelease").ok()?;
@@ -1196,7 +1196,7 @@ fn rvu_nicpf_version_gate(
 /// `/sys/class/net/<iface>/device/driver` (a symlink into
 /// `/sys/bus/*/drivers/<driver>`). Returns `None` for netdevs that
 /// have no underlying device (veth pairs, bridges, loopback) or when
-/// the file isn't present. Doesn't try ethtool — sysfs is
+/// the file isn't present. Doesn't try ethtool, sysfs is
 /// netns-aware when mounted per-netns and avoids another
 /// capability-gated syscall just for a name.
 fn read_iface_driver(iface: &str) -> Option<String> {
@@ -1292,7 +1292,7 @@ fn populate_mutation_progs(ebpf: &mut Ebpf) -> ModuleResult<()> {
 /// §2.3: per-interface trial-attach. `Native` and `Generic` are explicit
 /// (no fallback); `Auto` tries native first, falls back to generic on
 /// any error. The spec calls out that `bpftool feature probe` is
-/// unreliable — we find out what works by actually trying. Each
+/// unreliable, we find out what works by actually trying. Each
 /// successful attach immediately pins its link under
 /// `<bpffs-root>/fast-path/links/<iface>` so the kernel attach
 /// survives process exit (§8.5).
@@ -1352,7 +1352,7 @@ fn try_attach_with_fallback(
 
 /// Attach + `take_link`, then try to pin. Returns:
 ///
-/// - `LinkHandle::Pinned` on success — the kernel attach survives
+/// - `LinkHandle::Pinned` on success, the kernel attach survives
 ///   process exit via the bpffs inode.
 /// - `LinkHandle::Transient` if pinning was rejected (EPERM on
 ///   generic-mode XDP links on some kernels, for instance). The
@@ -1360,7 +1360,7 @@ fn try_attach_with_fallback(
 ///   the kernel-side program.
 ///
 /// Hard errors (attach fails, `take_link` fails, link isn't
-/// bpf_link_create-backed) remain hard errors — the caller bubbles
+/// bpf_link_create-backed) remain hard errors, the caller bubbles
 /// them up.
 fn attach_and_pin(
     prog: &mut Xdp,
@@ -1387,7 +1387,7 @@ fn attach_and_pin(
             MODULE_NAME,
             // SPEC.md requires kernel ≥5.15; ≥5.9 gives us bpf_link_create
             // + FdLink. On older kernels aya returns an NlLink which can't
-            // pin — that path is reachable only if someone runs on a
+            // pin, that path is reachable only if someone runs on a
             // kernel the probe missed.
             format!(
                 "XDP link for {iface} is netlink-backed (kernel too old for bpf_link_create?): {e}",
@@ -1412,7 +1412,7 @@ fn attach_and_pin(
             // Re-attach so we have an FdLink to hold. `attach_to_if_index`
             // was already called; calling it again would double-attach
             // which the kernel rejects. Fortunately `FdLink::pin`
-            // consumes `self` even on error — the link FD is already
+            // consumes `self` even on error, the link FD is already
             // gone. Re-attach from scratch:
             let link_id = prog.attach_to_if_index(ifindex, flags).map_err(|e| {
                 ModuleError::other(
@@ -1438,7 +1438,7 @@ fn attach_and_pin(
 }
 
 /// Walk a std::error::Error's source chain and join into one display
-/// string — aya's `SyscallError` hides the underlying `io::Error`
+/// string, aya's `SyscallError` hides the underlying `io::Error`
 /// behind `#[source]`, so plain `{}` drops the errno. This matters on
 /// any BPF syscall where the errno is the whole diagnostic.
 fn format_error_chain(err: &dyn std::error::Error) -> String {
@@ -1455,12 +1455,12 @@ fn format_error_chain(err: &dyn std::error::Error) -> String {
 /// subinterface maps its ifindex → (physical parent ifindex, VID) so
 /// the BPF program can push/pop/rewrite per SPEC §4.7 when the FIB
 /// resolves to a subif. Missing `/proc/net/vlan/config` (no 8021q
-/// kernel module loaded) is not an error — we just insert nothing.
+/// kernel module loaded) is not an error, we just insert nothing.
 fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
     let entries = match read_vlan_config() {
         Ok(e) => e,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            info!("/proc/net/vlan/config missing — no VLAN subifs to resolve");
+            info!("/proc/net/vlan/config missing, no VLAN subifs to resolve");
             return Ok(());
         }
         Err(e) => {
@@ -1472,7 +1472,7 @@ fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
     };
 
     if entries.is_empty() {
-        info!("/proc/net/vlan/config empty — no VLAN subifs configured");
+        info!("/proc/net/vlan/config empty, no VLAN subifs configured");
         return Ok(());
     }
 
@@ -1553,7 +1553,7 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
 
     // Drop every PinnedLink next: this closes our userspace FDs but
     // the kernel keeps the attach alive via the bpffs inodes. Drain
-    // in reverse attach order — no practical consequence here, matches
+    // in reverse attach order, no practical consequence here, matches
     // typical lifecycle expectations.
     while let Some(link) = state.links.pop() {
         info!(iface = %link.iface, "fast-path detaching");
@@ -1562,7 +1562,7 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
 
     // Unlink every pin under the module's pin root. Pace the link-pin
     // removals by `attach_settle_time` so we don't trigger an STP
-    // reconvergence storm on shared bridge masters — same hazard
+    // reconvergence storm on shared bridge masters, same hazard
     // §11.8 calls out for the attach path. Removing all link pins in
     // ~1 ms (the pre-rc5 behavior) wedged the bridge stack on rvu-
     // nicpf with eth0/eth4/eth5 all bridged on switch0, kernel-
@@ -1579,7 +1579,7 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
 /// Walk `/sys/class/net` and return the `(name, ifindex)` of every
 /// iface that's a viable XDP redirect target:
 ///
-/// - `type == 1` (ARPHRD_ETHER) — covers physical NICs, bridges,
+/// - `type == 1` (ARPHRD_ETHER), covers physical NICs, bridges,
 ///   VLAN subifs, veth, bonded masters. Excludes loopback (772),
 ///   PPP, SLIP, tunnels (`ip_vti`, `ip6tnl`, `ip_tunnel`, tailscale,
 ///   WireGuard, etc. which use ARPHRD_NONE or similar).
@@ -1625,7 +1625,7 @@ pub(crate) fn enumerate_redirect_targets() -> Vec<(String, u32)> {
 }
 
 /// Emit a warning if two or more of the attach ifaces share a bridge
-/// master. SPEC.md §11.8 — on drivers that bounce the link at attach
+/// master. SPEC.md §11.8, on drivers that bounce the link at attach
 /// time, bouncing multiple bridge members inside one STP reconvergence
 /// window has been observed to trigger L2 loops. `attach_settle_time`
 /// between per-iface attaches mitigates but does not eliminate this.
@@ -1653,7 +1653,7 @@ fn warn_shared_bridge_masters(ifaces: &[&str], settle_time: std::time::Duration)
             bridge = %master,
             members = ?members,
             settle_secs = settle_time.as_secs_f64(),
-            "multiple attach ifaces share bridge master — XDP attach can cause L2 loops \
+            "multiple attach ifaces share bridge master, XDP attach can cause L2 loops \
              during STP reconvergence (§11.8). `attach-settle-time` spaces the attaches; \
              ensure it is long enough for your bridge to reconverge (default 2s)."
         );
@@ -1679,7 +1679,7 @@ pub(crate) fn if_nametoindex(name: &str) -> ModuleResult<u32> {
 /// Per-interface native-XDP trial-attach probe for the feasibility
 /// report (§2.3). Loads a minimal no-op XDP program and tries to
 /// attach it to each interface in native mode, reporting per-interface
-/// verdict. The no-op program is the `fast_path` program itself —
+/// verdict. The no-op program is the `fast_path` program itself
 /// any attached program's load/attach path is the same.
 pub fn trial_attach_native(iface: &str) -> TrialResult {
     if !FAST_PATH_BPF_AVAILABLE {
@@ -1706,7 +1706,7 @@ pub fn trial_attach_native(iface: &str) -> TrialResult {
     }
     match prog.attach_to_if_index(ifindex, XdpFlags::DRV_MODE) {
         Ok(link_id) => {
-            // Detach immediately — this was a probe.
+            // Detach immediately, this was a probe.
             let _ = prog.detach(link_id);
             TrialResult::NativeOk
         }
@@ -1748,7 +1748,7 @@ pub fn snapshot_links(state: &ActiveState) -> Vec<(String, u32, AttachMode)> {
         .collect()
 }
 
-// Read current stats — aggregated across all CPUs.
+// Read current stats, aggregated across all CPUs.
 pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
     use aya::maps::PerCpuArray;
 
@@ -1764,7 +1764,7 @@ pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
 }
 
 /// Snapshot of the custom-FIB control-plane state that's readable
-/// from a separate process via the bpffs pins — i.e., no live
+/// from a separate process via the bpffs pins, i.e., no live
 /// `FibProgrammer` handle required. Used by `packetframe status` to
 /// surface an operator-facing summary during and after cutover.
 ///
@@ -1794,7 +1794,7 @@ pub struct FibStatusSnapshot {
     pub nh_stale: u32,
     pub nh_unwritten_or_incomplete: u32,
     pub nh_max_entries: u32,
-    /// ECMP groups where `nh_count > 0` — a conservative estimate
+    /// ECMP groups where `nh_count > 0`, a conservative estimate
     /// of "how many groups are actively in use." Slots with nh_count=0
     /// are either unwritten or tombstoned; we can't distinguish
     /// without programmer state.
@@ -1804,7 +1804,7 @@ pub struct FibStatusSnapshot {
 
 /// Read the custom-FIB snapshot from the bpffs pins. Best-effort:
 /// missing or malformed pins produce warnings and default values
-/// rather than hard errors — `packetframe status` should still
+/// rather than hard errors, `packetframe status` should still
 /// show whatever it can even if a subset of the custom-FIB maps
 /// aren't pinned yet (e.g., kernel-fib mode).
 pub fn fib_status_from_pin(bpffs_root: &Path) -> FibStatusSnapshot {
@@ -1900,7 +1900,7 @@ fn read_nexthops_state_distribution(bpffs_root: &Path) -> ModuleResult<(NhStateD
 
     let mut dist = NhStateDistribution::default();
     // Walk up to NEXTHOPS_CAP (8192). At ~100ns per Array::get syscall
-    // this is ~1ms on a modern box — fine for status on demand.
+    // this is ~1ms on a modern box, fine for status on demand.
     for idx in 0..NEXTHOPS_CAP {
         let entry = match arr.get(&idx, 0) {
             Ok(e) => e,
@@ -1940,7 +1940,7 @@ fn read_ecmp_groups_active(bpffs_root: &Path) -> ModuleResult<(u32, u32)> {
     Ok((active, ECMP_GROUPS_CAP))
 }
 
-/// Read STATS directly from the bpffs pin — no live module required.
+/// Read STATS directly from the bpffs pin, no live module required.
 /// Used by `packetframe status` when the loader isn't running.
 pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
     use aya::maps::{Map, MapData, PerCpuArray};
@@ -1987,7 +1987,7 @@ fn read_stats<T: std::borrow::Borrow<aya::maps::MapData>>(
 /// fast-pathed packet.
 ///
 /// aya 0.13's ProgramArray exposes `indices()` (which keys are set)
-/// but not a getter that returns the populated `ProgramFd`/prog_id —
+/// but not a getter that returns the populated `ProgramFd`/prog_id
 /// the BPF_MAP_TYPE_PROG_ARRAY value is a kernel RawFd that becomes
 /// invalid outside the loader's process. We just report populated/
 /// empty here; operators can confirm prog_id via

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -2,8 +2,8 @@
 //! (SPEC.md §7.3, §4.6).
 //!
 //! Counter names mirror the `StatIdx` discriminants in
-//! `bpf/src/maps.rs`. The order is append-only once v0.1 ships —
-//! renumbering `StatIdx` would break operator dashboards — so this
+//! `bpf/src/maps.rs`. The order is append-only once v0.1 ships
+//! renumbering `StatIdx` would break operator dashboards, so this
 //! table is implicitly ordered by discriminant. Runtime formatting
 //! depends on both lists matching: the zipping loop in
 //! `render_textfile` assumes `NAMES` and `stats` line up.
@@ -20,7 +20,7 @@ use std::fmt::Write as _;
 /// Wire-format counter names, index-aligned with `StatIdx` in
 /// `bpf/src/maps.rs`. These become the `packetframe_<name>_total`
 /// metric names; changing any value changes the operator-facing
-/// metric name. Append-only — renumbering breaks dashboards.
+/// metric name. Append-only, renumbering breaks dashboards.
 ///
 /// Phase 1 (Option F custom FIB): length grew from 19 → 32. The
 /// pre-existing 19 was already off-by-one (`err_head_shift` at
@@ -66,7 +66,7 @@ pub const COUNTER_NAMES: [&str; 33] = [
 /// Render a Prometheus textfile body from stat values + module uptime.
 /// Every counter gets `# TYPE` and `# HELP` headers so Prometheus's
 /// textfile collector categorizes it correctly. Counter names that
-/// already end in `_total` (e.g. `rx_total`) get emitted as-is —
+/// already end in `_total` (e.g. `rx_total`) get emitted as-is
 /// Prometheus convention requires one `_total` suffix, not two.
 pub fn render_textfile(stats: &[u64], uptime_seconds: u64) -> String {
     let mut out = String::with_capacity(4096);
@@ -204,7 +204,7 @@ mod tests {
     #[test]
     fn counter_names_match_stats_count() {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
-        // drift, the zip() in render_textfile silently truncates —
+        // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
         assert_eq!(COUNTER_NAMES.len(), 33);
     }
@@ -290,7 +290,7 @@ mod tests {
             ecmp_max_entries: 0,
         };
         let body = render_fib_gauges(&snap);
-        // With `forwarding_mode: None`, no mode is "active" — every
+        // With `forwarding_mode: None`, no mode is "active", every
         // one-hot emits 0.
         assert!(body.contains(
             "packetframe_fib_forwarding_mode{module=\"fast-path\",mode=\"custom-fib\"} 0"
@@ -298,7 +298,7 @@ mod tests {
         assert!(body.contains(
             "packetframe_fib_forwarding_mode{module=\"fast-path\",mode=\"kernel-fib\"} 0"
         ));
-        // default_hash_mode absent when the CFG pin isn't readable —
+        // default_hash_mode absent when the CFG pin isn't readable
         // scrapers see the metric simply not emitted.
         assert!(!body.contains("packetframe_fib_default_hash_mode"));
         assert!(body.contains("packetframe_nexthops_max{module=\"fast-path\"} 0"));

--- a/crates/modules/fast-path/src/pin.rs
+++ b/crates/modules/fast-path/src/pin.rs
@@ -14,7 +14,7 @@
 //!
 //! v0.1 refuses startup when pins already exist from a prior
 //! invocation. Full adoption (zero-disruption daemon restart) is
-//! deferred — the operator runs `packetframe detach --all` to clean
+//! deferred, the operator runs `packetframe detach --all` to clean
 //! up before restarting.
 
 use std::path::{Path, PathBuf};
@@ -104,7 +104,7 @@ pub fn link_path(bpffs_root: &Path, iface: &str) -> PathBuf {
 }
 
 /// Create the module's pin subdirectories if missing. The bpffs root
-/// itself must already be mounted — [`packetframe_common::probe`]'s
+/// itself must already be mounted, [`packetframe_common::probe`]'s
 /// `bpffs` probe checks that.
 pub fn ensure_dirs(bpffs_root: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(progs_dir(bpffs_root))?;
@@ -114,7 +114,7 @@ pub fn ensure_dirs(bpffs_root: &Path) -> std::io::Result<()> {
 }
 
 /// True when any pinned object exists under the module's pin root.
-/// Startup checks this before fresh-loading — pinned state from a prior
+/// Startup checks this before fresh-loading, pinned state from a prior
 /// invocation must be cleaned via `packetframe detach --all` first.
 pub fn has_existing_pins(bpffs_root: &Path) -> bool {
     for sub in [
@@ -135,12 +135,12 @@ pub fn has_existing_pins(bpffs_root: &Path) -> bool {
 
 /// Remove every pin under the module's pin root. Called by
 /// `packetframe detach`. Missing files and missing directories are
-/// not errors — the post-condition is "no pins", regardless of
+/// not errors, the post-condition is "no pins", regardless of
 /// starting state.
 ///
 /// Removing a link pin causes the kernel to detach the XDP program
 /// from the iface. Removing the program and map pins is housekeeping
-/// — their kernel-side objects disappear once no FDs or links
+/// their kernel-side objects disappear once no FDs or links
 /// reference them.
 pub fn remove_all(bpffs_root: &Path) -> std::io::Result<()> {
     remove_all_paced(bpffs_root, std::time::Duration::ZERO)
@@ -151,7 +151,7 @@ pub fn remove_all(bpffs_root: &Path) -> std::io::Result<()> {
 ///
 /// **Why this exists.** Removing a link pin causes the kernel to
 /// detach the XDP program from the iface. On certain drivers (rvu-
-/// nicpf in particular — observed during Phase 4 cutover testing),
+/// nicpf in particular, observed during Phase 4 cutover testing),
 /// detach briefly bounces the link, which the bridge stack treats as
 /// a port-state change. Bouncing multiple bridge members inside one
 /// STP/RSTP reconvergence window can wedge the bridge into a brief
@@ -159,7 +159,7 @@ pub fn remove_all(bpffs_root: &Path) -> std::io::Result<()> {
 /// a kernel panic + full reboot.
 ///
 /// SPEC.md §11.8 documents this for the attach side. The detach side
-/// is symmetric and was missing — pre-rc5 `pin::remove_all` deleted
+/// is symmetric and was missing, pre-rc5 `pin::remove_all` deleted
 /// every link inode in a tight loop with no spacing. This function
 /// fixes that by sleeping `settle_time` between consecutive bridge-
 /// member detaches.
@@ -173,7 +173,7 @@ pub fn remove_all_paced(
     settle_time: std::time::Duration,
 ) -> std::io::Result<()> {
     // Remove links first so the kernel-side attach is gone before the
-    // program is unreferenced. Order is defensive — the kernel copes
+    // program is unreferenced. Order is defensive, the kernel copes
     // with reverse order too.
     let links = links_dir(bpffs_root);
     let link_files: Vec<std::path::PathBuf> = match std::fs::read_dir(&links) {
@@ -194,7 +194,7 @@ pub fn remove_all_paced(
 
     for (idx, path) in link_files.iter().enumerate() {
         if idx > 0 && bridged_count >= 2 && !settle_time.is_zero() {
-            // Only pace once we've removed at least one — the first
+            // Only pace once we've removed at least one, the first
             // removal doesn't need a preceding sleep.
             std::thread::sleep(settle_time);
         }
@@ -227,7 +227,7 @@ pub fn remove_all_paced(
 /// Count how many of the given link-pin paths refer to interfaces
 /// that share a bridge master. Returns 0 if none are bridged, the
 /// total count of bridge members otherwise. Used to gate detach
-/// pacing — paying the per-iface settle cost only matters when a
+/// pacing, paying the per-iface settle cost only matters when a
 /// bridge is actually involved.
 fn count_shared_bridge_masters(link_files: &[std::path::PathBuf]) -> usize {
     use std::collections::HashMap;
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn remove_all_paced_zero_duration_matches_unpaced() {
-        // settle_time=ZERO must behave identically to remove_all —
+        // settle_time=ZERO must behave identically to remove_all
         // tests rely on this and the cli `detach --all` without
         // config defaults to the standard 2 s, but should still
         // function with zero in unit-test context.
@@ -341,7 +341,7 @@ mod tests {
         // /sys/class/net lookups will fail for our fake "eth0"
         // pin (it's not a real interface), so `count_shared_bridge_masters`
         // returns 0 and pacing is skipped. The point of this test is
-        // to confirm pacing-when-no-bridge doesn't slow tests down —
+        // to confirm pacing-when-no-bridge doesn't slow tests down
         // a 5 s settle must NOT be slept here.
         let dir = tempdir();
         ensure_dirs(&dir).unwrap();

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -7,7 +7,7 @@
 //! state and applies adds + removes without reloading the BPF
 //! program.
 //!
-//! Map updates aren't transactional — if an individual insert or
+//! Map updates aren't transactional, if an individual insert or
 //! delete fails we log it and continue. Partial-update state is
 //! strictly better than halting mid-reconcile. Attach-set changes
 //! (new iface or iface removed from the config) are **not** handled
@@ -209,7 +209,7 @@ where
 
 fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
     // Rebuild the desired set from /proc/net/vlan/config. Missing file
-    // means no VLAN subifs — desired is empty, which will remove any
+    // means no VLAN subifs, desired is empty, which will remove any
     // stale entries.
     let vlan_entries = match read_vlan_config() {
         Ok(e) => e,
@@ -225,7 +225,7 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
     let desired: HashSet<(u32, u32, u16)> = vlan_entries
         .iter()
         .filter_map(|(subif, vid, parent)| {
-            // Skip entries whose ifindexes don't resolve — the proc
+            // Skip entries whose ifindexes don't resolve, the proc
             // file is a snapshot; an iface may have disappeared between
             // read and here.
             let subif_idx = if_nametoindex(subif).ok()?;
@@ -241,7 +241,7 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
     let mut hm: AyaHashMap<_, u32, VlanResolve> = AyaHashMap::try_from(map)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("VLAN_RESOLVE try_from: {e}")))?;
 
-    // Gather current state — value is VlanResolve { phys_ifindex, vid }.
+    // Gather current state, value is VlanResolve { phys_ifindex, vid }.
     let current: HashSet<(u32, u32, u16)> = hm
         .iter()
         .filter_map(Result::ok)
@@ -465,7 +465,7 @@ fn reconcile_mss_clamp(
                 desired_iface.insert(iface_filter, *mss);
             }
             (None, None) => {
-                // Global — handled by reconcile_cfg.
+                // Global, handled by reconcile_cfg.
             }
         }
     }
@@ -508,7 +508,7 @@ where
         let key = LpmKey::new(*len, *data);
         // Treat any insert as either an add (key not present) or an
         // update (key present, value possibly changed). The delta
-        // counts adds only; updates are silent — operators see them
+        // counts adds only; updates are silent, operators see them
         // as "0 added, 0 removed" and have to look at counters to
         // confirm new values landed.
         let was_present = current_keys.contains(&(*len, *data));

--- a/crates/modules/fast-path/src/registry.rs
+++ b/crates/modules/fast-path/src/registry.rs
@@ -47,7 +47,7 @@ pub struct AttachmentRecord {
 }
 
 /// Serde-compatible mirror of [`HookType`]. Doesn't derive
-/// Serialize/Deserialize on the trait type itself — that's
+/// Serialize/Deserialize on the trait type itself, that's
 /// `packetframe-common`'s concern, and we'd rather not widen its
 /// public surface just for this one consumer.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/crates/modules/fast-path/tests/attach.rs
+++ b/crates/modules/fast-path/tests/attach.rs
@@ -2,10 +2,10 @@
 #![cfg(target_os = "linux")]
 
 //! Integration test: load the fast-path BPF ELF, create a veth pair,
-//! attach to one end (native XDP, falling back to generic — veth
+//! attach to one end (native XDP, falling back to generic, veth
 //! supports native on modern kernels), detach, and clean up.
 //!
-//! This is the lightweight version of a full netns routing test — the
+//! This is the lightweight version of a full netns routing test, the
 //! point is to exercise the aya attach/detach round-trip against a real
 //! ifindex, which `bpf_prog_test_run` can't do. Full end-to-end
 //! forwarding (packet in → redirect → packet out) lands in a later PR

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -36,7 +36,7 @@ use packetframe_fast_path::{
 };
 
 /// Layout mirror of `FpCfg` in `bpf/src/maps.rs`. Must track
-/// `linux_impl::FpCfg` — if you change one, change both (and both's
+/// `linux_impl::FpCfg`, if you change one, change both (and both's
 /// ordering in the StatIdx enum at the same time).
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
@@ -121,7 +121,7 @@ impl Harness {
     /// jumps into finalize. Panics if BPF isn't built or the verifier
     /// rejects either program.
     ///
-    /// `bpf_prog_test_run` follows tail-calls — the kernel re-enters
+    /// `bpf_prog_test_run` follows tail-calls, the kernel re-enters
     /// its BPF dispatcher for the target program, so tests that issue
     /// `harness.run(&packet)` see the verdict + mutations from the full
     /// chain (fast_path → finalize) when the packet is a successful
@@ -266,7 +266,7 @@ impl Harness {
     }
 
     /// Set a nexthop entry's state to something other than `Resolved`
-    /// — tests exercising the `NoNeigh` path use this.
+    /// tests exercising the `NoNeigh` path use this.
     pub fn set_nexthop_state(&mut self, idx: u32, state: u8) {
         let map = self.bpf.map_mut("NEXTHOPS").expect("NEXTHOPS map");
         let mut arr: Array<_, NexthopEntry> = Array::try_from(map).expect("NEXTHOPS try_from");
@@ -445,7 +445,7 @@ fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
     // `mem::zeroed` over a struct-literal init: the kernel's CHECK_ATTR
     // macro validates that bytes past `batch_size` (the last field of
     // the TEST_RUN variant) are zero. A `#[derive(Default)]` init only
-    // zeros named fields — the 4 bytes of trailing padding we carry to
+    // zeros named fields, the 4 bytes of trailing padding we carry to
     // hit 8-byte alignment stay uninitialized and land as garbage in
     // the attr buffer → kernel 6.0+ returns EINVAL with no log. Zeroing
     // the whole buffer first is the fix.
@@ -662,7 +662,7 @@ impl Ipv6TcpBuilder {
                 pkt.extend_from_slice(&self.payload);
             }
             _ => {
-                // Extension header or unknown — caller-supplied payload only.
+                // Extension header or unknown, caller-supplied payload only.
                 pkt.extend_from_slice(&self.payload);
             }
         }

--- a/crates/modules/fast-path/tests/fib_comparison.rs
+++ b/crates/modules/fast-path/tests/fib_comparison.rs
@@ -1,8 +1,8 @@
 //! Offline FIB comparison harness (Option F, Phase 3.8).
 //!
-//! Drives the programmer with a data-driven synthetic RIB — mixed
+//! Drives the programmer with a data-driven synthetic RIB, mixed
 //! V4/V6, single-nexthop + ECMP + overlapping prefixes + default
-//! route — then runs LPM lookups for a curated set of query IPs
+//! route, then runs LPM lookups for a curated set of query IPs
 //! and asserts each resolves to the prefix we expect.
 //!
 //! Positioned as the "offline comparison harness" called out in
@@ -27,7 +27,7 @@
 //! Runs under CAP_BPF. `#[ignore]`-gated; CI qemu jobs run it via
 //! `sudo -E cargo test -- --ignored`.
 //!
-//! Setup is duplicated from `fib_programmer_integration.rs` —
+//! Setup is duplicated from `fib_programmer_integration.rs`
 //! each `tests/*.rs` is its own crate so cross-file imports aren't
 //! possible. Factoring into `tests/common/` is a separate refactor.
 
@@ -252,7 +252,7 @@ fn synthetic_rib_v4() -> Vec<(IpPrefix, Vec<IpAddr>)> {
             },
             vec![IpAddr::V4(Ipv4Addr::new(10, 0, 0, 6))],
         ),
-        // Another ECMP with *same* nexthop set as 192.0.2.0/24 —
+        // Another ECMP with *same* nexthop set as 192.0.2.0/24
         // must dedup to the same EcmpGroupId.
         (
             IpPrefix::V4 {
@@ -304,7 +304,7 @@ fn synthetic_rib_v6() -> Vec<(IpPrefix, Vec<IpAddr>)> {
             },
             vec![IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2))],
         ),
-        // 2001:db8:1::/48 — nested under the above.
+        // 2001:db8:1::/48, nested under the above.
         (
             IpPrefix::V6 {
                 addr: [
@@ -353,7 +353,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
     // Each query IP → expected (prefix_addr_str, kind, nh_count).
     // Verifies longest-prefix-match + correct FibValue encoding.
 
-    // IPv4: 192.0.2.200 — host route wins over /25 wins over /24.
+    // IPv4: 192.0.2.200, host route wins over /25 wins over /24.
     let v = h.lookup_v4([192, 0, 2, 200]).expect("FIB_V4[host-route]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
@@ -361,12 +361,12 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
     let v = h.lookup_v4([192, 0, 2, 130]).expect("FIB_V4[/25 scope]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
-    // 192.0.2.10 — no more-specific; /24 ECMP wins.
+    // 192.0.2.10, no more-specific; /24 ECMP wins.
     let v = h.lookup_v4([192, 0, 2, 10]).expect("FIB_V4[/24 scope]");
     assert_eq!(v.kind, FIB_KIND_ECMP);
     let ecmp_192 = v.idx;
 
-    // 198.51.100.5 — same nexthop set as 192.0.2.0/24; must share
+    // 198.51.100.5, same nexthop set as 192.0.2.0/24; must share
     // group_id (ECMP dedup).
     let v = h.lookup_v4([198, 51, 100, 5]).expect("FIB_V4[dedup]");
     assert_eq!(v.kind, FIB_KIND_ECMP);
@@ -375,29 +375,29 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
         "ECMP groups with identical nexthop sets should share id"
     );
 
-    // 203.0.113.5 — different nexthop set; different group.
+    // 203.0.113.5, different nexthop set; different group.
     let v = h
         .lookup_v4([203, 0, 113, 5])
         .expect("FIB_V4[different-ecmp]");
     assert_eq!(v.kind, FIB_KIND_ECMP);
     assert_ne!(v.idx, ecmp_192, "different nexthop set → different group");
 
-    // 10.0.0.42 — /8.
+    // 10.0.0.42, /8.
     let v = h.lookup_v4([10, 0, 0, 42]).expect("FIB_V4[/8 scope]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
-    // 1.1.1.1 — nothing more-specific; default route.
+    // 1.1.1.1, nothing more-specific; default route.
     let v = h.lookup_v4([1, 1, 1, 1]).expect("FIB_V4[default]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
-    // IPv6: 2001:db8:1:: — /48 wins over /32.
+    // IPv6: 2001:db8:1::, /48 wins over /32.
     let mut v6_a = [0u8; 16];
     v6_a[..4].copy_from_slice(&[0x20, 0x01, 0x0d, 0xb8]);
     v6_a[5] = 0x01;
     let v = h.lookup_v6(v6_a).expect("FIB_V6[/48 scope]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
-    // 2001:db8:ff::1 — /32 covers.
+    // 2001:db8:ff::1, /32 covers.
     let mut v6_b = [0u8; 16];
     v6_b[..4].copy_from_slice(&[0x20, 0x01, 0x0d, 0xb8]);
     v6_b[5] = 0xff;
@@ -405,7 +405,7 @@ fn synthetic_rib_programs_and_resolves_as_expected() {
     let v = h.lookup_v6(v6_b).expect("FIB_V6[/32 scope]");
     assert_eq!(v.kind, FIB_KIND_SINGLE);
 
-    // fe80::1 — default route (no more-specific /32 or /48 match).
+    // fe80::1, default route (no more-specific /32 or /48 match).
     let mut v6_c = [0u8; 16];
     v6_c[..2].copy_from_slice(&[0xfe, 0x80]);
     v6_c[15] = 1;

--- a/crates/modules/fast-path/tests/fib_fixtures.rs
+++ b/crates/modules/fast-path/tests/fib_fixtures.rs
@@ -18,7 +18,7 @@
 //! scope here because `bpf_prog_test_run` doesn't run a real
 //! `bpf_fib_lookup` against configured kernel routes.
 //!
-//! Every test is `#[ignore]` — it needs CAP_BPF + a BPF build. CI
+//! Every test is `#[ignore]`, it needs CAP_BPF + a BPF build. CI
 //! runs the full set under sudo via `cargo test --tests -- --ignored`.
 
 #![cfg(target_os = "linux")]
@@ -128,7 +128,7 @@ fn custom_fib_v6_single_nexthop_hit_redirects() {
 fn custom_fib_v4_incomplete_nexthop_returns_noneigh() {
     let mut h = prep_custom_fib_harness();
     h.add_allow_v4("10.0.0.0/8");
-    // Write the nexthop resolved first, then flip to incomplete — this
+    // Write the nexthop resolved first, then flip to incomplete, this
     // exercises the code path where the seqlock discipline is
     // respected (even `seq`) but `state != Resolved`.
     h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
@@ -210,7 +210,7 @@ fn custom_fib_v4_ecmp_dead_leg_falls_over() {
     let dmac_dead: [u8; 6] = [0xbb, 0, 0, 0, 0, 0x02];
     h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, dmac_live);
     h.add_nexthop_v4(2, LO_IFINDEX, EGRESS_MAC, dmac_dead);
-    // Mark nexthop 2 as incomplete — fallover should walk to NH 1.
+    // Mark nexthop 2 as incomplete, fallover should walk to NH 1.
     h.set_nexthop_state(2, NH_STATE_INCOMPLETE);
     h.add_ecmp_group(0, 5, &[1, 2]);
     h.add_fib_v4_ecmp("10.0.0.0/24", 0);
@@ -219,7 +219,7 @@ fn custom_fib_v4_ecmp_dead_leg_falls_over() {
 
     // Feed 32 5-tuples. With 2 legs and one dead, every packet must
     // land on NH 1 after the fallover. `EcmpDeadLegFallback` bumps
-    // only when we *advance past index 0* — i.e. when the hash picked
+    // only when we *advance past index 0*, i.e. when the hash picked
     // the dead leg first. With uniform hashing, that's ~50% of packets.
     let mut live = 0;
     for sport in 1000u16..1032u16 {
@@ -257,7 +257,7 @@ fn custom_fib_seqlock_permanent_odd_drains_retries() {
     let mut h = prep_custom_fib_harness();
     h.add_allow_v4("10.0.0.0/8");
     h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
-    // Force seq to an odd value and leave it there — no even follow-up.
+    // Force seq to an odd value and leave it there, no even follow-up.
     set_nexthop_seq_permanent_odd(&mut h, 1);
     h.add_fib_v4_single("10.0.0.0/24", 1);
 
@@ -286,7 +286,7 @@ fn custom_fib_seqlock_permanent_odd_drains_retries() {
     );
 }
 
-/// Force `NEXTHOPS[idx].seq` to stay odd across userspace writes —
+/// Force `NEXTHOPS[idx].seq` to stay odd across userspace writes
 /// simulates a writer that's stuck mid-update. Uses the raw Array
 /// handle so we can poke `seq` without the `add_nexthop_*` helpers'
 /// odd→even finalization.

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -3,13 +3,13 @@
 //! Exercises the programmer's route-side write path end-to-end
 //! against real BPF maps: Add / Del / PeerDown / ECMP dedup /
 //! refcounted nexthop recycling. Not a "BMP mock test" as originally
-//! scoped — constructing valid BMP byte streams from scratch is its
+//! scoped, constructing valid BMP byte streams from scratch is its
 //! own sub-project, and the real value is proving the programmer
 //! writes the right bits into the BPF maps when fed RouteEvents,
 //! which is exactly what the `apply_route_event` handle does.
 //!
 //! **Map-handle duplication.** The programmer takes ownership of
-//! `Array<MapData, _>` handles via `Ebpf::take_map` — after which
+//! `Array<MapData, _>` handles via `Ebpf::take_map`, after which
 //! the test can't read those maps via the same `Ebpf`. Solution:
 //! pin each map to a bpffs tempdir first, then have both the
 //! programmer and the test open independent `MapData::from_pin`
@@ -50,7 +50,7 @@ static BPFFS_MOUNT: Once = Once::new();
 
 /// Ensure `/sys/fs/bpf` exists and has bpffs mounted on it. GitHub's
 /// hosted Ubuntu runner already has this; virtme-ng's VM does not, so
-/// we mount it ourselves. Best-effort: errors are tolerated — the
+/// we mount it ourselves. Best-effort: errors are tolerated, the
 /// subsequent `create_dir_all` / `pin` call will surface the real
 /// problem with a clearer message.
 fn ensure_bpffs_mounted() {

--- a/crates/modules/fast-path/tests/fixtures.rs
+++ b/crates/modules/fast-path/tests/fixtures.rs
@@ -1,6 +1,6 @@
 //! Packet-level fixtures via `bpf_prog_test_run`. Covers the
-//! non-FIB §9 Phase 1 cases — parse errors, fragments, low TTL,
-//! allowlist misses, complex headers — deferred from PR #3 where aya
+//! non-FIB §9 Phase 1 cases, parse errors, fragments, low TTL,
+//! allowlist misses, complex headers, deferred from PR #3 where aya
 //! 0.13.1 didn't wrap `BPF_PROG_TEST_RUN`. The raw-syscall harness in
 //! `tests/common/mod.rs` bridges that gap.
 //!
@@ -9,7 +9,7 @@
 //! `redirect_devmap`; those belong in a netns-backed integration test,
 //! a separate slice.
 //!
-//! Every test is `#[ignore]` — it needs CAP_BPF + BPF build. CI runs
+//! Every test is `#[ignore]`, it needs CAP_BPF + BPF build. CI runs
 //! the full set under sudo via `cargo test --tests -- --ignored`.
 
 #![cfg(target_os = "linux")]
@@ -29,7 +29,7 @@ fn rx_total_delta(before: u64, h: &Harness) -> u64 {
 fn arp_passes_with_pass_not_ip() {
     let h = Harness::new();
 
-    // ARP (ethertype 0x0806) — plausibly-shaped but not IP.
+    // ARP (ethertype 0x0806), plausibly-shaped but not IP.
     let mut pkt = vec![0u8; 64];
     pkt[0..6].copy_from_slice(&[0xff; 6]); // dst = broadcast
     pkt[6..12].copy_from_slice(&[0xaa, 0, 0, 0, 0, 1]); // src
@@ -155,7 +155,7 @@ fn ipv4_neither_in_allowlist_passes_silently() {
     assert_eq!(verdict, xdp_action::XDP_PASS);
     // No matched counter bumped.
     assert_eq!(h.stat(StatIdx::MatchedV4), before_matched);
-    // But rx_total did bump — every packet is counted at the hook.
+    // But rx_total did bump, every packet is counted at the hook.
     assert_eq!(rx_total_delta(before_rx, &h), 1);
 }
 
@@ -168,7 +168,7 @@ fn ipv6_fragment_extension_passes_with_complex_header() {
     h.add_allow_v6("2001:db8::/32");
 
     // IPv6 Fragment header next_hdr = 44. Our impl XDP_PASSes on any
-    // non-{TCP, UDP, ICMPv6} next_hdr and bumps pass_complex_header —
+    // non-{TCP, UDP, ICMPv6} next_hdr and bumps pass_complex_header
     // per our interpretation of the SPEC §4.4 step 4 ambiguity (see
     // audit in PR #3).
     let pkt = Ipv6TcpBuilder {
@@ -333,7 +333,7 @@ fn every_packet_bumps_rx_total() {
     h.run(&p);
     assert_eq!(h.stat(StatIdx::RxTotal), before + 2);
 
-    // IPv4 match (dry-run off — would try FIB, but that likely NO_NEIGH
+    // IPv4 match (dry-run off, would try FIB, but that likely NO_NEIGH
     // in our no-netns test env; we only check rx_total).
     h.add_allow_v4("10.0.0.0/8");
     h.run(&p);
@@ -344,7 +344,7 @@ fn every_packet_bumps_rx_total() {
 //
 // `bpf_prog_test_run` can't exercise the §4.7 egress push/pop/rewrite
 // directly because that path sits behind a `bpf_fib_lookup` SUCCESS
-// which needs real routes configured — that's netns-integration-test
+// which needs real routes configured, that's netns-integration-test
 // territory, deferred. What the tests below *do* cover:
 //
 // - Tagged packets are recognized as 802.1Q and the inner ethertype
@@ -412,7 +412,7 @@ fn vlan_tagged_ipv4_with_options_routes_to_complex_header() {
     h.add_allow_v4("10.0.0.0/8");
 
     let base = Ipv4TcpBuilder {
-        ihl: 6, // IPv4 options — routed to pass_complex_header
+        ihl: 6, // IPv4 options, routed to pass_complex_header
         ..Default::default()
     }
     .build();
@@ -448,7 +448,7 @@ fn vlan_tagged_ipv4_fragment_routes_to_pass_fragment() {
 fn vlan_tagged_non_ip_inner_passes_with_pass_not_ip() {
     let h = Harness::new();
 
-    // Tagged ARP — inner ethertype after VLAN tag is 0x0806 (not v4/v6).
+    // Tagged ARP, inner ethertype after VLAN tag is 0x0806 (not v4/v6).
     let mut base = vec![0u8; 64];
     base[0..6].copy_from_slice(&[0xff; 6]);
     base[6..12].copy_from_slice(&[0xaa, 0, 0, 0, 0, 1]);
@@ -464,7 +464,7 @@ fn vlan_tagged_non_ip_inner_passes_with_pass_not_ip() {
 // ========== Jumbo frames (SPEC §11.5) =====================================
 //
 // Reference EFG has 9182-byte MTU on VLAN trunks. Test with a 4K-class
-// TCP payload — XDP_PACKET_HEADROOM (256) + 4K body + slab tailroom
+// TCP payload, XDP_PACKET_HEADROOM (256) + 4K body + slab tailroom
 // fits comfortably under the kernel's ~4096-byte `max_data_sz` cap for
 // test_run without LIVE_FRAMES. A true 9K frame needs LIVE_FRAMES mode
 // (5.18+) which is netns-integration-test territory. This fixture

--- a/crates/modules/fast-path/tests/neigh_resolver_netns.rs
+++ b/crates/modules/fast-path/tests/neigh_resolver_netns.rs
@@ -8,7 +8,7 @@
 //!
 //! Not covered here:
 //!   - Proactive resolve (`request_resolve`): validating kernel ARP kick
-//!     from a netns test is fragile — would require an unresolved
+//!     from a netns test is fragile, would require an unresolved
 //!     nexthop on an interface with routed connectivity. The existing
 //!     best-effort fallback (first-packet kernel ARP) is validated by
 //!     the fact that `Add`-without-pre-seeded-neigh test below still
@@ -162,7 +162,7 @@ fn ns_run(netns: &str, cmd: &[&str]) {
 
 /// Move the current thread into the netns and return the owned
 /// /var/run/netns/<name> fd. Dropping the fd after the test is fine
-/// — the netns itself is torn down via `ip netns del` in NetnsGuard.
+/// the netns itself is torn down via `ip netns del` in NetnsGuard.
 fn enter_netns(netns: &str) -> OwnedFd {
     let path = format!("/var/run/netns/{netns}");
     let fd: OwnedFd = File::open(&path)
@@ -180,7 +180,7 @@ fn if_nametoindex(name: &str) -> u32 {
     idx
 }
 
-/// Read an iface's MAC via SIOCGIFHWADDR ioctl — netns-scoped because
+/// Read an iface's MAC via SIOCGIFHWADDR ioctl, netns-scoped because
 /// it goes through a socket (sysfs is not reliably remounted per-netns
 /// on every distro).
 fn mac_of(iface: &str) -> [u8; 6] {
@@ -223,7 +223,7 @@ fn resolver_emits_learned_with_src_mac_and_ifindex() {
     let names = Names::new();
     let _guard = NetnsGuard::setup(&names);
 
-    // Enter the netns on this thread — tokio's current-thread runtime
+    // Enter the netns on this thread, tokio's current-thread runtime
     // we build below runs on this thread, so all tokio-spawned tasks
     // inherit the netns. `setns` on a single thread is safe in a
     // multithreaded process per `man 2 setns`.

--- a/crates/modules/fast-path/tests/netns.rs
+++ b/crates/modules/fast-path/tests/netns.rs
@@ -12,7 +12,7 @@
 //! black-holed every matched-and-not-in-devmap packet for several
 //! minutes before the rollback. See SPEC.md §11.13.
 //!
-//! `bpf_prog_test_run` can't reach the bug — it returns verdict and
+//! `bpf_prog_test_run` can't reach the bug, it returns verdict and
 //! output bytes but doesn't perform a real `bpf_fib_lookup` against
 //! configured routes. This test sets up:
 //!
@@ -95,7 +95,7 @@ const ROUTED_NEIGH_LLADDR: &str = "de:ad:be:ef:00:01";
 const ALLOW_PREFIX: ([u8; 4], u32) = ([10, 77, 0, 0], 16);
 
 /// RAII wrapper around `ip netns add` / `ip netns del`. Drop tears the
-/// whole namespace down — that also destroys every iface we made
+/// whole namespace down, that also destroys every iface we made
 /// inside it, so we don't need per-iface cleanup.
 struct NetnsGuard {
     name: String,
@@ -110,7 +110,7 @@ impl NetnsGuard {
 
         run(&["ip", "netns", "add", &names.netns]);
 
-        // Sysctls first — `default.*` is a template for ifaces created
+        // Sysctls first, `default.*` is a template for ifaces created
         // after the set, so this needs to run before `ip link add`.
         //
         // `ip_forward=1`: mainline kernels boot with forwarding off,
@@ -172,7 +172,7 @@ impl NetnsGuard {
             &["ip", "route", "add", ROUTED_PREFIX, "dev", &names.dum],
         );
         // Permanent neighbor so `bpf_fib_lookup` resolves without
-        // triggering kernel ARP/ND — returns SUCCESS with `dmac` set
+        // triggering kernel ARP/ND, returns SUCCESS with `dmac` set
         // to `ROUTED_NEIGH_LLADDR` directly.
         ns_run(
             &names.netns,
@@ -212,7 +212,7 @@ fn run(cmd: &[&str]) {
 }
 
 /// Run `cmd` inside the given netns via `ip netns exec`. Simpler than
-/// calling `setns` for every setup step — only the test thread itself
+/// calling `setns` for every setup step, only the test thread itself
 /// needs to enter the netns (it does so once, below).
 fn ns_run(netns: &str, cmd: &[&str]) {
     let mut args = vec!["netns", "exec", netns];
@@ -225,7 +225,7 @@ fn ns_run(netns: &str, cmd: &[&str]) {
 }
 
 /// Move the current thread into the netns. `setns(2)` on a single
-/// thread is safe in a multithreaded process — it only re-associates
+/// thread is safe in a multithreaded process, it only re-associates
 /// the calling thread, per the man page.
 fn enter_netns(netns: &str) -> OwnedFd {
     // `ip netns add` bind-mounts the created ns at this path.
@@ -247,7 +247,7 @@ fn if_nametoindex(name: &str) -> u32 {
 
 /// Read an iface's MAC via `SIOCGIFHWADDR` ioctl on a scratch socket.
 /// `/sys/class/net` would be simpler but isn't reliably re-mounted for
-/// the new netns on every distro — the sysfs view is frozen to
+/// the new netns on every distro, the sysfs view is frozen to
 /// whichever netns held it at mount time, which is usually init. The
 /// ioctl goes through a socket and so is properly netns-scoped.
 fn mac_of(iface: &str) -> [u8; 6] {
@@ -291,7 +291,7 @@ fn mac_of(iface: &str) -> [u8; 6] {
 }
 
 /// Open a `PF_PACKET` `SOCK_RAW` socket bound to `ifindex` with
-/// `ETH_P_ALL`. Used both for injection (send) and capture (recv) — the
+/// `ETH_P_ALL`. Used both for injection (send) and capture (recv), the
 /// kernel behavior matches whichever direction we use it for.
 fn open_packet_socket(ifindex: u32) -> OwnedFd {
     // Both socket()'s `protocol` arg and sockaddr_ll.sll_protocol are in
@@ -415,7 +415,7 @@ fn recv_matching(
     }
 }
 
-/// Recognise our test packet by IPv4 src+dst — these bytes survive
+/// Recognise our test packet by IPv4 src+dst, these bytes survive
 /// the pre-PR #11 mutation (which only touched L2 MACs and TTL/csum),
 /// so the filter catches both the correct (unmutated) case and the
 /// regression case. We want the byte-equality assertion to fire on
@@ -479,14 +479,14 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
         .expect("CFG set");
     }
 
-    // REDIRECT_DEVMAP intentionally left empty — the dummy ifindex is
+    // REDIRECT_DEVMAP intentionally left empty, the dummy ifindex is
     // therefore NOT in it, which is what drives the pre-check miss.
 
     // Scoped so the `&mut bpf` borrow held by `prog` ends before we
     // read stats via shared `&bpf`. `link_id` is a plain value and
     // stays live for the subsequent detach.
     //
-    // Generic XDP is enough — veth supports it across every kernel we
+    // Generic XDP is enough, veth supports it across every kernel we
     // target, and we're testing logic not performance. Sticking to
     // SKB_MODE also keeps this test from being flaky on kernels where
     // native veth XDP has quirks.
@@ -506,7 +506,7 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
 
     // Craft a matched packet. Src in the allowlist (10.77.0.2 covered
     // by 10.77.0.0/16), dst routed via dummy (198.51.100.1). TTL is
-    // the builder default (64) — the mutation check is easier to read
+    // the builder default (64), the mutation check is easier to read
     // if the ingress TTL is distinctive from 1 (low-ttl branch).
     let frame = Ipv4TcpBuilder {
         src_mac: mac_b,
@@ -523,10 +523,10 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
 
     // Capture. Filter on IPv4 src+dst (bytes the fast path never
     // touches) so a MAC- or TTL-mutated frame is still captured and
-    // then rejected by the byte-equality assertion below — we want
+    // then rejected by the byte-equality assertion below, we want
     // the assertion to fire on mutation, not a capture timeout.
     let captured = recv_matching(&cap_fd, Duration::from_millis(1000), is_test_packet).expect(
-        "no frame captured on XDP-attached veth within 1s — \
+        "no frame captured on XDP-attached veth within 1s, \
              did the fast path XDP_REDIRECT (devmap leak?) or \
              XDP_DROP the matched frame?",
     );
@@ -552,33 +552,33 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
     // another push-and-wait cycle.
     let dump = format!("delta: {deltas:?}");
 
-    // Counter assertions first — if these fail, the byte-equality
+    // Counter assertions first, if these fail, the byte-equality
     // assertion is academic.
     assert_eq!(
         after[StatIdx::RxTotal as usize] - before[StatIdx::RxTotal as usize],
         1,
-        "expected exactly one rx_total increment — {dump}"
+        "expected exactly one rx_total increment, {dump}"
     );
     assert_eq!(
         after[StatIdx::MatchedV4 as usize] - before[StatIdx::MatchedV4 as usize],
         1,
-        "packet should have matched the IPv4 allowlist — {dump}"
+        "packet should have matched the IPv4 allowlist, {dump}"
     );
     assert_eq!(
         after[StatIdx::PassNotInDevmap as usize] - before[StatIdx::PassNotInDevmap as usize],
         1,
         "FIB egress (dummy) is not in REDIRECT_DEVMAP; \
-         pass_not_in_devmap should bump — {dump}"
+         pass_not_in_devmap should bump, {dump}"
     );
     assert_eq!(
         after[StatIdx::FwdOk as usize] - before[StatIdx::FwdOk as usize],
         0,
-        "no redirect should have happened — {dump}"
+        "no redirect should have happened, {dump}"
     );
 
     // §11.13 invariant: the frame the kernel slow path received must
     // be the frame we injected, byte-for-byte. Mutation before the
-    // devmap pre-check would make this assertion trip — captured TTL
+    // devmap pre-check would make this assertion trip, captured TTL
     // would be 63, IP checksum patched, L2 MACs rewritten to the
     // neighbor's lladdr.
     assert_eq!(
@@ -588,7 +588,7 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
     );
     assert_eq!(
         captured, frame,
-        "packet bytes mutated on pass path — §11.13 invariant violation \
+        "packet bytes mutated on pass path, §11.13 invariant violation \
          (compare captured[14..] against frame[14..] for the IP+TCP diff)"
     );
 }

--- a/crates/modules/fast-path/tests/verifier.rs
+++ b/crates/modules/fast-path/tests/verifier.rs
@@ -4,7 +4,7 @@
 //! Integration test: load the fast-path BPF ELF through aya.
 //!
 //! aya's `Xdp::load()` round-trips the program through the kernel
-//! verifier — if it succeeds the verifier accepted our §4.4 program,
+//! verifier, if it succeeds the verifier accepted our §4.4 program,
 //! and that's the single most valuable guard we can ship in PR #3.
 //!
 //! Packet-level `bpf_prog_test_run` fixtures (for parse errors,

--- a/crates/modules/probe/Cargo.toml
+++ b/crates/modules/probe/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "PacketFrame XDP probe — diagnostic BPF program for inspecting raw ingress frames per driver (SPEC.md §11.1(c))"
+description = "PacketFrame XDP probe: diagnostic BPF program for inspecting raw ingress frames per driver"
 build = "build.rs"
 
 [lib]
@@ -19,7 +19,7 @@ tracing.workspace = true
 libc.workspace = true
 
 # aya is Linux-only. The probe's userspace path compiles out entirely
-# on non-Linux — the CLI subcommand returns an error on macOS dev.
+# on non-Linux, the CLI subcommand returns an error on macOS dev.
 [target.'cfg(target_os = "linux")'.dependencies]
 aya.workspace = true
 

--- a/crates/modules/probe/bpf/Cargo.toml
+++ b/crates/modules/probe/bpf/Cargo.toml
@@ -3,7 +3,7 @@ name = "packetframe-probe-bpf"
 version = "0.0.1"
 edition = "2021"
 # See crates/modules/fast-path/bpf/Cargo.toml for the rationale behind
-# this field — documents the stable MSRV even though the BPF build runs
+# this field, documents the stable MSRV even though the BPF build runs
 # on nightly (pinned in ./rust-toolchain.toml).
 rust-version = "1.95"
 license = "GPL-3.0-or-later"

--- a/crates/modules/probe/bpf/rust-toolchain.toml
+++ b/crates/modules/probe/bpf/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# Matched to crates/modules/fast-path/bpf/rust-toolchain.toml — keep the
+# Matched to crates/modules/fast-path/bpf/rust-toolchain.toml, keep the
 # two in sync. Rationale in that file's comments (`bpfel-unknown-none`
 # tier-3 target, `build-std` for core, don't list `targets`).
 channel = "nightly-2026-04-14"

--- a/crates/modules/probe/bpf/src/main.rs
+++ b/crates/modules/probe/bpf/src/main.rs
@@ -10,7 +10,7 @@
 //! Purpose: SPEC.md §11.1(c). On rvu-nicpf (Marvell CN10K) native XDP,
 //! attach succeeds and `bpftool net show` reports `xdpdrv`, but
 //! `ctx->data` apparently doesn't point at the standard Ethernet
-//! header — every packet classifies as `pass_not_ip` in the fast-path
+//! header, every packet classifies as `pass_not_ip` in the fast-path
 //! program. The canonical way to answer "what does this driver hand
 //! to XDP?" is to dump the raw head bytes, which this tool does
 //! without touching the packet or disturbing traffic.
@@ -31,7 +31,7 @@ use core::mem;
 /// reader can cast incoming ringbuf bytes directly into this layout;
 /// changing the layout requires bumping a version field and updating
 /// the userspace `ProbeEvent` in sync. `u64 + u32 + [u8;16] + [u8;4]`
-/// packs to a flat 32 bytes with no compiler-inserted padding — the
+/// packs to a flat 32 bytes with no compiler-inserted padding, the
 /// kernel insists `align_of::<T>() ≤ 8` for `RingBuf::reserve`, which
 /// this struct satisfies.
 ///
@@ -46,7 +46,7 @@ use core::mem;
 /// padding that `RingBuf::reserve` (returning `MaybeUninit<T>` over
 /// a kernel-allocated slot that the kernel does NOT zero) would
 /// publish to userspace carrying whatever the ringbuf cell last
-/// held — a 4-byte information leak per sample. See SPEC.md §11.1(c)
+/// held, a 4-byte information leak per sample. See SPEC.md §11.1(c)
 /// + the May 2026 audit Slice 3 fix for the longer rationale.
 #[repr(C)]
 #[derive(Copy, Clone)]
@@ -77,7 +77,7 @@ pub static EVENTS: RingBuf = RingBuf::with_byte_size(256 * 1024, 0);
 ///
 /// `offset` is the byte offset at which the BPF program samples the
 /// 16-byte head. Normally `0`, but some broken drivers point
-/// `xdp->data` into headroom instead of at the packet — the CLI
+/// `xdp->data` into headroom instead of at the packet, the CLI
 /// surfaces `--offset N` so the operator can confirm where the packet
 /// really starts. `OTX2_HEAD_ROOM = 128` is the interesting value for
 /// rvu-nicpf on pre-upstream-v6.8 kernels; see SPEC.md §11.1(c).
@@ -110,7 +110,7 @@ pub fn probe(ctx: XdpContext) -> u32 {
         .unwrap_or(0)
         .min(MAX_OFFSET) as usize;
 
-    // Reserve a slot before reading packet bytes — keeps the hot path
+    // Reserve a slot before reading packet bytes, keeps the hot path
     // cheap when the ringbuf is full (no reads, no work). Rust's
     // `#[must_use]` on `RingBufEntry` enforces that we either submit
     // or discard before returning, which is also the BPF verifier's
@@ -127,7 +127,7 @@ pub fn probe(ctx: XdpContext) -> u32 {
 
     // Verifier-friendly bounds check for the 16-byte head read at
     // `start + offset`. Short packets (or a too-large offset on a
-    // small frame) discard the sample rather than fault — the probe
+    // small frame) discard the sample rather than fault, the probe
     // is diagnostic; frames that don't fit just aren't interesting
     // evidence and we keep forwarding.
     if start + offset + mem::size_of::<[u8; 16]>() > end {
@@ -140,7 +140,7 @@ pub fn probe(ctx: XdpContext) -> u32 {
 
     // SAFETY: `RingBufEntry::as_mut_ptr` gives a valid, 8-aligned,
     // `mem::size_of::<ProbeEvent>()`-sized slot. **The kernel does
-    // NOT zero the reservation** — `RingBuf::reserve` returns
+    // NOT zero the reservation**, `RingBuf::reserve` returns
     // `MaybeUninit<T>` over whatever bytes the ringbuf cell last
     // held. Every byte of the slot must be written before `submit`
     // or the leftover content goes out to userspace as kernel-memory
@@ -162,7 +162,7 @@ pub fn probe(ctx: XdpContext) -> u32 {
 
     entry.submit(0);
 
-    // Diagnostic only — never perturb traffic.
+    // Diagnostic only, never perturb traffic.
     xdp_action::XDP_PASS
 }
 

--- a/crates/modules/probe/build.rs
+++ b/crates/modules/probe/build.rs
@@ -1,6 +1,6 @@
 //! Build the probe BPF crate at `./bpf/` and stage its ELF for
 //! `include_bytes!` in the userspace crate. Mirror of the fast-path
-//! module's build.rs — when one is updated, the other likely needs the
+//! module's build.rs, when one is updated, the other likely needs the
 //! same change. Separate file (not a shared helper) because the
 //! `PROBE_BPF_OBJ` / `PACKETFRAME_PROBE_BPF_OBJ_PATH` env var names
 //! differ per crate and there's not enough other logic to factor out.
@@ -40,7 +40,7 @@ fn main() {
         );
     }
 
-    // Pre-built ELF override — release workflow staging. See fast-path
+    // Pre-built ELF override, release workflow staging. See fast-path
     // build.rs for the full rationale.
     if let Some(path) = bpf_obj_override {
         let src = PathBuf::from(&path);
@@ -139,7 +139,7 @@ fn main() {
         Ok(out) => {
             forward_output(&[], &out.stderr);
             let msg = format!(
-                "probe BPF build failed (exit {}) — see cargo:warning lines above for the real error, or run `(cd crates/modules/probe/bpf && cargo build --release)` directly",
+                "probe BPF build failed (exit {}), see cargo:warning lines above for the real error, or run `(cd crates/modules/probe/bpf && cargo build --release)` directly",
                 out.status.code().unwrap_or(-1)
             );
             fail_or_stub(&obj_out, bpf_required, &msg);
@@ -177,7 +177,7 @@ fn find_artifact(stdout: &[u8]) -> Option<PathBuf> {
 fn fail_or_stub(obj_out: &std::path::Path, required: bool, msg: &str) {
     if required {
         panic!(
-            "PACKETFRAME_BPF_REQUIRED is set but {msg}. Refusing to stub the ELF — that would make every BPF-dependent test a silent no-op."
+            "PACKETFRAME_BPF_REQUIRED is set but {msg}. Refusing to stub the ELF, that would make every BPF-dependent test a silent no-op."
         );
     }
     println!(

--- a/crates/modules/probe/src/lib.rs
+++ b/crates/modules/probe/src/lib.rs
@@ -1,4 +1,4 @@
-//! PacketFrame probe — userspace wrapper.
+//! PacketFrame probe, userspace wrapper.
 //!
 //! Embeds the probe BPF ELF (via [`build.rs`](../build.rs)) and
 //! exposes a tiny [`run`] helper that attaches the XDP program to an
@@ -7,24 +7,24 @@
 //! formatting; nothing else in the workspace uses it.
 //!
 //! Unlike [`crate::fast-path`], the probe is not a [`Module`]
-//! implementation. It's a one-shot diagnostic — load, attach, drain,
-//! detach — so it never participates in the daemon lifecycle, pin
+//! implementation. It's a one-shot diagnostic, load, attach, drain,
+//! detach, so it never participates in the daemon lifecycle, pin
 //! registry, or reconcile flow.
 
 pub const MODULE_NAME: &str = "probe";
 
 /// The compiled probe BPF ELF, staged by `build.rs` and embedded at
 /// crate-compile time. Empty (zero bytes) when the BPF toolchain
-/// isn't available — see [`PROBE_BPF_AVAILABLE`].
+/// isn't available, see [`PROBE_BPF_AVAILABLE`].
 ///
 /// Note: `include_bytes!` returns a 1-byte-aligned slice. Passing it
 /// directly to `aya::Ebpf::load` fails with "Invalid ELF header size
-/// or alignment" on every non-8-byte-aligned placement — which is
+/// or alignment" on every non-8-byte-aligned placement, which is
 /// wherever the linker happens to drop a `.rodata` blob of the
 /// current size. v0.1.1's probe ELF grew from 1432 → 1608 bytes (CFG
 /// map added) and its in-binary address flipped from aligned to
 /// unaligned, which is how that release shipped broken. Callers must
-/// copy to an aligned buffer — use [`aligned_bpf_copy`].
+/// copy to an aligned buffer, use [`aligned_bpf_copy`].
 pub const PROBE_BPF: &[u8] = include_bytes!(env!("PROBE_BPF_OBJ"));
 
 /// `true` when `build.rs` produced a real probe BPF ELF; `false` when
@@ -42,7 +42,7 @@ pub fn aligned_bpf_copy() -> Vec<u8> {
 }
 
 /// One packet sample. `#[repr(C)]` and layout-identical to the BPF
-/// program's `ProbeEvent` struct — the ringbuf delivers these bytes
+/// program's `ProbeEvent` struct, the ringbuf delivers these bytes
 /// unchanged. Changing the layout here requires the BPF side to
 /// change in lockstep (and vice versa). The pinned size (32 bytes)
 /// is asserted at compile time below.
@@ -96,7 +96,7 @@ pub const MAX_OFFSET: u16 = 512;
 /// `Generic` is SKB XDP, `Auto` tries native then falls back. The
 /// probe exposes all three so operators can confirm whether a
 /// non-conformant head in native mode becomes conformant in generic
-/// mode — which it should, since generic runs after the kernel has
+/// mode, which it should, since generic runs after the kernel has
 /// already built an skb with a standard Ethernet frame.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum AttachMode {
@@ -123,7 +123,7 @@ pub struct ProbeOutput {
     /// Samples collected during the probe window. Ordered by arrival.
     pub samples: Vec<ProbeEvent>,
     /// Offset (bytes) at which the BPF program sampled each packet's
-    /// head. Echoed back so the CLI can label the output — e.g. an
+    /// head. Echoed back so the CLI can label the output, e.g. an
     /// rvu-nicpf pre-v6.8 trace at `offset=128` shows the real frame
     /// while `offset=0` shows the headroom zeros.
     pub offset: u16,
@@ -133,7 +133,7 @@ pub struct ProbeOutput {
     /// "bump your duration" vs. "your iface is quiet".
     pub saw_traffic: bool,
     /// Packet count lost to reserve-failures on the BPF side. Always
-    /// 0 in v0.1 — the reserve-failure path isn't counted separately
+    /// 0 in v0.1, the reserve-failure path isn't counted separately
     /// yet. Placeholder so adding a counter doesn't change the API.
     pub dropped_samples: u64,
 }
@@ -168,7 +168,7 @@ mod linux_impl {
     };
 
     /// Layout mirror of `ProbeCfg` in `bpf/src/main.rs`. Bytes-for-
-    /// bytes equal — if you change one, change the other. `u16` +
+    /// bytes equal, if you change one, change the other. `u16` +
     /// `[u8; 6]` packs to 8 bytes; `repr(C)` with all-bit-patterns-
     /// valid primitives makes `aya::Pod` safe to impl.
     #[repr(C)]
@@ -187,10 +187,10 @@ mod linux_impl {
     /// samples in arrival order.
     ///
     /// `offset` selects the byte offset at which the BPF program
-    /// samples each packet's head — normally `0` (real frame start).
+    /// samples each packet's head, normally `0` (real frame start).
     /// Non-zero values are for diagnosing drivers that point
     /// `xdp->data` into headroom (e.g. `128` on rvu-nicpf pre-v6.8,
-    /// see SPEC.md §11.1(c)). Clamped to [`MAX_OFFSET`] — past that,
+    /// see SPEC.md §11.1(c)). Clamped to [`MAX_OFFSET`], past that,
     /// the function rejects rather than silently truncate.
     ///
     /// Uses a short (~50ms) poll interval on the ringbuf fd so
@@ -213,7 +213,7 @@ mod linux_impl {
 
         let ifindex = if_nametoindex(iface)?;
 
-        // Heap-copy PROBE_BPF into an aligned `Vec<u8>` — passing the
+        // Heap-copy PROBE_BPF into an aligned `Vec<u8>`, passing the
         // raw `include_bytes!` static to `Ebpf::load` fails on
         // unaligned placements (v0.1.1 regression). The alignment
         // pattern mirrors `packetframe-fast-path::aligned_bpf_copy`.
@@ -246,7 +246,7 @@ mod linux_impl {
         }
 
         // Attach in the requested mode, with the same "auto" semantics
-        // that the fast-path module uses — try native, fall back to
+        // that the fast-path module uses, try native, fall back to
         // generic if the driver refuses the native attach. `Auto` is
         // the operator-friendly default; explicit `native` / `generic`
         // are for deliberate A/B testing of native vs skb delivery.
@@ -261,7 +261,7 @@ mod linux_impl {
 
             prog.load().map_err(|e| {
                 ProbeError::Other(format!(
-                    "verifier rejected probe program: {e} — this is a PacketFrame bug; file an issue"
+                    "verifier rejected probe program: {e}, this is a PacketFrame bug; file an issue"
                 ))
             })?;
 
@@ -270,7 +270,7 @@ mod linux_impl {
                     prog.attach_to_if_index(ifindex, XdpFlags::DRV_MODE)
                         .map_err(|e| {
                             ProbeError::Other(format!(
-                                "native XDP attach on {iface}: {e} — \
+                                "native XDP attach on {iface}: {e}, \
                                  driver may not support native XDP; try `--mode generic`"
                             ))
                         })?,
@@ -353,7 +353,7 @@ mod linux_impl {
         let mut any = false;
 
         loop {
-            // Drain whatever is already queued before we poll — keeps
+            // Drain whatever is already queued before we poll, keeps
             // us from sleeping with samples sitting in the ringbuf.
             while let Some(item) = ring.next() {
                 let bytes: &[u8] = &item;
@@ -414,7 +414,7 @@ mod linux_impl {
         if idx == 0 {
             let e = std::io::Error::last_os_error();
             return Err(ProbeError::Other(format!(
-                "if_nametoindex({name}): {e} — iface does not exist in current netns"
+                "if_nametoindex({name}): {e}, iface does not exist in current netns"
             )));
         }
         Ok(idx)
@@ -422,7 +422,7 @@ mod linux_impl {
 
     /// Render an error's full source chain into one string. aya's
     /// `EbpfError::ParseError` display drops the inner `object`
-    /// error — so a bare `{e}` emits only `"error parsing ELF data"`
+    /// error, so a bare `{e}` emits only `"error parsing ELF data"`
     /// with no indication whether the cause is alignment, a truncated
     /// header, a malformed section, etc. Walking `Error::source()`
     /// picks up what the outer formatter skipped.

--- a/crates/modules/probe/tests/load_attach.rs
+++ b/crates/modules/probe/tests/load_attach.rs
@@ -3,12 +3,12 @@
 
 //! Integration test: load the probe BPF ELF, create a veth pair,
 //! attach the probe XDP program, detach, and clean up. Mirrors
-//! `packetframe-fast-path/tests/attach.rs` — we're testing that the
+//! `packetframe-fast-path/tests/attach.rs`, we're testing that the
 //! ELF has a valid program named `probe` + a ringbuf map named
 //! `EVENTS`, that aya accepts it, the verifier accepts it, and the
 //! kernel accepts the XDP attach.
 //!
-//! Does NOT inject packets or drain the ringbuf — the probe's
+//! Does NOT inject packets or drain the ringbuf, the probe's
 //! ringbuf consumer is exercised by operators against real interfaces
 //! (SPEC §11.1(c)). Extending this test with packet injection would
 //! largely duplicate `fast-path/tests/netns.rs`'s AF_PACKET scaffolding
@@ -68,7 +68,7 @@ fn load_attach_detach_roundtrip_on_veth() {
         idx
     };
 
-    // Use the aligned copy, same as production — passing the raw
+    // Use the aligned copy, same as production, passing the raw
     // `PROBE_BPF` static trips aya's ELF header alignment check on
     // unlucky placements (see v0.1.1 regression).
     let bytes = aligned_bpf_copy();

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -12,7 +12,7 @@ how to roll back to the kernel-FIB path if something goes wrong.
 - [Connected fast-path (v0.2.1)](#connected-fast-path-v021)
 - [Cutover and rollback](#cutover-and-rollback)
 - [Triage by symptom](#triage-by-symptom)
-- [Known gaps](#known-gaps)
+- [Resolved items](#resolved-items)
 
 ## Architecture at a glance
 
@@ -794,44 +794,44 @@ Check:
 - If `unlimited` and still failing: reduce `FIB_V4_MAX_ENTRIES` in
   `crates/modules/fast-path/bpf/src/maps.rs`, rebuild.
 
-## Known gaps
+## Resolved items
 
-The following are known limitations. Listed here so you don't spend
-time debugging behaviors that are known-missing. Items marked ✅
-landed since the runbook was first written.
+This section tracks features that landed since the runbook was first
+written. They were originally listed as known gaps; the entries are
+retained as a changelog of what shipped and when.
 
-- ✅ **Proactive resolve** (Phase 3.6). `request_resolve(ip)` now
+- **Proactive resolve** (Phase 3.6). `request_resolve(ip)` now
   issues `RTM_NEWNEIGH NUD_NONE` after looking up the route to find
   the egress ifindex. Best-effort: if route lookup or neighbor add
   fails, first-packet kernel ARP remains the fallback.
-- ✅ **`src_mac` via RTM_GETLINK** (Phase 3.6). The NeighborResolver
+- **`src_mac` via RTM_GETLINK** (Phase 3.6). The NeighborResolver
   now caches `ifindex → MAC` from an RTM_GETLINK dump at startup and
   RTM_NEWLINK / RTM_DELLINK multicast events thereafter.
   `NEXTHOPS[id].src_mac` is the egress iface MAC, not zero.
-- ✅ **InitiationComplete quiescence timer** (Phase 3.5). Fires once
+- **InitiationComplete quiescence timer** (Phase 3.5). Fires once
   per BMP connection after 5 s of no RouteMonitoring frames.
-- ✅ **`packetframe fib` subcommands** (Phase 3.8). `dump-v4 / dump-v6
+- **`packetframe fib` subcommands** (Phase 3.8). `dump-v4 / dump-v6
   / lookup <ip> / stats` ship in the main binary. Opens the pinned
   maps directly; works without the daemon running.
-- ✅ **Custom-FIB Prometheus metrics** (Phase 3.8). The textfile
+- **Custom-FIB Prometheus metrics** (Phase 3.8). The textfile
   exporter now emits `packetframe_fib_forwarding_mode{mode="..."}`,
   `packetframe_nexthops{state="..."}`, `packetframe_nexthops_max`,
   `packetframe_ecmp_groups_active`, `packetframe_ecmp_groups_max`,
   and `packetframe_fib_default_hash_mode` on the usual 15 s cadence.
-- ✅ **Offline comparison harness** (Phase 3.8). `tests/fib_comparison.rs`
+- **Offline comparison harness** (Phase 3.8). `tests/fib_comparison.rs`
   drives a synthetic RIB through the programmer and asserts the LPM
   lookups resolve correctly. Runs in every qemu-verifier CI job.
-- ✅ **Integrity check + BmpStalled alert** (Phase 3.8). When BMP is
+- **Integrity check + BmpStalled alert** (Phase 3.8). When BMP is
   configured, the RouteController spawns a 5-minute periodic job
   that cross-checks `birdc show route count` against the mirror size
   and logs a warning on ≥1% drift. BmpStalled fires (warning log)
   when no ROUTE MONITORING in 5 min AND bird reports ≥1 Established
   peer AND process uptime > 10 min.
-- ✅ **Netns integration test + BMP integration test** (Phase 3.7).
+- **Netns integration test + BMP integration test** (Phase 3.7).
   `tests/neigh_resolver_netns.rs` + `tests/fib_programmer_integration.rs`
   cover the resolver and programmer paths end-to-end under sudo in
   CI's qemu-verifier jobs.
-- ✅ **BGP route source + BMP Loc-RIB safety mode** (Phase 3.9).
+- **BGP route source + BMP Loc-RIB safety mode** (Phase 3.9).
   `route-source bgp <addr>:<port> local-as <asn> peer-as <asn>`
   spawns an iBGP listener that receives bird's selected best paths;
   bird's `protocol bgp` export filter runs after best-path so we
@@ -839,7 +839,7 @@ landed since the runbook was first written.
   `require-loc-rib` which hard-rejects non-Loc-RIB frames. The
   iBGP feed is the recommended forwarding path for bird; the
   BMP path is for Loc-RIB-emitting daemons (FRR; future bird).
-- ✅ **BgpListener direct-origin fallback + connected fast-path**
+- **BgpListener direct-origin fallback + connected fast-path**
   (v0.2.1). Pre-v0.2.1 the BgpListener silently dropped iBGP UPDATEs
   whose decoded NEXT_HOP was None: exactly what bird emits for
   `protocol direct` (and static-origin) routes when the BGP block has
@@ -850,12 +850,12 @@ landed since the runbook was first written.
   counters reflect reality. The `local-prefix <cidr> via <iface>`
   directive turns those /24s into per-/32 fast-paths. See the
   [Connected fast-path](#connected-fast-path-v021) section above.
-- ✅ **`fallback-default` synthetic /0** (v0.2.1, issue #31). Inject
+- **`fallback-default` synthetic /0** (v0.2.1, issue #31). Inject
   a catch-all default into the custom-FIB so bogon-bound traffic
   XDP-redirects to upstream instead of slow-pathing.
-- ✅ **`arp-scavenge` for quiet LANs** (v0.2.1, issue #32). One-shot
+- **`arp-scavenge` for quiet LANs** (v0.2.1, issue #32). One-shot
   ARP sweep of declared local-prefix CIDRs at startup so storage
   networks (Ceph) get fast-path coverage even when their hosts don't
   voluntarily talk to the gateway.
-- ✅ **`block-prefix` XDP-time drop** (v0.2.1, issue #33). Bogon
+- **`block-prefix` XDP-time drop** (v0.2.1, issue #33). Bogon
   destinations dropped at XDP instead of forwarded-and-failed.


### PR DESCRIPTION
## Summary

- Reword the [README](README.md) and the [example config](conf/example.conf) so the directive index and inline guidance read as plain prose.
- Restructure the "Known gaps" section of the [custom-FIB runbook](docs/runbooks/custom-fib.md): the items in that list had shipped, so they move into a "Resolved items" subsection that doubles as a short changelog.
- Tighten inline rustdoc and clap `--help` text across the workspace. Drops a few internal spec/PR references from user-facing CLI help and the probe crate's crates.io description; module-internal references are kept.

## Test plan

- [ ] CI green: fmt + clippy + workspace tests + four cross-builds + qemu-verifier matrix
- [ ] `packetframe --help` and each subcommand `--help` render cleanly with no internal-doc artifacts
- [ ] README renders correctly on github.com (the "Quick directive index" and the status table in particular)
- [ ] custom-fib runbook renders with a "Resolved items" subsection

🤖 Generated with [Claude Code](https://claude.com/claude-code)