### PR TITLE
feat(fast-path): local-prefix6 connected fast-path, and keep NDP off it

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ sudo packetframe reconfigure                # synchronous; exits non-zero on par
 sudo systemctl reload packetframe           # equivalent under systemd; both end up sending SIGHUP
 ```
 
-What's hot-reloadable: `allow-prefix*`, `block-prefix`, `dry-run`, `forwarding-mode`, `mss-clamp`, VLAN-subif resolution, and the redirect devmap. Attach-set changes (interfaces added/removed), `route-source` config, `circuit-breaker` thresholds, and `local-prefix` still require a full restart. See [docs/runbooks/reconfigure.md](docs/runbooks/reconfigure.md).
+What's hot-reloadable: `allow-prefix*`, `block-prefix`, `dry-run`, `forwarding-mode`, `mss-clamp`, VLAN-subif resolution, and the redirect devmap. Attach-set changes (interfaces added/removed), `route-source` config, `circuit-breaker` thresholds, and `local-prefix`/`local-prefix6` still require a full restart. See [docs/runbooks/reconfigure.md](docs/runbooks/reconfigure.md).
 
 ### 6. Tear down
 
@@ -260,7 +260,8 @@ Quick directive index:
 - `forwarding-mode {kernel-fib|custom-fib|compare}`
 - `route-source bgp <addr>:<port> local-as <asn> peer-as <asn> [router-id <ipv4>]`
 - `route-source bmp <addr>:<port> [require-loc-rib]`
-- `local-prefix <cidr> via <iface> [arp-scavenge]`: per-host fast-path for connected destinations
+- `local-prefix <cidr> via <iface> [arp-scavenge]`: per-host /32 fast-path for connected IPv4 destinations
+- `local-prefix6 <cidr> via <iface>`: per-host /128 equivalent, resolved via NDP (no `arp-scavenge`; a /64 is not enumerable)
 - `fallback-default via <iface> nexthop <ipv4>`: synthetic 0.0.0.0/0 catch-all
 - `block-prefix <cidr>`: XDP-time drop for unrouteable destinations
 - `ecmp-default-hash-mode {3|4|5}`: tuple width for ECMP hashing
@@ -274,7 +275,7 @@ Quick directive index:
 **Module fast-path: driver opt-ins**
 - `driver-workaround rvu-nicpf-head-shift {auto|on|off}`
 
-`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, and forwarding-mode bits. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, or editing `local-prefix` requires a restart.
+`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, and forwarding-mode bits. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, or editing `local-prefix`/`local-prefix6` requires a restart.
 
 ## Operator tools
 

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -181,6 +181,33 @@ module fast-path
   # only (storage, management, customer LANs).
   # local-prefix 10.88.1.0/24 via br88 arp-scavenge
 
+  # IPv6 form (`local-prefix6`). Same idea, resolved via NDP instead of
+  # ARP: one /128 per neighbour the kernel knows, nexthop = the host
+  # itself, so the /128 wins the FIB_V6 LPM walk over any covering
+  # route from the BGP feed.
+  #
+  # Declare the /64 (or whatever is actually configured on the iface),
+  # NOT the aggregate you announce to the world. The aggregate is a
+  # null-routed static in bird and is not a connected prefix.
+  #
+  # Needs a matching `allow-prefix6` covering it: the allowlist is
+  # checked BEFORE the FIB lookup, so a /128 in FIB_V6 does nothing on
+  # its own.
+  #
+  # There is deliberately no `arp-scavenge` equivalent. A /64 is not
+  # enumerable, and SLAAC (RFC 4862) / stable-privacy (RFC 7217)
+  # scatter host addresses across the full 64-bit interface identifier,
+  # so a swept range would find almost no autoconfigured host. IPv6
+  # relies on reactive seeding: the startup neighbour dump plus
+  # RTM_NEWNEIGH, which already covers every host the kernel resolved.
+  #
+  # Multicast (ff00::/8), link-local (fe80::/10), ::/0, ::, ::1 and
+  # IPv4-mapped prefixes are rejected at parse: none can be a
+  # forwarded connected-host destination, and harvesting them would
+  # burn NEXTHOPS slots (the kernel keeps NUD_NOARP neighbour entries
+  # for multicast groups that look just like resolved unicast ones).
+  # local-prefix6 2602:f7d8:0:1337::/64 via br1337
+
   # Synthetic IPv4 default route (v0.2.1, issue #31). Custom-FIB only
   # has the prefixes bird's iBGP feed advertised. For destinations
   # bird doesn't have specific routes for (RFC 1918, CGNAT,

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -895,53 +895,11 @@ fn print_tail_call_chain(bpffs_root: &Path) {
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn print_stats(bpffs_root: &Path) {
-    // §4.6 counter names, indexed by `StatIdx` discriminants. Order
-    // matches `crates/modules/fast-path/bpf/src/maps.rs::StatIdx`.
-    // Append-only, adding new entries at the end is fine; renumbering
-    // breaks dashboards. Indices 0-19 are the kernel-fib counter set;
-    // 20-31 were appended in the Option F custom-FIB rollout (§4.11).
-    const NAMES: [&str; 37] = [
-        "rx_total",
-        "matched_v4",
-        "matched_v6",
-        "matched_src_only",
-        "matched_dst_only",
-        "matched_both",
-        "fwd_ok",
-        "fwd_dry_run",
-        "pass_fragment",
-        "pass_low_ttl",
-        "pass_no_neigh",
-        "pass_not_ip",
-        "pass_frag_needed",
-        "drop_unreachable",
-        "err_parse",
-        "err_fib_other",
-        "err_vlan",
-        "pass_not_in_devmap",
-        "pass_complex_header",
-        "err_head_shift",
-        // --- Custom FIB (Option F, Phase 1) ---
-        "custom_fib_hit",
-        "custom_fib_miss",
-        "custom_fib_no_neigh",
-        "compare_agree",
-        "compare_disagree",
-        "ecmp_hash_v4",
-        "ecmp_hash_v6",
-        "ecmp_dead_leg_fallback",
-        "route_source_resync",
-        "neigh_cache_miss",
-        "nexthop_seq_retry",
-        "bmp_peer_down",
-        "bogon_dropped",
-        // --- v0.2.4: mss-clamp ---
-        "mss_clamp_applied",
-        "mss_clamp_skipped",
-        // --- v0.2.5: two-stage datapath ---
-        "err_tail_call",
-        "err_mutation_ctx",
-    ];
+    // §4.6 counter names, indexed by `StatIdx` discriminants. The
+    // authoritative userspace mirror is
+    // `packetframe_fast_path::metrics::COUNTER_NAMES`; this used to be
+    // a third hand-copied list and drifted (see the comment there).
+    let names = &packetframe_fast_path::metrics::COUNTER_NAMES;
 
     print_fib_status(bpffs_root);
 
@@ -949,8 +907,8 @@ fn print_stats(bpffs_root: &Path) {
         Ok(values) => {
             println!();
             println!("counters (from {}):", bpffs_root.display());
-            let name_w = NAMES.iter().map(|n| n.len()).max().unwrap_or(20);
-            for (name, value) in NAMES.iter().zip(values.iter()) {
+            let name_w = names.iter().map(|n| n.len()).max().unwrap_or(20);
+            for (name, value) in names.iter().zip(values.iter()) {
                 println!("  {name:<name_w$}  {value}");
             }
         }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -173,6 +173,30 @@ pub enum ModuleDirective {
         arp_scavenge: bool,
         line: usize,
     },
+    /// IPv6 counterpart of [`Self::LocalPrefix`]: `local-prefix6 <cidr>
+    /// via <iface>`. The resolver synthesizes per-/128 routes from the
+    /// kernel's NDP neighbour table, nexthop = the host itself, so the
+    /// /128 wins the `FIB_V6` LPM walk over any covering route.
+    ///
+    /// Deliberately has **no** `arp-scavenge` counterpart. Enumeration
+    /// is the wrong tool for IPv6 at any cap: SLAAC (RFC 4862) and
+    /// stable-privacy addressing (RFC 7217) scatter host addresses
+    /// across the full 64-bit interface-identifier space, so a swept
+    /// range would match essentially no autoconfigured host. The hosts a
+    /// sweep *could* find (hand-numbered `::1..::ff` servers) are
+    /// statically configured and actively talking, which means they are
+    /// already in the neighbour table that reactive seeding reads. See
+    /// `docs/runbooks/custom-fib.md`.
+    ///
+    /// Requires a matching `allow-prefix6`: the allowlist is consulted
+    /// before the FIB lookup, so a /128 in `FIB_V6` does nothing if the
+    /// covering prefix isn't allowlisted. Restart-only, like its v4
+    /// sibling; SIGHUP does not reconcile it.
+    LocalPrefix6 {
+        cidr: Ipv6Prefix,
+        iface: String,
+        line: usize,
+    },
     /// Synthetic IPv4 default route for the custom FIB (v0.2.1). With
     /// `fallback-default via <iface> nexthop <ipv4>`, the resolver
     /// injects a `RouteEvent::Add { prefix: 0.0.0.0/0, nexthops: [nh] }`
@@ -483,6 +507,225 @@ pub struct Ipv6Prefix {
     pub prefix_len: u8,
 }
 
+impl Ipv4Prefix {
+    /// The prefix's network address, i.e. `addr` with host bits cleared.
+    ///
+    /// Declarations are not required to be aligned: `10.0.0.5/24` is
+    /// accepted and treated as `10.0.0.0/24`. Callers that need the
+    /// canonical form use this.
+    pub fn network(&self) -> Ipv4Addr {
+        Ipv4Addr::from(u32::from(self.addr) & mask_v4(self.prefix_len))
+    }
+
+    /// True iff `ip` falls within this prefix. Host bits in the
+    /// declaration are ignored (see [`Self::network`]).
+    pub fn contains_addr(&self, ip: Ipv4Addr) -> bool {
+        let m = mask_v4(self.prefix_len);
+        u32::from(ip) & m == u32::from(self.addr) & m
+    }
+
+    /// True iff `inner` is equal to or wholly contained within `self`.
+    ///
+    /// A longer prefix can never contain a shorter one, so this is
+    /// `false` whenever `inner` is less specific than `self`.
+    pub fn contains_prefix(&self, inner: &Ipv4Prefix) -> bool {
+        self.prefix_len <= inner.prefix_len && self.contains_addr(inner.addr)
+    }
+}
+
+impl Ipv6Prefix {
+    /// The prefix's network address, i.e. `addr` with host bits cleared.
+    /// See [`Ipv4Prefix::network`] for the alignment convention.
+    pub fn network(&self) -> Ipv6Addr {
+        Ipv6Addr::from((u128::from(self.addr) & mask_v6(self.prefix_len)).to_be_bytes())
+    }
+
+    /// True iff `ip` falls within this prefix. Host bits in the
+    /// declaration are ignored.
+    pub fn contains_addr(&self, ip: Ipv6Addr) -> bool {
+        let m = mask_v6(self.prefix_len);
+        u128::from(ip) & m == u128::from(self.addr) & m
+    }
+
+    /// True iff `inner` is equal to or wholly contained within `self`.
+    pub fn contains_prefix(&self, inner: &Ipv6Prefix) -> bool {
+        self.prefix_len <= inner.prefix_len && self.contains_addr(inner.addr)
+    }
+}
+
+/// Host-bit mask for an IPv4 prefix length.
+///
+/// Both ends need guarding: `!0u32 << 32` is a shift-overflow panic in
+/// debug, and in release Rust masks the shift amount to `32 & 31 == 0`,
+/// yielding `!0` — so a `/0` would silently match only its own exact
+/// address instead of everything. The release behavior is the dangerous
+/// one because it fails silently.
+#[inline]
+fn mask_v4(prefix_len: u8) -> u32 {
+    if prefix_len == 0 {
+        0
+    } else if prefix_len >= 32 {
+        !0
+    } else {
+        (!0u32) << (32 - prefix_len as u32)
+    }
+}
+
+/// Host-bit mask for an IPv6 prefix length. Same shift-overflow
+/// reasoning as [`mask_v4`], with `!0u128 << 128` as the trap.
+#[inline]
+fn mask_v6(prefix_len: u8) -> u128 {
+    if prefix_len == 0 {
+        0
+    } else if prefix_len >= 128 {
+        !0
+    } else {
+        (!0u128) << (128 - prefix_len as u32)
+    }
+}
+
+/// True iff `a` could plausibly be a connected host we should
+/// synthesize a `/128` FIB entry for.
+///
+/// The rejected classes all share one property: forwarding a packet to
+/// them via `bpf_redirect_map` is either meaningless or actively wrong,
+/// so a `/128` naming one wastes a slot in the shared 8192-entry
+/// `NEXTHOPS` pool at best and misroutes at worst.
+///
+/// - **Multicast** (`ff00::/8`): the kernel keeps `NUD_NOARP` neighbour
+///   entries for multicast groups with a derived `33:33:xx` MAC, so they
+///   look exactly like resolved unicast neighbours to the resolver. They
+///   are never `NUD_GC`'d either, so a bad entry would persist for the
+///   process lifetime.
+/// - **Link-local** (`fe80::/10`): not a routed destination, and the
+///   resolver's neighbour cache is keyed by address alone — the same
+///   `fe80::` address legitimately exists on several interfaces with
+///   different MACs, so any entry would be ambiguous by construction.
+/// - **Unspecified / loopback / IPv4-mapped**: never valid on the wire
+///   as a forwarded destination. IPv4-mapped would additionally create a
+///   second, conflicting route for an address already covered by
+///   `FIB_V4`.
+///
+/// Unique-local (`fc00::/7`) is deliberately **allowed** — it is a
+/// legitimate choice for an internal connected segment.
+///
+/// Predicates are hand-rolled on the octets rather than using
+/// `Ipv6Addr::is_unicast_link_local` and friends: `is_global` and
+/// `is_unicast` are still nightly-only, so hand-rolling keeps this
+/// working on the pinned stable toolchain and testable without any
+/// toolchain-feature dependency.
+pub fn is_harvestable_v6(a: Ipv6Addr) -> bool {
+    let o = a.octets();
+    // ff00::/8 multicast
+    if o[0] == 0xff {
+        return false;
+    }
+    // fe80::/10 link-local unicast
+    if o[0] == 0xfe && (o[1] & 0xc0) == 0x80 {
+        return false;
+    }
+    // ::ffff:0:0/96 IPv4-mapped
+    if o[..10].iter().all(|b| *b == 0) && o[10] == 0xff && o[11] == 0xff {
+        return false;
+    }
+    // :: and ::1
+    if a.is_unspecified() || a.is_loopback() {
+        return false;
+    }
+    true
+}
+
+/// The address classes [`is_harvestable_v6`] rejects, as prefixes, so a
+/// `local-prefix6` declaration can be screened for overlap at parse
+/// time. Paired with the operator-facing reason.
+const FORBIDDEN_V6_CLASSES: [(Ipv6Prefix, &str); 5] = [
+    (
+        Ipv6Prefix {
+            addr: Ipv6Addr::new(0xff00, 0, 0, 0, 0, 0, 0, 0),
+            prefix_len: 8,
+        },
+        "multicast (ff00::/8)",
+    ),
+    (
+        Ipv6Prefix {
+            addr: Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 0),
+            prefix_len: 10,
+        },
+        "link-local (fe80::/10)",
+    ),
+    (
+        Ipv6Prefix {
+            addr: Ipv6Addr::new(0, 0, 0, 0, 0, 0xffff, 0, 0),
+            prefix_len: 96,
+        },
+        "IPv4-mapped (::ffff:0:0/96)",
+    ),
+    (
+        Ipv6Prefix {
+            addr: Ipv6Addr::UNSPECIFIED,
+            prefix_len: 128,
+        },
+        "the unspecified address (::/128)",
+    ),
+    (
+        Ipv6Prefix {
+            addr: Ipv6Addr::LOCALHOST,
+            prefix_len: 128,
+        },
+        "loopback (::1/128)",
+    ),
+];
+
+/// Reject a `local-prefix6` CIDR that is, or overlaps, an address class
+/// that must never be harvested into a `/128`.
+///
+/// A well-formed global `/64` excludes `ff02::` and `fe80::` on its own
+/// via containment, so this exists to catch the copy-paste cases (an
+/// operator building the directive from `ip -6 neigh show`, which is
+/// mostly `fe80::` addresses) and `::/0`, which would harvest the entire
+/// neighbour table.
+fn reject_non_harvestable_prefix(line: usize, p: &Ipv6Prefix) -> Result<(), ConfigError> {
+    if p.prefix_len == 0 {
+        return Err(ConfigError::parse(
+            line,
+            "local-prefix6: `::/0` is not a valid connected prefix. It would harvest every \
+             entry in the neighbour table, including multicast and link-local, and burn one \
+             NEXTHOPS slot each. Declare the connected prefix instead (e.g. \
+             `local-prefix6 2602:f7d8:0:1337::/64 via br1337`)",
+        ));
+    }
+    for (class, reason) in FORBIDDEN_V6_CLASSES {
+        if class.contains_prefix(p) || p.contains_prefix(&class) {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "local-prefix6 {}/{} is or overlaps {reason}, which can never be a \
+                     forwarded connected-host destination. Declare the global-unicast \
+                     prefix assigned to the segment instead",
+                    p.addr, p.prefix_len
+                ),
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Append a "did you mean the other family?" hint when a CIDR fails to
+/// parse for one family but succeeds for the other.
+///
+/// `local-prefix` and `local-prefix6` are separate keywords, so pasting
+/// a v6 CIDR under the v4 directive is the obvious slip. The underlying
+/// `FromStr` message is preserved rather than replaced, so a genuinely
+/// malformed CIDR still reports precisely what was wrong with it.
+fn wrong_family_hint(err: String, tok: &str, directive: &str) -> String {
+    let other = match directive {
+        "local-prefix" if tok.parse::<Ipv6Prefix>().is_ok() => "local-prefix6",
+        "local-prefix6" if tok.parse::<Ipv4Prefix>().is_ok() => "local-prefix",
+        _ => return err,
+    };
+    format!("{err} (did you mean `{other}`?)")
+}
+
 impl FromStr for Ipv4Prefix {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -624,6 +867,7 @@ impl Config {
                 let (iface, line) = match d {
                     ModuleDirective::Attach { iface, line, .. } => (iface, line),
                     ModuleDirective::LocalPrefix { iface, line, .. } => (iface, line),
+                    ModuleDirective::LocalPrefix6 { iface, line, .. } => (iface, line),
                     ModuleDirective::FallbackDefault { iface, line, .. } => (iface, line),
                     _ => continue,
                 };
@@ -638,6 +882,68 @@ impl Config {
         }
         Ok(())
     }
+}
+
+/// One warning per `local-prefix` / `local-prefix6` directive that no
+/// same-family `allow-prefix` / `allow-prefix6` even overlaps.
+///
+/// The allowlist is consulted *before* the FIB lookup, so a synthesized
+/// host route does nothing when inbound traffic to it never matches the
+/// allowlist — the feature silently no-ops. The runbook names this the
+/// top operator footgun, and `local-prefix6` doubles the exposure
+/// because the v4 and v6 allowlists are declared separately.
+///
+/// Advisory only, never fatal: the check looks for *any overlap* rather
+/// than full coverage, so it fires only on the forgot-it-entirely case
+/// and cannot false-positive on a prefix jointly covered by several
+/// narrower allow entries. Callers log each returned string at WARN.
+pub fn uncovered_local_prefix_warnings(directives: &[ModuleDirective]) -> Vec<String> {
+    let mut allow_v4: Vec<Ipv4Prefix> = Vec::new();
+    let mut allow_v6: Vec<Ipv6Prefix> = Vec::new();
+    for d in directives {
+        match d {
+            ModuleDirective::AllowPrefix4(p) => allow_v4.push(*p),
+            ModuleDirective::AllowPrefix6(p) => allow_v6.push(*p),
+            _ => {}
+        }
+    }
+    let overlaps_v4 = |l: &Ipv4Prefix| {
+        allow_v4
+            .iter()
+            .any(|a| a.contains_prefix(l) || l.contains_prefix(a))
+    };
+    let overlaps_v6 = |l: &Ipv6Prefix| {
+        allow_v6
+            .iter()
+            .any(|a| a.contains_prefix(l) || l.contains_prefix(a))
+    };
+
+    let mut out = Vec::new();
+    for d in directives {
+        match d {
+            ModuleDirective::LocalPrefix {
+                cidr, iface, line, ..
+            } if !overlaps_v4(cidr) => {
+                out.push(format!(
+                    "local-prefix {}/{} via {iface} (line {line}) has no overlapping \
+                     allow-prefix; the allowlist is checked before the FIB lookup, so its \
+                     synthesized /32s will never be used. Add a covering `allow-prefix`",
+                    cidr.addr, cidr.prefix_len
+                ));
+            }
+            ModuleDirective::LocalPrefix6 { cidr, iface, line } if !overlaps_v6(cidr) => {
+                out.push(format!(
+                    "local-prefix6 {}/{} via {iface} (line {line}) has no overlapping \
+                     allow-prefix6; the allowlist is checked before the FIB lookup, so its \
+                     synthesized /128s will never be used. Add a covering `allow-prefix6` \
+                     (the v4 allowlist does not cover v6)",
+                    cidr.addr, cidr.prefix_len
+                ));
+            }
+            _ => {}
+        }
+    }
+    out
 }
 
 enum Cursor {
@@ -987,9 +1293,9 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                     }
                 }
             }
-            let p: Ipv4Prefix = cidr_tok
-                .parse()
-                .map_err(|e: String| ConfigError::parse(line, e))?;
+            let p: Ipv4Prefix = cidr_tok.parse().map_err(|e: String| {
+                ConfigError::parse(line, wrong_family_hint(e, cidr_tok, "local-prefix"))
+            })?;
             // Cap arp-scavenge at /22 (≤ 1024 hosts) to avoid kernel
             // gc_thresh3 overflow. Larger prefixes silently fall back to
             // arp-scavenge=false with a config-error so the operator
@@ -1008,6 +1314,72 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 cidr: p,
                 iface: iface.to_string(),
                 arp_scavenge,
+                line,
+            })
+        }
+        "local-prefix6" => {
+            // Grammar: local-prefix6 <cidr> via <iface>
+            //
+            // Structure mirrors the `local-prefix` arm above, including
+            // the ordering: `via`/iface/tail-flag errors are reported
+            // before the CIDR is parsed. There are no valid tail flags
+            // here, so the tail loop only rejects.
+            let cidr_tok = rest.next().ok_or_else(|| {
+                ConfigError::parse(
+                    line,
+                    "local-prefix6 requires a CIDR (e.g. 2602:f7d8:0:1337::/64)",
+                )
+            })?;
+            let via_tok = rest.next().ok_or_else(|| {
+                ConfigError::parse(line, "local-prefix6 requires `via <iface>` after the CIDR")
+            })?;
+            if via_tok != "via" {
+                return Err(ConfigError::parse(
+                    line,
+                    format!(
+                        "local-prefix6: expected `via` after the CIDR, got `{via_tok}` \
+                         (form: `local-prefix6 <cidr> via <iface>`)"
+                    ),
+                ));
+            }
+            let iface = rest.next().ok_or_else(|| {
+                ConfigError::parse(
+                    line,
+                    "local-prefix6: expected an interface name after `via`",
+                )
+            })?;
+            validate_iface_name(line, "local-prefix6", iface)?;
+            // No valid tail flags in this grammar, so the first extra
+            // token is always an error. `arp-scavenge` gets a specific
+            // message because reaching for it here is the natural
+            // mistake once an operator knows the v4 form.
+            if let Some(tail) = rest.next() {
+                if tail == "arp-scavenge" {
+                    return Err(ConfigError::parse(
+                        line,
+                        "local-prefix6: arp-scavenge is IPv4-only. A /64 is not enumerable, \
+                         and SLAAC / RFC 7217 scatter host addresses across the whole \
+                         64-bit interface identifier, so a swept range would find almost \
+                         nothing. IPv6 relies on reactive seeding instead (startup \
+                         neighbour dump + RTM_NEWNEIGH), which already covers every host \
+                         the kernel has resolved",
+                    ));
+                }
+                return Err(ConfigError::parse(
+                    line,
+                    format!(
+                        "local-prefix6: unknown tail flag `{tail}` \
+                         (form: `local-prefix6 <cidr> via <iface>`; no flags are recognized)"
+                    ),
+                ));
+            }
+            let p: Ipv6Prefix = cidr_tok.parse().map_err(|e: String| {
+                ConfigError::parse(line, wrong_family_hint(e, cidr_tok, "local-prefix6"))
+            })?;
+            reject_non_harvestable_prefix(line, &p)?;
+            Ok(ModuleDirective::LocalPrefix6 {
+                cidr: p,
+                iface: iface.to_string(),
                 line,
             })
         }
@@ -2120,6 +2492,109 @@ module fast-path
         assert_eq!(p.prefix_len, 48);
     }
 
+    // --- Prefix containment helpers -------------------------------------
+    //
+    // These back `LocalPrefixSpec::contains` in the fast-path resolver
+    // and `prefix_contains` in linux_impl, so the `/0` and `/max` cases
+    // are guarding real shift-overflow traps, not hypotheticals.
+
+    fn v4(s: &str) -> Ipv4Prefix {
+        s.parse().expect("v4 prefix")
+    }
+
+    fn v6(s: &str) -> Ipv6Prefix {
+        s.parse().expect("v6 prefix")
+    }
+
+    #[test]
+    fn v4_contains_addr_basic() {
+        let p = v4("23.191.200.0/24");
+        assert!(p.contains_addr("23.191.200.0".parse().unwrap()));
+        assert!(p.contains_addr("23.191.200.10".parse().unwrap()));
+        assert!(p.contains_addr("23.191.200.255".parse().unwrap()));
+        assert!(!p.contains_addr("23.191.201.0".parse().unwrap()));
+        assert!(!p.contains_addr("23.191.199.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn v4_contains_addr_slash32_is_exact() {
+        let p = v4("10.10.1.2/32");
+        assert!(p.contains_addr("10.10.1.2".parse().unwrap()));
+        assert!(!p.contains_addr("10.10.1.3".parse().unwrap()));
+        assert!(!p.contains_addr("10.10.1.0".parse().unwrap()));
+    }
+
+    #[test]
+    fn v4_contains_addr_slash0_matches_everything() {
+        // Guards `!0u32 << 32`.
+        let p = v4("0.0.0.0/0");
+        assert!(p.contains_addr("1.2.3.4".parse().unwrap()));
+        assert!(p.contains_addr("255.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn v4_contains_addr_ignores_declared_host_bits() {
+        let p = v4("23.191.200.5/24");
+        assert!(p.contains_addr("23.191.200.10".parse().unwrap()));
+        assert_eq!(p.network(), "23.191.200.0".parse::<Ipv4Addr>().unwrap());
+    }
+
+    #[test]
+    fn v6_contains_addr_basic() {
+        let p = v6("2602:f7d8:0:1337::/64");
+        assert!(p.contains_addr("2602:f7d8:0:1337::1".parse().unwrap()));
+        assert!(p.contains_addr("2602:f7d8:0:1337:dead:beef::42".parse().unwrap()));
+        assert!(!p.contains_addr("2602:f7d8:0:1338::1".parse().unwrap()));
+        assert!(!p.contains_addr("2602:f7d8:1::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn v6_contains_addr_slash128_is_exact() {
+        let p = v6("2001:db8::2/128");
+        assert!(p.contains_addr("2001:db8::2".parse().unwrap()));
+        assert!(!p.contains_addr("2001:db8::3".parse().unwrap()));
+    }
+
+    #[test]
+    fn v6_contains_addr_slash0_matches_everything() {
+        // Guards `!0u128 << 128`. In release that shift silently yields
+        // `!0`, which would make `::/0` match only `::` — a quiet
+        // wrong-answer rather than a panic.
+        let p = v6("::/0");
+        assert!(p.contains_addr("2001:db8::1".parse().unwrap()));
+        assert!(p.contains_addr("::".parse().unwrap()));
+        assert!(p.contains_addr("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap()));
+    }
+
+    #[test]
+    fn v6_contains_addr_ignores_declared_host_bits() {
+        let p = v6("2602:f7d8:0:1337::5/64");
+        assert!(p.contains_addr("2602:f7d8:0:1337::10".parse().unwrap()));
+        assert_eq!(
+            p.network(),
+            "2602:f7d8:0:1337::".parse::<Ipv6Addr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn contains_prefix_rejects_less_specific_inner() {
+        // A /24 does not contain the /16 that covers it.
+        assert!(!v4("10.1.0.0/24").contains_prefix(&v4("10.1.0.0/16")));
+        assert!(v4("10.1.0.0/16").contains_prefix(&v4("10.1.0.0/24")));
+        // Equal prefixes contain each other.
+        assert!(v4("10.1.0.0/24").contains_prefix(&v4("10.1.0.0/24")));
+        // Disjoint.
+        assert!(!v4("10.1.0.0/16").contains_prefix(&v4("10.2.0.0/24")));
+    }
+
+    #[test]
+    fn contains_prefix_v6() {
+        assert!(v6("2602:f7d8::/48").contains_prefix(&v6("2602:f7d8:0:1337::/64")));
+        assert!(!v6("2602:f7d8::/48").contains_prefix(&v6("2602:f7d8:1::/48")));
+        assert!(!v6("2602:f7d8:0:1337::/64").contains_prefix(&v6("2602:f7d8::/48")));
+        assert!(v6("::/0").contains_prefix(&v6("2001:db8::/32")));
+    }
+
     // --- Option F config directive tests ---
 
     fn parse_module_body(body: &str) -> Result<ModuleSection, ConfigError> {
@@ -2811,6 +3286,299 @@ module fast-path
             other => panic!("expected InterfaceMissing, got {other:?}"),
         }
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // --- local-prefix6 (IPv6 connected fast-path) ------------------------
+
+    fn extract_local_prefixes6(body: &str) -> Vec<(Ipv6Prefix, String)> {
+        let m = parse_module_body(body).expect("parse");
+        m.directives
+            .iter()
+            .filter_map(|d| match d {
+                ModuleDirective::LocalPrefix6 { cidr, iface, .. } => Some((*cidr, iface.clone())),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn local_prefix6_parses_basic_form() {
+        let lp = extract_local_prefixes6("  local-prefix6 2602:f7d8:0:1337::/64 via br1337\n");
+        assert_eq!(lp.len(), 1);
+        assert_eq!(
+            lp[0].0.addr,
+            "2602:f7d8:0:1337::".parse::<Ipv6Addr>().unwrap()
+        );
+        assert_eq!(lp[0].0.prefix_len, 64);
+        assert_eq!(lp[0].1, "br1337");
+    }
+
+    #[test]
+    fn local_prefix6_multiple_directives_accumulate() {
+        let body = "  local-prefix6 2602:f7d8:0:1337::/64 via br1337\n\
+                    local-prefix6 2602:f7d8:0:88::/64 via br88\n\
+                    local-prefix6 fd00:1::/64 via br0\n";
+        let lp = extract_local_prefixes6(body);
+        assert_eq!(lp.len(), 3);
+        let ifaces: Vec<&str> = lp.iter().map(|(_, i)| i.as_str()).collect();
+        assert_eq!(ifaces, ["br1337", "br88", "br0"]);
+    }
+
+    #[test]
+    fn local_prefix6_unique_local_is_allowed() {
+        // fc00::/7 is a legitimate connected segment; only the classes
+        // that can never be forwarded are rejected.
+        let lp = extract_local_prefixes6("  local-prefix6 fd00:1234::/64 via br0\n");
+        assert_eq!(lp.len(), 1);
+    }
+
+    #[test]
+    fn local_prefix6_and_v4_coexist_without_cross_contamination() {
+        let body = "  local-prefix 23.191.200.0/24 via br1337\n\
+                    local-prefix6 2602:f7d8:0:1337::/64 via br1337\n";
+        let v4 = extract_local_prefixes(body);
+        let v6 = extract_local_prefixes6(body);
+        assert_eq!(v4.len(), 1, "v4 extractor must see only the v4 directive");
+        assert_eq!(v6.len(), 1, "v6 extractor must see only the v6 directive");
+        assert_eq!(v4[0].0.prefix_len, 24);
+        assert_eq!(v6[0].0.prefix_len, 64);
+    }
+
+    #[test]
+    fn local_prefix6_rejects_default_route() {
+        // The highest-value rejection: ::/0 would harvest the entire
+        // neighbour table, multicast and link-local included.
+        let e = parse_module_body("  local-prefix6 ::/0 via br0\n").unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("::/0"), "got: {msg}");
+    }
+
+    #[test]
+    fn local_prefix6_rejects_multicast_prefix() {
+        for cidr in ["ff00::/8", "ff02::/16", "ff02::1/128"] {
+            let e = parse_module_body(&format!("  local-prefix6 {cidr} via br0\n")).unwrap_err();
+            let msg = format!("{e}");
+            assert!(msg.contains("multicast"), "{cidr} -> {msg}");
+        }
+    }
+
+    #[test]
+    fn local_prefix6_rejects_link_local_prefix() {
+        for cidr in ["fe80::/10", "fe80::/64", "fe80::1/128"] {
+            let e = parse_module_body(&format!("  local-prefix6 {cidr} via br0\n")).unwrap_err();
+            let msg = format!("{e}");
+            assert!(msg.contains("link-local"), "{cidr} -> {msg}");
+        }
+    }
+
+    #[test]
+    fn local_prefix6_rejects_unspecified_loopback_and_ipv4_mapped() {
+        for (cidr, needle) in [
+            ("::/128", "unspecified"),
+            ("::1/128", "loopback"),
+            ("::ffff:0:0/96", "IPv4-mapped"),
+        ] {
+            let e = parse_module_body(&format!("  local-prefix6 {cidr} via br0\n")).unwrap_err();
+            let msg = format!("{e}");
+            assert!(msg.contains(needle), "{cidr} -> {msg}");
+        }
+    }
+
+    #[test]
+    fn local_prefix6_rejects_arp_scavenge_with_reason() {
+        let e = parse_module_body("  local-prefix6 2602:f7d8:0:1337::/64 via br0 arp-scavenge\n")
+            .unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("IPv4-only"), "got: {msg}");
+        assert!(msg.contains("not enumerable"), "got: {msg}");
+    }
+
+    #[test]
+    fn local_prefix6_missing_via_keyword_errors() {
+        let e = parse_module_body("  local-prefix6 2602:f7d8::/48 br0\n").unwrap_err();
+        assert!(format!("{e}").contains("expected `via`"));
+    }
+
+    #[test]
+    fn local_prefix6_missing_iface_errors() {
+        let e = parse_module_body("  local-prefix6 2602:f7d8::/48 via\n").unwrap_err();
+        assert!(matches!(e, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn local_prefix6_missing_cidr_errors() {
+        let e = parse_module_body("  local-prefix6\n").unwrap_err();
+        assert!(matches!(e, ConfigError::Parse { .. }));
+    }
+
+    #[test]
+    fn local_prefix6_unknown_tail_flag_errors() {
+        let e = parse_module_body("  local-prefix6 2602:f7d8::/48 via br0 garbage\n").unwrap_err();
+        assert!(format!("{e}").contains("unknown tail flag"));
+    }
+
+    #[test]
+    fn local_prefix6_iface_sanitized() {
+        let e = parse_module_body("  local-prefix6 2602:f7d8::/48 via has space\n").unwrap_err();
+        assert!(matches!(e, ConfigError::Parse { .. }));
+    }
+
+    /// Regression guard for the paired-keyword design. A malformed v6
+    /// CIDR must still surface the precise `FromStr` diagnostic; a
+    /// try-v4-then-v6 polymorphic parser would collapse both into a
+    /// generic "cannot parse as IPv4 or IPv6".
+    #[test]
+    fn local_prefix6_bad_cidr_surfaces_precise_error() {
+        let e = parse_module_body("  local-prefix6 2001:db8::gg/64 via br0\n").unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("bad IPv6"), "got: {msg}");
+
+        let e = parse_module_body("  local-prefix6 2001:db8::/129 via br0\n").unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("0..=128"), "got: {msg}");
+    }
+
+    #[test]
+    fn local_prefix_family_mismatch_hints_at_other_directive() {
+        // v6 CIDR under the v4 keyword.
+        let e = parse_module_body("  local-prefix 2602:f7d8::/48 via br0\n").unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("local-prefix6"), "got: {msg}");
+
+        // v4 CIDR under the v6 keyword.
+        let e = parse_module_body("  local-prefix6 23.191.200.0/24 via br0\n").unwrap_err();
+        let msg = format!("{e}");
+        assert!(msg.contains("did you mean `local-prefix`"), "got: {msg}");
+    }
+
+    #[test]
+    fn local_prefix6_iface_validated_against_sysfs() {
+        let dir = std::env::temp_dir().join(format!(
+            "pf-cfg-local-prefix6-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(dir.join("br1337")).unwrap();
+        // Note: br88 is deliberately missing.
+        let cfg = Config::parse(
+            "module fast-path\n  attach br1337 generic\n  \
+             local-prefix6 2602:f7d8:0:1337::/64 via br1337\n  \
+             local-prefix6 2602:f7d8:0:88::/64 via br88\n",
+        )
+        .expect("parse ok; validation runs separately");
+        let err = cfg.validate_interfaces_in(&dir).unwrap_err();
+        match err {
+            ConfigError::InterfaceMissing { iface, .. } => assert_eq!(iface, "br88"),
+            other => panic!("expected InterfaceMissing, got {other:?}"),
+        }
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn is_harvestable_v6_rejects_non_global_unicast() {
+        for a in [
+            "ff02::1",
+            "ff02::2",
+            "ff02::1:ff00:1", // solicited-node
+            "ff05::c",
+            "fe80::1",
+            "fe80::200:5eff:fe00:1",
+            "::",
+            "::1",
+            "::ffff:192.0.2.1",
+        ] {
+            assert!(
+                !is_harvestable_v6(a.parse().unwrap()),
+                "{a} must not be harvestable"
+            );
+        }
+        for a in [
+            "2602:f7d8:0:1337::42",
+            "2602:f7d8:0:1337::", // subnet-router anycast: a real address
+            "2001:db8::1",
+            "fd00:1::1", // unique-local is fine
+        ] {
+            assert!(
+                is_harvestable_v6(a.parse().unwrap()),
+                "{a} must be harvestable"
+            );
+        }
+    }
+
+    /// The per-address gate and the parse-time class table must agree,
+    /// or a prefix could pass validation and then have every address
+    /// inside it filtered at emission (or vice versa).
+    #[test]
+    fn harvestable_gate_agrees_with_forbidden_class_table() {
+        for (class, reason) in FORBIDDEN_V6_CLASSES {
+            assert!(
+                !is_harvestable_v6(class.addr),
+                "{reason}: class network address should be rejected by is_harvestable_v6"
+            );
+        }
+    }
+
+    // --- uncovered_local_prefix_warnings ---------------------------------
+
+    fn warnings_for(body: &str) -> Vec<String> {
+        let m = parse_module_body(body).expect("parse");
+        uncovered_local_prefix_warnings(&m.directives)
+    }
+
+    #[test]
+    fn covered_local_prefixes_produce_no_warnings() {
+        let w = warnings_for(
+            "  allow-prefix 23.191.200.0/24\n\
+             allow-prefix6 2602:f7d8::/48\n\
+             local-prefix 23.191.200.0/24 via br1337\n\
+             local-prefix6 2602:f7d8:0:1337::/64 via br1337\n",
+        );
+        assert!(w.is_empty(), "unexpected warnings: {w:?}");
+    }
+
+    /// The exact production slip this exists for: the operator carried
+    /// over the v4 pair but declared only half of the v6 pair.
+    #[test]
+    fn local_prefix6_without_allow_prefix6_warns() {
+        let w = warnings_for(
+            "  allow-prefix 23.191.200.0/24\n\
+             local-prefix 23.191.200.0/24 via br1337\n\
+             local-prefix6 2602:f7d8:0:1337::/64 via br1337\n",
+        );
+        assert_eq!(w.len(), 1, "got: {w:?}");
+        assert!(w[0].contains("local-prefix6"), "got: {}", w[0]);
+        assert!(w[0].contains("allow-prefix6"), "got: {}", w[0]);
+    }
+
+    #[test]
+    fn local_prefix_v4_without_allow_warns() {
+        let w = warnings_for("  local-prefix 10.88.1.0/24 via br88\n");
+        assert_eq!(w.len(), 1, "got: {w:?}");
+        assert!(w[0].contains("local-prefix 10.88.1.0/24"), "got: {}", w[0]);
+    }
+
+    #[test]
+    fn cross_family_allow_does_not_cover() {
+        // A v4 allowlist must not silence the v6 warning or vice versa.
+        let w = warnings_for(
+            "  allow-prefix6 2602:f7d8::/48\n\
+             local-prefix 23.191.200.0/24 via br1337\n",
+        );
+        assert_eq!(w.len(), 1, "got: {w:?}");
+    }
+
+    #[test]
+    fn overlap_counts_even_when_allow_is_narrower() {
+        // An allow entry narrower than the local prefix still means the
+        // operator wired the two together; only zero overlap warns.
+        let w = warnings_for(
+            "  allow-prefix 23.191.200.128/25\n\
+             local-prefix 23.191.200.0/24 via br1337\n",
+        );
+        assert!(w.is_empty(), "narrower allow overlaps, no warn: {w:?}");
     }
 
     // --- v0.2.1 fallback-default + block-prefix ---

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -51,6 +51,15 @@ const PROTO_TCP: u8 = IpProto::Tcp as u8;
 const PROTO_UDP: u8 = IpProto::Udp as u8;
 const PROTO_ICMPV6: u8 = IpProto::Ipv6Icmp as u8;
 
+/// ICMPv6 neighbor-discovery message types (RFC 4861 §4): Router
+/// Solicitation (133), Router Advertisement (134), Neighbor Solicitation
+/// (135), Neighbor Advertisement (136), Redirect (137). All four of the
+/// first are hop-limit-255 messages whose receivers discard anything
+/// else; Redirect is likewise link-scoped. Contiguous, so the check is a
+/// range compare.
+const ICMPV6_ND_TYPE_MIN: u8 = 133;
+const ICMPV6_ND_TYPE_MAX: u8 = 137;
+
 /// Sentinel u16 representing "no VLAN" in the VID-passing API below.
 /// 802.1Q reserves VID 0 for priority-only tagging, so `vid == 0`
 /// means absent from the fast-path's perspective. Using a single u16
@@ -331,6 +340,33 @@ fn handle_ipv6(
         _ => {
             bump_stat(StatIdx::PassComplexHeader);
             return Ok(xdp_action::XDP_PASS);
+        }
+    }
+
+    // Neighbor discovery must never be fast-pathed. NDP mandates a hop
+    // limit of 255 and receivers silently discard NS/NA/RS/RA that
+    // arrive with anything else (RFC 4861 §6.1.1, §7.1.1), but
+    // `forward_success` decrements the hop limit and rewrites the
+    // source MAC. Redirecting NDP therefore breaks neighbor resolution
+    // on the segment: NUD fails and hosts fall back to permanent
+    // multicast re-resolution.
+    //
+    // This is reachable as soon as a `local-prefix6` installs /128s for
+    // connected hosts, because host-to-host unicast NDP (NUD probes,
+    // unsolicited NA) then matches the allowlist on src and resolves in
+    // FIB_V6 on dst. IPv4 never had this exposure: ARP is EtherType
+    // 0x0806, which is never dispatched into `handle_ipv4`.
+    //
+    // Gate on message type rather than `hop_limit == 255` so legitimate
+    // transit ICMPv6 (echo sent with a high hop limit) still fast-paths.
+    // MLD (types 130-132, 143) travels at hop limit 1 and is already
+    // caught by the `hop_limit <= 1` check below.
+    if next == PROTO_ICMPV6 {
+        if let Some(t) = icmpv6_type(ctx, ip_offset + Ipv6Hdr::LEN) {
+            if t >= ICMPV6_ND_TYPE_MIN && t <= ICMPV6_ND_TYPE_MAX {
+                bump_stat(StatIdx::PassNdp);
+                return Ok(xdp_action::XDP_PASS);
+            }
         }
     }
 
@@ -693,6 +729,21 @@ fn l4_ports(ctx: &XdpContext, offset: usize, proto: u8) -> (u16, u16) {
         let dport = core::ptr::read_unaligned(p.add(2) as *const u16);
         (sport, dport)
     }
+}
+
+/// Read the ICMPv6 `type` field, the first octet of the ICMPv6 header.
+///
+/// `None` when the read would run past `data_end`; callers treat that as
+/// "not an NDP message" and fall through to the normal path, which is
+/// fail-safe (a truncated ICMPv6 header can't be a valid NS/NA anyway).
+/// Bounds-check shape mirrors [`l4_ports`].
+#[inline(always)]
+fn icmpv6_type(ctx: &XdpContext, offset: usize) -> Option<u8> {
+    let start = ctx.data();
+    if start + offset + 1 > ctx.data_end() {
+        return None;
+    }
+    Some(unsafe { core::ptr::read_unaligned((start + offset) as *const u8) })
 }
 
 #[inline(always)]

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -145,11 +145,25 @@ pub enum StatIdx {
     /// scratch slot. Shouldn't happen, fast_path always writes before
     /// tail_call. Diagnostic; finalize XDP_PASSes on this error.
     ErrMutationCtx = 36,
+    /// ICMPv6 neighbor-discovery message (RFC 4861 types 133-137)
+    /// deliberately handed to the kernel instead of fast-pathed.
+    ///
+    /// NDP mandates a hop limit of 255 and requires receivers to
+    /// silently discard NS/NA/RS/RA arriving with anything else
+    /// (RFC 4861 §6.1.1, §7.1.1). `forward_success` decrements the hop
+    /// limit and rewrites the source MAC, so redirecting NDP would
+    /// break neighbor resolution on the segment. IPv4 has no analogue:
+    /// ARP is EtherType 0x0806, which never reaches `handle_ipv4`.
+    ///
+    /// Expected to be non-zero and climbing on any box with a
+    /// `local-prefix6`, since that installs the /128s that would
+    /// otherwise make host-to-host NDP FIB-eligible.
+    PassNdp = 37,
 }
 
 /// Total counter count. Used as `stats` map `max_entries`. New counters
 /// bump this; dashboards keying on indices keep working.
-pub const STATS_COUNT: u32 = 37;
+pub const STATS_COUNT: u32 = 38;
 
 /// Flag bits for `FpCfg.flags`. Bits 0-1 are the IPv4/IPv6 enable
 /// mask (historical, load-bearing for dashboards). Bit 2 is the

--- a/crates/modules/fast-path/src/breaker.rs
+++ b/crates/modules/fast-path/src/breaker.rs
@@ -167,10 +167,9 @@ mod tests {
     }
 
     fn stats(matched_v4: u64, drops: u64) -> Vec<u64> {
-        // Matches STATS_COUNT in bpf/src/maps.rs (32 after the Option F
-        // Phase 1 additions). Was 19 pre-Phase-1, that was already
-        // off-by-one against the 20-variant StatIdx enum; fixed in
-        // passing by the custom-FIB work that bumped STATS_COUNT.
+        // Sized from `metrics::COUNTER_NAMES`, the single userspace
+        // mirror of STATS_COUNT in bpf/src/maps.rs, so this helper
+        // tracks new counters automatically.
         let mut s = vec![0u64; crate::metrics::COUNTER_NAMES.len()];
         s[STAT_MATCHED_V4] = matched_v4;
         s[STAT_DROP_UNREACHABLE] = drops;

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -405,20 +405,20 @@ impl NetlinkNeighborResolver {
             }
         }
 
-        // v0.2.1: seed the FibProgrammer with one /32 RouteEvent::Add
-        // per kernel ARP entry that lives within an operator-declared
-        // local-prefix CIDR + iface. The /32 wins in LPM over the /24
+        // v0.2.1: seed the FibProgrammer with one host route
+        // (/32 for v4, /128 for v6) per kernel neighbour entry that
+        // lives within an operator-declared local-prefix CIDR + iface.
+        // The host route wins in LPM over the covering prefix from
         // bird's iBGP exports (with state=Incomplete from the v0.2.1-A
         // listen-addr fallback), so inbound traffic to those hosts
         // fast-paths via XDP redirect. Without local-prefix configured
         // (`local_prefixes` empty), this loop is a no-op.
         //
-        // The neigh_cache lookup inside FibProgrammer's register_nexthop
-        // ↔ NeighborResolver ↔ programmer feedback path does the heavy
-        // lifting once the route lands: registering nexthop=host_ip
-        // calls request_resolve, which (post-rc4) consults this same
-        // neigh_cache and synthesizes a Learned event back to the
-        // programmer with the kernel-cached MAC. State flips Resolved.
+        // Each Add is followed by a synthetic Learned emitted directly
+        // from the dump snapshot, so seeding does not depend on the
+        // bounded resolve queue — which nothing drains until the
+        // select loop below starts; see seed_local_prefix_routes for
+        // the full rationale.
         // Clone the handle so the &self borrow on `prog_handle` is
         // released before the call below takes &mut self for counter
         // updates. FibProgrammerHandle is `Clone` (cheap mpsc sender
@@ -642,23 +642,41 @@ impl NetlinkNeighborResolver {
         }
     }
 
-    /// Walk the seeded `neigh_cache` once at startup and emit a
-    /// `RouteEvent::Add` for each entry that falls in a configured
-    /// local-prefix CIDR + ifindex pair. v0.2.1.
+    /// Walk the seeded `neigh_cache` once at startup and, for each
+    /// entry that falls in a configured local-prefix CIDR + ifindex
+    /// pair, emit a `RouteEvent::Add` followed directly by a synthetic
+    /// `NeighEvent::Learned` carrying the cached MAC. v0.2.1.
+    ///
+    /// The direct `Learned` is load-bearing, not an optimization. The
+    /// Add makes the programmer register the nexthop, which fires a
+    /// `request_resolve` into the bounded resolve queue
+    /// (`RESOLVE_QUEUE_CAPACITY` = 1024, `try_send`) — but this method
+    /// runs *before* `run()` enters its select loop, so nothing drains
+    /// that queue while we seed. Past 1024 matching neighbours the
+    /// overflow requests would drop silently, and since these are
+    /// already-stable cached entries that may emit no further
+    /// multicast event, their host routes would sit `Incomplete`
+    /// (slow-path fallback) until NUD churn happened to touch them.
+    /// Emitting the `Learned` here uses the MAC we already hold from
+    /// the dump, mirrors what the resolve queue's cache-hit arm would
+    /// have done, and scales to any snapshot size: `events_tx` applies
+    /// backpressure and the programmer drains it concurrently. The
+    /// queued resolve requests that do survive become harmless
+    /// duplicate cache-hits once the select loop starts.
     async fn seed_local_prefix_routes(&mut self, prog: &FibProgrammerHandle) {
         // Snapshot the cache under a copy so the iteration doesn't
         // borrow self while we call &mut self below for counter
         // updates. Cache is small (low thousands at most on the
         // reference EFG); allocation cost is irrelevant against the
         // single-shot startup work.
-        let snapshot: Vec<(IpAddr, u32)> = self
+        let snapshot: Vec<(IpAddr, u32, [u8; 6])> = self
             .neigh_cache
             .iter()
-            .map(|(ip, (ifindex, _mac))| (*ip, *ifindex))
+            .map(|(ip, (ifindex, mac))| (*ip, *ifindex, *mac))
             .collect();
         let mut emitted_v4 = 0usize;
         let mut emitted_v6 = 0usize;
-        for (ip, ifindex) in snapshot {
+        for (ip, ifindex, mac) in snapshot {
             if !may_synthesize(ip) {
                 continue;
             }
@@ -674,12 +692,30 @@ impl NetlinkNeighborResolver {
                     .await
                 {
                     warn!(?ip, error = %e, "local-prefix seed RouteEvent::Add dispatch failed");
-                } else if ip.is_ipv4() {
+                    continue;
+                }
+                if ip.is_ipv4() {
                     emitted_v4 += 1;
                     self.local_arp_routes_added += 1;
                 } else {
                     emitted_v6 += 1;
                     self.local_nd_routes_added += 1;
+                }
+                // Same construction as the resolve queue's cache-hit
+                // arm, including the zeroed src_mac fallback for
+                // MAC-less ifaces.
+                let src_mac = self.iface_mac.get(&ifindex).copied().unwrap_or([0; 6]);
+                let evt = NeighEvent::Learned {
+                    ip,
+                    mac,
+                    ifindex,
+                    src_mac,
+                };
+                match self.events_tx.send(evt).await {
+                    Ok(()) => self.synth_learned_emitted += 1,
+                    Err(e) => {
+                        warn!(?ip, error = %e, "seed synthetic Learned send failed");
+                    }
                 }
             }
         }

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -45,22 +45,31 @@ use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
+use packetframe_common::config::{is_harvestable_v6, Ipv4Prefix, Ipv6Prefix};
 use packetframe_common::fib::{IpPrefix, NeighError, NeighEvent, PeerId, RouteEvent};
 
 use crate::fib::programmer::FibProgrammerHandle;
 
 /// Operator-declared local prefix (v0.2.1 connected fast-path). The
-/// resolver walks the kernel ARP table for IPs falling in `cidr` that
-/// are reachable via `iface`, and synthesizes per-/32 `RouteEvent::Add`s
-/// into FibProgrammer so inbound traffic to those hosts fast-paths
-/// through XDP redirect instead of falling to kernel slow path. See
-/// [`packetframe_common::config::ModuleDirective::LocalPrefix`] for the
-/// config-side surface.
+/// resolver walks the kernel neighbour table for IPs falling in `cidr`
+/// that are reachable via `iface`, and synthesizes per-host
+/// `RouteEvent::Add`s (a /32 for IPv4, a /128 for IPv6) into
+/// FibProgrammer so inbound traffic to those hosts fast-paths through
+/// XDP redirect instead of falling to kernel slow path. See
+/// [`packetframe_common::config::ModuleDirective::LocalPrefix`] and
+/// [`packetframe_common::config::ModuleDirective::LocalPrefix6`] for the
+/// config-side surfaces.
+///
+/// Both families share this one type so the emission path
+/// ([`NetlinkNeighborResolver::seed_local_prefix_routes`],
+/// `maybe_emit_local_arp_add`/`_del`, `match_local_prefix`) is written
+/// once rather than duplicated per family.
 #[derive(Debug, Clone)]
 pub struct LocalPrefixSpec {
-    /// Network address (host bits zeroed) of the prefix.
-    pub addr: Ipv4Addr,
-    /// Prefix length in bits, 0..=32.
+    /// Network address of the prefix. Host bits need not be zeroed;
+    /// containment ignores them.
+    pub addr: IpAddr,
+    /// Prefix length in bits: 0..=32 for v4, 0..=128 for v6.
     pub prefix_len: u8,
     /// The kernel iface name (e.g., `br1337`). Resolved to ifindex
     /// once at resolver startup via the RTM_GETLINK dump; if the iface
@@ -75,6 +84,11 @@ pub struct LocalPrefixSpec {
     /// communicate L3 with the gateway and therefore never appear in
     /// `ip neigh show <iface>`. Off by default, generates noticeable
     /// ARP traffic during startup.
+    ///
+    /// **IPv4 only.** The config parser rejects `arp-scavenge` on
+    /// `local-prefix6`, so this is always `false` for a v6 spec; see
+    /// [`packetframe_common::config::ModuleDirective::LocalPrefix6`] for
+    /// why there is no v6 equivalent.
     pub arp_scavenge: bool,
 }
 
@@ -99,13 +113,66 @@ pub struct FallbackDefaultSpec {
 
 impl LocalPrefixSpec {
     /// True iff `ip` falls within this prefix.
-    fn contains(&self, ip: Ipv4Addr) -> bool {
-        if self.prefix_len == 0 {
-            return true;
+    ///
+    /// A family mismatch is `false`, not an error: a v4 spec must never
+    /// match a v6 neighbour and vice versa, and the resolver walks one
+    /// mixed-family list against every neighbour event.
+    ///
+    /// Mask arithmetic (including the `/0` and `/max` shift-overflow
+    /// guards) lives in the shared prefix helpers in `common` so it has
+    /// exactly one implementation.
+    fn contains(&self, ip: IpAddr) -> bool {
+        match (self.addr, ip) {
+            (IpAddr::V4(net), IpAddr::V4(ip)) => Ipv4Prefix {
+                addr: net,
+                prefix_len: self.prefix_len,
+            }
+            .contains_addr(ip),
+            (IpAddr::V6(net), IpAddr::V6(ip)) => Ipv6Prefix {
+                addr: net,
+                prefix_len: self.prefix_len,
+            }
+            .contains_addr(ip),
+            _ => false,
         }
-        let mask: u32 = (!0u32) << (32 - self.prefix_len as u32);
-        let net = u32::from(self.addr) & mask;
-        u32::from(ip) & mask == net
+    }
+}
+
+/// The single-host prefix we synthesize for a connected neighbour: a /32
+/// for IPv4, a /128 for IPv6. Being maximally specific is the whole
+/// point — it wins the LPM walk over any covering route from the BGP
+/// feed, which is what routes the packet to this host's own MAC rather
+/// than to an upstream nexthop.
+fn host_prefix(ip: IpAddr) -> IpPrefix {
+    match ip {
+        IpAddr::V4(v4) => IpPrefix::V4 {
+            addr: v4.octets(),
+            prefix_len: 32,
+        },
+        IpAddr::V6(v6) => IpPrefix::V6 {
+            addr: v6.octets(),
+            prefix_len: 128,
+        },
+    }
+}
+
+/// Whether a neighbour address may be synthesized into a host route.
+///
+/// v4 is unconditional: the ARP table holds only unicast entries, and
+/// the scavenge sweep already skips network and broadcast addresses.
+///
+/// v6 needs a real gate. The kernel's neighbour table carries
+/// `NUD_NOARP` entries for multicast groups with a derived `33:33:xx`
+/// MAC, which are indistinguishable from resolved unicast neighbours at
+/// this layer, plus link-local addresses that are ambiguous across
+/// interfaces. See [`is_harvestable_v6`] for the full reasoning.
+///
+/// Applied symmetrically on add **and** delete: an asymmetric filter
+/// would leak routes that were installed before a config change.
+fn may_synthesize(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(_) => true,
+        IpAddr::V6(v6) => is_harvestable_v6(v6),
     }
 }
 
@@ -159,6 +226,13 @@ pub struct NetlinkNeighborResolver {
     /// whether the local-prefix sweep is doing useful work.
     local_arp_routes_added: u64,
     local_arp_routes_removed: u64,
+    /// Same, for `local-prefix6` /128s resolved via NDP. Kept separate
+    /// from the ARP counters rather than summed: the runbook points
+    /// operators at `local_arp_routes_added` as the "is it working"
+    /// signal, and merging the families would make both numbers
+    /// unreadable on a dual-stack segment.
+    local_nd_routes_added: u64,
+    local_nd_routes_removed: u64,
     /// Cache mapping ifindex → egress MAC. Populated at startup via
     /// a single `RTM_GETLINK` dump; maintained by `RTM_NEWLINK` /
     /// `RTM_DELLINK` multicast events. Used to attach `src_mac` to
@@ -228,6 +302,8 @@ impl NetlinkNeighborResolver {
                 cache_misses: 0,
                 local_arp_routes_added: 0,
                 local_arp_routes_removed: 0,
+                local_nd_routes_added: 0,
+                local_nd_routes_removed: 0,
                 local_prefixes: Vec::new(),
                 prog_handle: None,
                 fallback_default: None,
@@ -457,6 +533,8 @@ impl NetlinkNeighborResolver {
                         cache_misses = self.cache_misses,
                         local_arp_routes_added = self.local_arp_routes_added,
                         local_arp_routes_removed = self.local_arp_routes_removed,
+                        local_nd_routes_added = self.local_nd_routes_added,
+                        local_nd_routes_removed = self.local_nd_routes_removed,
                         "neighbour resolver stats"
                     );
                 }
@@ -578,17 +656,17 @@ impl NetlinkNeighborResolver {
             .iter()
             .map(|(ip, (ifindex, _mac))| (*ip, *ifindex))
             .collect();
-        let mut emitted = 0usize;
+        let mut emitted_v4 = 0usize;
+        let mut emitted_v6 = 0usize;
         for (ip, ifindex) in snapshot {
-            let IpAddr::V4(v4) = ip else { continue };
-            if let Some(peer_id) = self.match_local_prefix(v4, ifindex) {
+            if !may_synthesize(ip) {
+                continue;
+            }
+            if let Some(peer_id) = self.match_local_prefix(ip, ifindex) {
                 if let Err(e) = prog
                     .apply_route_event(RouteEvent::Add {
                         peer_id,
-                        prefix: IpPrefix::V4 {
-                            addr: v4.octets(),
-                            prefix_len: 32,
-                        },
+                        prefix: host_prefix(ip),
                         nexthops: vec![ip],
                         path_id: None,
                         local_pref: None,
@@ -596,16 +674,20 @@ impl NetlinkNeighborResolver {
                     .await
                 {
                     warn!(?ip, error = %e, "local-prefix seed RouteEvent::Add dispatch failed");
-                } else {
-                    emitted += 1;
+                } else if ip.is_ipv4() {
+                    emitted_v4 += 1;
                     self.local_arp_routes_added += 1;
+                } else {
+                    emitted_v6 += 1;
+                    self.local_nd_routes_added += 1;
                 }
             }
         }
         info!(
-            emitted,
+            emitted_v4,
+            emitted_v6,
             local_prefixes = self.local_prefixes.len(),
-            "local-prefix /32 seed complete"
+            "local-prefix host-route seed complete (/32 for v4, /128 for v6)"
         );
 
         // v0.2.1 issue #32: ARP-scavenge any prefix the operator
@@ -677,7 +759,22 @@ impl NetlinkNeighborResolver {
         }
         let mut total_probed = 0usize;
         for (spec, oif) in specs {
-            let net_u32 = u32::from(spec.addr);
+            // Belt-and-braces: the config parser rejects `arp-scavenge`
+            // on `local-prefix6`, so a v6 spec can never have the flag
+            // set and this is unreachable. It guards against a future
+            // caller constructing LocalPrefixSpec directly — sweeping a
+            // v6 prefix is not merely unsupported but unrepresentable
+            // (a /64 is 2^64 addresses).
+            let IpAddr::V4(net_v4) = spec.addr else {
+                warn!(
+                    iface = %spec.iface,
+                    cidr = %format_args!("{}/{}", spec.addr, spec.prefix_len),
+                    "arp-scavenge is IPv4-only and should have been rejected at config \
+                     parse; ignoring this spec"
+                );
+                continue;
+            };
+            let net_u32 = u32::from(net_v4);
             let plen = spec.prefix_len;
             // Number of host bits + the host range.
             let host_bits = 32u8.saturating_sub(plen) as u32;
@@ -806,11 +903,20 @@ impl NetlinkNeighborResolver {
 
     /// Same as [`Self::seed_local_prefix_routes`] but for a single
     /// (ip, ifindex) pair, called from the multicast event handler
-    /// on RTM_NEWNEIGH. Idempotent against the FibProgrammer side
-    /// (multiple Adds for the same /32 just bump a refcount).
+    /// on RTM_NEWNEIGH.
+    ///
+    /// Idempotent against the FibProgrammer side: a repeated Add for an
+    /// unchanged nexthop set short-circuits in `recompute_fib_entry`
+    /// before any map write, so there is no churn and nothing to leak.
+    /// (This is a no-change comparison, not a refcount bump; refcounting
+    /// only engages when the nexthop set actually changes.) IPv6
+    /// exercises this path harder than v4 because SLAAC hosts hold
+    /// several addresses that go stale and get re-probed independently.
     async fn maybe_emit_local_arp_add(&mut self, ip: IpAddr, ifindex: u32) {
-        let IpAddr::V4(v4) = ip else { return };
-        let Some(peer_id) = self.match_local_prefix(v4, ifindex) else {
+        if !may_synthesize(ip) {
+            return;
+        }
+        let Some(peer_id) = self.match_local_prefix(ip, ifindex) else {
             return;
         };
         // Clone to release the &self borrow on prog_handle before the
@@ -823,10 +929,7 @@ impl NetlinkNeighborResolver {
         if let Err(e) = prog
             .apply_route_event(RouteEvent::Add {
                 peer_id,
-                prefix: IpPrefix::V4 {
-                    addr: v4.octets(),
-                    prefix_len: 32,
-                },
+                prefix: host_prefix(ip),
                 nexthops: vec![ip],
                 path_id: None,
                 local_pref: None,
@@ -834,15 +937,23 @@ impl NetlinkNeighborResolver {
             .await
         {
             warn!(?ip, error = %e, "local-prefix RouteEvent::Add dispatch failed");
-        } else {
+        } else if ip.is_ipv4() {
             self.local_arp_routes_added += 1;
+        } else {
+            self.local_nd_routes_added += 1;
         }
     }
 
     /// Symmetric withdrawal for a single (ip, ifindex) on RTM_DELNEIGH.
+    ///
+    /// The `may_synthesize` gate must match the add path exactly. An
+    /// asymmetric filter would strand host routes that were installed
+    /// before the gate changed, with no path to withdraw them.
     async fn maybe_emit_local_arp_del(&mut self, ip: IpAddr, ifindex: u32) {
-        let IpAddr::V4(v4) = ip else { return };
-        let Some(peer_id) = self.match_local_prefix(v4, ifindex) else {
+        if !may_synthesize(ip) {
+            return;
+        }
+        let Some(peer_id) = self.match_local_prefix(ip, ifindex) else {
             return;
         };
         let Some(prog) = self.prog_handle.clone() else {
@@ -851,17 +962,16 @@ impl NetlinkNeighborResolver {
         if let Err(e) = prog
             .apply_route_event(RouteEvent::Del {
                 peer_id,
-                prefix: IpPrefix::V4 {
-                    addr: v4.octets(),
-                    prefix_len: 32,
-                },
+                prefix: host_prefix(ip),
                 path_id: None,
             })
             .await
         {
             warn!(?ip, error = %e, "local-prefix RouteEvent::Del dispatch failed");
-        } else {
+        } else if ip.is_ipv4() {
             self.local_arp_routes_removed += 1;
+        } else {
+            self.local_nd_routes_removed += 1;
         }
     }
 
@@ -905,7 +1015,18 @@ impl NetlinkNeighborResolver {
     /// Linear scan; the operator-declared list is small (handful at
     /// most on the reference EFG) so this is cheap on every neighbour
     /// event.
-    fn match_local_prefix(&self, ip: Ipv4Addr, ifindex: u32) -> Option<PeerId> {
+    ///
+    /// The list holds both families and `LocalPrefixSpec::contains`
+    /// returns `false` on a family mismatch, so a v6 neighbour can only
+    /// ever match a `local-prefix6` spec.
+    ///
+    /// The returned `PeerId` is keyed on ifindex alone, deliberately
+    /// **not** on family: a v4 and a v6 local-prefix on the same
+    /// interface share one peer, so a single `RouteEvent::PeerDown` on
+    /// `RTM_DELLINK` withdraws both families' host routes in one sweep.
+    /// `FibProgrammer` keeps them distinct internally because
+    /// `prefix_peer_key` discriminates on an `is_v4` flag.
+    fn match_local_prefix(&self, ip: IpAddr, ifindex: u32) -> Option<PeerId> {
         for spec in &self.local_prefixes {
             if !spec.contains(ip) {
                 continue;
@@ -1328,5 +1449,206 @@ mod tests {
             arp_scavenge: false,
         };
         assert!(spec.contains("23.191.200.10".parse().unwrap()));
+    }
+
+    // --- local-prefix6 (IPv6 connected fast-path) ------------------------
+
+    fn spec6(cidr: &str, prefix_len: u8, iface: &str) -> LocalPrefixSpec {
+        LocalPrefixSpec {
+            addr: cidr.parse().unwrap(),
+            prefix_len,
+            iface: iface.into(),
+            arp_scavenge: false,
+        }
+    }
+
+    #[test]
+    fn local_prefix6_contains_basic() {
+        let spec = spec6("2602:f7d8:0:1337::", 64, "br1337");
+        assert!(spec.contains("2602:f7d8:0:1337::1".parse().unwrap()));
+        assert!(spec.contains("2602:f7d8:0:1337:dead:beef::42".parse().unwrap()));
+        assert!(!spec.contains("2602:f7d8:0:1338::1".parse().unwrap()));
+        // The adjacent /48 must not match: 2602:f7d8:1:: is a different
+        // allocation, not part of this segment.
+        assert!(!spec.contains("2602:f7d8:1::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn local_prefix6_contains_handles_slash128() {
+        let spec = spec6("2001:db8::2", 128, "br0");
+        assert!(spec.contains("2001:db8::2".parse().unwrap()));
+        assert!(!spec.contains("2001:db8::3".parse().unwrap()));
+    }
+
+    #[test]
+    fn local_prefix6_contains_handles_slash0() {
+        // Guards the u128 shift-by-128. In release that shift silently
+        // yields !0, which would make ::/0 match only :: — the
+        // directive would quietly do nothing rather than panic.
+        let spec = spec6("::", 0, "br0");
+        assert!(spec.contains("2001:db8::1".parse().unwrap()));
+        assert!(spec.contains("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff".parse().unwrap()));
+    }
+
+    #[test]
+    fn local_prefix6_contains_misalignment_is_treated_as_aligned() {
+        let spec = spec6("2602:f7d8:0:1337::5", 64, "br1337");
+        assert!(spec.contains("2602:f7d8:0:1337::10".parse().unwrap()));
+    }
+
+    /// A spec must never match across families. The resolver walks one
+    /// mixed-family list against every neighbour event, so a v4 spec
+    /// seeing a v6 neighbour (and vice versa) is the normal case, not an
+    /// error case.
+    #[test]
+    fn local_prefix_contains_rejects_family_mismatch_both_ways() {
+        let v4 = LocalPrefixSpec {
+            addr: "23.191.200.0".parse().unwrap(),
+            prefix_len: 24,
+            iface: "br1337".into(),
+            arp_scavenge: false,
+        };
+        assert!(!v4.contains("2602:f7d8:0:1337::1".parse().unwrap()));
+
+        let v6 = spec6("2602:f7d8:0:1337::", 64, "br1337");
+        assert!(!v6.contains("23.191.200.10".parse().unwrap()));
+
+        // A v6 /0 spec still must not swallow v4 addresses, even though
+        // its mask matches everything within its own family.
+        let v6_default = spec6("::", 0, "br0");
+        assert!(!v6_default.contains("23.191.200.10".parse().unwrap()));
+    }
+
+    #[test]
+    fn host_prefix_is_maximally_specific_per_family() {
+        match host_prefix("23.191.200.7".parse().unwrap()) {
+            IpPrefix::V4 { addr, prefix_len } => {
+                assert_eq!(prefix_len, 32);
+                assert_eq!(addr, [23, 191, 200, 7]);
+            }
+            other => panic!("expected V4, got {other:?}"),
+        }
+        match host_prefix("2602:f7d8:0:1337::7".parse().unwrap()) {
+            IpPrefix::V6 { addr, prefix_len } => {
+                assert_eq!(prefix_len, 128);
+                assert_eq!(
+                    addr,
+                    "2602:f7d8:0:1337::7"
+                        .parse::<std::net::Ipv6Addr>()
+                        .unwrap()
+                        .octets()
+                );
+            }
+            other => panic!("expected V6, got {other:?}"),
+        }
+    }
+
+    /// The emission gate. v4 is unconditional; v6 rejects the classes
+    /// the kernel keeps in its neighbour table that must never become
+    /// forwarding entries.
+    #[test]
+    fn may_synthesize_gates_v6_but_never_v4() {
+        // Every v4 address is fair game, including ones that look odd.
+        for a in ["23.191.200.7", "0.0.0.0", "255.255.255.255", "127.0.0.1"] {
+            assert!(may_synthesize(a.parse().unwrap()), "v4 {a}");
+        }
+        // v6 classes that must be filtered.
+        for a in [
+            "ff02::1",
+            "ff02::1:ff00:1", // solicited-node, NUD_NOARP with a 33:33 MAC
+            "fe80::1",
+            "::",
+            "::1",
+            "::ffff:192.0.2.1",
+        ] {
+            assert!(!may_synthesize(a.parse().unwrap()), "v6 {a}");
+        }
+        // v6 addresses that are legitimate connected hosts.
+        for a in [
+            "2602:f7d8:0:1337::42",
+            "2602:f7d8:0:1337::", // subnet-router anycast
+            "fd00:1::1",          // unique-local
+        ] {
+            assert!(may_synthesize(a.parse().unwrap()), "v6 {a}");
+        }
+    }
+
+    // --- match_local_prefix ---------------------------------------------
+    //
+    // Previously untested at any family. Needs a resolver with a
+    // populated `iface_to_ifindex`, which is why it had no coverage.
+
+    fn resolver_with(
+        specs: Vec<LocalPrefixSpec>,
+        ifaces: &[(&str, u32)],
+    ) -> NetlinkNeighborResolver {
+        let (mut r, _rx, _h) = NetlinkNeighborResolver::new(CancellationToken::new());
+        r.local_prefixes = specs;
+        for (name, idx) in ifaces {
+            r.iface_to_ifindex.insert((*name).to_string(), *idx);
+        }
+        r
+    }
+
+    #[test]
+    fn match_local_prefix_requires_prefix_and_ifindex_to_agree() {
+        let r = resolver_with(
+            vec![spec6("2602:f7d8:0:1337::", 64, "br1337")],
+            &[("br1337", 33)],
+        );
+        let inside: IpAddr = "2602:f7d8:0:1337::7".parse().unwrap();
+        let outside: IpAddr = "2602:f7d8:0:9999::7".parse().unwrap();
+
+        assert_eq!(
+            r.match_local_prefix(inside, 33),
+            Some(PeerId::local_arp(33)),
+            "right prefix + right ifindex must match"
+        );
+        assert_eq!(
+            r.match_local_prefix(inside, 34),
+            None,
+            "right prefix on the wrong iface must not match"
+        );
+        assert_eq!(
+            r.match_local_prefix(outside, 33),
+            None,
+            "wrong prefix on the right iface must not match"
+        );
+    }
+
+    #[test]
+    fn match_local_prefix_returns_none_when_iface_unresolvable() {
+        // Operator staged config before the bridge existed: the spec is
+        // kept but cannot match until RTM_NEWLINK fills in the ifindex.
+        let r = resolver_with(vec![spec6("2602:f7d8:0:1337::", 64, "br-later")], &[]);
+        assert_eq!(
+            r.match_local_prefix("2602:f7d8:0:1337::7".parse().unwrap(), 33),
+            None
+        );
+    }
+
+    /// Pins the design decision: one PeerId per ifindex, shared across
+    /// families, so a single PeerDown on RTM_DELLINK withdraws both the
+    /// v4 /32s and the v6 /128s behind that interface. Do not "fix" this
+    /// into a per-family PeerId.
+    #[test]
+    fn match_local_prefix_shares_peer_id_across_families_on_one_iface() {
+        let r = resolver_with(
+            vec![
+                LocalPrefixSpec {
+                    addr: "23.191.200.0".parse().unwrap(),
+                    prefix_len: 24,
+                    iface: "br1337".into(),
+                    arp_scavenge: false,
+                },
+                spec6("2602:f7d8:0:1337::", 64, "br1337"),
+            ],
+            &[("br1337", 33)],
+        );
+        let v4 = r.match_local_prefix("23.191.200.7".parse().unwrap(), 33);
+        let v6 = r.match_local_prefix("2602:f7d8:0:1337::7".parse().unwrap(), 33);
+        assert_eq!(v4, Some(PeerId::local_arp(33)));
+        assert_eq!(v6, Some(PeerId::local_arp(33)));
+        assert_eq!(v4, v6, "both families must resolve to the same peer");
     }
 }

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -208,6 +208,73 @@ impl FibProgrammerHandle {
     }
 }
 
+/// Shared log of every [`RouteEvent`] a [`recording_handle`] observed,
+/// in dispatch order.
+#[doc(hidden)]
+#[derive(Clone, Default)]
+pub struct RouteEventLog(std::sync::Arc<std::sync::Mutex<Vec<RouteEvent>>>);
+
+#[doc(hidden)]
+impl RouteEventLog {
+    /// Snapshot the events recorded so far.
+    pub fn events(&self) -> Vec<RouteEvent> {
+        self.0.lock().expect("RouteEventLog poisoned").clone()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.lock().expect("RouteEventLog poisoned").len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// Build a [`FibProgrammerHandle`] that records `RouteEvent`s instead of
+/// writing BPF maps, plus the log to inspect.
+///
+/// Exists so the neighbour resolver's `local-prefix` emission path can
+/// be tested against a real kernel neighbour table without also needing
+/// CAP_BPF, a bpffs mount, and a loaded ELF. That combination is why
+/// `with_local_prefixes` had no integration coverage at either family:
+/// the netns harness and the bpffs harness live in separate test crates
+/// that cannot import each other.
+///
+/// Replies `Ok` to everything. `Command` stays private; only the
+/// recorded events are observable.
+#[doc(hidden)]
+pub fn recording_handle() -> (FibProgrammerHandle, RouteEventLog) {
+    let (tx, mut rx) = mpsc::channel::<Command>(256);
+    let log = RouteEventLog::default();
+    let sink = log.clone();
+    tokio::spawn(async move {
+        let mut next_id: NexthopId = 1;
+        while let Some(cmd) = rx.recv().await {
+            match cmd {
+                Command::ApplyRouteEvent { event, reply } => {
+                    sink.0
+                        .lock()
+                        .expect("RouteEventLog poisoned")
+                        .push(event.clone());
+                    let _ = reply.send(Ok(()));
+                }
+                Command::RegisterNexthop { reply, .. } => {
+                    let id = next_id;
+                    next_id = next_id.wrapping_add(1);
+                    let _ = reply.send(Ok(id));
+                }
+                Command::UnregisterNexthop { reply, .. } => {
+                    let _ = reply.send(Ok(()));
+                }
+                Command::MirrorCounts { reply } => {
+                    let _ = reply.send((0, 0));
+                }
+            }
+        }
+    });
+    (FibProgrammerHandle { tx }, log)
+}
+
 enum Command {
     RegisterNexthop {
         ip: IpAddr,

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -6,6 +6,7 @@
 //! stub (`stub_impl.rs`). macOS dev loops compile either way.
 
 use std::ffi::CString;
+use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 use aya::{
@@ -19,7 +20,8 @@ use aya::{
 };
 use packetframe_common::{
     config::{
-        AttachMode, DriverWorkaround, Ipv4Prefix, Ipv6Prefix, ModuleDirective, ToggleAutoOnOff,
+        uncovered_local_prefix_warnings, AttachMode, DriverWorkaround, Ipv4Prefix, Ipv6Prefix,
+        ModuleDirective, ToggleAutoOnOff,
     },
     module::{Attachment, HookType, LoaderCtx, ModuleConfig, ModuleError, ModuleResult},
 };
@@ -436,6 +438,11 @@ fn populate_blocklists(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult
             _ => None,
         })
         .collect();
+    // v4-only by construction: the grammar has no `block-prefix6`, so
+    // `BLOCK_V6` is always empty and a `local-prefix6` has nothing to
+    // overlap against. TODO: if `block-prefix6` is ever added, this
+    // check must grow a v6 arm considering `LocalPrefix6` and
+    // `AllowPrefix6`, or v6 declarations will be silently unprotected.
     let local_v4: Vec<Ipv4Prefix> = mcfg
         .section
         .directives
@@ -485,16 +492,50 @@ fn populate_blocklists(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult
 /// True iff `outer` contains `inner` (inner's network is in outer
 /// AND inner's prefix_len is >= outer's). Used to detect overlap
 /// between block-prefix and allow-/local-prefix at startup.
+///
+/// Delegates to the shared helper so the mask arithmetic (and its
+/// shift-overflow guards) has one implementation.
 fn prefix_contains(outer: &Ipv4Prefix, inner: &Ipv4Prefix) -> bool {
-    if outer.prefix_len > inner.prefix_len {
-        return false;
+    outer.contains_prefix(inner)
+}
+
+/// Read `net.<family>.neigh.default.gc_thresh3` from procfs. `None` on
+/// any read/parse failure — the caller's check is advisory, so a
+/// missing sysctl (containers, exotic kernels) must not block startup.
+fn read_gc_thresh3(family: &str) -> Option<u64> {
+    std::fs::read_to_string(format!("/proc/sys/net/{family}/neigh/default/gc_thresh3"))
+        .ok()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// Startup capacity warning for the connected fast-path: the kernel's
+/// neighbour tables are the feed for local-prefix host routes, and each
+/// live neighbour inside a declared prefix consumes one slot in the
+/// shared `NEXTHOPS` pool (nexthop == destination, so no sharing).
+///
+/// On default sysctls (`gc_thresh3` = 1024 per family) the kernel caps
+/// the feed well below the pool and this never fires. Routers commonly
+/// raise `gc_thresh3`, though — and that moves the ceiling invisibly.
+/// Comparing the summed thresholds against the pool turns that cliff
+/// into a config-time diagnostic instead of a runtime surprise where
+/// dense segments starve BGP nexthops (`ProgrammerError::Full`).
+fn gc_thresh3_capacity_warning(v4: Option<u64>, v6: Option<u64>, cap: u32) -> Option<String> {
+    let total = v4.unwrap_or(0) + v6.unwrap_or(0);
+    if total <= u64::from(cap) {
+        return None;
     }
-    let mask: u32 = if outer.prefix_len == 0 {
-        0
-    } else {
-        (!0u32) << (32 - outer.prefix_len as u32)
-    };
-    (u32::from(outer.addr) & mask) == (u32::from(inner.addr) & mask)
+    Some(format!(
+        "kernel neighbour tables can hold {total} entries \
+         (net.ipv4/ipv6.neigh.default.gc_thresh3 = {} + {}), more than the shared \
+         NEXTHOPS pool ({cap}). Each neighbour inside a local-prefix consumes one \
+         slot, so dense segments can exhaust the pool and starve BGP nexthops; \
+         affected routes fall to the kernel slow path. See \
+         docs/runbooks/custom-fib.md (capacity considerations)",
+        v4.unwrap_or(0),
+        v6.unwrap_or(0),
+    ))
 }
 
 /// Extract the global `mss-clamp <mtu>` directive (the form with no
@@ -913,6 +954,9 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         // v0.2.1: collect operator-declared `local-prefix` directives
         // and pass them to the controller. Empty list = feature off
         // (back-compat with v0.2.0 configs that never had this).
+        //
+        // Both families land in one list; the resolver's spec type is
+        // IpAddr-based so its emission path handles them uniformly.
         let local_prefixes: Vec<crate::fib::netlink_neigh::LocalPrefixSpec> = cfg
             .section
             .directives
@@ -924,19 +968,43 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                     arp_scavenge,
                     ..
                 } => Some(crate::fib::netlink_neigh::LocalPrefixSpec {
-                    addr: cidr.addr,
+                    addr: IpAddr::V4(cidr.addr),
                     prefix_len: cidr.prefix_len,
                     iface: iface.clone(),
                     arp_scavenge: *arp_scavenge,
                 }),
+                ModuleDirective::LocalPrefix6 { cidr, iface, .. } => {
+                    Some(crate::fib::netlink_neigh::LocalPrefixSpec {
+                        addr: IpAddr::V6(cidr.addr),
+                        prefix_len: cidr.prefix_len,
+                        iface: iface.clone(),
+                        // No v6 scavenge; parse-enforced.
+                        arp_scavenge: false,
+                    })
+                }
                 _ => None,
             })
             .collect();
         if !local_prefixes.is_empty() {
+            let v6_count = local_prefixes.iter().filter(|s| s.addr.is_ipv6()).count();
             info!(
-                count = local_prefixes.len(),
-                "v0.2.1 local-prefix connected fast-path enabled"
+                v4_count = local_prefixes.len() - v6_count,
+                v6_count, "local-prefix connected fast-path enabled"
             );
+            // Advisory startup checks for the two ways this feature
+            // silently no-ops or over-commits. Warn-only: an operator
+            // may stage config deliberately, and neither condition can
+            // corrupt anything.
+            for w in uncovered_local_prefix_warnings(&cfg.section.directives) {
+                warn!("{w}");
+            }
+            if let Some(w) = gc_thresh3_capacity_warning(
+                read_gc_thresh3("ipv4"),
+                read_gc_thresh3("ipv6"),
+                crate::fib::programmer::NEXTHOPS_CAP,
+            ) {
+                warn!("{w}");
+            }
         }
         // v0.2.1 issue #31: optional synthetic 0.0.0.0/0.
         let fallback_default: Option<crate::fib::netlink_neigh::FallbackDefaultSpec> =
@@ -1963,13 +2031,12 @@ pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
 fn read_stats<T: std::borrow::Borrow<aya::maps::MapData>>(
     stats: &aya::maps::PerCpuArray<T, u64>,
 ) -> ModuleResult<Vec<u64>> {
-    // `STATS_COUNT` in bpf/src/maps.rs. Keep in lockstep with the BPF
-    // side or the last counters show zero unfairly. Prior versions
-    // hardcoded an off-by-one (19 hid `err_head_shift`; 33 hid
-    // `mss_clamp_*`); v0.2.5 = 37 (32 + bogon + 2 mss-clamp + 2
-    // tail-call diagnostics).
-    const STATS_LEN: usize = 37;
-    let mut out = vec![0u64; STATS_LEN];
+    // Sized from `metrics::COUNTER_NAMES`, the single userspace mirror
+    // of `STATS_COUNT` in bpf/src/maps.rs. Prior versions hardcoded a
+    // separate length here, and it drifted three times (19 hid
+    // `err_head_shift`; 33 hid `mss_clamp_*`; 37 hid `pass_ndp`) —
+    // each time the newest counters silently read as absent.
+    let mut out = vec![0u64; crate::metrics::COUNTER_NAMES.len()];
     for (idx, slot) in out.iter_mut().enumerate() {
         let values = stats
             .get(&(idx as u32), 0)
@@ -2027,4 +2094,46 @@ pub fn bpffs_pin_root(state: &ActiveState) -> PathBuf {
 #[allow(dead_code)]
 pub fn state_dir(state: &ActiveState) -> &Path {
     &state.state_dir
+}
+
+#[cfg(test)]
+mod tests {
+    use super::gc_thresh3_capacity_warning;
+
+    #[test]
+    fn default_sysctls_do_not_warn() {
+        // Kernel defaults: 1024 per family, far under the 8192 pool.
+        assert_eq!(
+            gc_thresh3_capacity_warning(Some(1024), Some(1024), 8192),
+            None
+        );
+    }
+
+    #[test]
+    fn raised_thresholds_warn_with_both_values() {
+        let w = gc_thresh3_capacity_warning(Some(8192), Some(16384), 8192)
+            .expect("must warn when the sum exceeds the pool");
+        assert!(w.contains("24576"), "total in message: {w}");
+        assert!(w.contains("8192 + 16384"), "per-family values: {w}");
+    }
+
+    #[test]
+    fn boundary_is_exclusive() {
+        // Exactly at the cap is not over-committed; only exceeding warns.
+        assert_eq!(
+            gc_thresh3_capacity_warning(Some(4096), Some(4096), 8192),
+            None
+        );
+        assert!(gc_thresh3_capacity_warning(Some(4096), Some(4097), 8192).is_some());
+    }
+
+    #[test]
+    fn unreadable_sysctls_never_warn() {
+        // Containers and exotic kernels may not expose the sysctl at
+        // all; the advisory check must stay silent rather than guess.
+        assert_eq!(gc_thresh3_capacity_warning(None, None, 8192), None);
+        // ...but a single readable family that alone exceeds the pool
+        // still warns.
+        assert!(gc_thresh3_capacity_warning(Some(65536), None, 8192).is_some());
+    }
 }

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -22,11 +22,16 @@ use std::fmt::Write as _;
 /// metric names; changing any value changes the operator-facing
 /// metric name. Append-only, renumbering breaks dashboards.
 ///
-/// Phase 1 (Option F custom FIB): length grew from 19 → 32. The
-/// pre-existing 19 was already off-by-one (`err_head_shift` at
-/// index 19 silently dropped); fixed in passing. Indices 20-31 are
-/// the new custom-FIB counters.
-pub const COUNTER_NAMES: [&str; 33] = [
+/// This is the **single userspace mirror** of `StatIdx` /
+/// `STATS_COUNT`: `read_stats` in linux_impl sizes its map read from
+/// this list's length, and the CLI's `status` output prints these
+/// names. When a counter is appended to `StatIdx`, this list is the
+/// one place userspace must follow. It earned that role the hard way:
+/// three prior lengths each silently hid the newest counters from
+/// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
+/// tail-call diagnostics from the Prometheus export; a separate
+/// hardcoded 37 hid `pass_ndp` from `packetframe status`).
+pub const COUNTER_NAMES: [&str; 38] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -61,6 +66,14 @@ pub const COUNTER_NAMES: [&str; 33] = [
     "nexthop_seq_retry",
     "bmp_peer_down",
     "bogon_dropped",
+    // --- v0.2.4: mss-clamp ---
+    "mss_clamp_applied",
+    "mss_clamp_skipped",
+    // --- v0.2.5: two-stage datapath ---
+    "err_tail_call",
+    "err_mutation_ctx",
+    // --- local-prefix6: NDP kept off the fast path ---
+    "pass_ndp",
 ];
 
 /// Render a Prometheus textfile body from stat values + module uptime.
@@ -206,7 +219,10 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 33);
+        assert_eq!(COUNTER_NAMES.len(), 38);
+        // The newest counter, as a canary that the tail of the list
+        // stayed aligned with the `StatIdx` discriminants.
+        assert_eq!(COUNTER_NAMES[37], "pass_ndp");
     }
 
     #[test]

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -50,7 +50,7 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V1: u32 = 0;
-pub const STATS_COUNT: u32 = 32;
+pub const STATS_COUNT: u32 = 38;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.
@@ -99,6 +99,12 @@ pub enum StatIdx {
     NeighCacheMiss = 29,
     NexthopSeqRetry = 30,
     BmpPeerDown = 31,
+    BogonDropped = 32,
+    MssClampApplied = 33,
+    MssClampSkipped = 34,
+    ErrTailCall = 35,
+    ErrMutationCtx = 36,
+    PassNdp = 37,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a

--- a/crates/modules/fast-path/tests/fib_fixtures.rs
+++ b/crates/modules/fast-path/tests/fib_fixtures.rs
@@ -121,6 +121,211 @@ fn custom_fib_v6_single_nexthop_hit_redirects() {
     assert_eq!(h.stat(StatIdx::CustomFibHit), before_hit + 1);
 }
 
+// ========== /128 vs covering route (local-prefix6 premise) ================
+//
+// The entire premise of `local-prefix6` is that a synthesized /128 for a
+// connected host wins the FIB_V6 LPM walk over any covering route from
+// the BGP feed. Without that, inbound traffic to the segment would be
+// redirected to an upstream nexthop instead of the host's own MAC.
+
+/// MAC behind the covering /64 — stands in for an upstream transit
+/// nexthop from the BGP feed.
+const COVERING_MAC: [u8; 6] = [0xde, 0xad, 0xbe, 0xef, 0, 0x0c];
+/// MAC behind the more-specific /128 — stands in for the connected
+/// host's own MAC, learned via NDP.
+const HOST_MAC: [u8; 6] = [0xde, 0xad, 0xbe, 0xef, 0, 0x0d];
+
+fn v6_dst(pkt_dst: &str) -> [u8; 16] {
+    pkt_dst.parse::<std::net::Ipv6Addr>().unwrap().octets()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn custom_fib_v6_slash128_beats_covering_routes() {
+    let mut h = prep_custom_fib_harness();
+    h.add_allow_v6("2001:db8::/32");
+    h.add_nexthop_v6(1, LO_IFINDEX, EGRESS_MAC, COVERING_MAC);
+    h.add_nexthop_v6(2, LO_IFINDEX, EGRESS_MAC, HOST_MAC);
+    h.add_fib_v6_single("2001:db8::/64", 1);
+    h.add_fib_v6_single("2001:db8::2/128", 2);
+
+    // 1. The /128'd host: the more specific entry must win.
+    let pkt = Ipv6TcpBuilder {
+        dst_ip: v6_dst("2001:db8::2"),
+        ..Default::default()
+    }
+    .build();
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[0..6],
+        &HOST_MAC,
+        "/128 must win the LPM walk over the covering /64"
+    );
+
+    // 2. Negative control: a sibling address with no /128 falls to the
+    //    /64. Proves this is real longest-prefix matching and not
+    //    "whichever entry was written last".
+    let pkt = Ipv6TcpBuilder {
+        dst_ip: v6_dst("2001:db8::3"),
+        ..Default::default()
+    }
+    .build();
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[0..6],
+        &COVERING_MAC,
+        "address without a /128 must fall to the covering /64"
+    );
+
+    // 3. Adding a default route must not disturb the /128. Exercises
+    //    prefix_len == 0 in the v6 trie.
+    h.add_nexthop_v6(3, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v6_single("::/0", 3);
+    let pkt = Ipv6TcpBuilder {
+        dst_ip: v6_dst("2001:db8::2"),
+        ..Default::default()
+    }
+    .build();
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(&out[0..6], &HOST_MAC, "/128 must still win over ::/0");
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn custom_fib_v6_slash128_wins_regardless_of_insertion_order() {
+    // Same assertion as above with the inserts reversed, ruling out an
+    // ordering artifact in the LPM trie.
+    let mut h = prep_custom_fib_harness();
+    h.add_allow_v6("2001:db8::/32");
+    h.add_nexthop_v6(2, LO_IFINDEX, EGRESS_MAC, HOST_MAC);
+    h.add_fib_v6_single("2001:db8::2/128", 2);
+    h.add_nexthop_v6(1, LO_IFINDEX, EGRESS_MAC, COVERING_MAC);
+    h.add_fib_v6_single("2001:db8::/64", 1);
+
+    let pkt = Ipv6TcpBuilder {
+        dst_ip: v6_dst("2001:db8::2"),
+        ..Default::default()
+    }
+    .build();
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(&out[0..6], &HOST_MAC);
+}
+
+// ========== NDP must never be fast-pathed ================================
+//
+// RFC 4861 §6.1.1/§7.1.1: receivers silently discard NS/NA/RS/RA whose
+// hop limit is not 255. `forward_success` decrements the hop limit and
+// rewrites the source MAC, so redirecting NDP breaks neighbor resolution
+// on the segment. `local-prefix6` makes this reachable by installing the
+// /128s that let host-to-host NDP resolve in FIB_V6.
+
+const ICMPV6: u8 = 58;
+
+/// Build an ICMPv6 packet of `icmp_type` toward `dst`, hop limit 255,
+/// from an allowlisted source. Body is a plausible NS/NA shape:
+/// 4 reserved bytes + a 16-byte target address.
+fn icmpv6_pkt(icmp_type: u8, dst: &str) -> Vec<u8> {
+    let mut body = vec![icmp_type, 0, 0, 0]; // type, code, checksum (unchecked by XDP)
+    body.extend_from_slice(&[0, 0, 0, 0]); // reserved
+    body.extend_from_slice(&v6_dst(dst)); // target address
+    Ipv6TcpBuilder {
+        dst_ip: v6_dst(dst),
+        hop_limit: 255,
+        next_hdr: ICMPV6,
+        payload: body,
+        ..Default::default()
+    }
+    .build()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ndp_is_passed_untouched_even_when_fib_would_redirect() {
+    let mut h = prep_custom_fib_harness();
+    h.add_allow_v6("2001:db8::/32");
+    // A /128 for the destination: without the guard this would redirect.
+    h.add_nexthop_v6(2, LO_IFINDEX, EGRESS_MAC, HOST_MAC);
+    h.add_fib_v6_single("2001:db8::2/128", 2);
+
+    // 135 = Neighbor Solicitation, 136 = Neighbor Advertisement.
+    // 133/134 (RS/RA) and 137 (Redirect) take the same path.
+    for icmp_type in [133u8, 134, 135, 136, 137] {
+        let pkt = icmpv6_pkt(icmp_type, "2001:db8::2");
+        let before_ndp = h.stat(StatIdx::PassNdp);
+        let before_hit = h.stat(StatIdx::CustomFibHit);
+        let before_matched = h.stat(StatIdx::MatchedV6);
+
+        let (verdict, out) = h.run(&pkt);
+
+        assert_eq!(
+            verdict,
+            xdp_action::XDP_PASS,
+            "ICMPv6 type {icmp_type} must be passed to the kernel"
+        );
+        assert_eq!(
+            h.stat(StatIdx::PassNdp),
+            before_ndp + 1,
+            "type {icmp_type} must bump pass_ndp"
+        );
+        assert_eq!(
+            h.stat(StatIdx::CustomFibHit),
+            before_hit,
+            "type {icmp_type} must not reach the FIB"
+        );
+        assert_eq!(
+            h.stat(StatIdx::MatchedV6),
+            before_matched,
+            "type {icmp_type} is gated before the allowlist, so must not count as matched"
+        );
+        // Byte-identity is the assertion that actually matters: hop
+        // limit still 255 and MACs untouched, so the receiver will
+        // accept it.
+        assert_eq!(out, pkt, "type {icmp_type} must be delivered unmodified");
+        assert_eq!(out[21], 255, "hop limit must not be decremented");
+    }
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn ndp_guard_does_not_deoptimize_other_icmpv6_or_tcp() {
+    let mut h = prep_custom_fib_harness();
+    h.add_allow_v6("2001:db8::/32");
+    h.add_nexthop_v6(2, LO_IFINDEX, EGRESS_MAC, HOST_MAC);
+    h.add_fib_v6_single("2001:db8::2/128", 2);
+
+    // ICMPv6 echo request (128) is not an NDP type; it must still
+    // fast-path even at hop limit 255. This is why the guard keys on
+    // message type rather than `hop_limit == 255`.
+    let pkt = icmpv6_pkt(128, "2001:db8::2");
+    let before_ndp = h.stat(StatIdx::PassNdp);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(
+        verdict,
+        xdp_action::XDP_REDIRECT,
+        "echo must still redirect"
+    );
+    assert_eq!(&out[0..6], &HOST_MAC);
+    assert_eq!(
+        h.stat(StatIdx::PassNdp),
+        before_ndp,
+        "echo must not bump pass_ndp"
+    );
+
+    // And ordinary TCP to the same destination is unaffected.
+    let pkt = Ipv6TcpBuilder {
+        dst_ip: v6_dst("2001:db8::2"),
+        ..Default::default()
+    }
+    .build();
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(&out[0..6], &HOST_MAC);
+}
+
 // ========== Custom-FIB hit with incomplete neighbor =======================
 
 #[test]

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -34,7 +34,8 @@ use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent};
 use packetframe_fast_path::aligned_bpf_copy;
 use packetframe_fast_path::fib::programmer::FibProgrammer;
 use packetframe_fast_path::fib::types::{
-    EcmpGroup, FibValue, NexthopEntry, FIB_KIND_ECMP, FIB_KIND_SINGLE, NH_STATE_INCOMPLETE,
+    EcmpGroup, FibValue, NexthopEntry, FIB_KIND_ECMP, FIB_KIND_SINGLE, NH_FAMILY_V4, NH_FAMILY_V6,
+    NH_STATE_INCOMPLETE,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -199,6 +200,15 @@ impl ProgrammerHarness {
     /// contend with the programmer's handle.
     fn read_fib_v4(&self, addr: [u8; 4], prefix_len: u8) -> Option<FibValue> {
         let trie = open_lpm_v4(&self.pins.path("FIB_V4"));
+        let key = LpmKey::new(u32::from(prefix_len), addr);
+        trie.get(&key, 0).ok()
+    }
+
+    /// FIB_V6 counterpart of [`Self::read_fib_v4`]. `open_lpm_v6` and
+    /// the `fib_v6` handle were already wired for the programmer; this
+    /// is the missing reader that lets tests assert on the v6 half.
+    fn read_fib_v6(&self, addr: [u8; 16], prefix_len: u8) -> Option<FibValue> {
+        let trie = open_lpm_v6(&self.pins.path("FIB_V6"));
         let key = LpmKey::new(u32::from(prefix_len), addr);
         trie.get(&key, 0).ok()
     }
@@ -423,6 +433,268 @@ fn peer_down_withdraws_all_peer_routes() {
     assert!(h.read_fib_v4([192, 0, 2, 0], 24).is_none());
     assert!(h.read_fib_v4([198, 51, 100, 0], 24).is_none());
     assert!(h.read_fib_v4([203, 0, 113, 0], 24).is_none());
+}
+
+// ========== IPv6 / local-prefix6 ==========
+//
+// The programmer's v6 write path had no integration coverage at all
+// before this, despite `open_lpm_v6` and the `fib_v6` handle being wired.
+
+fn v6(s: &str) -> [u8; 16] {
+    s.parse::<std::net::Ipv6Addr>().unwrap().octets()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn add_single_nexthop_route_writes_fib_v6() {
+    let h = ProgrammerHarness::new();
+    let nh = IpAddr::V6("2001:db8::1".parse().unwrap());
+    let prefix = IpPrefix::V6 {
+        addr: v6("2001:db8:1::"),
+        prefix_len: 48,
+    };
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: PeerId(0xbbbb),
+                prefix,
+                nexthops: vec![nh],
+                path_id: None,
+                local_pref: None,
+            })
+            .await
+    })
+    .expect("apply Add");
+
+    let fib = h
+        .read_fib_v6(v6("2001:db8:1::"), 48)
+        .expect("FIB_V6[2001:db8:1::/48]");
+    assert_eq!(fib.kind, FIB_KIND_SINGLE, "single-nexthop route");
+    let entry = h.read_nexthop(fib.idx);
+    assert_eq!(entry.state, NH_STATE_INCOMPLETE);
+    // The family tag is set by the programmer but asserted nowhere else.
+    // XDP treats it as diagnostic-only, so a regression here would be
+    // invisible without this check.
+    assert_eq!(
+        entry.family, NH_FAMILY_V6,
+        "v6 nexthop must be tagged NH_FAMILY_V6"
+    );
+}
+
+/// The exact event shape `local-prefix6` emits: a /128 whose nexthop is
+/// the destination itself. Nexthop-equals-destination is unique to the
+/// connected fast-path and was untested at either family.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn local_prefix6_slash128_self_nexthop_round_trips() {
+    let h = ProgrammerHarness::new();
+    let host: std::net::Ipv6Addr = "2602:f7d8:0:1337::7".parse().unwrap();
+    let peer = PeerId::local_arp(33);
+    let prefix = IpPrefix::V6 {
+        addr: host.octets(),
+        prefix_len: 128,
+    };
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![IpAddr::V6(host)],
+                path_id: None,
+                local_pref: None,
+            })
+            .await
+    })
+    .expect("apply Add");
+
+    let fib = h
+        .read_fib_v6(host.octets(), 128)
+        .expect("FIB_V6 /128 present");
+    assert_eq!(fib.kind, FIB_KIND_SINGLE);
+    let idx = fib.idx;
+    assert_eq!(h.read_nexthop(idx).family, NH_FAMILY_V6);
+
+    // A repeated Add for an unchanged nexthop set must be a no-op
+    // rather than churning the map or leaking a slot. The resolver hits
+    // this constantly as v6 neighbours go stale and get re-probed.
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: peer,
+                prefix,
+                nexthops: vec![IpAddr::V6(host)],
+                path_id: None,
+                local_pref: None,
+            })
+            .await
+    })
+    .expect("apply duplicate Add");
+    let fib_again = h
+        .read_fib_v6(host.octets(), 128)
+        .expect("FIB_V6 /128 still present");
+    assert_eq!(fib_again.idx, idx, "duplicate Add must not reallocate");
+
+    // Withdrawal releases the entry.
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer,
+                prefix,
+                path_id: None,
+            })
+            .await
+    })
+    .expect("apply Del");
+    assert!(
+        h.read_fib_v6(host.octets(), 128).is_none(),
+        "Del must remove the /128"
+    );
+}
+
+/// One `PeerId::local_arp(ifindex)` covers both families, so a single
+/// PeerDown on RTM_DELLINK must sweep the v4 /32s and the v6 /128s
+/// together. This is the only exercise of that design decision.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn peer_down_withdraws_both_families_under_one_local_arp_peer_id() {
+    let h = ProgrammerHarness::new();
+    let peer = PeerId::local_arp(33);
+
+    let v4_hosts = [[23, 191, 200, 7], [23, 191, 200, 8], [23, 191, 200, 9]];
+    let v6_hosts = [
+        "2602:f7d8:0:1337::7",
+        "2602:f7d8:0:1337::8",
+        "2602:f7d8:0:1337::9",
+    ];
+
+    h.run(async {
+        for octets in v4_hosts {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix: IpPrefix::V4 {
+                        addr: octets,
+                        prefix_len: 32,
+                    },
+                    nexthops: vec![IpAddr::V4(Ipv4Addr::from(octets))],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("apply v4 Add");
+        }
+        for s in v6_hosts {
+            let a: std::net::Ipv6Addr = s.parse().unwrap();
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix: IpPrefix::V6 {
+                        addr: a.octets(),
+                        prefix_len: 128,
+                    },
+                    nexthops: vec![IpAddr::V6(a)],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("apply v6 Add");
+        }
+    });
+
+    for octets in v4_hosts {
+        assert!(
+            h.read_fib_v4(octets, 32).is_some(),
+            "{octets:?} /32 present"
+        );
+    }
+    for s in v6_hosts {
+        assert!(h.read_fib_v6(v6(s), 128).is_some(), "{s} /128 present");
+    }
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::PeerDown { peer_id: peer })
+            .await
+    })
+    .expect("apply PeerDown");
+
+    for octets in v4_hosts {
+        assert!(
+            h.read_fib_v4(octets, 32).is_none(),
+            "{octets:?} /32 must be withdrawn"
+        );
+    }
+    for s in v6_hosts {
+        assert!(
+            h.read_fib_v6(v6(s), 128).is_none(),
+            "{s} /128 must be withdrawn by the same PeerDown"
+        );
+    }
+}
+
+/// The 8192-entry NEXTHOPS pool is shared across families and every BGP
+/// nexthop, and `local-prefix6` consumes one slot per connected host
+/// because nexthop == destination. Documents the single-pool invariant
+/// that capacity planning rests on.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn nexthop_pool_is_shared_across_families() {
+    let h = ProgrammerHarness::new();
+    let peer = PeerId(0xcccc);
+
+    h.run(async {
+        for i in 0..3u8 {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix: IpPrefix::V4 {
+                        addr: [192, 0, 2, i],
+                        prefix_len: 32,
+                    },
+                    nexthops: vec![IpAddr::V4(Ipv4Addr::new(192, 0, 2, i))],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("v4 Add");
+            let a = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, i as u16);
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix: IpPrefix::V6 {
+                        addr: a.octets(),
+                        prefix_len: 128,
+                    },
+                    nexthops: vec![IpAddr::V6(a)],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("v6 Add");
+        }
+    });
+
+    // Six distinct nexthops from one pool: no family partitioning, no
+    // id reuse across families.
+    let mut ids = Vec::new();
+    for i in 0..3u8 {
+        ids.push(h.read_fib_v4([192, 0, 2, i], 32).expect("v4 fib").idx);
+        let a = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, i as u16);
+        ids.push(h.read_fib_v6(a.octets(), 128).expect("v6 fib").idx);
+    }
+    let unique: std::collections::HashSet<u32> = ids.iter().copied().collect();
+    assert_eq!(unique.len(), 6, "each host consumes its own slot: {ids:?}");
+
+    // Family tags still discriminate even though the pool is shared.
+    for i in 0..3u8 {
+        let v4_idx = h.read_fib_v4([192, 0, 2, i], 32).unwrap().idx;
+        assert_eq!(h.read_nexthop(v4_idx).family, NH_FAMILY_V4);
+        let a = std::net::Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, i as u16);
+        let v6_idx = h.read_fib_v6(a.octets(), 128).unwrap().idx;
+        assert_eq!(h.read_nexthop(v6_idx).family, NH_FAMILY_V6);
+    }
 }
 
 #[test]

--- a/crates/modules/fast-path/tests/local_prefix_netns.rs
+++ b/crates/modules/fast-path/tests/local_prefix_netns.rs
@@ -1,0 +1,605 @@
+//! Integration coverage for the `local-prefix` / `local-prefix6`
+//! connected fast-path against a real kernel neighbour table.
+//!
+//! Before this file, `NetlinkNeighborResolver::with_local_prefixes` had
+//! no integration coverage at **either** family: the two tests in
+//! `neigh_resolver_netns.rs` never attach a `FibProgrammerHandle`, so
+//! host-route synthesis was only exercised by pure `contains()` unit
+//! tests.
+//!
+//! The obstacle was that driving the real `FibProgrammer` needs CAP_BPF,
+//! a bpffs mount and a loaded ELF, none of which the netns harness has.
+//! `programmer::recording_handle()` supplies a handle that records
+//! `RouteEvent`s instead of writing maps, so these tests need only
+//! CAP_NET_ADMIN + CAP_SYS_ADMIN and assert on exactly the events the
+//! resolver emits.
+//!
+//! Setup utilities are copied from `tests/netns.rs` /
+//! `neigh_resolver_netns.rs` rather than shared, per the convention
+//! documented there: each `tests/*.rs` is its own crate and cannot
+//! import from peers.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::CString;
+use std::fs::File;
+use std::net::IpAddr;
+use std::os::fd::{AsRawFd, OwnedFd};
+use std::process::Command;
+use std::time::Duration;
+
+use tokio_util::sync::CancellationToken;
+
+use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent};
+use packetframe_fast_path::fib::netlink_neigh::{LocalPrefixSpec, NetlinkNeighborResolver};
+use packetframe_fast_path::fib::programmer::{recording_handle, RouteEventLog};
+
+// --- Test setup utilities (copied from tests/netns.rs) -----------------
+
+struct Names {
+    netns: String,
+    veth_a: String,
+    veth_b: String,
+}
+
+static NAMES_COUNTER: std::sync::atomic::AtomicU16 = std::sync::atomic::AtomicU16::new(0);
+
+impl Names {
+    fn new() -> Self {
+        let pid = (std::process::id() % 1000) as u16;
+        let n = NAMES_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let suffix = format!("{pid:03}{n:02}");
+        Self {
+            netns: format!("pfln{suffix}"),
+            veth_a: format!("pfla{suffix}"),
+            veth_b: format!("pflb{suffix}"),
+        }
+    }
+}
+
+struct NetnsGuard {
+    name: String,
+}
+
+impl NetnsGuard {
+    fn setup(names: &Names) -> Self {
+        let _ = Command::new("ip")
+            .args(["netns", "del", &names.netns])
+            .status();
+
+        run(&["ip", "netns", "add", &names.netns]);
+        ns_run(&names.netns, &["sysctl", "-wq", "net.ipv4.ip_forward=1"]);
+        ns_run(
+            &names.netns,
+            &["sysctl", "-wq", "net.ipv4.conf.all.rp_filter=0"],
+        );
+        ns_run(
+            &names.netns,
+            &["sysctl", "-wq", "net.ipv6.conf.all.forwarding=1"],
+        );
+
+        ns_run(
+            &names.netns,
+            &[
+                "ip",
+                "link",
+                "add",
+                &names.veth_a,
+                "type",
+                "veth",
+                "peer",
+                "name",
+                &names.veth_b,
+            ],
+        );
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_a, "up"]);
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_b, "up"]);
+        ns_run(
+            &names.netns,
+            &[
+                "ip",
+                "addr",
+                "add",
+                "198.51.100.254/24",
+                "dev",
+                &names.veth_a,
+            ],
+        );
+        // `nodad` skips duplicate-address detection. Without it the
+        // address sits tentative for ~1s and the interface's neighbour
+        // state is in flux, which would make these tests need a sleep
+        // rather than being deterministic.
+        ns_run(
+            &names.netns,
+            &[
+                "ip",
+                "-6",
+                "addr",
+                "add",
+                "2001:db8:0:1::254/64",
+                "dev",
+                &names.veth_a,
+                "nodad",
+            ],
+        );
+        ns_run(
+            &names.netns,
+            &[
+                "ip",
+                "-6",
+                "addr",
+                "add",
+                "2001:db8:0:1::253/64",
+                "dev",
+                &names.veth_b,
+                "nodad",
+            ],
+        );
+
+        Self {
+            name: names.netns.clone(),
+        }
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("ip")
+            .args(["netns", "del", &self.name])
+            .status();
+    }
+}
+
+fn run(cmd: &[&str]) {
+    let status = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("spawn `{}`: {e}", cmd.join(" ")));
+    assert!(status.success(), "`{}` exited {status}", cmd.join(" "));
+}
+
+fn ns_run(netns: &str, cmd: &[&str]) {
+    let mut args = vec!["netns", "exec", netns];
+    args.extend_from_slice(cmd);
+    let status = Command::new("ip")
+        .args(&args)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn `ip {}`: {e}", args.join(" ")));
+    assert!(status.success(), "`ip {}` exited {status}", args.join(" "));
+}
+
+/// Best-effort variant: some probes are expected to fail (no peer
+/// answers), and their failure is not the thing under test.
+fn ns_run_ok(netns: &str, cmd: &[&str]) {
+    let mut args = vec!["netns", "exec", netns];
+    args.extend_from_slice(cmd);
+    let _ = Command::new("ip").args(&args).status();
+}
+
+fn enter_netns(netns: &str) -> OwnedFd {
+    let path = format!("/var/run/netns/{netns}");
+    let fd: OwnedFd = File::open(&path)
+        .unwrap_or_else(|e| panic!("open {path}: {e}"))
+        .into();
+    let rc = unsafe { libc::setns(fd.as_raw_fd(), libc::CLONE_NEWNET) };
+    assert_eq!(rc, 0, "setns({path}): {}", std::io::Error::last_os_error());
+    fd
+}
+
+fn if_nametoindex(name: &str) -> u32 {
+    let c = CString::new(name).expect("iface name with NUL");
+    let idx = unsafe { libc::if_nametoindex(c.as_ptr()) };
+    assert!(idx > 0, "if_nametoindex({name}) failed");
+    idx
+}
+
+// --- Harness -----------------------------------------------------------
+
+/// Spin up a resolver with `specs` wired to a recording handle, run
+/// `body` (which seeds neighbour state), then return the recorded
+/// events.
+///
+/// Uses a current-thread runtime so every spawned task inherits the
+/// netns this thread was moved into — the same requirement documented in
+/// `neigh_resolver_netns.rs`.
+fn collect_events(
+    netns: &str,
+    specs: Vec<LocalPrefixSpec>,
+    body: impl FnOnce(&str),
+) -> Vec<RouteEvent> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime");
+
+    rt.block_on(async move {
+        let shutdown = CancellationToken::new();
+        let (resolver, _events_rx, _resolve_handle) =
+            NetlinkNeighborResolver::new(shutdown.clone());
+        let (prog, log): (_, RouteEventLog) = recording_handle();
+        let resolver = resolver.with_local_prefixes(specs, prog);
+
+        let task = tokio::spawn(async move {
+            let _ = resolver.run().await;
+        });
+
+        // Let the RTM_GETLINK / RTM_GETNEIGH dumps land and the
+        // multicast socket bind before mutating neighbour state.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        body(netns);
+
+        // Give the multicast path time to deliver and the emission path
+        // time to dispatch into the recording handle.
+        tokio::time::sleep(Duration::from_millis(600)).await;
+
+        shutdown.cancel();
+        let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
+        log.events()
+    })
+}
+
+fn spec(cidr: &str, prefix_len: u8, iface: &str) -> LocalPrefixSpec {
+    LocalPrefixSpec {
+        addr: cidr.parse().expect("addr"),
+        prefix_len,
+        iface: iface.to_string(),
+        arp_scavenge: false,
+    }
+}
+
+/// Every `Add`ed prefix in the log, as `(IpAddr, prefix_len)`.
+fn added_prefixes(events: &[RouteEvent]) -> Vec<(IpAddr, u8)> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            RouteEvent::Add { prefix, .. } => Some(prefix_to_ip(prefix)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn deleted_prefixes(events: &[RouteEvent]) -> Vec<(IpAddr, u8)> {
+    events
+        .iter()
+        .filter_map(|e| match e {
+            RouteEvent::Del { prefix, .. } => Some(prefix_to_ip(prefix)),
+            _ => None,
+        })
+        .collect()
+}
+
+fn prefix_to_ip(p: &IpPrefix) -> (IpAddr, u8) {
+    match p {
+        IpPrefix::V4 { addr, prefix_len } => (IpAddr::from(*addr), *prefix_len),
+        IpPrefix::V6 { addr, prefix_len } => (IpAddr::from(*addr), *prefix_len),
+    }
+}
+
+// --- Tests -------------------------------------------------------------
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix6_emits_slash128_for_kernel_neighbour() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let ifindex = if_nametoindex(&names.veth_a);
+    let host: IpAddr = "2001:db8:0:1::7".parse().unwrap();
+
+    let veth_a = names.veth_a.clone();
+    let events = collect_events(
+        &names.netns,
+        vec![spec("2001:db8:0:1::", 64, &names.veth_a)],
+        |ns| {
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "-6",
+                    "neigh",
+                    "replace",
+                    "2001:db8:0:1::7",
+                    "dev",
+                    &veth_a,
+                    "lladdr",
+                    "de:ad:be:ef:00:07",
+                    "nud",
+                    "permanent",
+                ],
+            );
+        },
+    );
+
+    let adds = added_prefixes(&events);
+    assert!(
+        adds.contains(&(host, 128)),
+        "expected a /128 Add for {host}; got {adds:?}"
+    );
+
+    // The Add must name the host as its own nexthop and carry the
+    // per-iface local_arp peer. That self-nexthop is what makes NDP
+    // resolve to the host's own MAC rather than an upstream gateway.
+    let add = events
+        .iter()
+        .find(
+            |e| matches!(e, RouteEvent::Add { prefix, .. } if prefix_to_ip(prefix) == (host, 128)),
+        )
+        .expect("the /128 Add");
+    match add {
+        RouteEvent::Add {
+            peer_id, nexthops, ..
+        } => {
+            assert_eq!(*peer_id, PeerId::local_arp(ifindex));
+            assert_eq!(nexthops, &vec![host], "nexthop must be the host itself");
+        }
+        other => panic!("expected Add, got {other:?}"),
+    }
+}
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix6_withdraws_slash128_on_neigh_delete() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let host: IpAddr = "2001:db8:0:1::8".parse().unwrap();
+
+    let veth_a = names.veth_a.clone();
+    let events = collect_events(
+        &names.netns,
+        vec![spec("2001:db8:0:1::", 64, &names.veth_a)],
+        |ns| {
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "-6",
+                    "neigh",
+                    "replace",
+                    "2001:db8:0:1::8",
+                    "dev",
+                    &veth_a,
+                    "lladdr",
+                    "de:ad:be:ef:00:08",
+                    "nud",
+                    "permanent",
+                ],
+            );
+            std::thread::sleep(Duration::from_millis(200));
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "-6",
+                    "neigh",
+                    "del",
+                    "2001:db8:0:1::8",
+                    "dev",
+                    &veth_a,
+                ],
+            );
+        },
+    );
+
+    assert!(
+        added_prefixes(&events).contains(&(host, 128)),
+        "expected the /128 to be added first; got {events:?}"
+    );
+    assert!(
+        deleted_prefixes(&events).contains(&(host, 128)),
+        "expected a /128 Del after `ip -6 neigh del`; got {events:?}"
+    );
+}
+
+/// The emission-time gate, proved against the kernel's own neighbour
+/// table rather than synthetic events.
+///
+/// A well-formed `/64` excludes `ff02::` and `fe80::` by containment, so
+/// this configures the pathological `::/0` that the config parser
+/// rejects — reachable only by constructing `LocalPrefixSpec` directly,
+/// which is exactly the belt-and-braces case `may_synthesize` exists for.
+/// Multicast entries are `NUD_NOARP` with a derived `33:33:xx` MAC and
+/// are never garbage-collected, so without the gate they would install
+/// permanent bogus `/128`s.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix6_slash0_does_not_harvest_multicast_or_link_local() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let host: IpAddr = "2001:db8:0:1::9".parse().unwrap();
+
+    let veth_a = names.veth_a.clone();
+    let events = collect_events(&names.netns, vec![spec("::", 0, &names.veth_a)], |ns| {
+        // Force the kernel to create multicast and link-local neighbour
+        // entries on the interface.
+        ns_run_ok(
+            ns,
+            &["ping6", "-c", "1", "-W", "1", "-I", &veth_a, "ff02::1"],
+        );
+        ns_run_ok(ns, &["ip", "-6", "neigh", "add", "ff02::1", "dev", &veth_a]);
+        ns_run_ok(
+            ns,
+            &[
+                "ip",
+                "-6",
+                "neigh",
+                "replace",
+                "fe80::dead:beef",
+                "dev",
+                &veth_a,
+                "lladdr",
+                "de:ad:be:ef:00:fe",
+                "nud",
+                "permanent",
+            ],
+        );
+        // A legitimate global-unicast host, which must still be picked up.
+        ns_run(
+            ns,
+            &[
+                "ip",
+                "-6",
+                "neigh",
+                "replace",
+                "2001:db8:0:1::9",
+                "dev",
+                &veth_a,
+                "lladdr",
+                "de:ad:be:ef:00:09",
+                "nud",
+                "permanent",
+            ],
+        );
+    });
+
+    let adds = added_prefixes(&events);
+    for (ip, _len) in &adds {
+        let IpAddr::V6(v6) = ip else { continue };
+        assert!(
+            !v6.is_multicast(),
+            "multicast {v6} must never be harvested; adds: {adds:?}"
+        );
+        let o = v6.octets();
+        assert!(
+            !(o[0] == 0xfe && (o[1] & 0xc0) == 0x80),
+            "link-local {v6} must never be harvested; adds: {adds:?}"
+        );
+        assert!(!v6.is_unspecified() && !v6.is_loopback());
+    }
+    assert!(
+        adds.contains(&(host, 128)),
+        "the global-unicast host must still be harvested; adds: {adds:?}"
+    );
+}
+
+/// Regression guard: the v6 work removed three `IpAddr::V4` guards that
+/// the v4 path shared, so v4 synthesis must be re-proved.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix_v4_still_emits_slash32() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let ifindex = if_nametoindex(&names.veth_a);
+    let host: IpAddr = "198.51.100.7".parse().unwrap();
+
+    let veth_a = names.veth_a.clone();
+    let events = collect_events(
+        &names.netns,
+        vec![spec("198.51.100.0", 24, &names.veth_a)],
+        |ns| {
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "neigh",
+                    "replace",
+                    "198.51.100.7",
+                    "dev",
+                    &veth_a,
+                    "lladdr",
+                    "de:ad:be:ef:00:07",
+                    "nud",
+                    "permanent",
+                ],
+            );
+        },
+    );
+
+    let adds = added_prefixes(&events);
+    assert!(
+        adds.contains(&(host, 32)),
+        "expected a /32 Add for {host}; got {adds:?}"
+    );
+    let add = events
+        .iter()
+        .find(|e| matches!(e, RouteEvent::Add { prefix, .. } if prefix_to_ip(prefix) == (host, 32)))
+        .expect("the /32 Add");
+    match add {
+        RouteEvent::Add { peer_id, .. } => assert_eq!(*peer_id, PeerId::local_arp(ifindex)),
+        other => panic!("expected Add, got {other:?}"),
+    }
+}
+
+/// `RTM_DELLINK` emits one `PeerDown` for the interface, and because the
+/// `PeerId` is family-blind that single event withdraws both the v4
+/// `/32`s and the v6 `/128`s behind it. `maybe_emit_local_arp_peerdown`
+/// was also previously untested.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix_peer_down_on_dellink_covers_both_families() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let ifindex = if_nametoindex(&names.veth_a);
+
+    let veth_a = names.veth_a.clone();
+    let events = collect_events(
+        &names.netns,
+        vec![
+            spec("198.51.100.0", 24, &names.veth_a),
+            spec("2001:db8:0:1::", 64, &names.veth_a),
+        ],
+        |ns| {
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "neigh",
+                    "replace",
+                    "198.51.100.7",
+                    "dev",
+                    &veth_a,
+                    "lladdr",
+                    "de:ad:be:ef:00:07",
+                    "nud",
+                    "permanent",
+                ],
+            );
+            ns_run(
+                ns,
+                &[
+                    "ip",
+                    "-6",
+                    "neigh",
+                    "replace",
+                    "2001:db8:0:1::7",
+                    "dev",
+                    &veth_a,
+                    "lladdr",
+                    "de:ad:be:ef:01:07",
+                    "nud",
+                    "permanent",
+                ],
+            );
+            std::thread::sleep(Duration::from_millis(250));
+            ns_run(ns, &["ip", "link", "del", &veth_a]);
+        },
+    );
+
+    // Both families were synthesized under the same peer...
+    let adds = added_prefixes(&events);
+    assert!(
+        adds.contains(&("198.51.100.7".parse().unwrap(), 32)),
+        "adds: {adds:?}"
+    );
+    assert!(
+        adds.contains(&("2001:db8:0:1::7".parse().unwrap(), 128)),
+        "adds: {adds:?}"
+    );
+
+    // ...and one PeerDown for the ifindex tears both down.
+    let peer_downs: Vec<PeerId> = events
+        .iter()
+        .filter_map(|e| match e {
+            RouteEvent::PeerDown { peer_id } => Some(*peer_id),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        peer_downs.contains(&PeerId::local_arp(ifindex)),
+        "expected PeerDown for local_arp({ifindex}); got {peer_downs:?}"
+    );
+}

--- a/crates/modules/fast-path/tests/local_prefix_netns.rs
+++ b/crates/modules/fast-path/tests/local_prefix_netns.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use tokio_util::sync::CancellationToken;
 
-use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent};
+use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, RouteEvent};
 use packetframe_fast_path::fib::netlink_neigh::{LocalPrefixSpec, NetlinkNeighborResolver};
 use packetframe_fast_path::fib::programmer::{recording_handle, RouteEventLog};
 
@@ -206,7 +206,7 @@ fn collect_events(
     netns: &str,
     specs: Vec<LocalPrefixSpec>,
     body: impl FnOnce(&str),
-) -> Vec<RouteEvent> {
+) -> (Vec<RouteEvent>, Vec<NeighEvent>) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()
@@ -214,7 +214,7 @@ fn collect_events(
 
     rt.block_on(async move {
         let shutdown = CancellationToken::new();
-        let (resolver, _events_rx, _resolve_handle) =
+        let (resolver, mut events_rx, _resolve_handle) =
             NetlinkNeighborResolver::new(shutdown.clone());
         let (prog, log): (_, RouteEventLog) = recording_handle();
         let resolver = resolver.with_local_prefixes(specs, prog);
@@ -235,7 +235,17 @@ fn collect_events(
 
         shutdown.cancel();
         let _ = tokio::time::timeout(Duration::from_secs(2), task).await;
-        log.events()
+
+        // Drain whatever NeighEvents the resolver produced. Nothing
+        // consumed the channel during the run (the tests replace the
+        // programmer with a recording handle), so the buffered backlog
+        // is the complete stream — EVENTS_CAPACITY is 8192, far above
+        // anything these single-digit-neighbour tests generate.
+        let mut neigh_events = Vec::new();
+        while let Ok(e) = events_rx.try_recv() {
+            neigh_events.push(e);
+        }
+        (log.events(), neigh_events)
     })
 }
 
@@ -288,7 +298,7 @@ fn local_prefix6_emits_slash128_for_kernel_neighbour() {
     let host: IpAddr = "2001:db8:0:1::7".parse().unwrap();
 
     let veth_a = names.veth_a.clone();
-    let events = collect_events(
+    let (events, _) = collect_events(
         &names.netns,
         vec![spec("2001:db8:0:1::", 64, &names.veth_a)],
         |ns| {
@@ -346,7 +356,7 @@ fn local_prefix6_withdraws_slash128_on_neigh_delete() {
     let host: IpAddr = "2001:db8:0:1::8".parse().unwrap();
 
     let veth_a = names.veth_a.clone();
-    let events = collect_events(
+    let (events, _) = collect_events(
         &names.netns,
         vec![spec("2001:db8:0:1::", 64, &names.veth_a)],
         |ns| {
@@ -411,7 +421,7 @@ fn local_prefix6_slash0_does_not_harvest_multicast_or_link_local() {
     let host: IpAddr = "2001:db8:0:1::9".parse().unwrap();
 
     let veth_a = names.veth_a.clone();
-    let events = collect_events(&names.netns, vec![spec("::", 0, &names.veth_a)], |ns| {
+    let (events, _) = collect_events(&names.netns, vec![spec("::", 0, &names.veth_a)], |ns| {
         // Force the kernel to create multicast and link-local neighbour
         // entries on the interface.
         ns_run_ok(
@@ -486,7 +496,7 @@ fn local_prefix_v4_still_emits_slash32() {
     let host: IpAddr = "198.51.100.7".parse().unwrap();
 
     let veth_a = names.veth_a.clone();
-    let events = collect_events(
+    let (events, _) = collect_events(
         &names.netns,
         vec![spec("198.51.100.0", 24, &names.veth_a)],
         |ns| {
@@ -536,7 +546,7 @@ fn local_prefix_peer_down_on_dellink_covers_both_families() {
     let ifindex = if_nametoindex(&names.veth_a);
 
     let veth_a = names.veth_a.clone();
-    let events = collect_events(
+    let (events, _) = collect_events(
         &names.netns,
         vec![
             spec("198.51.100.0", 24, &names.veth_a),
@@ -601,5 +611,75 @@ fn local_prefix_peer_down_on_dellink_covers_both_families() {
     assert!(
         peer_downs.contains(&PeerId::local_arp(ifindex)),
         "expected PeerDown for local_arp({ifindex}); got {peer_downs:?}"
+    );
+}
+
+/// The startup-seed path, as opposed to the incremental RTM_NEWNEIGH
+/// path every other test here exercises: the neighbour exists *before*
+/// the resolver starts, so it arrives via the RTM_GETNEIGH dump and
+/// `seed_local_prefix_routes`.
+///
+/// Asserts the two halves of seeding independently: the RouteEvent::Add
+/// that installs the /128, and the synthetic NeighEvent::Learned that
+/// resolves it. The Learned must come directly from the dump snapshot —
+/// not via the bounded resolve queue, which nothing drains during
+/// seeding, so past RESOLVE_QUEUE_CAPACITY matching neighbours the
+/// queue-dependent design left routes Incomplete (flagged by review on
+/// PR #72). A stable pre-existing neighbour may never multicast again,
+/// making the direct emission the only reliable resolution source.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn local_prefix6_seed_resolves_preexisting_neighbour_without_resolve_queue() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    let _nsfd = enter_netns(&names.netns);
+    let ifindex = if_nametoindex(&names.veth_a);
+    let host: IpAddr = "2001:db8:0:1::42".parse().unwrap();
+    let host_mac = [0xde, 0xad, 0xbe, 0xef, 0x00, 0x42];
+
+    // Neighbour exists BEFORE the resolver starts.
+    ns_run(
+        &names.netns,
+        &[
+            "ip",
+            "-6",
+            "neigh",
+            "replace",
+            "2001:db8:0:1::42",
+            "dev",
+            &names.veth_a,
+            "lladdr",
+            "de:ad:be:ef:00:42",
+            "nud",
+            "permanent",
+        ],
+    );
+
+    let (events, neigh_events) = collect_events(
+        &names.netns,
+        vec![spec("2001:db8:0:1::", 64, &names.veth_a)],
+        |_ns| {}, // no mutations after startup; everything comes from the seed
+    );
+
+    // Half one: the /128 was installed from the dump.
+    assert!(
+        added_prefixes(&events).contains(&(host, 128)),
+        "seed must install the /128 for a pre-existing neighbour; got {events:?}"
+    );
+
+    // Half two: the seed itself emitted the synthetic Learned with the
+    // kernel-cached MAC, so resolution never depended on the resolve
+    // queue round-trip.
+    let learned = neigh_events.iter().any(|e| {
+        matches!(
+            e,
+            NeighEvent::Learned { ip, mac, ifindex: ifi, .. }
+                if *ip == host && *mac == host_mac && *ifi == ifindex
+        )
+    });
+    assert!(
+        learned,
+        "seed must emit a synthetic Learned for {host} with {host_mac:02x?}; \
+         got {neigh_events:?}"
     );
 }

--- a/crates/modules/fast-path/tests/netns.rs
+++ b/crates/modules/fast-path/tests/netns.rs
@@ -613,43 +613,26 @@ fn snapshot_all_stats(bpf: &Ebpf) -> Vec<u64> {
 }
 
 /// Produce a vec of `(name, delta)` for every counter whose value
-/// changed between snapshots. Names match the `StatIdx` enum variants
-/// so the output is readable in CI failure logs.
+/// changed between snapshots, named from the authoritative
+/// `metrics::COUNTER_NAMES` mirror so the output is readable in CI
+/// failure logs.
 fn delta_labels(before: &[u64], after: &[u64]) -> Vec<(&'static str, u64)> {
-    const NAMES: &[&str] = &[
-        "rx_total",
-        "matched_v4",
-        "matched_v6",
-        "matched_src_only",
-        "matched_dst_only",
-        "matched_both",
-        "fwd_ok",
-        "fwd_dry_run",
-        "pass_fragment",
-        "pass_low_ttl",
-        "pass_no_neigh",
-        "pass_not_ip",
-        "pass_frag_needed",
-        "drop_unreachable",
-        "err_parse",
-        "err_fib_other",
-        "err_vlan",
-        "pass_not_in_devmap",
-        "pass_complex_header",
-        "err_head_shift",
-    ];
+    let names = &packetframe_fast_path::metrics::COUNTER_NAMES;
     before
         .iter()
         .zip(after.iter())
         .enumerate()
-        .filter_map(
-            |(i, (b, a))| {
-                if a > b {
-                    Some((NAMES[i], a - b))
-                } else {
-                    None
-                }
-            },
-        )
+        .filter_map(|(i, (b, a))| {
+            if a > b {
+                // `.get()` rather than `names[i]`: the snapshot is sized
+                // from the test-local STATS_COUNT, so a counter appended
+                // to StatIdx without a name landing here yet would
+                // otherwise panic the test instead of reporting the
+                // delta it was written to catch.
+                Some((names.get(i).copied().unwrap_or("unknown_stat"), a - b))
+            } else {
+                None
+            }
+        })
         .collect()
 }

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -262,6 +262,10 @@ module fast-path
   local-prefix 23.191.200.0/24 via br1337    # customer LAN
   local-prefix 10.88.1.0/24    via br88      # Ceph internal
   local-prefix 10.10.1.0/24    via br0       # other LAN
+
+  # IPv6: same idea, one /128 per NDP neighbour. Declare the prefix
+  # actually configured on the iface, not the aggregate you announce.
+  local-prefix6 2602:f7d8:0:1337::/64 via br1337
 ```
 
 The `via <iface>` is required and must match the kernel iface
@@ -299,6 +303,37 @@ journalctl -u packetframe -f | grep 'neighbour resolver stats'
 sudo packetframe status | grep -E 'matched_v4|custom_fib_hit|custom_fib_miss|custom_fib_no_neigh'
 ```
 
+For `local-prefix6`, the same four checks with the v6 tools. Note
+`fib lookup` already accepts either family, so only the dump command
+differs:
+
+```sh
+# 1. One /128 per NDP neighbour inside each declared local-prefix6.
+sudo packetframe fib dump-v6 | grep '2602:f7d8:0:1337'
+
+# 2. A specific host: expect the connected iface's ifindex and that
+# host's own MAC, NOT one of your transit nexthops.
+sudo packetframe fib lookup 2602:f7d8:0:1337::7
+
+# 3. v6 has its own counters in the same stats line, kept separate so
+# a dual-stack segment stays readable.
+journalctl -u packetframe -f | grep 'neighbour resolver stats'
+#   ... local_nd_routes_added=12 local_nd_routes_removed=1
+
+# 4. pass_ndp should be non-zero and climbing: neighbor discovery is
+# deliberately handed to the kernel (see the NDP note below).
+sudo packetframe status | grep -E 'matched_v6|pass_ndp|custom_fib_hit|custom_fib_miss'
+```
+
+Cross-check the /128 set against the kernel. These two should agree,
+and the packetframe side must contain **no** `fe80::` or `ff02::`
+entries:
+
+```sh
+ip -6 neigh show dev br1337 | grep -v fe80
+sudo packetframe fib dump-v6 | grep '2602:f7d8:0:1337'
+```
+
 ### Capacity considerations
 
 Each declared local-prefix can register up to one /32 per active
@@ -308,6 +343,39 @@ under this (the reference EFG configured below uses ~500-1000 of
 8192). If you operate a *very* dense LAN where active hosts
 approach 8192, plan to either raise the cap (BPF rebuild) or skip
 the directive on that prefix and accept the slow-path fallback.
+
+**The pool is shared.** NEXTHOPS is one 8192-entry allocation covering
+v4 /32s, v6 /128s, *and* every BGP nexthop. Because these synthesized
+routes use nexthop == destination, there is no sharing: each connected
+host consumes its own slot. FIB_V6 itself holds 1,048,576 entries, so
+NEXTHOPS is always the binding constraint.
+
+**IPv6 multiplies this.** A host has one address in v4 and several in
+v6: a stable SLAAC address plus RFC 4941/8981 temporary addresses that
+rotate (Linux defaults give up to ~7 concurrently valid), plus possibly
+DHCPv6 and static. Only addresses that actually source traffic get
+learned, so 2-3 per host is typical and ~9 is the worst case — call it
+900-2700 hosts before the pool is the limit.
+
+In practice the kernel bounds this before packetframe does:
+`net.ipv6.neigh.default.gc_thresh3` defaults to 1024, and you cannot
+harvest more /128s than the kernel holds entries. **If you have raised
+`gc_thresh3`** (routers often do), that ceiling moves and the shared
+pool becomes reachable. packetframe checks this itself: at startup,
+when any local-prefix is configured, it compares the summed thresholds
+against the pool and logs a WARN when they exceed it. To check by hand:
+
+```sh
+cat /proc/sys/net/ipv4/neigh/default/gc_thresh3
+cat /proc/sys/net/ipv6/neigh/default/gc_thresh3
+```
+
+Exhaustion degrades cleanly rather than corrupting: the programmer
+returns `Full`, unwinds any partially-allocated nexthops, and the route
+simply isn't installed — one `WARN` per event, and that destination
+falls to the kernel. The risk worth watching is that a dense v6 segment
+starves *BGP* nexthops, which matters much more than losing a
+connected /128.
 
 ### When NOT to enable it
 
@@ -319,7 +387,24 @@ the directive on that prefix and accept the slow-path fallback.
 - **Operator hasn't declared the customer prefix in `allow-prefix`.**
   XDP filters on allowlist BEFORE the FIB lookup, so a /32 in the
   FIB does nothing if the parent prefix isn't matched. Add the
-  customer /24 to `allow-prefix` first.
+  customer /24 to `allow-prefix` first. Same for `local-prefix6`:
+  it needs a covering `allow-prefix6`, and that is a separate
+  directive — declaring only the v4 pair is the common slip.
+  packetframe logs a startup WARN for any local-prefix directive
+  with no overlapping same-family allow entry.
+- **The prefix isn't actually connected.** Declare what is configured
+  on the interface (`ip -6 addr show dev <iface>`), not the aggregate
+  you announce to the world. The announced aggregate is a null-routed
+  static in bird; it is not a connected prefix and must never reach
+  the FIB as a forwarding entry.
+- **Non-global-unicast v6 prefixes.** `local-prefix6` refuses
+  multicast (`ff00::/8`), link-local (`fe80::/10`), `::/0`, `::`,
+  `::1` and IPv4-mapped at parse time. None can be a forwarded
+  connected-host destination. `fe80::/10` is the tempting one, since
+  `ip -6 neigh show` is mostly link-local addresses — but they are
+  ambiguous across interfaces (the same `fe80::` address legitimately
+  exists on several with different MACs) and would burn a NEXTHOPS
+  slot each for routes that can never be used.
 - **Tunnels and weirdness.** Don't declare local-prefix on a tunnel
   iface (WireGuard, GRE, IPSec). The BPF program can't redirect
   to non-XDP-capable interfaces, so the /32 just sits unused.
@@ -327,11 +412,11 @@ the directive on that prefix and accept the slow-path fallback.
 
 ### Disabling
 
-Remove (or comment out) the `local-prefix` lines and restart
-packetframe. SIGHUP doesn't reconcile this directive in v0.2.1.
-A future version may add live add/remove via SIGHUP, but for
-now it's a startup-time-only configuration. The /32 entries get
-flushed on detach and don't reappear at next startup without the
+Remove (or comment out) the `local-prefix` / `local-prefix6` lines and
+restart packetframe. SIGHUP doesn't reconcile these directives in
+v0.2.1. A future version may add live add/remove via SIGHUP, but for
+now it's a startup-time-only configuration. The /32 and /128 entries
+get flushed on detach and don't reappear at next startup without the
 directive.
 
 ### `arp-scavenge` for quiet LANs (v0.2.1, issue #32)
@@ -371,6 +456,40 @@ fabric, which violates IX ToS (MANRS, anti-DoS) on most exchanges.
 customer LAN). For IX peer subnets, rely on bird's natural ARP
 behavior: bird already maintains ARP for active BGP peers, so
 their /32s will land via the normal nexthop-resolution path.
+
+#### There is no IPv6 equivalent, and there should not be
+
+`local-prefix6` rejects `arp-scavenge` at parse time. This is not a
+missing feature; enumeration is the wrong tool for IPv6 at any cap:
+
+- **A /64 is 2^64 addresses.** Even a "safe" cap of /118 (1024 hosts,
+  matching the v4 limit) only sweeps the bottom of the range.
+- **IPv6 hosts are not at the bottom of the range.** SLAAC (RFC 4862)
+  derives the interface identifier from the MAC, and stable-privacy
+  addressing (RFC 7217) hashes it. Both scatter hosts across the full
+  64-bit identifier space, so a swept range matches essentially no
+  autoconfigured host. The only hosts a sweep *could* find are
+  hand-numbered `::1..::ff` servers — and those are statically
+  configured and actively talking, which means they are already in the
+  neighbour table that reactive seeding reads.
+- **NS is noisier than ARP per probe.** Neighbor solicitation goes to
+  the target's solicited-node multicast group, so an N-address sweep
+  hits N *distinct* groups, defeating MLD-snooping caches, and
+  `mcast_solicit` retries each unanswered probe.
+
+So IPv6 relies entirely on reactive seeding: the startup neighbour dump
+plus `RTM_NEWNEIGH` events. In practice this is sufficient where the v4
+case was not, because v6 hosts announce themselves far more readily —
+DAD, router solicitation, and neighbor unreachability detection all put
+a host in the router's neighbour table without the router asking.
+
+If a v6 host is genuinely missing, force one round of resolution rather
+than reaching for a sweep:
+
+```sh
+ping6 -c1 -I br1337 ff02::1        # all-nodes on the segment
+ip -6 neigh show dev br1337        # then confirm it landed
+```
 
 ### `fallback-default` synthetic /0 (v0.2.1, issue #31)
 
@@ -713,6 +832,39 @@ The BMP route source is useful when:
   per fast-path module.
 
 ## Triage by symptom
+
+### Symptom: IPv4 is fine, IPv6 is flaky, and `ip -6 neigh` looks normal
+
+What it means: neighbor discovery is being disrupted on the segment.
+This is the signature to recognise, because nothing in `ip -6 neigh`
+output hints at it — entries look resolved, they just go stale and
+re-resolve constantly, and connections stall intermittently.
+
+The mechanism: NDP mandates a hop limit of 255, and RFC 4861 §6.1.1 /
+§7.1.1 require receivers to **silently discard** NS/NA/RS/RA that arrive
+with anything else. Fast-pathing decrements the hop limit and rewrites
+the source MAC, so a redirected neighbor solicitation is dropped by the
+host it was sent to. IPv4 never had this exposure: ARP is EtherType
+0x0806 and is never dispatched into the IPv4 path at all.
+
+packetframe guards against this by passing ICMPv6 types 133-137 (RS, RA,
+NS, NA, Redirect) straight to the kernel, before the allowlist and
+before any FIB lookup. Confirm the guard is active:
+
+```sh
+sudo packetframe status | grep pass_ndp
+```
+
+`pass_ndp` should be non-zero and climbing on any box with a
+`local-prefix6`. If it is flat at zero while v6 traffic is flowing and
+`matched_v6` is climbing, the running binary predates the guard —
+`local-prefix6` is unsafe on that build, and you should roll back to
+`forwarding-mode kernel-fib` or remove the `local-prefix6` lines until
+you can deploy a build that has it.
+
+Note that other ICMPv6 (echo, errors) is deliberately *not* gated: the
+guard keys on message type, not on hop limit, so ordinary ICMPv6 still
+fast-paths.
 
 ### Symptom: `custom_fib_miss` climbs without `custom_fib_hit` keeping pace
 

--- a/docs/runbooks/reconfigure.md
+++ b/docs/runbooks/reconfigure.md
@@ -50,7 +50,7 @@ These need `systemctl restart packetframe` (or stop + run):
 - **`attach` directives (interface added or removed).** XDP attach mutates kernel-side state and risks brief link bounce on some drivers (SPEC §11.8). The reconcile path explicitly logs a warning and skips attach-set changes; your delta does not silently apply.
 - **`route-source` config (custom-FIB only).** The RouteController's runtime is started at attach. Editing the BGP/BMP listener address or peer-AS requires bringing the runtime down and back up.
 - **`circuit-breaker` thresholds.** The breaker sampler thread reads its config at thread start; it doesn't currently observe SIGHUP.
-- **`local-prefix` directives (custom-FIB only).** The connected-fast-path resolver is similarly attach-time-bound.
+- **`local-prefix` / `local-prefix6` directives (custom-FIB only).** The connected-fast-path resolver is similarly attach-time-bound. Both families are collected once at attach and handed to the resolver; editing either and reloading leaves the running set untouched with no warning.
 - **`bpffs-root`, `state-dir`.** Used at module load only; baked into the running daemon's pin paths and the metrics file location.
 
 If you change one of these in the config and reload, the daemon keeps using the old value silently (with a `WARN`-level log line for attach-set changes). Restart is the only way through.


### PR DESCRIPTION
## What

Adds `local-prefix6 <cidr> via <iface>` — the IPv6 counterpart of the v0.2.1 connected fast-path. The resolver synthesizes one `/128` per NDP neighbour with nexthop = the host itself, so inbound traffic to a connected v6 segment takes the XDP redirect instead of falling to the kernel via `custom_fib_miss`.

Ships with a datapath guard that keeps neighbor discovery off the fast path entirely: ICMPv6 types 133–137 now `XDP_PASS` before the allowlist, counted in a new `pass_ndp` counter (StatIdx 37).

## Why

A FIB entry resolves to one `(ifindex, smac, dmac)` triple while every host on a connected segment has its own MAC, so no route a route-source could advertise can express a connected prefix — that's why `local-prefix` synthesizes per-host routes from the neighbour table. With no v6 equivalent, `allow-prefix6` fast-pathed only the outbound direction (verified on edge1-mci1-net: outbound hits, inbound `NO MATCH`).

**The NDP guard is load-bearing, not hygiene.** `forward_success` decrements the hop limit and rewrites the source MAC, but RFC 4861 §6.1.1/§7.1.1 require receivers to silently discard NS/NA/RS/RA arriving at anything other than 255. Installing `/128`s for connected hosts makes host-to-host unicast NDP (NUD probes, unsolicited NA) FIB-eligible — it would be redirected at 254 and dropped by the target, degrading v6 into permanent multicast re-resolution with a baffling signature (v4 fine, v6 flaky, `ip -6 neigh` looks normal). IPv4 never had this exposure: ARP is EtherType 0x0806 and never reaches `handle_ipv4`. The guard keys on message type rather than hop limit so transit ICMPv6 echo still fast-paths; both behaviors are pinned by `bpf_prog_test_run` fixtures asserting byte-identity.

## Design decisions

- **Separate keyword, unified internals.** `local-prefix6` mirrors `allow-prefix6` (which the operator must declare anyway — the allowlist runs before the FIB lookup), keeps precise `bad IPv6` parse errors, and lets `arp-scavenge` simply not exist in the v6 grammar. Internally one `Vec<LocalPrefixSpec>` with `addr: IpAddr`, so seed/add/del/match stay single-implementation.
- **No v6 scavenge, by design.** SLAAC (RFC 4862) and stable-privacy (RFC 7217) scatter hosts across the full 64-bit IID space, so a swept range at any cap finds essentially no autoconfigured host; the hosts it *could* find are already in the neighbour table that reactive seeding reads. Rejected at parse with a message saying why.
- **Non-harvestable classes rejected at parse and gated at emission** (multicast, link-local, `::/0`, `::`, `::1`, IPv4-mapped), symmetric on add and delete. The kernel keeps `NUD_NOARP` multicast entries with derived `33:33:xx` MACs that look exactly like resolved unicast neighbours; `fe80::` is the live copy-paste footgun and is ambiguous across interfaces by construction.
- **`PeerId::local_arp(ifindex)` stays family-blind**: one `RTM_DELLINK` PeerDown sweeps both families' host routes; `prefix_peer_key` keeps them distinct internally. Pinned by tests.
- **Mask arithmetic hoisted to `Ipv4Prefix`/`Ipv6Prefix` in common** instead of a fourth hand copy. The v6 version needs the shift guard at both ends: in release, `!0u128 << 128` silently yields `!0`, which would make `::/0` match only `::`.

## Also in this PR

- **Counter-mirror consolidation.** Appending `pass_ndp` exposed that userspace hand-mirrored the counter list in four places, already diverged three times (19 hid `err_head_shift`; metrics.rs's 33 hid the mss-clamp/tail-call counters from the Prometheus export; `read_stats`' hardcoded 37 would have hidden `pass_ndp` from `packetframe status` — making the new runbook triage entry advise rolling back a healthy build). `metrics::COUNTER_NAMES` is now the single userspace mirror; `read_stats`, the status command, and the netns delta labels all derive from it. Side effect: `mss_clamp_*`/`err_tail_call`/`err_mutation_ctx` appear in the Prometheus export for the first time.
- **Two advisory startup warnings** replacing manual runbook steps: no-overlapping-allowlist per local-prefix directive (the silently-no-ops footgun, doubled by the separate v6 pair), and summed `gc_thresh3` exceeding the shared 8192-entry `NEXTHOPS` pool (each connected neighbour consumes one slot since nexthop == destination).
- **Test-tooling fixes found in passing**: `tests/netns.rs` `delta_labels` indexed a 20-name list against 32-length snapshots (any counter past 19 that moved would panic the diagnostic itself); `tests/common` `StatIdx`/`STATS_COUNT` had drifted to 31/32.

## Test coverage added

- Config: 19 new unit tests (grammar mirrors, all rejection classes, cross-family hints, precise-error regression guard against a future polymorphic "simplification")
- Resolver: v6 `contains` incl. the u128 `/0` shift-guard, `is_harvestable_v6` table, and first-ever coverage of `match_local_prefix` (either family), pinning the shared-PeerId design
- `bpf_prog_test_run`: `/128`-beats-covering-`/64` in both insertion orders plus `::/0` (the feature's premise, previously untested), NDP passed byte-identical with `pass_ndp` bumped, echo/TCP negative controls
- Programmer integration: first `IpPrefix::V6` coverage (`read_fib_v6` was half-wired, unused), self-nexthop `/128` round-trip incl. duplicate-Add idempotency, cross-family PeerDown sweep, shared-pool invariant
- New `tests/local_prefix_netns.rs` (5 tests against a real kernel neighbour table via a new `#[doc(hidden)] recording_handle()` seam): first integration coverage of `with_local_prefixes` at any family, including the `::/0`-does-not-harvest-multicast/link-local test driven by the kernel's own `ff02::`/`fe80::` entries

## Verified

`fmt` clean; `clippy --workspace --all-targets --all-features -D warnings` (x86_64) 0 errors; 242 unit + 67 sudo-gated tests, 0 failures — run in a rust:1.95 container with the BPF ELF actually built (`bpf-linker` 0.10.3), netns tests against a real kernel.

## Reviewer notes

- One unreproduced `fib_comparison` flake was observed once in ~6 full-suite container runs (never in isolation, 25/25 solo, also clean on main). Possibly shared-`/sys/fs/bpf` interference in the Docker VM. Worth watching on the qemu matrix.
- SPEC.md (out of repo) needs follow-up touches: §4.6 counter table gains `pass_ndp = 37`, §4.8 grammar gains `local-prefix6`, and the reload table gains a `local-prefix6 | ✗` row.
- Deliberately deferred to their own slices (pre-existing, v6 raises the churn that triggers the first two): resolver restart-with-backoff (BMP/BGP have it, the resolver doesn't — a netlink `ENOBUFS` kills neighbour tracking for the process lifetime), periodic neighbour re-dump reconcile (a lost `RTM_DELNEIGH` currently leaks a `NEXTHOPS` slot permanently), runtime pool high-water metrics, and the advertisement-leak-on-`Full` mirror inflation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)