### PR TITLE
ci(qemu): retry once when the VM dies before the guest script runs

### DIFF
--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -140,7 +140,9 @@ jobs:
           cargo test -p packetframe-probe --tests --no-run
 
       - name: Run integration tests in QEMU
-        timeout-minutes: 10
+        # Two full attempts must fit (see retry policy below); a
+        # healthy run is ~7 minutes under TCG.
+        timeout-minutes: 20
         run: |
           set -eux
           # Pass the installed vmlinuz path (not the .deb). virtme-ng
@@ -155,10 +157,26 @@ jobs:
           # rtnetlink + netlink-packet-route + futures) pushes
           # incremental-relink tmpfs usage past the old ~500 MB.
           # 4 GB RAM ⇒ ~2 GB writable tmpfs, comfortable headroom.
-          virtme-ng \
-            --run "${KERNEL_IMG}" \
-            --pwd \
-            --memory 4096 \
-            --disable-kvm \
-            --verbose \
-            -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
+          run_vm() {
+            virtme-ng \
+              --run "${KERNEL_IMG}" \
+              --pwd \
+              --memory 4096 \
+              --disable-kvm \
+              --verbose \
+              -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
+          }
+          # Retry policy: virtme-ng propagates the guest command's exit
+          # status, so a genuine test failure arrives as cargo's 101
+          # and fails immediately — no retry. Exit 255 means the VM
+          # died before the guest script ever ran (observed on hosted
+          # runners as a TCG boot hang: dmesg stops mid PCI
+          # enumeration ~20s in, zero test output; PR #69's v6.6 job).
+          # That failure mode is runner noise, not a signal about the
+          # code, so it gets exactly one more attempt.
+          rc=0; run_vm || rc=$?
+          if [ "${rc}" -eq 255 ]; then
+            echo "::warning::virtme-ng exited 255 before the guest script ran (boot flake); retrying once"
+            rc=0; run_vm || rc=$?
+          fi
+          exit "${rc}"


### PR DESCRIPTION
## What

Wraps the qemu-verifier's virtme-ng invocation in a retry that fires **only** when the exit code is 255 — the signature of the VM dying before the guest script ran — and bumps the step timeout from 10 to 20 minutes so two full attempts fit.

## Why

PR #69's v6.6 job failed with exit 255 twenty seconds in: guest dmesg stopped mid PCI enumeration, zero test output, and an untouched manual rerun passed. TCG boot hangs on hosted runners are noise about the infrastructure, not the code, but they block PRs (notably dependabot's) until someone notices and reruns.

## Why the retry can't mask real failures

virtme-ng propagates the guest command's exit status, and the two failure modes are empirically distinguishable on this repo's own history:

- **Genuine test/build failure → 101.** Verified against the July 6 run of PR #69, where a real BPF compile break (aya-ebpf 0.2.x removing `helpers::gen`) surfaced as exit 101 on both kernels.
- **Boot flake → 255**, with no test output at all.

So a real failure still fails on the first attempt with no retry, and a double boot-flake still fails the job. The retry semantics are simulated for all three exit classes (0 / 101 / 255 → 1 / 1 / 2 attempts) in the commit's development, and the workflow YAML parses clean.

The theoretical residual — a guest script that itself exits 255 — would cost one redundant attempt bounded by the 20-minute cap, and nothing in the guest script (cargo, rustup, coreutils) exits 255 in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)