### PR TITLE
perf: generic-mode CPU optimization — hot-path map-op reduction, probes, benchmark

### DIFF
--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 
 use packetframe_common::{
     config::{Config, ModuleDirective},
-    probe::{run_probes, Capability, CapabilityStatus, FeasibilityReport},
+    probe::{run_iface_probes, run_probes, Capability, CapabilityStatus, FeasibilityReport},
 };
 
 pub struct Rendered {
@@ -40,6 +40,13 @@ pub fn probe_and_render(bpffs_root: &Path, attach_ifaces: &[String], human: bool
         .capabilities
         .retain(|c| c.name != "xdp.per_interface_attach_probe");
     for cap in trial_attach_caps(attach_ifaces) {
+        report.capabilities.push(cap);
+    }
+    // Per-iface performance probes (GRO state, RPS masks). All
+    // informational; they exist so a CPU-limited generic-XDP box
+    // surfaces its highest-leverage host tuning knobs in the same
+    // report operators already collect.
+    for cap in run_iface_probes(attach_ifaces) {
         report.capabilities.push(cap);
     }
     // `passed` needs recomputing after the iface probes; the trial

--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -164,6 +164,22 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
     ));
     caps.push(probe_memlock());
 
+    // CPU-performance probes (generic-XDP deployments are typically
+    // CPU-limited; these surface the host knobs that matter most).
+    // None are required: a JIT-off or harden-on host still *works*,
+    // just slower, and feasibility gating `packetframe run` on them
+    // would brick a functional deployment on restart.
+    caps.push(probe_bpf_jit_enable());
+    caps.push(probe_sysctl_any(
+        "sysctl.net.core.bpf_jit_harden",
+        "/proc/sys/net/core/bpf_jit_harden",
+        &["0"],
+        false,
+        "set `net.core.bpf_jit_harden = 0` unless constant blinding is a hard requirement; \
+         hardening adds per-instruction cost to every JITed program",
+    ));
+    caps.push(probe_kernel_version());
+
     // §2.3 per-interface native-XDP trial-attach, deferred. The probe needs
     // a real attachable program, which doesn't exist in v0.0.1.
     caps.push(Capability::deferred(
@@ -172,6 +188,20 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
     ));
 
     FeasibilityReport::new(caps)
+}
+
+/// Per-attach-interface performance probes: GRO state and RPS masks.
+/// Called by the feasibility subcommand with the config's attach set
+/// (mirrors how the trial-attach probes graft in). All informational
+/// (`required = false`); see `docs/runbooks/generic-mode-performance.md`
+/// for what to do with the answers.
+pub fn run_iface_probes(ifaces: &[String]) -> Vec<Capability> {
+    let mut caps = Vec::with_capacity(ifaces.len() * 2);
+    for iface in ifaces {
+        caps.push(probe_iface_gro(iface));
+        caps.push(probe_iface_rps(iface));
+    }
+    caps
 }
 
 fn probe_kconfig() -> Capability {
@@ -546,20 +576,91 @@ fn probe_sysctl(
     required: bool,
     fix_hint: &str,
 ) -> Capability {
+    probe_sysctl_any(name, path, &[expected], required, fix_hint)
+}
+
+/// Like [`probe_sysctl`] but accepting any of several values, for
+/// sysctls where more than one setting is fine (e.g.
+/// `bpf_jit_enable` = 1 or 2, both of which mean "JIT on").
+fn probe_sysctl_any(
+    name: &str,
+    path: &str,
+    accepted: &[&str],
+    required: bool,
+    fix_hint: &str,
+) -> Capability {
     match fs::read_to_string(path) {
         Ok(raw) => {
             let val = raw.trim();
-            if val == expected {
+            if accepted.contains(&val) {
                 Capability::pass(name, format!("{path} = {val}"), required)
             } else {
                 Capability::fail(
                     name,
-                    format!("{path} = {val} (expected {expected}); fix: {fix_hint}"),
+                    format!(
+                        "{path} = {val} (expected {}); fix: {fix_hint}",
+                        accepted.join(" or ")
+                    ),
                     required,
                 )
             }
         }
         Err(e) => Capability::unknown(name, format!("could not read {path}: {e}"), required),
+    }
+}
+
+/// `net.core.bpf_jit_enable`: 1 (JIT on) or 2 (JIT on with debug
+/// output) both pass; 0 means every BPF program on the box runs in
+/// the interpreter, which on a CPU-limited generic-XDP router is the
+/// single most expensive misconfiguration possible.
+///
+/// Kernels built with `CONFIG_BPF_JIT_ALWAYS_ON=y` pin the sysctl to
+/// 1, but some hardened/embedded configs hide or restrict the file;
+/// when it's unreadable, fall back to the kconfig flag before
+/// reporting Unknown.
+fn probe_bpf_jit_enable() -> Capability {
+    const NAME: &str = "sysctl.net.core.bpf_jit_enable";
+    const PATH: &str = "/proc/sys/net/core/bpf_jit_enable";
+    match fs::read_to_string(PATH) {
+        Ok(raw) => {
+            let val = raw.trim();
+            if val == "1" || val == "2" {
+                Capability::pass(NAME, format!("{PATH} = {val} (JIT on)"), false)
+            } else {
+                Capability::fail(
+                    NAME,
+                    format!(
+                        "{PATH} = {val}: BPF runs INTERPRETED, expect several-fold higher \
+                         per-packet CPU; fix: sysctl -w net.core.bpf_jit_enable=1"
+                    ),
+                    false,
+                )
+            }
+        }
+        Err(read_err) => match read_kconfig() {
+            Ok(contents) if kconfig_flag_set(&contents, "CONFIG_BPF_JIT_ALWAYS_ON") => {
+                Capability::pass(
+                    NAME,
+                    "sysctl not readable but CONFIG_BPF_JIT_ALWAYS_ON=y (JIT compiled always-on)",
+                    false,
+                )
+            }
+            _ => Capability::unknown(
+                NAME,
+                format!("could not read {PATH}: {read_err}; JIT state undetermined"),
+                false,
+            ),
+        },
+    }
+}
+
+/// Informational kernel version report. Never fails; exists so a
+/// feasibility report captured from an operator includes the exact
+/// kernel without a second command.
+fn probe_kernel_version() -> Capability {
+    match uname_release() {
+        Ok(release) => Capability::pass("kernel.version", release, false),
+        Err(e) => Capability::unknown("kernel.version", format!("uname failed: {e}"), false),
     }
 }
 
@@ -608,6 +709,148 @@ fn probe_memlock() -> Capability {
             true,
         )
     }
+}
+
+// --- Per-interface performance probes ----------------------------------
+
+/// GRO state via the `SIOCETHTOOL`/`ETHTOOL_GGRO` ioctl (GRO is not
+/// exposed in sysfs). Informational either way: with generic XDP, GRO
+/// means the program sees aggregated super-skbs that the kernel must
+/// linearize (copy) before the program runs, but disabling it raises
+/// the per-packet count for any traffic that still traverses the
+/// kernel stack. The runbook covers the trade-off; this probe just
+/// reports the state.
+fn probe_iface_gro(iface: &str) -> Capability {
+    let name = format!("iface.{iface}.gro");
+    match iface_gro_state(iface) {
+        Ok(true) => Capability::pass(
+            &name,
+            "GRO on (generic XDP linearizes aggregated skbs; see generic-mode-performance runbook)",
+            false,
+        ),
+        Ok(false) => Capability::pass(&name, "GRO off", false),
+        Err(e) => Capability::unknown(&name, e, false),
+    }
+}
+
+/// RPS masks from `/sys/class/net/<iface>/queues/rx-*/rps_cpus`.
+/// Since v5.3, generic XDP runs *after* RPS steering, so a non-zero
+/// mask spreads the whole XDP + skb-prep workload across CPUs. An
+/// all-zeros mask on every queue is reported as a (non-required)
+/// failure because on a CPU-limited generic-XDP box it is the
+/// highest-leverage free tuning knob.
+fn probe_iface_rps(iface: &str) -> Capability {
+    let name = format!("iface.{iface}.rps");
+    let queues_dir = PathBuf::from(format!("/sys/class/net/{iface}/queues"));
+    let entries = match fs::read_dir(&queues_dir) {
+        Ok(e) => e,
+        Err(e) => {
+            return Capability::unknown(
+                &name,
+                format!("could not read {}: {e}", queues_dir.display()),
+                false,
+            );
+        }
+    };
+
+    let mut masks: Vec<(String, String)> = Vec::new();
+    for entry in entries.flatten() {
+        let qname = entry.file_name().to_string_lossy().into_owned();
+        if !qname.starts_with("rx-") {
+            continue;
+        }
+        if let Ok(raw) = fs::read_to_string(entry.path().join("rps_cpus")) {
+            masks.push((qname, raw.trim().to_string()));
+        }
+    }
+    masks.sort();
+
+    if masks.is_empty() {
+        return Capability::unknown(&name, "no rx queues with rps_cpus found", false);
+    }
+
+    let all_zero = masks.iter().all(|(_, m)| rps_mask_is_zero(m));
+    let rendered = masks
+        .iter()
+        .map(|(q, m)| format!("{q}={m}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    if all_zero {
+        Capability::fail(
+            &name,
+            format!(
+                "rps_cpus all zero ({rendered}): all generic-XDP work runs on the NIC's IRQ \
+                 CPUs; set a spread mask, e.g. \
+                 `echo <cpumask> > /sys/class/net/{iface}/queues/rx-0/rps_cpus` \
+                 (see generic-mode-performance runbook)"
+            ),
+            false,
+        )
+    } else {
+        Capability::pass(&name, rendered, false)
+    }
+}
+
+/// An RPS cpumask is zero when every hex digit is `0` (commas are
+/// group separators on >32-CPU hosts).
+fn rps_mask_is_zero(mask: &str) -> bool {
+    mask.chars().all(|c| c == '0' || c == ',')
+}
+
+#[cfg(target_os = "linux")]
+fn iface_gro_state(iface: &str) -> Result<bool, String> {
+    // ethtool_value { cmd, data } with ETHTOOL_GGRO. A read-only get;
+    // no privileges required.
+    const ETHTOOL_GGRO: u32 = 0x0000_002b;
+    // Kept target-width-neutral: libc::ioctl's request parameter is
+    // `c_ulong` (u64) on glibc but `c_int` (i32) on musl, so the
+    // constant is a plain u32 and the call site casts with `as _` to
+    // whichever type the target's libc declares (the value fits both).
+    // Same targeted-cast pattern as `statfs.f_type` in probe_bpffs.
+    const SIOCETHTOOL: u32 = 0x8946;
+    #[repr(C)]
+    struct EthtoolValue {
+        cmd: u32,
+        data: u32,
+    }
+
+    let name_bytes = iface.as_bytes();
+    let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+    if name_bytes.len() >= ifr.ifr_name.len() {
+        return Err(format!("interface name `{iface}` exceeds IFNAMSIZ"));
+    }
+    for (dst, src) in ifr.ifr_name.iter_mut().zip(name_bytes) {
+        *dst = *src as libc::c_char;
+    }
+
+    let mut value = EthtoolValue {
+        cmd: ETHTOOL_GGRO,
+        data: 0,
+    };
+    ifr.ifr_ifru.ifru_data = &mut value as *mut EthtoolValue as *mut libc::c_char;
+
+    let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+    if sock < 0 {
+        return Err(format!(
+            "socket(AF_INET, SOCK_DGRAM) failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    #[allow(clippy::unnecessary_cast)]
+    let r = unsafe { libc::ioctl(sock, SIOCETHTOOL as _, &mut ifr) };
+    let ioctl_err = std::io::Error::last_os_error();
+    unsafe { libc::close(sock) };
+    if r != 0 {
+        return Err(format!(
+            "SIOCETHTOOL/ETHTOOL_GGRO on {iface} failed: {ioctl_err}"
+        ));
+    }
+    Ok(value.data != 0)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn iface_gro_state(_iface: &str) -> Result<bool, String> {
+    Err("GRO probe is Linux-only".to_string())
 }
 
 #[cfg(test)]
@@ -677,5 +920,77 @@ CONFIG_HZ=250
             Capability::deferred("deferred_probe", "see v0.1"),
         ];
         assert!(FeasibilityReport::new(caps).passed);
+    }
+
+    #[test]
+    fn sysctl_any_accepts_each_listed_value() {
+        let dir = std::env::temp_dir().join(format!("pf-probe-test-{}", std::process::id()));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("jit");
+        let path_str = path.to_str().unwrap();
+
+        for good in ["1", "2"] {
+            fs::write(&path, format!("{good}\n")).unwrap();
+            let cap = probe_sysctl_any("t", path_str, &["1", "2"], false, "hint");
+            assert_eq!(cap.status, CapabilityStatus::Pass, "value {good}");
+        }
+
+        fs::write(&path, "0\n").unwrap();
+        let cap = probe_sysctl_any("t", path_str, &["1", "2"], false, "hint");
+        assert_eq!(cap.status, CapabilityStatus::Fail);
+        assert!(cap.detail.contains("1 or 2"), "detail: {}", cap.detail);
+
+        let cap = probe_sysctl_any(
+            "t",
+            dir.join("absent").to_str().unwrap(),
+            &["1"],
+            false,
+            "h",
+        );
+        assert_eq!(cap.status, CapabilityStatus::Unknown);
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rps_mask_zero_detection() {
+        assert!(rps_mask_is_zero("0"));
+        assert!(rps_mask_is_zero("00000000"));
+        assert!(rps_mask_is_zero("00000000,00000000"));
+        assert!(!rps_mask_is_zero("f"));
+        assert!(!rps_mask_is_zero("00000000,00000001"));
+    }
+
+    /// Loopback GRO smoke test: the probe must produce a clean verdict
+    /// (Pass or Unknown), never panic. Runs unprivileged; the get-side
+    /// ethtool ioctl needs no capabilities.
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn iface_gro_probe_on_loopback() {
+        let cap = probe_iface_gro("lo");
+        assert!(
+            matches!(
+                cap.status,
+                CapabilityStatus::Pass | CapabilityStatus::Unknown
+            ),
+            "unexpected status {:?}: {}",
+            cap.status,
+            cap.detail
+        );
+        assert!(!cap.required);
+    }
+
+    #[test]
+    fn iface_probes_shape() {
+        // Two caps per iface, names prefixed with the iface. On
+        // non-Linux both come back Unknown, which is fine — the shape
+        // is what this asserts.
+        let caps = run_iface_probes(&["eth0".to_string(), "eth1".to_string()]);
+        assert_eq!(caps.len(), 4);
+        assert_eq!(caps[0].name, "iface.eth0.gro");
+        assert_eq!(caps[1].name, "iface.eth0.rps");
+        assert_eq!(caps[2].name, "iface.eth1.gro");
+        assert_eq!(caps[3].name, "iface.eth1.rps");
+        assert!(caps.iter().all(|c| !c.required));
     }
 }

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -21,7 +21,7 @@
 use aya_ebpf::maps::lpm_trie::Key;
 
 use crate::maps::{
-    bump_stat, EcmpGroup, FibValue, NexthopEntry, StatIdx, ECMP_GROUPS, FIB_KIND_ECMP,
+    bump, EcmpGroup, FibValue, NexthopEntry, StatIdx, StatsPtr, ECMP_GROUPS, FIB_KIND_ECMP,
     FIB_KIND_SINGLE, FIB_V4, FIB_V6, MAX_ECMP_PATHS, NEXTHOPS, NH_STATE_RESOLVED,
 };
 
@@ -94,6 +94,7 @@ impl CustomFibResult {
 /// between BPF and the userspace reference in `src/fib/hash.rs`.
 #[inline(always)]
 pub fn lookup_v4(
+    stats: StatsPtr,
     src: [u8; 4],
     dst: [u8; 4],
     proto: u8,
@@ -104,27 +105,27 @@ pub fn lookup_v4(
     let fib = match FIB_V4.get(&key) {
         Some(v) => *v,
         None => {
-            bump_stat(StatIdx::CustomFibMiss);
+            bump(stats, StatIdx::CustomFibMiss);
             return CustomFibResult::miss();
         }
     };
 
-    let nh_idx = match resolve_fib_value_v4(&fib, src, dst, proto, sport, dport) {
+    let nh_idx = match resolve_fib_value_v4(stats, &fib, src, dst, proto, sport, dport) {
         Some(idx) => idx,
         None => {
             // ECMP walked every leg; none resolved.
-            bump_stat(StatIdx::CustomFibNoNeigh);
+            bump(stats, StatIdx::CustomFibNoNeigh);
             return CustomFibResult::no_neigh();
         }
     };
 
-    match read_nexthop(nh_idx) {
+    match read_nexthop(stats, nh_idx) {
         Some((ifindex, smac, dmac)) => {
-            bump_stat(StatIdx::CustomFibHit);
+            bump(stats, StatIdx::CustomFibHit);
             CustomFibResult::forward(ifindex, smac, dmac)
         }
         None => {
-            bump_stat(StatIdx::CustomFibNoNeigh);
+            bump(stats, StatIdx::CustomFibNoNeigh);
             CustomFibResult::no_neigh()
         }
     }
@@ -134,6 +135,7 @@ pub fn lookup_v4(
 /// contract on `sport` / `dport`.
 #[inline(always)]
 pub fn lookup_v6(
+    stats: StatsPtr,
     src: [u8; 16],
     dst: [u8; 16],
     proto: u8,
@@ -144,26 +146,26 @@ pub fn lookup_v6(
     let fib = match FIB_V6.get(&key) {
         Some(v) => *v,
         None => {
-            bump_stat(StatIdx::CustomFibMiss);
+            bump(stats, StatIdx::CustomFibMiss);
             return CustomFibResult::miss();
         }
     };
 
-    let nh_idx = match resolve_fib_value_v6(&fib, src, dst, proto, sport, dport) {
+    let nh_idx = match resolve_fib_value_v6(stats, &fib, src, dst, proto, sport, dport) {
         Some(idx) => idx,
         None => {
-            bump_stat(StatIdx::CustomFibNoNeigh);
+            bump(stats, StatIdx::CustomFibNoNeigh);
             return CustomFibResult::no_neigh();
         }
     };
 
-    match read_nexthop(nh_idx) {
+    match read_nexthop(stats, nh_idx) {
         Some((ifindex, smac, dmac)) => {
-            bump_stat(StatIdx::CustomFibHit);
+            bump(stats, StatIdx::CustomFibHit);
             CustomFibResult::forward(ifindex, smac, dmac)
         }
         None => {
-            bump_stat(StatIdx::CustomFibNoNeigh);
+            bump(stats, StatIdx::CustomFibNoNeigh);
             CustomFibResult::no_neigh()
         }
     }
@@ -173,6 +175,7 @@ pub fn lookup_v6(
 
 #[inline(always)]
 fn resolve_fib_value_v4(
+    stats: StatsPtr,
     fib: &FibValue,
     src: [u8; 4],
     dst: [u8; 4],
@@ -183,10 +186,10 @@ fn resolve_fib_value_v4(
     match fib.kind {
         FIB_KIND_SINGLE => Some(fib.idx),
         FIB_KIND_ECMP => {
-            bump_stat(StatIdx::EcmpHashV4);
+            bump(stats, StatIdx::EcmpHashV4);
             let group = ECMP_GROUPS.get(fib.idx)?;
             let h = hash_v4(src, dst, proto, sport, dport, group.hash_mode);
-            pick_ecmp_leg(group, h)
+            pick_ecmp_leg(stats, group, h)
         }
         _ => None,
     }
@@ -194,6 +197,7 @@ fn resolve_fib_value_v4(
 
 #[inline(always)]
 fn resolve_fib_value_v6(
+    stats: StatsPtr,
     fib: &FibValue,
     src: [u8; 16],
     dst: [u8; 16],
@@ -204,10 +208,10 @@ fn resolve_fib_value_v6(
     match fib.kind {
         FIB_KIND_SINGLE => Some(fib.idx),
         FIB_KIND_ECMP => {
-            bump_stat(StatIdx::EcmpHashV6);
+            bump(stats, StatIdx::EcmpHashV6);
             let group = ECMP_GROUPS.get(fib.idx)?;
             let h = hash_v6(src, dst, proto, sport, dport, group.hash_mode);
-            pick_ecmp_leg(group, h)
+            pick_ecmp_leg(stats, group, h)
         }
         _ => None,
     }
@@ -224,7 +228,7 @@ fn resolve_fib_value_v6(
 /// `EcmpDeadLegFallback`, that's diagnostic signal that a leg is
 /// down and we're compensating.
 #[inline(always)]
-fn pick_ecmp_leg(group: &EcmpGroup, hash: u32) -> Option<u32> {
+fn pick_ecmp_leg(stats: StatsPtr, group: &EcmpGroup, hash: u32) -> Option<u32> {
     let nh_count = group.nh_count as u32;
     if nh_count == 0 {
         return None;
@@ -250,7 +254,7 @@ fn pick_ecmp_leg(group: &EcmpGroup, hash: u32) -> Option<u32> {
                 if let Some(entry) = NEXTHOPS.get(nh_idx) {
                     if entry.state == NH_STATE_RESOLVED {
                         if walked > 0 {
-                            bump_stat(StatIdx::EcmpDeadLegFallback);
+                            bump(stats, StatIdx::EcmpDeadLegFallback);
                         }
                         return Some(nh_idx);
                     }
@@ -282,7 +286,7 @@ fn pick_ecmp_leg(group: &EcmpGroup, hash: u32) -> Option<u32> {
 /// After 4 attempts, give up. Every retry bumps `NexthopSeqRetry` so
 /// sustained-high values expose hot neighbor churn.
 #[inline(always)]
-fn read_nexthop(idx: u32) -> Option<(u32, [u8; 6], [u8; 6])> {
+fn read_nexthop(stats: StatsPtr, idx: u32) -> Option<(u32, [u8; 6], [u8; 6])> {
     let ptr = NEXTHOPS.get_ptr(idx)?;
 
     // Manual 4-retry unroll. Each block is identical; we could
@@ -292,21 +296,21 @@ fn read_nexthop(idx: u32) -> Option<(u32, [u8; 6], [u8; 6])> {
     if let Some(result) = try_read_seqlock(ptr) {
         return Some(result);
     }
-    bump_stat(StatIdx::NexthopSeqRetry);
+    bump(stats, StatIdx::NexthopSeqRetry);
     if let Some(result) = try_read_seqlock(ptr) {
         return Some(result);
     }
-    bump_stat(StatIdx::NexthopSeqRetry);
+    bump(stats, StatIdx::NexthopSeqRetry);
     if let Some(result) = try_read_seqlock(ptr) {
         return Some(result);
     }
-    bump_stat(StatIdx::NexthopSeqRetry);
+    bump(stats, StatIdx::NexthopSeqRetry);
     if let Some(result) = try_read_seqlock(ptr) {
         return Some(result);
     }
-    bump_stat(StatIdx::NexthopSeqRetry);
+    bump(stats, StatIdx::NexthopSeqRetry);
 
-    bump_stat(StatIdx::NeighCacheMiss);
+    bump(stats, StatIdx::NeighCacheMiss);
     None
 }
 
@@ -424,14 +428,7 @@ fn pack_ports(proto: u8, sport: u16, dport: u16, mode: u8) -> u32 {
 
 /// IPv4 flow hash. `mode` is 3 / 4 / 5; any other value falls back to 3.
 #[inline(always)]
-pub fn hash_v4(
-    src: [u8; 4],
-    dst: [u8; 4],
-    proto: u8,
-    sport: u16,
-    dport: u16,
-    mode: u8,
-) -> u32 {
+pub fn hash_v4(src: [u8; 4], dst: [u8; 4], proto: u8, sport: u16, dport: u16, mode: u8) -> u32 {
     let a = u32::from_be_bytes(src).wrapping_add(JHASH_INITVAL);
     let b = u32::from_be_bytes(dst).wrapping_add(JHASH_INITVAL);
     let c = pack_ports(proto, sport, dport, mode).wrapping_add(JHASH_INITVAL);
@@ -442,14 +439,7 @@ pub fn hash_v4(
 /// IPv6 flow hash. Absorbs the 8 × u32 words of the v6 addresses
 /// through three `jhash_mix` invocations before the final avalanche.
 #[inline(always)]
-pub fn hash_v6(
-    src: [u8; 16],
-    dst: [u8; 16],
-    proto: u8,
-    sport: u16,
-    dport: u16,
-    mode: u8,
-) -> u32 {
+pub fn hash_v6(src: [u8; 16], dst: [u8; 16], proto: u8, sport: u16, dport: u16, mode: u8) -> u32 {
     let s0 = u32::from_be_bytes([src[0], src[1], src[2], src[3]]);
     let s1 = u32::from_be_bytes([src[4], src[5], src[6], src[7]]);
     let s2 = u32::from_be_bytes([src[8], src[9], src[10], src[11]]);

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -18,8 +18,9 @@
 //! asserts agreement. If the two sides drift, the test fails before
 //! any XDP packet is ever forwarded.
 
-use aya_ebpf::maps::lpm_trie::Key;
+use aya_ebpf::{maps::lpm_trie::Key, programs::XdpContext};
 
+use crate::l4_ports;
 use crate::maps::{
     bump, EcmpGroup, FibValue, NexthopEntry, StatIdx, StatsPtr, ECMP_GROUPS, FIB_KIND_ECMP,
     FIB_KIND_SINGLE, FIB_V4, FIB_V6, MAX_ECMP_PATHS, NEXTHOPS, NH_STATE_RESOLVED,
@@ -82,24 +83,21 @@ impl CustomFibResult {
 
 // --- Top-level lookup -------------------------------------------------
 
-/// IPv4 custom-FIB lookup. Caller passes the parsed src/dst/proto +
-/// L4 ports from the packet. Returns a [`CustomFibResult`] the caller
-/// feeds into the existing `dispatch_fib` success / miss paths in
-/// `main.rs`.
-///
-/// `sport` / `dport` are **native-order u16** (host byte order). The
-/// caller is responsible for byte-swapping from the BE-in-memory
-/// representation that `l4_ports` returns for the kernel-FIB's
-/// `__be16` contract. This keeps the hash byte-order-agnostic
-/// between BPF and the userspace reference in `src/fib/hash.rs`.
+/// IPv4 custom-FIB lookup. Caller passes the parsed src/dst/proto plus
+/// the L4 header offset; **port extraction is deferred** into the ECMP
+/// arm (`resolve_fib_value_v4`), because ports feed only the ECMP flow
+/// hash — on the single-nexthop path (the common case on deployments
+/// with no ECMP groups) no port bytes are read at all. Returns a
+/// [`CustomFibResult`] the caller feeds into the existing
+/// `dispatch_fib` success / miss paths in `main.rs`.
 #[inline(always)]
 pub fn lookup_v4(
     stats: StatsPtr,
+    ctx: &XdpContext,
+    l4_off: usize,
     src: [u8; 4],
     dst: [u8; 4],
     proto: u8,
-    sport: u16,
-    dport: u16,
 ) -> CustomFibResult {
     let key = Key::new(32, dst);
     let fib = match FIB_V4.get(&key) {
@@ -110,16 +108,17 @@ pub fn lookup_v4(
         }
     };
 
-    let nh_idx = match resolve_fib_value_v4(stats, &fib, src, dst, proto, sport, dport) {
-        Some(idx) => idx,
+    let nh_ptr = match resolve_fib_value_v4(stats, ctx, l4_off, &fib, src, dst, proto) {
+        Some(p) => p,
         None => {
-            // ECMP walked every leg; none resolved.
+            // ECMP walked every leg and none resolved, or the single
+            // nexthop index was out of range.
             bump(stats, StatIdx::CustomFibNoNeigh);
             return CustomFibResult::no_neigh();
         }
     };
 
-    match read_nexthop(stats, nh_idx) {
+    match read_nexthop_ptr(stats, nh_ptr) {
         Some((ifindex, smac, dmac)) => {
             bump(stats, StatIdx::CustomFibHit);
             CustomFibResult::forward(ifindex, smac, dmac)
@@ -131,16 +130,16 @@ pub fn lookup_v4(
     }
 }
 
-/// IPv6 custom-FIB lookup. See [`lookup_v4`], same byte-order
-/// contract on `sport` / `dport`.
+/// IPv6 custom-FIB lookup. See [`lookup_v4`]; same deferred-port
+/// contract.
 #[inline(always)]
 pub fn lookup_v6(
     stats: StatsPtr,
+    ctx: &XdpContext,
+    l4_off: usize,
     src: [u8; 16],
     dst: [u8; 16],
     proto: u8,
-    sport: u16,
-    dport: u16,
 ) -> CustomFibResult {
     let key = Key::new(128, dst);
     let fib = match FIB_V6.get(&key) {
@@ -151,15 +150,15 @@ pub fn lookup_v6(
         }
     };
 
-    let nh_idx = match resolve_fib_value_v6(stats, &fib, src, dst, proto, sport, dport) {
-        Some(idx) => idx,
+    let nh_ptr = match resolve_fib_value_v6(stats, ctx, l4_off, &fib, src, dst, proto) {
+        Some(p) => p,
         None => {
             bump(stats, StatIdx::CustomFibNoNeigh);
             return CustomFibResult::no_neigh();
         }
     };
 
-    match read_nexthop(stats, nh_idx) {
+    match read_nexthop_ptr(stats, nh_ptr) {
         Some((ifindex, smac, dmac)) => {
             bump(stats, StatIdx::CustomFibHit);
             CustomFibResult::forward(ifindex, smac, dmac)
@@ -171,24 +170,37 @@ pub fn lookup_v6(
     }
 }
 
-// --- FibValue → NexthopId ---------------------------------------------
+// --- FibValue → NexthopEntry pointer ------------------------------------
 
 #[inline(always)]
 fn resolve_fib_value_v4(
     stats: StatsPtr,
+    ctx: &XdpContext,
+    l4_off: usize,
     fib: &FibValue,
     src: [u8; 4],
     dst: [u8; 4],
     proto: u8,
-    sport: u16,
-    dport: u16,
-) -> Option<u32> {
+) -> Option<*const NexthopEntry> {
     match fib.kind {
-        FIB_KIND_SINGLE => Some(fib.idx),
+        FIB_KIND_SINGLE => NEXTHOPS.get_ptr(fib.idx),
         FIB_KIND_ECMP => {
             bump(stats, StatIdx::EcmpHashV4);
             let group = ECMP_GROUPS.get(fib.idx)?;
-            let h = hash_v4(src, dst, proto, sport, dport, group.hash_mode);
+            // Deferred port parse: only ECMP destinations hash on
+            // ports. `l4_ports` returns BE-in-memory u16s (the
+            // kernel-FIB `__be16` shape); the hash contract is
+            // native-order, so swap here — same values the caller
+            // used to compute, just only when actually needed.
+            let (sport_be, dport_be) = l4_ports(ctx, l4_off, proto);
+            let h = hash_v4(
+                src,
+                dst,
+                proto,
+                u16::from_be(sport_be),
+                u16::from_be(dport_be),
+                group.hash_mode,
+            );
             pick_ecmp_leg(stats, group, h)
         }
         _ => None,
@@ -198,19 +210,28 @@ fn resolve_fib_value_v4(
 #[inline(always)]
 fn resolve_fib_value_v6(
     stats: StatsPtr,
+    ctx: &XdpContext,
+    l4_off: usize,
     fib: &FibValue,
     src: [u8; 16],
     dst: [u8; 16],
     proto: u8,
-    sport: u16,
-    dport: u16,
-) -> Option<u32> {
+) -> Option<*const NexthopEntry> {
     match fib.kind {
-        FIB_KIND_SINGLE => Some(fib.idx),
+        FIB_KIND_SINGLE => NEXTHOPS.get_ptr(fib.idx),
         FIB_KIND_ECMP => {
             bump(stats, StatIdx::EcmpHashV6);
             let group = ECMP_GROUPS.get(fib.idx)?;
-            let h = hash_v6(src, dst, proto, sport, dport, group.hash_mode);
+            // See resolve_fib_value_v4 for the deferred-port rationale.
+            let (sport_be, dport_be) = l4_ports(ctx, l4_off, proto);
+            let h = hash_v6(
+                src,
+                dst,
+                proto,
+                u16::from_be(sport_be),
+                u16::from_be(dport_be),
+                group.hash_mode,
+            );
             pick_ecmp_leg(stats, group, h)
         }
         _ => None,
@@ -223,12 +244,19 @@ fn resolve_fib_value_v6(
 /// bound is a compile-time constant; the verifier sees a straight-line
 /// walk.
 ///
+/// Returns the entry *pointer* (from the walk's own `get_ptr`) so the
+/// caller's seqlock read doesn't repeat the NEXTHOPS lookup — the walk
+/// previously used `.get()` and the caller re-fetched by index, one
+/// redundant map op per ECMP packet. The state peek here is a plain
+/// racy read; the caller's seqlock discipline is what validates the
+/// final tuple.
+///
 /// If the starting slot is resolved, returns immediately (the common
 /// case). If we walked past the starting slot, bump
 /// `EcmpDeadLegFallback`, that's diagnostic signal that a leg is
 /// down and we're compensating.
 #[inline(always)]
-fn pick_ecmp_leg(stats: StatsPtr, group: &EcmpGroup, hash: u32) -> Option<u32> {
+fn pick_ecmp_leg(stats: StatsPtr, group: &EcmpGroup, hash: u32) -> Option<*const NexthopEntry> {
     let nh_count = group.nh_count as u32;
     if nh_count == 0 {
         return None;
@@ -251,12 +279,13 @@ fn pick_ecmp_leg(stats: StatsPtr, group: &EcmpGroup, hash: u32) -> Option<u32> {
         if slot < MAX_ECMP_PATHS {
             let nh_idx = group.nh_idx[slot];
             if nh_idx != u32::MAX {
-                if let Some(entry) = NEXTHOPS.get(nh_idx) {
-                    if entry.state == NH_STATE_RESOLVED {
+                if let Some(ptr) = NEXTHOPS.get_ptr(nh_idx) {
+                    let state = unsafe { core::ptr::read_volatile(&(*ptr).state) };
+                    if state == NH_STATE_RESOLVED {
                         if walked > 0 {
                             bump(stats, StatIdx::EcmpDeadLegFallback);
                         }
-                        return Some(nh_idx);
+                        return Some(ptr);
                     }
                 }
             }
@@ -270,75 +299,100 @@ fn pick_ecmp_leg(stats: StatsPtr, group: &EcmpGroup, hash: u32) -> Option<u32> {
 
 // --- Seqlock-aware nexthop read ---------------------------------------
 
-/// Read `NEXTHOPS[idx]` under the seqlock discipline. Returns
+/// Seqlock attempt outcomes. Integer codes rather than an enum for
+/// the same verifier-predictability reason as `FIB_ACTION_*`.
+const SEQ_OK: u8 = 0;
+/// Torn read: writer in progress (odd `seq`) or `seq` changed across
+/// the field reads. Retrying can succeed.
+const SEQ_RETRY: u8 = 1;
+/// Stable read of an entry whose `state != Resolved`. This cannot
+/// change within one program invocation — retrying is pointless.
+const SEQ_NOT_RESOLVED: u8 = 2;
+
+/// Read a `NEXTHOPS` entry under the seqlock discipline. Returns
 /// `Some((ifindex, smac, dmac))` on a stable even-`seq` read with
 /// `state == Resolved`, `None` otherwise.
 ///
-/// **Bounded retry.** Up to 4 attempts, manually unrolled so the
-/// verifier sees fixed instruction count. On every attempt:
-/// 1. Read `seq_before` volatile. If odd, the writer is in progress;
-///    skip to next attempt.
-/// 2. Read the fields volatile.
-/// 3. Read `seq_after` volatile. If it differs from `seq_before`,
-///    the writer mutated mid-read; skip to next attempt.
-/// 4. Check `state == NH_STATE_RESOLVED`. If so, return the tuple.
-///
-/// After 4 attempts, give up. Every retry bumps `NexthopSeqRetry` so
-/// sustained-high values expose hot neighbor churn.
+/// **Bounded retry, torn reads only.** Up to 4 attempts, manually
+/// unrolled so the verifier sees fixed instruction count. A stable
+/// read of a not-Resolved entry short-circuits immediately: earlier
+/// versions retried (and bumped `NexthopSeqRetry`) on that stable
+/// condition too, which burned up to 3 extra attempts per packet on
+/// unresolved nexthops and inflated the retry counter to ~4× the
+/// `custom_fib_no_neigh` rate — masking the genuine-churn signal the
+/// counter is documented to carry. `NexthopSeqRetry` now counts only
+/// real torn reads; `NeighCacheMiss` still counts every failed read.
 #[inline(always)]
-fn read_nexthop(stats: StatsPtr, idx: u32) -> Option<(u32, [u8; 6], [u8; 6])> {
-    let ptr = NEXTHOPS.get_ptr(idx)?;
+fn read_nexthop_ptr(stats: StatsPtr, ptr: *const NexthopEntry) -> Option<(u32, [u8; 6], [u8; 6])> {
+    let mut ifindex = 0u32;
+    let mut smac = [0u8; 6];
+    let mut dmac = [0u8; 6];
 
-    // Manual 4-retry unroll. Each block is identical; we could
-    // express this as a macro but the verifier reads every instruction
-    // so clarity > DRY here.
+    // Manual 4-attempt unroll; each retry is taken only on SEQ_RETRY.
+    let mut status = try_read_seqlock(ptr, &mut ifindex, &mut smac, &mut dmac);
+    if status == SEQ_RETRY {
+        bump(stats, StatIdx::NexthopSeqRetry);
+        status = try_read_seqlock(ptr, &mut ifindex, &mut smac, &mut dmac);
+    }
+    if status == SEQ_RETRY {
+        bump(stats, StatIdx::NexthopSeqRetry);
+        status = try_read_seqlock(ptr, &mut ifindex, &mut smac, &mut dmac);
+    }
+    if status == SEQ_RETRY {
+        bump(stats, StatIdx::NexthopSeqRetry);
+        status = try_read_seqlock(ptr, &mut ifindex, &mut smac, &mut dmac);
+    }
+    if status == SEQ_RETRY {
+        bump(stats, StatIdx::NexthopSeqRetry);
+    }
 
-    if let Some(result) = try_read_seqlock(ptr) {
-        return Some(result);
+    if status == SEQ_OK {
+        return Some((ifindex, smac, dmac));
     }
-    bump(stats, StatIdx::NexthopSeqRetry);
-    if let Some(result) = try_read_seqlock(ptr) {
-        return Some(result);
-    }
-    bump(stats, StatIdx::NexthopSeqRetry);
-    if let Some(result) = try_read_seqlock(ptr) {
-        return Some(result);
-    }
-    bump(stats, StatIdx::NexthopSeqRetry);
-    if let Some(result) = try_read_seqlock(ptr) {
-        return Some(result);
-    }
-    bump(stats, StatIdx::NexthopSeqRetry);
-
     bump(stats, StatIdx::NeighCacheMiss);
     None
 }
 
-/// One seqlock attempt. Extracted to its own inlined function so the
-/// 4-retry unroll above reads cleanly.
+/// One seqlock attempt. Outputs travel through caller-stack out-params
+/// (~16 bytes, well within budget) with a status-code return: the
+/// historic `Option<(u32, [u8;6], [u8;6])>` shape is fine, but a
+/// three-way outcome needs the RETRY/NOT_RESOLVED distinction and
+/// nested enums with niche payloads are exactly what this codebase
+/// avoids handing the verifier. Everything stays `#[inline(always)]`,
+/// so no argument spill crosses a real call boundary.
 #[inline(always)]
-fn try_read_seqlock(ptr: *const NexthopEntry) -> Option<(u32, [u8; 6], [u8; 6])> {
-    // SAFETY: `ptr` came from `NEXTHOPS.get_ptr(idx)` which bounds-
-    // checked the index and returned a pointer into kernel map memory
-    // valid for the duration of the program run. `read_volatile`
-    // prevents the compiler from CSE'ing reads across the seq checks.
+fn try_read_seqlock(
+    ptr: *const NexthopEntry,
+    out_ifindex: &mut u32,
+    out_smac: &mut [u8; 6],
+    out_dmac: &mut [u8; 6],
+) -> u8 {
+    // SAFETY: `ptr` came from `NEXTHOPS.get_ptr` which bounds-checked
+    // the index and returned a pointer into kernel map memory valid
+    // for the duration of the program run. `read_volatile` prevents
+    // the compiler from CSE'ing reads across the seq checks.
     unsafe {
         let seq_before = core::ptr::read_volatile(&(*ptr).seq);
         if seq_before & 1 != 0 {
-            return None;
+            return SEQ_RETRY;
         }
         let state = core::ptr::read_volatile(&(*ptr).state);
-        if state != NH_STATE_RESOLVED {
-            return None;
-        }
         let ifindex = core::ptr::read_volatile(&(*ptr).ifindex);
         let dmac = core::ptr::read_volatile(&(*ptr).dst_mac);
         let smac = core::ptr::read_volatile(&(*ptr).src_mac);
         let seq_after = core::ptr::read_volatile(&(*ptr).seq);
         if seq_after != seq_before {
-            return None;
+            return SEQ_RETRY;
         }
-        Some((ifindex, smac, dmac))
+        // Only a seq-stable read can classify the entry: an unstable
+        // `state` byte could be mid-write.
+        if state != NH_STATE_RESOLVED {
+            return SEQ_NOT_RESOLVED;
+        }
+        *out_ifindex = ifindex;
+        *out_smac = smac;
+        *out_dmac = dmac;
+        SEQ_OK
     }
 }
 

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -17,17 +17,14 @@
 //! `docs/runbooks/tail-call-architecture.md`.
 
 use aya_ebpf::{
-    bindings::xdp_action,
-    helpers::bpf_xdp_adjust_head,
-    macros::xdp,
-    maps::lpm_trie::Key,
+    bindings::xdp_action, helpers::bpf_xdp_adjust_head, macros::xdp, maps::lpm_trie::Key,
     programs::XdpContext,
 };
 use network_types::ip::{IpProto, Ipv4Hdr, Ipv6Hdr};
 
 use crate::maps::{
-    bump_stat, StatIdx, CFG, MSS_CLAMP_BY_IFACE, MSS_CLAMP_V4, MSS_CLAMP_V6, MUTATION_CTX,
-    REDIRECT_DEVMAP,
+    bump, stats_base, StatIdx, StatsPtr, CFG, MSS_CLAMP_BY_IFACE, MSS_CLAMP_V4, MSS_CLAMP_V6,
+    MUTATION_CTX, REDIRECT_DEVMAP,
 };
 
 /// 802.1Q TPID. Mirror of `main::TPID_8021Q`; kept local so finalize
@@ -52,6 +49,14 @@ const MAX_IP_OFFSET: usize = 64;
 
 #[xdp]
 pub fn finalize(ctx: XdpContext) -> u32 {
+    // Own STATS lookup: finalize is a separate program stage and the
+    // pointer cannot cross the tail-call boundary. Fail open on the
+    // unreachable None (index 0 of a 1-entry per-CPU array).
+    let stats = match stats_base() {
+        Some(s) => s,
+        None => return xdp_action::XDP_PASS,
+    };
+
     // Read the per-CPU mutation context written by fast_path right
     // before its tail_call. Always present in production; fail-safe
     // XDP_PASS if missing so traffic falls through to kernel rather
@@ -59,7 +64,7 @@ pub fn finalize(ctx: XdpContext) -> u32 {
     let mctx = match unsafe { MUTATION_CTX.get(0) } {
         Some(c) => *c,
         None => {
-            bump_stat(StatIdx::ErrMutationCtx);
+            bump(stats, StatIdx::ErrMutationCtx);
             return xdp_action::XDP_PASS;
         }
     };
@@ -91,20 +96,20 @@ pub fn finalize(ctx: XdpContext) -> u32 {
     // via bpf_xdp_adjust_head). mss-clamp's TCP-options walk relies on
     // ip_offset being valid relative to ctx.data(), true until VLAN
     // push/pop changes the layout.
-    mss_clamp_inline(&ctx, ip_offset, is_v4, egress_ifindex);
+    mss_clamp_inline(&ctx, stats, ip_offset, is_v4, egress_ifindex);
 
     if apply_vlan_egress(&ctx, ingress_vid, egress_vid).is_err() {
-        bump_stat(StatIdx::ErrVlan);
+        bump(stats, StatIdx::ErrVlan);
         return xdp_action::XDP_ABORTED;
     }
 
     match REDIRECT_DEVMAP.redirect(egress_ifindex, 0) {
         Ok(_) => {
-            bump_stat(StatIdx::FwdOk);
+            bump(stats, StatIdx::FwdOk);
             xdp_action::XDP_REDIRECT
         }
         Err(_) => {
-            bump_stat(StatIdx::ErrFibOther);
+            bump(stats, StatIdx::ErrFibOther);
             xdp_action::XDP_PASS
         }
     }
@@ -124,11 +129,17 @@ pub fn finalize(ctx: XdpContext) -> u32 {
 /// loses the verifier's bound-tracking when the cast is reached: see
 /// `R9 offset is outside of the packet` from the v0.2.5 prerelease build.
 #[inline(always)]
-fn mss_clamp_inline(ctx: &XdpContext, ip_offset: usize, is_v4: bool, egress_ifindex: u32) {
+fn mss_clamp_inline(
+    ctx: &XdpContext,
+    stats: StatsPtr,
+    ip_offset: usize,
+    is_v4: bool,
+    egress_ifindex: u32,
+) {
     if is_v4 {
-        mss_clamp_v4(ctx, ip_offset, egress_ifindex);
+        mss_clamp_v4(ctx, stats, ip_offset, egress_ifindex);
     } else {
-        mss_clamp_v6(ctx, ip_offset, egress_ifindex);
+        mss_clamp_v6(ctx, stats, ip_offset, egress_ifindex);
     }
 }
 
@@ -136,7 +147,7 @@ fn mss_clamp_inline(ctx: &XdpContext, ip_offset: usize, is_v4: bool, egress_ifin
 /// directly to `*const Ipv4Hdr`. Mirrors the `ptr_at` pattern from
 /// main.rs that the verifier accepts.
 #[inline(always)]
-fn mss_clamp_v4(ctx: &XdpContext, ip_offset: usize, egress_ifindex: u32) {
+fn mss_clamp_v4(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifindex: u32) {
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv4Hdr::LEN > end {
@@ -151,12 +162,12 @@ fn mss_clamp_v4(ctx: &XdpContext, ip_offset: usize, egress_ifindex: u32) {
     if clamp == 0 {
         return;
     }
-    mss_clamp_tcp(ctx, ip as *const u8, Ipv4Hdr::LEN, clamp);
+    mss_clamp_tcp(ctx, stats, ip as *const u8, Ipv4Hdr::LEN, clamp);
 }
 
 /// IPv6 path: same pattern as `mss_clamp_v4` but with a 40-byte bound.
 #[inline(always)]
-fn mss_clamp_v6(ctx: &XdpContext, ip_offset: usize, egress_ifindex: u32) {
+fn mss_clamp_v6(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifindex: u32) {
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv6Hdr::LEN > end {
@@ -171,7 +182,7 @@ fn mss_clamp_v6(ctx: &XdpContext, ip_offset: usize, egress_ifindex: u32) {
     if clamp == 0 {
         return;
     }
-    mss_clamp_tcp(ctx, ip as *const u8, Ipv6Hdr::LEN, clamp);
+    mss_clamp_tcp(ctx, stats, ip as *const u8, Ipv6Hdr::LEN, clamp);
 }
 
 /// Walk the TCP-options block of a matched SYN/SYN-ACK and mutate the MSS
@@ -195,7 +206,13 @@ fn mss_clamp_v6(ctx: &XdpContext, ip_offset: usize, egress_ifindex: u32) {
 /// exploration tractable (a 40-iteration walk hit the verifier's
 /// 1M-instruction limit during v0.2.4 development).
 #[inline(always)]
-fn mss_clamp_tcp(ctx: &XdpContext, ip_ptr: *const u8, ip_hdr_size: usize, clamp: u16) {
+fn mss_clamp_tcp(
+    ctx: &XdpContext,
+    stats: StatsPtr,
+    ip_ptr: *const u8,
+    ip_hdr_size: usize,
+    clamp: u16,
+) {
     let start = ctx.data();
     let end = ctx.data_end();
 
@@ -221,7 +238,7 @@ fn mss_clamp_tcp(ctx: &XdpContext, ip_ptr: *const u8, ip_hdr_size: usize, clamp:
     let tcp_hdr_len = doff_words * 4;
     let opts_len = tcp_hdr_len - 20;
     if opts_len == 0 {
-        bump_stat(StatIdx::MssClampSkipped);
+        bump(stats, StatIdx::MssClampSkipped);
         return;
     }
     if start + tcp_offset + tcp_hdr_len > end {
@@ -281,9 +298,9 @@ fn mss_clamp_tcp(ctx: &XdpContext, ip_ptr: *const u8, ip_hdr_size: usize, clamp:
                     *csum_p = new_csum_be[0];
                     *csum_p.add(1) = new_csum_be[1];
                 }
-                bump_stat(StatIdx::MssClampApplied);
+                bump(stats, StatIdx::MssClampApplied);
             } else {
-                bump_stat(StatIdx::MssClampSkipped);
+                bump(stats, StatIdx::MssClampSkipped);
             }
             found = true;
             break;
@@ -292,7 +309,7 @@ fn mss_clamp_tcp(ctx: &XdpContext, ip_ptr: *const u8, ip_hdr_size: usize, clamp:
     }
 
     if !found {
-        bump_stat(StatIdx::MssClampSkipped);
+        bump(stats, StatIdx::MssClampSkipped);
     }
 }
 

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -89,6 +89,11 @@ pub fn finalize(ctx: XdpContext) -> u32 {
     // for a future second VLAN tag without having to revisit this.
     let ip_offset = mctx.ip_offset as usize;
     if ip_offset > MAX_IP_OFFSET {
+        // Previously an uncounted XDP_PASS — and by finalize time the
+        // packet is already mutated (TTL, MACs), so this fail-open is
+        // a half-mutated frame handed to the kernel. Unreachable while
+        // fast_path writes only 14/18; count it so layout drift screams.
+        bump(stats, StatIdx::ErrCtxOffsetRange);
         return xdp_action::XDP_PASS;
     }
 
@@ -125,7 +130,11 @@ pub fn finalize(ctx: XdpContext) -> u32 {
             xdp_action::XDP_REDIRECT
         }
         Err(_) => {
-            bump(stats, StatIdx::ErrFibOther);
+            // Devmap entry vanished between fast_path's pre-check and
+            // here, or the kernel refused the redirect. Dedicated
+            // counter (v0.2.8): this used to bump ErrFibOther, hiding
+            // redirect-time failures inside the FIB-error bucket.
+            bump(stats, StatIdx::ErrRedirectFailed);
             xdp_action::XDP_PASS
         }
     }

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -23,8 +23,8 @@ use aya_ebpf::{
 use network_types::ip::{IpProto, Ipv4Hdr, Ipv6Hdr};
 
 use crate::maps::{
-    bump, stats_base, StatIdx, StatsPtr, CFG, MSS_CLAMP_BY_IFACE, MSS_CLAMP_V4, MSS_CLAMP_V6,
-    MUTATION_CTX, REDIRECT_DEVMAP,
+    bump, stats_base, StatIdx, StatsPtr, FP_CFG_FLAG_MSS_CLAMP_PRESENT, MSS_CLAMP_BY_IFACE,
+    MSS_CLAMP_V4, MSS_CLAMP_V6, MUTATION_CTX, REDIRECT_DEVMAP,
 };
 
 /// 802.1Q TPID. Mirror of `main::TPID_8021Q`; kept local so finalize
@@ -96,7 +96,23 @@ pub fn finalize(ctx: XdpContext) -> u32 {
     // via bpf_xdp_adjust_head). mss-clamp's TCP-options walk relies on
     // ip_offset being valid relative to ctx.data(), true until VLAN
     // push/pop changes the layout.
-    mss_clamp_inline(&ctx, stats, ip_offset, is_v4, egress_ifindex);
+    //
+    // Gated on MSS_CLAMP_PRESENT (carried across the tail call in
+    // mctx.cfg_flags): with no mss-clamp configured, the entire clamp
+    // chain — previously 3 LPM/hash lookups + a CFG read for EVERY
+    // forwarded TCP packet — costs one register test. The bit is set
+    // whenever any clamp source exists, so gating can never skip a
+    // configured clamp.
+    if mctx.cfg_flags & u16::from(FP_CFG_FLAG_MSS_CLAMP_PRESENT) != 0 {
+        mss_clamp_inline(
+            &ctx,
+            stats,
+            ip_offset,
+            is_v4,
+            egress_ifindex,
+            mctx.mss_clamp_global,
+        );
+    }
 
     if apply_vlan_egress(&ctx, ingress_vid, egress_vid).is_err() {
         bump(stats, StatIdx::ErrVlan);
@@ -135,11 +151,12 @@ fn mss_clamp_inline(
     ip_offset: usize,
     is_v4: bool,
     egress_ifindex: u32,
+    global_clamp: u16,
 ) {
     if is_v4 {
-        mss_clamp_v4(ctx, stats, ip_offset, egress_ifindex);
+        mss_clamp_v4(ctx, stats, ip_offset, egress_ifindex, global_clamp);
     } else {
-        mss_clamp_v6(ctx, stats, ip_offset, egress_ifindex);
+        mss_clamp_v6(ctx, stats, ip_offset, egress_ifindex, global_clamp);
     }
 }
 
@@ -147,7 +164,13 @@ fn mss_clamp_inline(
 /// directly to `*const Ipv4Hdr`. Mirrors the `ptr_at` pattern from
 /// main.rs that the verifier accepts.
 #[inline(always)]
-fn mss_clamp_v4(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifindex: u32) {
+fn mss_clamp_v4(
+    ctx: &XdpContext,
+    stats: StatsPtr,
+    ip_offset: usize,
+    egress_ifindex: u32,
+    global_clamp: u16,
+) {
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv4Hdr::LEN > end {
@@ -158,7 +181,16 @@ fn mss_clamp_v4(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifin
     if proto != PROTO_TCP {
         return;
     }
-    let clamp = lookup_mss_clamp_v4(ip, egress_ifindex);
+    // SYN hoist: clamp policy only ever applies to SYN/SYN-ACK, and
+    // established-flow packets are the overwhelming bulk of TCP. Read
+    // the flags byte (2-byte-cheap) BEFORE the up-to-three clamp map
+    // lookups; pre-hoist, every established TCP packet paid all of
+    // them just to bail at the same flag test inside mss_clamp_tcp.
+    // No counter change: non-SYN packets never bumped anything.
+    if !tcp_syn_flag_set(start, end, ip_offset + Ipv4Hdr::LEN) {
+        return;
+    }
+    let clamp = lookup_mss_clamp_v4(ip, egress_ifindex, global_clamp);
     if clamp == 0 {
         return;
     }
@@ -167,7 +199,13 @@ fn mss_clamp_v4(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifin
 
 /// IPv6 path: same pattern as `mss_clamp_v4` but with a 40-byte bound.
 #[inline(always)]
-fn mss_clamp_v6(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifindex: u32) {
+fn mss_clamp_v6(
+    ctx: &XdpContext,
+    stats: StatsPtr,
+    ip_offset: usize,
+    egress_ifindex: u32,
+    global_clamp: u16,
+) {
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv6Hdr::LEN > end {
@@ -178,11 +216,30 @@ fn mss_clamp_v6(ctx: &XdpContext, stats: StatsPtr, ip_offset: usize, egress_ifin
     if proto != PROTO_TCP {
         return;
     }
-    let clamp = lookup_mss_clamp_v6(ip, egress_ifindex);
+    // SYN hoist; see mss_clamp_v4.
+    if !tcp_syn_flag_set(start, end, ip_offset + Ipv6Hdr::LEN) {
+        return;
+    }
+    let clamp = lookup_mss_clamp_v6(ip, egress_ifindex, global_clamp);
     if clamp == 0 {
         return;
     }
     mss_clamp_tcp(ctx, stats, ip as *const u8, Ipv6Hdr::LEN, clamp);
+}
+
+/// Read TCP header byte 13 (flags) at `tcp_offset` and test SYN.
+/// Out-of-bounds → `false` (a truncated TCP header can't be a
+/// clampable SYN; mirrors the fail-open shape of `icmpv6_type` in
+/// main.rs). Bounds check uses the accepted `start + off + k > end`
+/// pattern; `tcp_offset` is `ip_offset + <const HDR>` where fast_path
+/// already clamped `ip_offset` ≤ MAX_IP_OFFSET.
+#[inline(always)]
+fn tcp_syn_flag_set(start: usize, end: usize, tcp_offset: usize) -> bool {
+    if start + tcp_offset + 14 > end {
+        return false;
+    }
+    let flags = unsafe { *((start + tcp_offset + 13) as *const u8) };
+    flags & TCP_FLAG_SYN != 0
 }
 
 /// Walk the TCP-options block of a matched SYN/SYN-ACK and mutate the MSS
@@ -322,7 +379,7 @@ fn csum_replace_u16(old_csum: u16, old_val: u16, new_val: u16) -> u16 {
 }
 
 #[inline(always)]
-fn lookup_mss_clamp_v4(ip: *const Ipv4Hdr, egress_ifindex: u32) -> u16 {
+fn lookup_mss_clamp_v4(ip: *const Ipv4Hdr, egress_ifindex: u32, global_clamp: u16) -> u16 {
     {
         let key = Key::new(32, unsafe { (*ip).src_addr });
         if let Some(entry) = MSS_CLAMP_V4.get(&key) {
@@ -344,14 +401,15 @@ fn lookup_mss_clamp_v4(ip: *const Ipv4Hdr, egress_ifindex: u32) -> u16 {
             return *mss;
         }
     }
-    if let Some(c) = CFG.get(0) {
-        return c.mss_clamp_global;
-    }
-    0
+    // Global fallback from MutationCtx (fast_path's single CFG read);
+    // finalize no longer touches the CFG map. Precedence order among
+    // the four sources (prefix-src, prefix-dst, iface, global) is
+    // unchanged per SPEC.
+    global_clamp
 }
 
 #[inline(always)]
-fn lookup_mss_clamp_v6(ip: *const Ipv6Hdr, egress_ifindex: u32) -> u16 {
+fn lookup_mss_clamp_v6(ip: *const Ipv6Hdr, egress_ifindex: u32, global_clamp: u16) -> u16 {
     {
         let key = Key::new(128, unsafe { (*ip).src_addr });
         if let Some(entry) = MSS_CLAMP_V6.get(&key) {
@@ -373,10 +431,8 @@ fn lookup_mss_clamp_v6(ip: *const Ipv6Hdr, egress_ifindex: u32) -> u16 {
             return *mss;
         }
     }
-    if let Some(c) = CFG.get(0) {
-        return c.mss_clamp_global;
-    }
-    0
+    // See lookup_mss_clamp_v4: global fallback rides in MutationCtx.
+    global_clamp
 }
 
 // --- VLAN choreography (relocated from main.rs in v0.2.5) -----------------

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -284,24 +284,21 @@ fn handle_ipv4(
         return Ok(xdp_action::XDP_PASS);
     }
 
-    let (sport, dport) = l4_ports(ctx, ip_offset + Ipv4Hdr::LEN, proto);
-
     // Option F: select between custom-FIB (LPM trie + NEXTHOPS) and
     // kernel-FIB (bpf_fib_lookup) based on runtime flags. Compare mode
     // runs both and forwards via the kernel result.
     //
-    // `l4_ports` returns BE-in-memory u16s (read_unaligned of BE wire
-    // bytes on an LE host) because that's what bpf_fib_lookup's
-    // `__be16` contract wants. Our own hash operates on native u16
-    // values so it's byte-order-agnostic between BPF and the userspace
-    // reference. Byte-swap once at the handoff.
+    // L4 port extraction is deferred to the consumers: the kernel-FIB
+    // scratch fill below (BE `__be16` contract) and the ECMP hash arm
+    // inside fib::lookup_* (native order, swapped there). The
+    // custom-fib single-nexthop path — the common case — never reads
+    // a port byte.
     let use_custom = cfg_flags & FP_CFG_FLAG_CUSTOM_FIB != 0;
     let compare = cfg_flags & FP_CFG_FLAG_COMPARE_MODE != 0;
-    let sport_h = u16::from_be(sport);
-    let dport_h = u16::from_be(dport);
+    let l4_off = ip_offset + Ipv4Hdr::LEN;
 
     if use_custom && !compare {
-        let custom = fib::lookup_v4(stats, src_bytes, dst_bytes, proto as u8, sport_h, dport_h);
+        let custom = fib::lookup_v4(stats, ctx, l4_off, src_bytes, dst_bytes, proto);
         return dispatch_custom_fib(
             custom,
             ctx,
@@ -314,6 +311,10 @@ fn handle_ipv4(
             ingress_vid,
         );
     }
+
+    // Kernel-FIB path: bpf_fib_lookup wants BE-in-memory `__be16`
+    // ports, which is exactly what `l4_ports` returns.
+    let (sport, dport) = l4_ports(ctx, l4_off, proto);
 
     // Use the per-CPU `FIB_LOOKUP_SCRATCH` map for the bpf_fib_lookup
     // struct rather than allocating it on the stack. Per-CPU array
@@ -374,7 +375,7 @@ fn handle_ipv4(
         // the operator managed to set COMPARE without CUSTOM_FIB (bug
         // or manual map poke), the branch above is unreachable and
         // we still do only the kernel lookup here.
-        let custom = fib::lookup_v4(stats, src_bytes, dst_bytes, proto, sport_h, dport_h);
+        let custom = fib::lookup_v4(stats, ctx, l4_off, src_bytes, dst_bytes, proto);
         compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
@@ -475,17 +476,14 @@ fn handle_ipv6(
         return Ok(xdp_action::XDP_PASS);
     }
 
-    let (sport, dport) = l4_ports(ctx, ip_offset + Ipv6Hdr::LEN, next);
-
     // Option F dispatch, see handle_ipv4 for commentary, including the
-    // port byte-swap rationale.
+    // deferred-port rationale.
     let use_custom = cfg_flags & FP_CFG_FLAG_CUSTOM_FIB != 0;
     let compare = cfg_flags & FP_CFG_FLAG_COMPARE_MODE != 0;
-    let sport_h = u16::from_be(sport);
-    let dport_h = u16::from_be(dport);
+    let l4_off = ip_offset + Ipv6Hdr::LEN;
 
     if use_custom && !compare {
-        let custom = fib::lookup_v6(stats, src_bytes, dst_bytes, next as u8, sport_h, dport_h);
+        let custom = fib::lookup_v6(stats, ctx, l4_off, src_bytes, dst_bytes, next);
         return dispatch_custom_fib(
             custom,
             ctx,
@@ -498,6 +496,8 @@ fn handle_ipv6(
             ingress_vid,
         );
     }
+
+    let (sport, dport) = l4_ports(ctx, l4_off, next);
 
     // See handle_ipv4 for the rationale behind using FIB_LOOKUP_SCRATCH
     // (per-CPU map) instead of stack-allocated bpf_fib_lookup.
@@ -534,7 +534,7 @@ fn handle_ipv6(
     let fib_ref = unsafe { &*fib_ptr };
 
     if compare {
-        let custom = fib::lookup_v6(stats, src_bytes, dst_bytes, next, sport_h, dport_h);
+        let custom = fib::lookup_v6(stats, ctx, l4_off, src_bytes, dst_bytes, next);
         compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
@@ -839,8 +839,9 @@ fn ptr_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<*mut T, ()> {
 /// network-order u16 bytes (via `read_unaligned`) matching what the
 /// kernel's `bpf_fib_lookup` expects for its `__be16` sport/dport
 /// fields on an LE host. (0, 0) for ICMP / ICMPv6 or truncated L4.
+/// `pub(crate)` so fib.rs's ECMP arm can call it at its point of use.
 #[inline(always)]
-fn l4_ports(ctx: &XdpContext, offset: usize, proto: u8) -> (u16, u16) {
+pub(crate) fn l4_ports(ctx: &XdpContext, offset: usize, proto: u8) -> (u16, u16) {
     if !matches!(proto, PROTO_TCP | PROTO_UDP) {
         return (0, 0);
     }

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -94,13 +94,15 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     // Single CFG read for the whole stage. Prior versions re-read
     // CFG.get(0) once per flag test (head-shift, dry-run, custom-fib,
     // compare — four opaque bpf_map_lookup_elem calls per packet that
-    // LLVM cannot CSE); the two scalars now travel in registers.
-    // Absent map (never happens; userspace populates before attach)
-    // degrades to "no flags, no dry-run", matching the old per-call
-    // `unwrap_or(false)` defaults.
-    let (cfg_flags, dry_run) = match CFG.get(0) {
-        Some(c) => (c.flags, c.dry_run != 0),
-        None => (0u8, false),
+    // LLVM cannot CSE); the three scalars now travel in registers.
+    // `mss_clamp_global` rides along so `forward_success` can stash it
+    // (plus the flags byte) in MUTATION_CTX for finalize, which then
+    // never reads CFG at all. Absent map (never happens; userspace
+    // populates before attach) degrades to "no flags, no dry-run",
+    // matching the old per-call `unwrap_or(false)` defaults.
+    let (cfg_flags, dry_run, mss_clamp_global) = match CFG.get(0) {
+        Some(c) => (c.flags, c.dry_run != 0, c.mss_clamp_global),
+        None => (0u8, false, 0u16),
     };
 
     // Pre-parse workaround for the pre-Linux-v6.8 rvu-nicpf XDP path
@@ -136,7 +138,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
         }
     }
 
-    match try_fast_path(&ctx, stats, cfg_flags, dry_run) {
+    match try_fast_path(&ctx, stats, cfg_flags, dry_run, mss_clamp_global) {
         Ok(action) => action,
         Err(()) => {
             bump(stats, StatIdx::ErrParse);
@@ -153,6 +155,7 @@ fn try_fast_path(
     stats: StatsPtr,
     cfg_flags: u8,
     dry_run: bool,
+    mss_clamp_global: u16,
 ) -> Result<u32, ()> {
     let eth: *mut EthHdr = ptr_mut_at(ctx, 0)?;
     let outer_ether = unsafe { (*eth).ether_type };
@@ -178,9 +181,27 @@ fn try_fast_path(
     };
 
     if inner_ether == EtherType::Ipv4 as u16 {
-        handle_ipv4(ctx, stats, cfg_flags, dry_run, eth, ip_offset, ingress_vid)
+        handle_ipv4(
+            ctx,
+            stats,
+            cfg_flags,
+            dry_run,
+            mss_clamp_global,
+            eth,
+            ip_offset,
+            ingress_vid,
+        )
     } else if inner_ether == EtherType::Ipv6 as u16 {
-        handle_ipv6(ctx, stats, cfg_flags, dry_run, eth, ip_offset, ingress_vid)
+        handle_ipv6(
+            ctx,
+            stats,
+            cfg_flags,
+            dry_run,
+            mss_clamp_global,
+            eth,
+            ip_offset,
+            ingress_vid,
+        )
     } else {
         bump(stats, StatIdx::PassNotIp);
         Ok(xdp_action::XDP_PASS)
@@ -194,6 +215,7 @@ fn handle_ipv4(
     stats: StatsPtr,
     cfg_flags: u8,
     dry_run: bool,
+    mss_clamp_global: u16,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -285,6 +307,7 @@ fn handle_ipv4(
             ctx,
             stats,
             cfg_flags,
+            mss_clamp_global,
             eth,
             ip as *mut u8,
             true,
@@ -360,6 +383,7 @@ fn handle_ipv4(
         ctx,
         stats,
         cfg_flags,
+        mss_clamp_global,
         eth,
         ip as *mut u8,
         true,
@@ -375,6 +399,7 @@ fn handle_ipv6(
     stats: StatsPtr,
     cfg_flags: u8,
     dry_run: bool,
+    mss_clamp_global: u16,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -466,6 +491,7 @@ fn handle_ipv6(
             ctx,
             stats,
             cfg_flags,
+            mss_clamp_global,
             eth,
             ip as *mut u8,
             false,
@@ -517,6 +543,7 @@ fn handle_ipv6(
         ctx,
         stats,
         cfg_flags,
+        mss_clamp_global,
         eth,
         ip as *mut u8,
         false,
@@ -532,6 +559,7 @@ fn dispatch_fib(
     ctx: &XdpContext,
     stats: StatsPtr,
     cfg_flags: u8,
+    mss_clamp_global: u16,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -543,6 +571,7 @@ fn dispatch_fib(
             ctx,
             stats,
             cfg_flags,
+            mss_clamp_global,
             eth,
             ip,
             is_v4,
@@ -587,6 +616,7 @@ fn forward_success(
     ctx: &XdpContext,
     stats: StatsPtr,
     cfg_flags: u8,
+    mss_clamp_global: u16,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -656,6 +686,11 @@ fn forward_success(
             // Single u32 store, LLVM has no adjacent zero stores to
             // merge into a memset libcall.
             (*mctx_ptr).is_v4 = u32::from(u8::from(is_v4));
+            // CFG state for finalize: flags byte widened into the u16
+            // slot (upper byte explicitly zero via the From) + the
+            // global clamp fallback. Individual stores, no memset bait.
+            (*mctx_ptr).cfg_flags = u16::from(cfg_flags);
+            (*mctx_ptr).mss_clamp_global = mss_clamp_global;
         }
     } else {
         // Per-CPU array index 0 is always present; this branch should
@@ -687,6 +722,7 @@ fn dispatch_custom_fib(
     ctx: &XdpContext,
     stats: StatsPtr,
     cfg_flags: u8,
+    mss_clamp_global: u16,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -697,6 +733,7 @@ fn dispatch_custom_fib(
             ctx,
             stats,
             cfg_flags,
+            mss_clamp_global,
             eth,
             ip,
             is_v4,

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -17,16 +17,14 @@ use aya_ebpf::{
         BPF_FIB_LKUP_RET_NO_NEIGH, BPF_FIB_LKUP_RET_PROHIBIT, BPF_FIB_LKUP_RET_SUCCESS,
         BPF_FIB_LKUP_RET_UNREACHABLE,
     },
-    helpers::{
-        bpf_fib_lookup as fib_lookup_helper, bpf_xdp_adjust_head, bpf_xdp_adjust_tail,
-    },
+    helpers::{bpf_fib_lookup as fib_lookup_helper, bpf_xdp_adjust_head, bpf_xdp_adjust_tail},
     macros::xdp,
     maps::lpm_trie::Key,
     programs::XdpContext,
 };
 use core::mem;
 use network_types::{
-    eth::{EtherType, EthHdr},
+    eth::{EthHdr, EtherType},
     ip::{IpProto, Ipv4Hdr, Ipv6Hdr},
 };
 
@@ -35,9 +33,9 @@ mod finalize;
 mod maps;
 
 use maps::{
-    bump_stat, StatIdx, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG, FIB_LOOKUP_SCRATCH,
-    FP_CFG_FLAG_COMPARE_MODE, FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_HEAD_SHIFT_128, MUTATION_CTX,
-    MUTATION_PROGS, REDIRECT_DEVMAP, VLAN_RESOLVE,
+    bump, stats_base, StatIdx, StatsPtr, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG,
+    FIB_LOOKUP_SCRATCH, FP_CFG_FLAG_COMPARE_MODE, FP_CFG_FLAG_CUSTOM_FIB,
+    FP_CFG_FLAG_HEAD_SHIFT_128, MUTATION_CTX, MUTATION_PROGS, REDIRECT_DEVMAP, VLAN_RESOLVE,
 };
 
 const AF_INET: u8 = 2;
@@ -82,7 +80,15 @@ const VLAN_HDR_LEN: usize = 4;
 
 #[xdp]
 pub fn fast_path(ctx: XdpContext) -> u32 {
-    bump_stat(StatIdx::RxTotal);
+    // Single STATS lookup for this whole program stage; every counter
+    // bump below is a constant-offset increment on this pointer. The
+    // `None` branch is unreachable (index 0 of a 1-entry per-CPU array
+    // always exists); fail open so traffic falls to the kernel.
+    let stats = match stats_base() {
+        Some(s) => s,
+        None => return xdp_action::XDP_PASS,
+    };
+    bump(stats, StatIdx::RxTotal);
 
     // Pre-parse workaround for the pre-Linux-v6.8 rvu-nicpf XDP path
     // bug (SPEC §11.1(c)). The driver passes
@@ -102,7 +108,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     if unsafe { cfg_has_flag(FP_CFG_FLAG_HEAD_SHIFT_128) } {
         let rc = unsafe { bpf_xdp_adjust_head(ctx.ctx as *mut _, 128) };
         if rc != 0 {
-            bump_stat(StatIdx::ErrHeadShift);
+            bump(stats, StatIdx::ErrHeadShift);
             return xdp_action::XDP_PASS;
         }
         // `adjust_tail(+128)` can fail if the current frame is close
@@ -112,15 +118,15 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
         // has half-mutated (SPEC §11.13).
         let rc = unsafe { bpf_xdp_adjust_tail(ctx.ctx as *mut _, 128) };
         if rc != 0 {
-            bump_stat(StatIdx::ErrHeadShift);
+            bump(stats, StatIdx::ErrHeadShift);
             return xdp_action::XDP_PASS;
         }
     }
 
-    match try_fast_path(&ctx) {
+    match try_fast_path(&ctx, stats) {
         Ok(action) => action,
         Err(()) => {
-            bump_stat(StatIdx::ErrParse);
+            bump(stats, StatIdx::ErrParse);
             xdp_action::XDP_PASS
         }
     }
@@ -137,7 +143,7 @@ unsafe fn cfg_has_flag(bit: u8) -> bool {
 /// Returns Err(()) on bounds-check failure (always counted as
 /// `err_parse` → `XDP_PASS`), Ok(action) for everything else.
 #[inline(always)]
-fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
+fn try_fast_path(ctx: &XdpContext, stats: StatsPtr) -> Result<u32, ()> {
     let eth: *mut EthHdr = ptr_mut_at(ctx, 0)?;
     let outer_ether = unsafe { (*eth).ether_type };
 
@@ -162,11 +168,11 @@ fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
     };
 
     if inner_ether == EtherType::Ipv4 as u16 {
-        handle_ipv4(ctx, eth, ip_offset, ingress_vid)
+        handle_ipv4(ctx, stats, eth, ip_offset, ingress_vid)
     } else if inner_ether == EtherType::Ipv6 as u16 {
-        handle_ipv6(ctx, eth, ip_offset, ingress_vid)
+        handle_ipv6(ctx, stats, eth, ip_offset, ingress_vid)
     } else {
-        bump_stat(StatIdx::PassNotIp);
+        bump(stats, StatIdx::PassNotIp);
         Ok(xdp_action::XDP_PASS)
     }
 }
@@ -174,6 +180,7 @@ fn try_fast_path(ctx: &XdpContext) -> Result<u32, ()> {
 #[inline(always)]
 fn handle_ipv4(
     ctx: &XdpContext,
+    stats: StatsPtr,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -184,20 +191,20 @@ fn handle_ipv4(
     // anything else means options → kernel slow path.
     let ihl_bytes = unsafe { (*ip).ihl() };
     if ihl_bytes != 20 {
-        bump_stat(StatIdx::PassComplexHeader);
+        bump(stats, StatIdx::PassComplexHeader);
         return Ok(xdp_action::XDP_PASS);
     }
 
     // Fragment check: MF bit (0x2000) or non-zero offset (low 13 bits).
     let frags_be = u16::from_be_bytes(unsafe { (*ip).frags });
     if (frags_be & 0x3fff) != 0 {
-        bump_stat(StatIdx::PassFragment);
+        bump(stats, StatIdx::PassFragment);
         return Ok(xdp_action::XDP_PASS);
     }
 
     let ttl = unsafe { (*ip).ttl };
     if ttl <= 1 {
-        bump_stat(StatIdx::PassLowTtl);
+        bump(stats, StatIdx::PassLowTtl);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -214,8 +221,8 @@ fn handle_ipv4(
         return Ok(xdp_action::XDP_PASS);
     }
 
-    bump_stat(StatIdx::MatchedV4);
-    bump_match_subset(src_hit, dst_hit);
+    bump(stats, StatIdx::MatchedV4);
+    bump_match_subset(stats, src_hit, dst_hit);
 
     // v0.2.1 issue #33: bogon block. After allowlist match (so we only
     // affect traffic we'd otherwise touch), check if dst falls in any
@@ -229,12 +236,12 @@ fn handle_ipv4(
     // in the bogon range, e.g. Tailscale DERP relay responses) which
     // is worse than the operator's intent.
     if BLOCK_V4.get(&dst_key).is_some() {
-        bump_stat(StatIdx::BogonDropped);
+        bump(stats, StatIdx::BogonDropped);
         return Ok(xdp_action::XDP_DROP);
     }
 
     if is_dry_run() {
-        bump_stat(StatIdx::FwdDryRun);
+        bump(stats, StatIdx::FwdDryRun);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -255,8 +262,8 @@ fn handle_ipv4(
     let dport_h = u16::from_be(dport);
 
     if use_custom && !compare {
-        let custom = fib::lookup_v4(src_bytes, dst_bytes, proto as u8, sport_h, dport_h);
-        return dispatch_custom_fib(custom, ctx, eth, ip as *mut u8, true, ingress_vid);
+        let custom = fib::lookup_v4(stats, src_bytes, dst_bytes, proto as u8, sport_h, dport_h);
+        return dispatch_custom_fib(custom, ctx, stats, eth, ip as *mut u8, true, ingress_vid);
     }
 
     // Use the per-CPU `FIB_LOOKUP_SCRATCH` map for the bpf_fib_lookup
@@ -277,7 +284,7 @@ fn handle_ipv4(
             // Per-CPU array index 0 is always present; this branch is
             // unreachable in practice. Fail-safe XDP_PASS so traffic
             // falls to kernel slow-path rather than getting dropped.
-            bump_stat(StatIdx::ErrFibOther);
+            bump(stats, StatIdx::ErrFibOther);
             return Ok(xdp_action::XDP_PASS);
         }
     };
@@ -318,16 +325,26 @@ fn handle_ipv4(
         // the operator managed to set COMPARE without CUSTOM_FIB (bug
         // or manual map poke), the branch above is unreachable and
         // we still do only the kernel lookup here.
-        let custom = fib::lookup_v4(src_bytes, dst_bytes, proto, sport_h, dport_h);
-        compare_and_bump(ret as u32, fib_ref, &custom);
+        let custom = fib::lookup_v4(stats, src_bytes, dst_bytes, proto, sport_h, dport_h);
+        compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
-    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, true, fib_ref, ingress_vid)
+    dispatch_fib(
+        ret as u32,
+        ctx,
+        stats,
+        eth,
+        ip as *mut u8,
+        true,
+        fib_ref,
+        ingress_vid,
+    )
 }
 
 #[inline(always)]
 fn handle_ipv6(
     ctx: &XdpContext,
+    stats: StatsPtr,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -338,7 +355,7 @@ fn handle_ipv6(
     match next {
         PROTO_TCP | PROTO_UDP | PROTO_ICMPV6 => {}
         _ => {
-            bump_stat(StatIdx::PassComplexHeader);
+            bump(stats, StatIdx::PassComplexHeader);
             return Ok(xdp_action::XDP_PASS);
         }
     }
@@ -364,7 +381,7 @@ fn handle_ipv6(
     if next == PROTO_ICMPV6 {
         if let Some(t) = icmpv6_type(ctx, ip_offset + Ipv6Hdr::LEN) {
             if t >= ICMPV6_ND_TYPE_MIN && t <= ICMPV6_ND_TYPE_MAX {
-                bump_stat(StatIdx::PassNdp);
+                bump(stats, StatIdx::PassNdp);
                 return Ok(xdp_action::XDP_PASS);
             }
         }
@@ -372,7 +389,7 @@ fn handle_ipv6(
 
     let hop_limit = unsafe { (*ip).hop_limit };
     if hop_limit <= 1 {
-        bump_stat(StatIdx::PassLowTtl);
+        bump(stats, StatIdx::PassLowTtl);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -388,17 +405,17 @@ fn handle_ipv6(
         return Ok(xdp_action::XDP_PASS);
     }
 
-    bump_stat(StatIdx::MatchedV6);
-    bump_match_subset(src_hit, dst_hit);
+    bump(stats, StatIdx::MatchedV6);
+    bump_match_subset(stats, src_hit, dst_hit);
 
     // v0.2.1 issue #33: bogon block (IPv6 side).
     if BLOCK_V6.get(&dst_key).is_some() {
-        bump_stat(StatIdx::BogonDropped);
+        bump(stats, StatIdx::BogonDropped);
         return Ok(xdp_action::XDP_DROP);
     }
 
     if is_dry_run() {
-        bump_stat(StatIdx::FwdDryRun);
+        bump(stats, StatIdx::FwdDryRun);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -412,8 +429,8 @@ fn handle_ipv6(
     let dport_h = u16::from_be(dport);
 
     if use_custom && !compare {
-        let custom = fib::lookup_v6(src_bytes, dst_bytes, next as u8, sport_h, dport_h);
-        return dispatch_custom_fib(custom, ctx, eth, ip as *mut u8, false, ingress_vid);
+        let custom = fib::lookup_v6(stats, src_bytes, dst_bytes, next as u8, sport_h, dport_h);
+        return dispatch_custom_fib(custom, ctx, stats, eth, ip as *mut u8, false, ingress_vid);
     }
 
     // See handle_ipv4 for the rationale behind using FIB_LOOKUP_SCRATCH
@@ -421,7 +438,7 @@ fn handle_ipv6(
     let fib_ptr = match FIB_LOOKUP_SCRATCH.get_ptr_mut(0) {
         Some(p) => p,
         None => {
-            bump_stat(StatIdx::ErrFibOther);
+            bump(stats, StatIdx::ErrFibOther);
             return Ok(xdp_action::XDP_PASS);
         }
     };
@@ -451,17 +468,28 @@ fn handle_ipv6(
     let fib_ref = unsafe { &*fib_ptr };
 
     if compare {
-        let custom = fib::lookup_v6(src_bytes, dst_bytes, next, sport_h, dport_h);
-        compare_and_bump(ret as u32, fib_ref, &custom);
+        let custom = fib::lookup_v6(stats, src_bytes, dst_bytes, next, sport_h, dport_h);
+        compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
-    dispatch_fib(ret as u32, ctx, eth, ip as *mut u8, false, fib_ref, ingress_vid)
+    dispatch_fib(
+        ret as u32,
+        ctx,
+        stats,
+        eth,
+        ip as *mut u8,
+        false,
+        fib_ref,
+        ingress_vid,
+    )
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn dispatch_fib(
     ret: u32,
     ctx: &XdpContext,
+    stats: StatsPtr,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -469,25 +497,31 @@ fn dispatch_fib(
     ingress_vid: u16,
 ) -> Result<u32, ()> {
     match ret {
-        BPF_FIB_LKUP_RET_SUCCESS => {
-            forward_success(ctx, eth, ip, is_v4, fib.ifindex, fib.smac, fib.dmac, ingress_vid)
-        }
+        BPF_FIB_LKUP_RET_SUCCESS => forward_success(
+            ctx,
+            stats,
+            eth,
+            ip,
+            is_v4,
+            fib.ifindex,
+            fib.smac,
+            fib.dmac,
+            ingress_vid,
+        ),
         BPF_FIB_LKUP_RET_NO_NEIGH => {
-            bump_stat(StatIdx::PassNoNeigh);
+            bump(stats, StatIdx::PassNoNeigh);
             Ok(xdp_action::XDP_PASS)
         }
-        BPF_FIB_LKUP_RET_BLACKHOLE
-        | BPF_FIB_LKUP_RET_UNREACHABLE
-        | BPF_FIB_LKUP_RET_PROHIBIT => {
-            bump_stat(StatIdx::DropUnreachable);
+        BPF_FIB_LKUP_RET_BLACKHOLE | BPF_FIB_LKUP_RET_UNREACHABLE | BPF_FIB_LKUP_RET_PROHIBIT => {
+            bump(stats, StatIdx::DropUnreachable);
             Ok(xdp_action::XDP_DROP)
         }
         BPF_FIB_LKUP_RET_FRAG_NEEDED => {
-            bump_stat(StatIdx::PassFragNeeded);
+            bump(stats, StatIdx::PassFragNeeded);
             Ok(xdp_action::XDP_PASS)
         }
         _ => {
-            bump_stat(StatIdx::ErrFibOther);
+            bump(stats, StatIdx::ErrFibOther);
             Ok(xdp_action::XDP_PASS)
         }
     }
@@ -505,8 +539,10 @@ fn dispatch_fib(
 /// stricter accounting. Splitting gives finalize its own 512-byte
 /// stack budget. See SPEC §4.x "Two-stage BPF datapath."
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn forward_success(
     ctx: &XdpContext,
+    stats: StatsPtr,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -533,7 +569,7 @@ fn forward_success(
     // on the reference EFG 2026-04-21. If we can't redirect, we must
     // leave the packet pristine.
     if REDIRECT_DEVMAP.get(egress_ifindex).is_none() {
-        bump_stat(StatIdx::PassNotInDevmap);
+        bump(stats, StatIdx::PassNotInDevmap);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -573,7 +609,7 @@ fn forward_success(
         // Per-CPU array index 0 is always present; this branch should
         // be unreachable. Fail-safe XDP_PASS so traffic falls to kernel
         // rather than getting blackholed.
-        bump_stat(StatIdx::ErrMutationCtx);
+        bump(stats, StatIdx::ErrMutationCtx);
         return Ok(xdp_action::XDP_PASS);
     }
 
@@ -583,7 +619,7 @@ fn forward_success(
     // somehow skipped slot 0, traffic falls through to kernel rather
     // than getting silently dropped.
     let _ = unsafe { MUTATION_PROGS.tail_call(ctx, 0) };
-    bump_stat(StatIdx::ErrTailCall);
+    bump(stats, StatIdx::ErrTailCall);
     Ok(xdp_action::XDP_PASS)
 }
 
@@ -596,6 +632,7 @@ fn forward_success(
 fn dispatch_custom_fib(
     result: fib::CustomFibResult,
     ctx: &XdpContext,
+    stats: StatsPtr,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -604,6 +641,7 @@ fn dispatch_custom_fib(
     match result.action {
         fib::FIB_ACTION_FORWARD => forward_success(
             ctx,
+            stats,
             eth,
             ip,
             is_v4,
@@ -613,11 +651,11 @@ fn dispatch_custom_fib(
             ingress_vid,
         ),
         fib::FIB_ACTION_NO_NEIGH => {
-            bump_stat(StatIdx::PassNoNeigh);
+            bump(stats, StatIdx::PassNoNeigh);
             Ok(xdp_action::XDP_PASS)
         }
         fib::FIB_ACTION_DROP => {
-            bump_stat(StatIdx::DropUnreachable);
+            bump(stats, StatIdx::DropUnreachable);
             Ok(xdp_action::XDP_DROP)
         }
         // FIB_ACTION_MISS or any unexpected action.
@@ -633,6 +671,7 @@ fn dispatch_custom_fib(
 /// expected; the userspace alert thresholds are set ratio-based.
 #[inline(always)]
 fn compare_and_bump(
+    stats: StatsPtr,
     kernel_ret: u32,
     kernel_fib: &bpf_fib_lookup,
     custom: &fib::CustomFibResult,
@@ -648,9 +687,9 @@ fn compare_and_bump(
         !kernel_forwards && !custom_forwards
     };
     if agree {
-        bump_stat(StatIdx::CompareAgree);
+        bump(stats, StatIdx::CompareAgree);
     } else {
-        bump_stat(StatIdx::CompareDisagree);
+        bump(stats, StatIdx::CompareDisagree);
     }
 }
 
@@ -679,11 +718,11 @@ fn decrement_ipv6_hop_limit(ip: *mut Ipv6Hdr) {
 }
 
 #[inline(always)]
-fn bump_match_subset(src_hit: bool, dst_hit: bool) {
+fn bump_match_subset(stats: StatsPtr, src_hit: bool, dst_hit: bool) {
     match (src_hit, dst_hit) {
-        (true, true) => bump_stat(StatIdx::MatchedBoth),
-        (true, false) => bump_stat(StatIdx::MatchedSrcOnly),
-        (false, true) => bump_stat(StatIdx::MatchedDstOnly),
+        (true, true) => bump(stats, StatIdx::MatchedBoth),
+        (true, false) => bump(stats, StatIdx::MatchedSrcOnly),
+        (false, true) => bump(stats, StatIdx::MatchedDstOnly),
         (false, false) => {}
     }
 }

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -34,8 +34,9 @@ mod maps;
 
 use maps::{
     bump, stats_base, StatIdx, StatsPtr, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG,
-    FIB_LOOKUP_SCRATCH, FP_CFG_FLAG_COMPARE_MODE, FP_CFG_FLAG_CUSTOM_FIB,
-    FP_CFG_FLAG_HEAD_SHIFT_128, MUTATION_CTX, MUTATION_PROGS, REDIRECT_DEVMAP, VLAN_RESOLVE,
+    FIB_LOOKUP_SCRATCH, FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_COMPARE_MODE,
+    FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT, MUTATION_CTX,
+    MUTATION_PROGS, REDIRECT_DEVMAP, VLAN_RESOLVE,
 };
 
 const AF_INET: u8 = 2;
@@ -90,6 +91,18 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     };
     bump(stats, StatIdx::RxTotal);
 
+    // Single CFG read for the whole stage. Prior versions re-read
+    // CFG.get(0) once per flag test (head-shift, dry-run, custom-fib,
+    // compare — four opaque bpf_map_lookup_elem calls per packet that
+    // LLVM cannot CSE); the two scalars now travel in registers.
+    // Absent map (never happens; userspace populates before attach)
+    // degrades to "no flags, no dry-run", matching the old per-call
+    // `unwrap_or(false)` defaults.
+    let (cfg_flags, dry_run) = match CFG.get(0) {
+        Some(c) => (c.flags, c.dry_run != 0),
+        None => (0u8, false),
+    };
+
     // Pre-parse workaround for the pre-Linux-v6.8 rvu-nicpf XDP path
     // bug (SPEC §11.1(c)). The driver passes
     // `xdp_prepare_buff(&xdp, hard_start, data - hard_start, seg_size, false)`
@@ -105,7 +118,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     // Scoped behind a CFG flag so correct drivers pay zero runtime
     // cost. Userspace sets the flag per attach iface's driver
     // (§11.12 compat matrix).
-    if unsafe { cfg_has_flag(FP_CFG_FLAG_HEAD_SHIFT_128) } {
+    if cfg_flags & FP_CFG_FLAG_HEAD_SHIFT_128 != 0 {
         let rc = unsafe { bpf_xdp_adjust_head(ctx.ctx as *mut _, 128) };
         if rc != 0 {
             bump(stats, StatIdx::ErrHeadShift);
@@ -123,7 +136,7 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
         }
     }
 
-    match try_fast_path(&ctx, stats) {
+    match try_fast_path(&ctx, stats, cfg_flags, dry_run) {
         Ok(action) => action,
         Err(()) => {
             bump(stats, StatIdx::ErrParse);
@@ -132,18 +145,15 @@ pub fn fast_path(ctx: XdpContext) -> u32 {
     }
 }
 
-/// Read the `FpCfg.flags` byte via the CFG array map and check
-/// whether `bit` is set. Returns `false` if the map is somehow empty
-/// (shouldn't happen, userspace always populates it before attach).
-#[inline(always)]
-unsafe fn cfg_has_flag(bit: u8) -> bool {
-    CFG.get(0).map(|c| c.flags & bit != 0).unwrap_or(false)
-}
-
 /// Returns Err(()) on bounds-check failure (always counted as
 /// `err_parse` → `XDP_PASS`), Ok(action) for everything else.
 #[inline(always)]
-fn try_fast_path(ctx: &XdpContext, stats: StatsPtr) -> Result<u32, ()> {
+fn try_fast_path(
+    ctx: &XdpContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
+) -> Result<u32, ()> {
     let eth: *mut EthHdr = ptr_mut_at(ctx, 0)?;
     let outer_ether = unsafe { (*eth).ether_type };
 
@@ -168,9 +178,9 @@ fn try_fast_path(ctx: &XdpContext, stats: StatsPtr) -> Result<u32, ()> {
     };
 
     if inner_ether == EtherType::Ipv4 as u16 {
-        handle_ipv4(ctx, stats, eth, ip_offset, ingress_vid)
+        handle_ipv4(ctx, stats, cfg_flags, dry_run, eth, ip_offset, ingress_vid)
     } else if inner_ether == EtherType::Ipv6 as u16 {
-        handle_ipv6(ctx, stats, eth, ip_offset, ingress_vid)
+        handle_ipv6(ctx, stats, cfg_flags, dry_run, eth, ip_offset, ingress_vid)
     } else {
         bump(stats, StatIdx::PassNotIp);
         Ok(xdp_action::XDP_PASS)
@@ -178,9 +188,12 @@ fn try_fast_path(ctx: &XdpContext, stats: StatsPtr) -> Result<u32, ()> {
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn handle_ipv4(
     ctx: &XdpContext,
     stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -235,12 +248,16 @@ fn handle_ipv4(
     // drop reply traffic (asymmetric flows where the *other* side is
     // in the bogon range, e.g. Tailscale DERP relay responses) which
     // is worse than the operator's intent.
-    if BLOCK_V4.get(&dst_key).is_some() {
+    //
+    // Gated on BLOCK_PRESENT: with no `block-prefix` configured the
+    // trie is empty and can never hit, so skipping the lookup is
+    // semantics-free and saves one LPM helper call per matched packet.
+    if cfg_flags & FP_CFG_FLAG_BLOCK_PRESENT != 0 && BLOCK_V4.get(&dst_key).is_some() {
         bump(stats, StatIdx::BogonDropped);
         return Ok(xdp_action::XDP_DROP);
     }
 
-    if is_dry_run() {
+    if dry_run {
         bump(stats, StatIdx::FwdDryRun);
         return Ok(xdp_action::XDP_PASS);
     }
@@ -256,14 +273,23 @@ fn handle_ipv4(
     // `__be16` contract wants. Our own hash operates on native u16
     // values so it's byte-order-agnostic between BPF and the userspace
     // reference. Byte-swap once at the handoff.
-    let use_custom = unsafe { cfg_has_flag(FP_CFG_FLAG_CUSTOM_FIB) };
-    let compare = unsafe { cfg_has_flag(FP_CFG_FLAG_COMPARE_MODE) };
+    let use_custom = cfg_flags & FP_CFG_FLAG_CUSTOM_FIB != 0;
+    let compare = cfg_flags & FP_CFG_FLAG_COMPARE_MODE != 0;
     let sport_h = u16::from_be(sport);
     let dport_h = u16::from_be(dport);
 
     if use_custom && !compare {
         let custom = fib::lookup_v4(stats, src_bytes, dst_bytes, proto as u8, sport_h, dport_h);
-        return dispatch_custom_fib(custom, ctx, stats, eth, ip as *mut u8, true, ingress_vid);
+        return dispatch_custom_fib(
+            custom,
+            ctx,
+            stats,
+            cfg_flags,
+            eth,
+            ip as *mut u8,
+            true,
+            ingress_vid,
+        );
     }
 
     // Use the per-CPU `FIB_LOOKUP_SCRATCH` map for the bpf_fib_lookup
@@ -333,6 +359,7 @@ fn handle_ipv4(
         ret as u32,
         ctx,
         stats,
+        cfg_flags,
         eth,
         ip as *mut u8,
         true,
@@ -342,9 +369,12 @@ fn handle_ipv4(
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn handle_ipv6(
     ctx: &XdpContext,
     stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
     eth: *mut EthHdr,
     ip_offset: usize,
     ingress_vid: u16,
@@ -408,13 +438,14 @@ fn handle_ipv6(
     bump(stats, StatIdx::MatchedV6);
     bump_match_subset(stats, src_hit, dst_hit);
 
-    // v0.2.1 issue #33: bogon block (IPv6 side).
-    if BLOCK_V6.get(&dst_key).is_some() {
+    // v0.2.1 issue #33: bogon block (IPv6 side). Gated on
+    // BLOCK_PRESENT, see handle_ipv4.
+    if cfg_flags & FP_CFG_FLAG_BLOCK_PRESENT != 0 && BLOCK_V6.get(&dst_key).is_some() {
         bump(stats, StatIdx::BogonDropped);
         return Ok(xdp_action::XDP_DROP);
     }
 
-    if is_dry_run() {
+    if dry_run {
         bump(stats, StatIdx::FwdDryRun);
         return Ok(xdp_action::XDP_PASS);
     }
@@ -423,14 +454,23 @@ fn handle_ipv6(
 
     // Option F dispatch, see handle_ipv4 for commentary, including the
     // port byte-swap rationale.
-    let use_custom = unsafe { cfg_has_flag(FP_CFG_FLAG_CUSTOM_FIB) };
-    let compare = unsafe { cfg_has_flag(FP_CFG_FLAG_COMPARE_MODE) };
+    let use_custom = cfg_flags & FP_CFG_FLAG_CUSTOM_FIB != 0;
+    let compare = cfg_flags & FP_CFG_FLAG_COMPARE_MODE != 0;
     let sport_h = u16::from_be(sport);
     let dport_h = u16::from_be(dport);
 
     if use_custom && !compare {
         let custom = fib::lookup_v6(stats, src_bytes, dst_bytes, next as u8, sport_h, dport_h);
-        return dispatch_custom_fib(custom, ctx, stats, eth, ip as *mut u8, false, ingress_vid);
+        return dispatch_custom_fib(
+            custom,
+            ctx,
+            stats,
+            cfg_flags,
+            eth,
+            ip as *mut u8,
+            false,
+            ingress_vid,
+        );
     }
 
     // See handle_ipv4 for the rationale behind using FIB_LOOKUP_SCRATCH
@@ -476,6 +516,7 @@ fn handle_ipv6(
         ret as u32,
         ctx,
         stats,
+        cfg_flags,
         eth,
         ip as *mut u8,
         false,
@@ -490,6 +531,7 @@ fn dispatch_fib(
     ret: u32,
     ctx: &XdpContext,
     stats: StatsPtr,
+    cfg_flags: u8,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -500,6 +542,7 @@ fn dispatch_fib(
         BPF_FIB_LKUP_RET_SUCCESS => forward_success(
             ctx,
             stats,
+            cfg_flags,
             eth,
             ip,
             is_v4,
@@ -543,6 +586,7 @@ fn dispatch_fib(
 fn forward_success(
     ctx: &XdpContext,
     stats: StatsPtr,
+    cfg_flags: u8,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -555,9 +599,17 @@ fn forward_success(
     // recorded in `vlan_resolve`, it's a VLAN subif, redirect to the
     // physical parent and push/rewrite to the recorded VID. Otherwise
     // the target is physical/untagged.
-    let (egress_ifindex, egress_vid) = match unsafe { VLAN_RESOLVE.get(&ifindex) } {
-        Some(vi) => (vi.phys_ifindex, vi.vid),
-        None => (ifindex, VLAN_NONE),
+    //
+    // Gated on VLAN_PRESENT: with no VLAN subifs on the host the map
+    // is empty and every lookup would miss, so the gate skips one hash
+    // helper call per forwarded packet with identical semantics.
+    let (egress_ifindex, egress_vid) = if cfg_flags & FP_CFG_FLAG_VLAN_PRESENT != 0 {
+        match unsafe { VLAN_RESOLVE.get(&ifindex) } {
+            Some(vi) => (vi.phys_ifindex, vi.vid),
+            None => (ifindex, VLAN_NONE),
+        }
+    } else {
+        (ifindex, VLAN_NONE)
     };
 
     // Defensive devmap pre-check (§4.4 step 9d), **before any packet
@@ -629,10 +681,12 @@ fn forward_success(
 /// so the allowlist / dry-run / VLAN-resolve plumbing upstream and
 /// downstream is unchanged whether we took the kernel or custom path.
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn dispatch_custom_fib(
     result: fib::CustomFibResult,
     ctx: &XdpContext,
     stats: StatsPtr,
+    cfg_flags: u8,
     eth: *mut EthHdr,
     ip: *mut u8,
     is_v4: bool,
@@ -642,6 +696,7 @@ fn dispatch_custom_fib(
         fib::FIB_ACTION_FORWARD => forward_success(
             ctx,
             stats,
+            cfg_flags,
             eth,
             ip,
             is_v4,
@@ -725,11 +780,6 @@ fn bump_match_subset(stats: StatsPtr, src_hit: bool, dst_hit: bool) {
         (false, true) => bump(stats, StatIdx::MatchedDstOnly),
         (false, false) => {}
     }
-}
-
-#[inline(always)]
-fn is_dry_run() -> bool {
-    CFG.get(0).map(|c| c.dry_run != 0).unwrap_or(false)
 }
 
 #[inline(always)]

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -159,12 +159,28 @@ pub enum StatIdx {
     /// `local-prefix6`, since that installs the /128s that would
     /// otherwise make host-to-host NDP FIB-eligible.
     PassNdp = 37,
+    /// finalize read a `MUTATION_CTX.ip_offset` above `MAX_IP_OFFSET`
+    /// (64) and XDP_PASSed a packet fast_path had already mutated
+    /// (TTL decremented, MACs rewritten). Should be 0 in steady state
+    /// — fast_path only ever writes 14 or 18 — so any non-zero value
+    /// means fast_path/finalize disagree about the context layout.
+    /// This path previously passed with NO counter at all, making the
+    /// half-mutated-frame hazard invisible.
+    ErrCtxOffsetRange = 38,
+    /// `bpf_redirect_map` failed in finalize after the fast_path
+    /// devmap pre-check had passed (entry removed in the microscopic
+    /// window between the two, or a kernel-level redirect failure).
+    /// The packet XDP_PASSes to the kernel already mutated.
+    /// Previously mislabeled as `ErrFibOther`, which made a
+    /// redirect-time failure indistinguishable from a FIB-lookup
+    /// failure.
+    ErrRedirectFailed = 39,
 }
 
 /// Total counter count. Sizes the `[u64; N]` value of the single-entry
 /// `STATS` per-CPU map. New counters bump this; dashboards keying on
 /// indices keep working.
-pub const STATS_COUNT: u32 = 38;
+pub const STATS_COUNT: u32 = 40;
 
 /// `STATS_COUNT` as usize, for the array-of-counters value type.
 pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -161,9 +161,19 @@ pub enum StatIdx {
     PassNdp = 37,
 }
 
-/// Total counter count. Used as `stats` map `max_entries`. New counters
-/// bump this; dashboards keying on indices keep working.
+/// Total counter count. Sizes the `[u64; N]` value of the single-entry
+/// `STATS` per-CPU map. New counters bump this; dashboards keying on
+/// indices keep working.
 pub const STATS_COUNT: u32 = 38;
+
+/// `STATS_COUNT` as usize, for the array-of-counters value type.
+pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;
+
+/// Pointer to this CPU's counter block, fetched once per program stage
+/// via [`stats_base`]. Threaded through the (fully inlined) call chain
+/// so counter bumps are plain constant-offset increments instead of
+/// one `bpf_map_lookup_elem` helper call each.
+pub type StatsPtr = *mut [u64; STATS_COUNT_USIZE];
 
 /// Flag bits for `FpCfg.flags`. Bits 0-1 are the IPv4/IPv6 enable
 /// mask (historical, load-bearing for dashboards). Bit 2 is the
@@ -450,13 +460,11 @@ impl FpFibCfg {
 /// `{prefix_len: u32, addr: [u8;4]}` via `LpmTrie`'s `Key<T>`.
 /// Value is the truthiness byte; only presence is consulted.
 #[map]
-pub static ALLOW_V4: LpmTrie<[u8; 4], u8> =
-    LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
+pub static ALLOW_V4: LpmTrie<[u8; 4], u8> = LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
 
 /// IPv6 allowlist. Same semantics, 16-byte address.
 #[map]
-pub static ALLOW_V6: LpmTrie<[u8; 16], u8> =
-    LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
+pub static ALLOW_V6: LpmTrie<[u8; 16], u8> = LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
 
 /// v0.2.1 issue #33: IPv4 destination block list. Matched packets
 /// whose dst falls in this LPM trie return `XDP_DROP` (counter
@@ -465,23 +473,31 @@ pub static ALLOW_V6: LpmTrie<[u8; 16], u8> =
 /// as the allowlist; expected entries are a handful of bogon ranges
 /// (RFC 1918, CGNAT, test-net) so 1024 is generous.
 #[map]
-pub static BLOCK_V4: LpmTrie<[u8; 4], u8> =
-    LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
+pub static BLOCK_V4: LpmTrie<[u8; 4], u8> = LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
 
 /// IPv6 destination block list. Same semantics. Currently unused by
 /// any common config; ULA (`fc00::/7`) is the obvious entry point but
 /// most operators will leave this empty.
 #[map]
-pub static BLOCK_V6: LpmTrie<[u8; 16], u8> =
-    LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
+pub static BLOCK_V6: LpmTrie<[u8; 16], u8> = LpmTrie::with_max_entries(ALLOWLIST_MAX_ENTRIES, 0);
 
 /// Runtime flags. One-entry array; userspace writes index 0.
 #[map]
 pub static CFG: Array<FpCfg> = Array::with_max_entries(1, 0);
 
 /// Per-CPU counters (SPEC §4.6). Userspace aggregates across CPUs.
+///
+/// **Shape (v0.2.8+):** a single-entry per-CPU array whose value is
+/// the whole `[u64; STATS_COUNT]` block, not `STATS_COUNT` separate
+/// u64 entries. The old shape cost one `bpf_map_lookup_elem` helper
+/// call per counter bump — 4-6 per forwarded packet; the block shape
+/// costs one lookup per program stage and plain constant-offset
+/// increments after that. Counter *indices and semantics are
+/// unchanged* (`StatIdx` discriminants are the array offsets), so the
+/// CLI/metrics surface is byte-identical. Only raw `bpftool map dump`
+/// consumers see the new one-key layout.
 #[map]
-pub static STATS: PerCpuArray<u64> = PerCpuArray::with_max_entries(STATS_COUNT, 0);
+pub static STATS: PerCpuArray<[u64; STATS_COUNT_USIZE]> = PerCpuArray::with_max_entries(1, 0);
 
 /// Debug event ringbuf (SPEC §3.7). Kept small in v0.1; structured
 /// event type lands with the reconfigure flow in PR #6.
@@ -557,8 +573,7 @@ pub static MUTATION_CTX: PerCpuArray<MutationCtx> = PerCpuArray::with_max_entrie
 /// fast_path's only writes are to fields the kernel reads (family,
 /// addrs, etc.), with no zero-padded blocks for LLVM to coalesce.
 #[map]
-pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> =
-    PerCpuArray::with_max_entries(1, 0);
+pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> = PerCpuArray::with_max_entries(1, 0);
 
 /// Tail-call jump table (v0.2.5+). fast_path tail_calls into slot 0 after
 /// classification + L2/TTL mutations. Slot 0 holds `finalize` today.
@@ -582,13 +597,11 @@ pub static MUTATION_PROGS: ProgramArray = ProgramArray::with_max_entries(8, 0);
 /// IPv4 custom FIB. Keyed by `{prefixlen, addr[4]}`; value is a
 /// `FibValue` pointing at `NEXTHOPS` (Single) or `ECMP_GROUPS` (Ecmp).
 #[map]
-pub static FIB_V4: LpmTrie<[u8; 4], FibValue> =
-    LpmTrie::with_max_entries(FIB_V4_MAX_ENTRIES, 0);
+pub static FIB_V4: LpmTrie<[u8; 4], FibValue> = LpmTrie::with_max_entries(FIB_V4_MAX_ENTRIES, 0);
 
 /// IPv6 custom FIB. Same semantics, 128-bit address key.
 #[map]
-pub static FIB_V6: LpmTrie<[u8; 16], FibValue> =
-    LpmTrie::with_max_entries(FIB_V6_MAX_ENTRIES, 0);
+pub static FIB_V6: LpmTrie<[u8; 16], FibValue> = LpmTrie::with_max_entries(FIB_V6_MAX_ENTRIES, 0);
 
 /// Nexthop cache. Seqlock-protected `NexthopEntry` per ID. The FIB
 /// trie values hold indices into this array; 180K routes sharing a
@@ -608,22 +621,34 @@ pub static ECMP_GROUPS: Array<EcmpGroup> = Array::with_max_entries(ECMP_GROUPS_M
 #[map]
 pub static FIB_CONFIG: Array<FpFibCfg> = Array::with_max_entries(1, 0);
 
-// --- Stat increment helper ---------------------------------------------
+// --- Stat increment helpers ----------------------------------------------
 
-/// Bump the per-CPU counter at `idx` by 1. Safe on the hot path, the
-/// verifier tolerates the single get_ptr_mut + deref, and on miss we
-/// simply skip the increment (a map hit is guaranteed iff `idx <
-/// STATS_COUNT`, which we enforce via the [`StatIdx`] enum).
+/// Fetch this CPU's counter block. Called exactly once per program
+/// stage (`fast_path` and `finalize` each need their own, the pointer
+/// cannot cross the tail call); the result is threaded through the
+/// inlined call chain as a scalar register argument.
+///
+/// `None` is unreachable in practice (index 0 of a 1-entry per-CPU
+/// array always exists); callers fail open to `XDP_PASS`.
 #[inline(always)]
-pub fn bump_stat(idx: StatIdx) {
-    let k = idx as u32;
-    if let Some(slot) = STATS.get_ptr_mut(k) {
-        // SAFETY: PerCpuArray with max_entries=STATS_COUNT guarantees
-        // that `get_ptr_mut` returns a pointer to our own CPU's slot
-        // for the entire NAPI cycle. Non-atomic increment is correct
-        // because PerCpuArray serializes per-CPU.
-        unsafe {
-            *slot = (*slot).saturating_add(1);
-        }
+pub fn stats_base() -> Option<StatsPtr> {
+    STATS.get_ptr_mut(0)
+}
+
+/// Bump the counter at `idx` by 1 within a block fetched via
+/// [`stats_base`]. Compiles to a constant-offset load/add/store on the
+/// map-value pointer — no helper call. `wrapping_add` (not saturating,
+/// which costs a compare+select per bump): u64 wrap is unreachable for
+/// packet counters.
+#[inline(always)]
+pub fn bump(stats: StatsPtr, idx: StatIdx) {
+    let i = idx as usize;
+    // SAFETY: `stats` came from `stats_base()` (a bounds-checked map
+    // value pointer valid for the whole program run, per-CPU so no
+    // concurrent writer), and `i < STATS_COUNT_USIZE` by construction
+    // of the `StatIdx` enum. Non-atomic RMW is correct because
+    // PerCpuArray serializes per-CPU.
+    unsafe {
+        (*stats)[i] = (*stats)[i].wrapping_add(1);
     }
 }

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -321,9 +321,15 @@ pub struct MssClampValue {
 /// Per-CPU because the NAPI cycle is single-CPU; the read in finalize is
 /// guaranteed to see the write in fast_path with no synchronization.
 ///
-/// 16 bytes, naturally aligned. Size + alignment is asserted in a
-/// userspace test (see `crates/modules/fast-path/src/linux_impl.rs`'s
-/// `MutationCtx` mirror).
+/// 20 bytes, naturally aligned, ZERO padding — asserted at compile
+/// time below. The no-padding property is load-bearing: any padding
+/// gives LLVM's "merge stores" optimization a zero-init block to
+/// lower into a `memset` libcall, which the BPF backend emits as a
+/// bpf-to-bpf subprogram, tripping the kernel verifier's
+///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
+/// guard on UniFi-style kernels (5.15-ui-cn9670 aarch64). Every field
+/// is written individually in `forward_success`; never write this
+/// struct wholesale.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct MutationCtx {
@@ -343,18 +349,25 @@ pub struct MutationCtx {
     /// 1 = IPv4 packet, 0 = IPv6. Determines which IP-header struct
     /// finalize casts to and which MSS_CLAMP map to consult.
     ///
-    /// Stored as `u32` (not `u8`) so the struct has no padding bytes.
-    /// With padding, LLVM's "merge stores" optimization recognizes the
-    /// 3 unwritten bytes between `is_v4: u8` and the end of the struct
-    /// as a zero-init block and lowers them into a `memset` libcall
-    /// emitted by the BPF backend as a separate bpf-to-bpf subprogram,
-    /// which then trips the kernel verifier's
-    ///   "tail_calls are not allowed in non-JITed programs with bpf-to-bpf calls"
-    /// guard on UniFi-style kernels (5.15-ui-cn9670 aarch64). Single
-    /// `u32` field = single store, no padding, no merge-able zero
-    /// pattern. Low byte holds the boolean.
+    /// Stored as `u32` (not `u8`) per the no-padding rule above; the
+    /// low byte holds the boolean.
     pub is_v4: u32,
+    /// Low byte = `FpCfg.flags` as read once at fast_path entry.
+    /// Carries the feature-presence bits (notably
+    /// `FP_CFG_FLAG_MSS_CLAMP_PRESENT`) across the tail call so
+    /// finalize never re-reads the CFG map. u16 so the struct stays
+    /// padding-free; upper byte is explicitly zero-stored.
+    pub cfg_flags: u16,
+    /// `FpCfg.mss_clamp_global` from the same single CFG read; the
+    /// clamp chain's final fallback. 0 = unset.
+    pub mss_clamp_global: u16,
 }
+
+// The layout contract: 20 bytes means no padding (4+2+2+4+4+2+2), so
+// LLVM has no zero-block to merge into a memset libcall (see struct
+// docs). If a field change reintroduces padding, this fails the build
+// instead of the UniFi 5.15 verifier failing the load.
+const _: () = assert!(core::mem::size_of::<MutationCtx>() == 20);
 
 // --- Custom FIB value layouts (Option F) -------------------------------
 

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -195,6 +195,26 @@ pub const FP_CFG_FLAG_CUSTOM_FIB: u8 = 0b0000_1000;
 /// `FP_CFG_FLAG_CUSTOM_FIB`; userspace rejects compare-mode without
 /// it. Temporary validation mode; removed in Phase 5.
 pub const FP_CFG_FLAG_COMPARE_MODE: u8 = 0b0001_0000;
+/// At least one `block-prefix` directive is configured, i.e. BLOCK_V4
+/// / BLOCK_V6 contain entries worth looking up. Clear (the default
+/// deployment) skips one LPM helper call per matched packet. Set by
+/// userspace from the config directives; semantics are identical
+/// either way because an empty trie can never hit.
+pub const FP_CFG_FLAG_BLOCK_PRESENT: u8 = 0b0010_0000;
+/// VLAN_RESOLVE has entries (host has VLAN subifs). Clear skips the
+/// per-forwarded-packet hash lookup; the egress is then always
+/// treated as physical/untagged, which is exactly what an empty map
+/// lookup would conclude. Set by userspace after VLAN discovery
+/// (populate/reconcile), not from directives.
+pub const FP_CFG_FLAG_VLAN_PRESENT: u8 = 0b0100_0000;
+/// At least one mss-clamp source is configured (any `mss-clamp`
+/// directive: global, per-prefix, or per-iface). Consumed by
+/// `finalize` (via `MutationCtx.cfg_flags`) to skip the entire clamp
+/// lookup chain for TCP packets when no clamp exists. Reserved here
+/// in the same change that gates BLOCK/VLAN so the bit layout is
+/// settled; the finalize-side gate lands with the MutationCtx
+/// widening.
+pub const FP_CFG_FLAG_MSS_CLAMP_PRESENT: u8 = 0b1000_0000;
 
 /// Max prefixes per allowlist trie. Sized generously: SPEC.md §4.5
 /// scales to /24-range tries comfortably. `1024` entries covers the

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -102,13 +102,15 @@ impl FastPathModule {
     pub fn stats(&self) -> ModuleResult<Vec<u64>> {
         match &self.state {
             Some(s) => linux_impl::snapshot_stats(s),
-            None => Ok(vec![0u64; 32]),
+            // Sized from COUNTER_NAMES like every other stats surface;
+            // a hardcoded length here previously drifted (32 < 38).
+            None => Ok(vec![0u64; metrics::COUNTER_COUNT]),
         }
     }
 
     #[cfg(not(target_os = "linux"))]
     pub fn stats(&self) -> ModuleResult<Vec<u64>> {
-        Ok(vec![0u64; 32])
+        Ok(vec![0u64; metrics::COUNTER_COUNT])
     }
 }
 

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -76,6 +76,81 @@ pub(crate) const FP_CFG_FLAG_CUSTOM_FIB: u8 = 0b0000_1000;
 #[allow(dead_code)]
 pub(crate) const FP_CFG_FLAG_COMPARE_MODE: u8 = 0b0001_0000;
 
+/// Mirrors of the `bpf/src/maps.rs` feature-presence bits (keep in
+/// lockstep). Each gates a per-packet map lookup the XDP program can
+/// skip when the feature is unconfigured; the invariant userspace must
+/// uphold is "bit set whenever the corresponding map/config has
+/// entries" — the bits are derived from the same directives that
+/// populate the maps (via [`feature_flags_from_config`]) so they can't
+/// drift, and every writer of CFG.flags goes through that helper (the
+/// `reconcile_cfg` flag rebuild included; a bit missing there would be
+/// silently wiped on SIGHUP, the head-shift-bug pattern).
+pub(crate) const FP_CFG_FLAG_BLOCK_PRESENT: u8 = 0b0010_0000;
+pub(crate) const FP_CFG_FLAG_VLAN_PRESENT: u8 = 0b0100_0000;
+pub(crate) const FP_CFG_FLAG_MSS_CLAMP_PRESENT: u8 = 0b1000_0000;
+
+/// Compute the feature-presence bits (5-7) of `FpCfg.flags` from the
+/// module directives plus the VLAN-subif discovery result. Shared by
+/// `populate_cfg` (initial load) and `reconcile::reconcile_cfg`
+/// (SIGHUP) so both agree — any new presence bit MUST be added here,
+/// never inline at one call site.
+///
+/// `vlan_subifs_present` comes from `/proc/net/vlan/config` rather
+/// than directives (VLAN_RESOLVE is discovery-populated); callers pass
+/// the current read. `populate_vlan_resolve` / `reconcile_vlan_resolve`
+/// additionally RMW-fix bit 6 after actually converging the map, which
+/// covers subifs appearing between the CFG write and VLAN discovery.
+pub(crate) fn feature_flags_from_config(
+    directives: &[ModuleDirective],
+    vlan_subifs_present: bool,
+) -> u8 {
+    let mut flags = 0u8;
+    if directives
+        .iter()
+        .any(|d| matches!(d, ModuleDirective::BlockPrefix { .. }))
+    {
+        flags |= FP_CFG_FLAG_BLOCK_PRESENT;
+    }
+    if directives
+        .iter()
+        .any(|d| matches!(d, ModuleDirective::MssClamp { .. }))
+    {
+        flags |= FP_CFG_FLAG_MSS_CLAMP_PRESENT;
+    }
+    if vlan_subifs_present {
+        flags |= FP_CFG_FLAG_VLAN_PRESENT;
+    }
+    flags
+}
+
+/// Whether `/proc/net/vlan/config` currently lists any VLAN subifs.
+/// Unreadable (module not loaded, non-Linux procfs oddity) counts as
+/// "none", matching `populate_vlan_resolve`'s NotFound handling.
+pub(crate) fn vlan_subifs_present() -> bool {
+    read_vlan_config().map(|v| !v.is_empty()).unwrap_or(false)
+}
+
+/// Read-modify-write one `FpCfg.flags` bit on the live CFG map.
+/// Same pattern as `apply_driver_quirks_cfg`'s head-shift OR: preserve
+/// every other bit and field.
+pub(crate) fn set_cfg_flag(ebpf: &mut Ebpf, bit: u8, on: bool) -> ModuleResult<()> {
+    let map = ebpf
+        .map_mut("CFG")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "CFG map missing from ELF"))?;
+    let mut arr: Array<_, FpCfg> = Array::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG Array::try_from: {e}")))?;
+    let mut cur: FpCfg = arr
+        .get(&0, 0)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG get: {e}")))?;
+    if on {
+        cur.flags |= bit;
+    } else {
+        cur.flags &= !bit;
+    }
+    arr.set(0, cur, 0)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG set: {e}")))
+}
+
 /// Minimum mainline Linux version that ships the rvu-nicpf XDP fix
 /// (commit 04f647c8e456). Kernels below this expose both the
 /// xdp.data_hard_start offset bug (workaroundable via head-shift) AND
@@ -289,9 +364,12 @@ fn populate_cfg(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<()> {
         dry_run: u8::from(dry_run),
         // bits 0-1: IPv4/IPv6 enabled (historical, load-bearing for
         // dashboards). bits 3-4: custom-FIB / compare (Option F).
+        // bits 5-7: feature-presence gates (block / vlan / mss-clamp).
         // bit 2 (HEAD_SHIFT_128) is OR'd on later in
         // apply_driver_quirks_cfg for rvu-nicpf attaches.
-        flags: 0b11 | fib_flags,
+        flags: 0b11
+            | fib_flags
+            | feature_flags_from_config(&mcfg.section.directives, vlan_subifs_present()),
         mss_clamp_global,
         version: FP_CFG_VERSION_V2,
     };
@@ -1574,6 +1652,12 @@ fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
             "vlan_resolve populated"
         );
     }
+
+    // Entries landed → make sure the VLAN_PRESENT gate bit is on, even
+    // if a subif appeared between populate_cfg's proc read and now.
+    // (The reverse case — bit set but map ended empty — is harmless:
+    // the gated lookup just misses, exactly like the ungated code did.)
+    set_cfg_flag(&mut state.ebpf, FP_CFG_FLAG_VLAN_PRESENT, true)?;
     Ok(())
 }
 
@@ -2106,6 +2190,63 @@ pub fn state_dir(state: &ActiveState) -> &Path {
 #[cfg(test)]
 mod tests {
     use super::gc_thresh3_capacity_warning;
+    use super::{
+        feature_flags_from_config, FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+        FP_CFG_FLAG_VLAN_PRESENT,
+    };
+    use packetframe_common::config::ModuleDirective;
+
+    #[test]
+    fn feature_flags_truth_table() {
+        let block = ModuleDirective::BlockPrefix {
+            cidr: "192.0.2.0/24".parse().unwrap(),
+            line: 1,
+        };
+        let clamp_global = ModuleDirective::MssClamp {
+            prefix: None,
+            iface: None,
+            mss: 1360,
+            line: 2,
+        };
+        let unrelated = ModuleDirective::DryRun(false);
+
+        assert_eq!(feature_flags_from_config(&[], false), 0);
+        assert_eq!(
+            feature_flags_from_config(std::slice::from_ref(&unrelated), false),
+            0,
+            "non-feature directives must not set presence bits"
+        );
+        assert_eq!(
+            feature_flags_from_config(std::slice::from_ref(&block), false),
+            FP_CFG_FLAG_BLOCK_PRESENT
+        );
+        assert_eq!(
+            feature_flags_from_config(std::slice::from_ref(&clamp_global), false),
+            FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+            "any mss-clamp grammar (global included) sets the presence bit"
+        );
+        assert_eq!(
+            feature_flags_from_config(&[], true),
+            FP_CFG_FLAG_VLAN_PRESENT
+        );
+        assert_eq!(
+            feature_flags_from_config(&[block, clamp_global, unrelated], true),
+            FP_CFG_FLAG_BLOCK_PRESENT | FP_CFG_FLAG_MSS_CLAMP_PRESENT | FP_CFG_FLAG_VLAN_PRESENT
+        );
+    }
+
+    /// Bits 5-7 must never collide with the established bits 0-4.
+    #[test]
+    fn presence_bits_are_disjoint_from_legacy_bits() {
+        let legacy = 0b0001_1111u8; // ipv4|ipv6|head-shift|custom-fib|compare
+        for bit in [
+            FP_CFG_FLAG_BLOCK_PRESENT,
+            FP_CFG_FLAG_VLAN_PRESENT,
+            FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+        ] {
+            assert_eq!(bit & legacy, 0);
+        }
+    }
 
     #[test]
     fn default_sysctls_do_not_warn() {

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1824,7 +1824,7 @@ pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
         .ebpf
         .map("STATS")
         .ok_or_else(|| ModuleError::other(MODULE_NAME, "STATS map missing from ELF"))?;
-    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map).map_err(|e| {
+    let stats: PerCpuArray<_, StatsBlock> = PerCpuArray::try_from(map).map_err(|e| {
         ModuleError::other(MODULE_NAME, format!("STATS PerCpuArray::try_from: {e}"))
     })?;
 
@@ -2023,25 +2023,32 @@ pub fn stats_from_pin(bpffs_root: &Path) -> ModuleResult<Vec<u64>> {
     // aya's `PerCpuArray::try_from` takes a `Map` enum, not a bare
     // `MapData`; wrap before converting.
     let map = Map::PerCpuArray(map_data);
-    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map)
+    let stats: PerCpuArray<_, StatsBlock> = PerCpuArray::try_from(map)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("STATS PerCpuArray: {e}")))?;
     read_stats(&stats)
 }
 
+/// Userspace mirror of the BPF side's `[u64; STATS_COUNT]` STATS value
+/// (v0.2.8+ single-entry map shape). Sized from
+/// `metrics::COUNTER_COUNT`, the single userspace mirror of
+/// `STATS_COUNT` in bpf/src/maps.rs — prior versions hardcoded
+/// separate lengths and drifted three times (19 hid `err_head_shift`;
+/// 33 hid `mss_clamp_*`; 37 hid `pass_ndp`).
+pub(crate) type StatsBlock = [u64; crate::metrics::COUNTER_COUNT];
+
 fn read_stats<T: std::borrow::Borrow<aya::maps::MapData>>(
-    stats: &aya::maps::PerCpuArray<T, u64>,
+    stats: &aya::maps::PerCpuArray<T, StatsBlock>,
 ) -> ModuleResult<Vec<u64>> {
-    // Sized from `metrics::COUNTER_NAMES`, the single userspace mirror
-    // of `STATS_COUNT` in bpf/src/maps.rs. Prior versions hardcoded a
-    // separate length here, and it drifted three times (19 hid
-    // `err_head_shift`; 33 hid `mss_clamp_*`; 37 hid `pass_ndp`) —
-    // each time the newest counters silently read as absent.
-    let mut out = vec![0u64; crate::metrics::COUNTER_NAMES.len()];
-    for (idx, slot) in out.iter_mut().enumerate() {
-        let values = stats
-            .get(&(idx as u32), 0)
-            .map_err(|e| ModuleError::other(MODULE_NAME, format!("STATS get[{idx}]: {e}")))?;
-        *slot = values.iter().copied().sum();
+    // One BPF_MAP_LOOKUP_ELEM for the whole counter block (previously
+    // one syscall per counter, O(counters) per metrics tick).
+    let per_cpu = stats
+        .get(&0, 0)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("STATS get[0]: {e}")))?;
+    let mut out = vec![0u64; crate::metrics::COUNTER_COUNT];
+    for cpu_block in per_cpu.iter() {
+        for (slot, v) in out.iter_mut().zip(cpu_block.iter()) {
+            *slot += *v;
+        }
     }
     Ok(out)
 }

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -96,10 +96,14 @@ pub(crate) const FP_CFG_FLAG_MSS_CLAMP_PRESENT: u8 = 0b1000_0000;
 /// never inline at one call site.
 ///
 /// `vlan_subifs_present` comes from `/proc/net/vlan/config` rather
-/// than directives (VLAN_RESOLVE is discovery-populated); callers pass
-/// the current read. `populate_vlan_resolve` / `reconcile_vlan_resolve`
-/// additionally RMW-fix bit 6 after actually converging the map, which
-/// covers subifs appearing between the CFG write and VLAN discovery.
+/// than directives (VLAN_RESOLVE is discovery-populated). Ownership of
+/// bit 6 differs by caller: `populate_cfg` passes the current proc
+/// read (initial seed; a read failure later aborts load in
+/// `populate_vlan_resolve` anyway), while `reconcile_cfg` passes
+/// `false` and ORs in the bit *preserved from the live flags* — on
+/// SIGHUP the bit may only change via `reconcile_vlan_resolve`'s
+/// post-convergence RMW, so a transient proc-read failure can never
+/// clear the gate while VLAN_RESOLVE still holds entries.
 pub(crate) fn feature_flags_from_config(
     directives: &[ModuleDirective],
     vlan_subifs_present: bool,

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -31,7 +31,7 @@ use std::fmt::Write as _;
 /// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
 /// tail-call diagnostics from the Prometheus export; a separate
 /// hardcoded 37 hid `pass_ndp` from `packetframe status`).
-pub const COUNTER_NAMES: [&str; 38] = [
+pub const COUNTER_NAMES: [&str; 40] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -74,6 +74,9 @@ pub const COUNTER_NAMES: [&str; 38] = [
     "err_mutation_ctx",
     // --- local-prefix6: NDP kept off the fast path ---
     "pass_ndp",
+    // --- v0.2.8: finalize error-path visibility ---
+    "err_ctx_offset_range",
+    "err_redirect_failed",
 ];
 
 /// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
@@ -225,10 +228,12 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 38);
-        // The newest counter, as a canary that the tail of the list
+        assert_eq!(COUNTER_NAMES.len(), 40);
+        assert_eq!(COUNTER_NAMES.len(), COUNTER_COUNT);
+        // The newest counters, as a canary that the tail of the list
         // stayed aligned with the `StatIdx` discriminants.
-        assert_eq!(COUNTER_NAMES[37], "pass_ndp");
+        assert_eq!(COUNTER_NAMES[38], "err_ctx_offset_range");
+        assert_eq!(COUNTER_NAMES[39], "err_redirect_failed");
     }
 
     #[test]

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -76,6 +76,12 @@ pub const COUNTER_NAMES: [&str; 38] = [
     "pass_ndp",
 ];
 
+/// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
+/// type of the single-entry STATS per-CPU map in `linux_impl` (v0.2.8+
+/// map shape) and the test harness mirror. Must equal the BPF side's
+/// `STATS_COUNT`.
+pub const COUNTER_COUNT: usize = COUNTER_NAMES.len();
+
 /// Render a Prometheus textfile body from stat values + module uptime.
 /// Every counter gets `# TYPE` and `# HELP` headers so Prometheus's
 /// textfile collector categorizes it correctly. Counter names that

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -23,8 +23,10 @@ use packetframe_common::{
 use tracing::{info, warn};
 
 use crate::linux_impl::{
-    fib_flags_from_forwarding_mode, if_nametoindex, mss_clamp_global_value, read_vlan_config,
-    ActiveState, FpCfg, MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_VERSION_V2,
+    feature_flags_from_config, fib_flags_from_forwarding_mode, if_nametoindex,
+    mss_clamp_global_value, read_vlan_config, set_cfg_flag, vlan_subifs_present, ActiveState,
+    FpCfg, MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT,
+    FP_CFG_VERSION_V2,
 };
 use crate::MODULE_NAME;
 
@@ -109,9 +111,17 @@ fn reconcile_cfg(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
 
     let mss_clamp_global = mss_clamp_global_value(&cfg.section.directives).unwrap_or(0);
 
+    // Feature-presence bits (5-7) are rebuilt through the same shared
+    // helper populate_cfg uses; a bit computed inline here (or
+    // forgotten) would be wiped on every SIGHUP — the head-shift-bug
+    // pattern the `head_shift` preservation above guards against.
+    // `reconcile_vlan_resolve` re-fixes bit 6 after map convergence.
     let new_cfg = FpCfg {
         dry_run: u8::from(dry_run),
-        flags: 0b11 | head_shift | fib_flags_from_forwarding_mode(forwarding),
+        flags: 0b11
+            | head_shift
+            | fib_flags_from_forwarding_mode(forwarding)
+            | feature_flags_from_config(&cfg.section.directives, vlan_subifs_present()),
         mss_clamp_global,
         version: FP_CFG_VERSION_V2,
     };
@@ -272,6 +282,15 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
             Err(e) => warn!(subif_idx, error = %e, "VLAN_RESOLVE remove failed"),
         }
     }
+
+    // Authoritative post-convergence fix of the VLAN_PRESENT gate bit:
+    // set iff the map has (desired) entries. Covers subifs appearing
+    // or disappearing between reconcile_cfg's proc read and here.
+    set_cfg_flag(
+        &mut state.ebpf,
+        FP_CFG_FLAG_VLAN_PRESENT,
+        !desired.is_empty(),
+    )?;
     Ok(delta)
 }
 

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -24,9 +24,8 @@ use tracing::{info, warn};
 
 use crate::linux_impl::{
     feature_flags_from_config, fib_flags_from_forwarding_mode, if_nametoindex,
-    mss_clamp_global_value, read_vlan_config, set_cfg_flag, vlan_subifs_present, ActiveState,
-    FpCfg, MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT,
-    FP_CFG_VERSION_V2,
+    mss_clamp_global_value, read_vlan_config, set_cfg_flag, ActiveState, FpCfg, MssClampValue,
+    VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT, FP_CFG_VERSION_V2,
 };
 use crate::MODULE_NAME;
 
@@ -104,24 +103,39 @@ fn reconcile_cfg(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
     // driver detection; SIGHUP reconfigure must not wipe it. Without
     // this preservation, a SIGHUP on an rvu-nicpf box would silently
     // disable the head-shift workaround until the next full restart.
+    //
+    // Bit 6 (VLAN_PRESENT) is preserved for a related reason: it is
+    // owned by VLAN *discovery*, not directives, and its only writer
+    // is `reconcile_vlan_resolve`'s post-convergence RMW. Recomputing
+    // it here from a fresh /proc/net/vlan/config read would clear the
+    // gate whenever that read transiently fails (any error maps to
+    // "no subifs") — and since the same failure then aborts
+    // `reconcile_vlan_resolve` before its fixup, VLAN_RESOLVE would
+    // keep its entries while the datapath stopped consulting them,
+    // mistagging subif egress until the next successful reconcile.
+    // (Found by review on the original recompute-on-SIGHUP version.)
     let current: FpCfg = cfg_arr
         .get(&0, 0)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("CFG get: {e}")))?;
     let head_shift = current.flags & FP_CFG_FLAG_HEAD_SHIFT_128;
+    let vlan_present = current.flags & FP_CFG_FLAG_VLAN_PRESENT;
 
     let mss_clamp_global = mss_clamp_global_value(&cfg.section.directives).unwrap_or(0);
 
-    // Feature-presence bits (5-7) are rebuilt through the same shared
-    // helper populate_cfg uses; a bit computed inline here (or
-    // forgotten) would be wiped on every SIGHUP — the head-shift-bug
-    // pattern the `head_shift` preservation above guards against.
-    // `reconcile_vlan_resolve` re-fixes bit 6 after map convergence.
+    // Directive-derived presence bits (5, 7) are rebuilt through the
+    // same shared helper populate_cfg uses; a bit computed inline here
+    // (or forgotten) would be wiped on every SIGHUP — the
+    // head-shift-bug pattern the preservation above guards against.
+    // `vlan_subifs_present: false` because bit 6 is carried over from
+    // the live flags instead (see comment above); OR-ing the preserved
+    // bit keeps it exactly as `reconcile_vlan_resolve` last set it.
     let new_cfg = FpCfg {
         dry_run: u8::from(dry_run),
         flags: 0b11
             | head_shift
+            | vlan_present
             | fib_flags_from_forwarding_mode(forwarding)
-            | feature_flags_from_config(&cfg.section.directives, vlan_subifs_present()),
+            | feature_flags_from_config(&cfg.section.directives, false),
         mss_clamp_global,
         version: FP_CFG_VERSION_V2,
     };

--- a/crates/modules/fast-path/tests/bench.rs
+++ b/crates/modules/fast-path/tests/bench.rs
@@ -1,0 +1,168 @@
+//! ns/packet microbenchmarks for the fast_path → finalize chain via
+//! `BPF_PROG_TEST_RUN`'s `repeat` + `duration` fields.
+//!
+//! These measure the BPF program in isolation. They deliberately do
+//! NOT capture the kernel-side generic-XDP overhead that dominates
+//! per-packet CPU on skb-mode deployments (`pskb_expand_head` for the
+//! 256-byte headroom guarantee, skb linearization, the un-bulked
+//! `generic_xdp_tx` transmit) — use `perf top` on the router for that.
+//! What they DO give is a stable before/after number for hot-path
+//! program changes, on any Linux host.
+//!
+//! Run locally (Linux, CAP_BPF):
+//! ```sh
+//! sudo -E cargo test --test bench -- --ignored --nocapture
+//! ```
+//!
+//! Run on the reference EFG (or any aarch64 router):
+//! ```sh
+//! cross build --target aarch64-unknown-linux-gnu --tests --release
+//! # find the bench binary under target/aarch64-unknown-linux-gnu/release/deps/bench-<hash>
+//! scp target/aarch64-unknown-linux-gnu/release/deps/bench-* router:/tmp/
+//! ssh router 'sudo /tmp/bench-<hash> --ignored --nocapture'
+//! ```
+//! Confirm `net.core.bpf_jit_enable=1` on the target first (see
+//! `packetframe feasibility`), otherwise the numbers measure the BPF
+//! interpreter, not what production runs.
+//!
+//! Regression gating (off by default, not for shared CI runners):
+//! `PACKETFRAME_BENCH_BASELINE_NS=<ns>` makes the established-flow
+//! forward bench fail if its median exceeds the baseline.
+//!
+//! **TTL budget:** `BPF_PROG_TEST_RUN` reuses one packet buffer across
+//! all `repeat` iterations inside a syscall, and the forward path
+//! decrements TTL per pass. Forward benches therefore use `ttl: 255`
+//! and `repeat` well below 253, looping the syscall many times and
+//! taking the median of the kernel-reported per-iteration averages.
+//! A `FwdOk` delta assertion guards against ever silently measuring
+//! the `PassLowTtl` path instead.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::{xdp_action, Harness, Ipv4TcpBuilder, StatIdx};
+
+/// Loopback ifindex; always 1 on Linux. The redirect never executes
+/// under TEST_RUN (the verdict is returned, not acted on), but the
+/// devmap pre-check needs a real entry.
+const LO_IFINDEX: u32 = 1;
+
+/// Iterations per syscall on paths that mutate TTL (must stay < 253
+/// with ttl=255; see module docs).
+const FWD_REPEAT: u32 = 200;
+/// Syscalls per forward bench: 200 × 5000 = 1M program executions.
+const FWD_CALLS: usize = 5000;
+
+/// The miss path never mutates the packet, so one syscall can run a
+/// large batch.
+const MISS_REPEAT: u32 = 10_000;
+const MISS_CALLS: usize = 200;
+
+const TCP_FLAG_SYN: u8 = 0x02;
+const TCP_FLAG_ACK: u8 = 0x10;
+
+/// Run `calls` syscalls of `repeat` iterations each and return the
+/// median of the kernel-reported mean-ns-per-iteration samples.
+/// Panics if any iteration's verdict differs from `expect_verdict`.
+fn median_ns(h: &Harness, pkt: &[u8], repeat: u32, calls: usize, expect_verdict: u32) -> u32 {
+    let mut samples = Vec::with_capacity(calls);
+    for _ in 0..calls {
+        let (verdict, ns) = h.run_timed(pkt, repeat);
+        assert_eq!(verdict, expect_verdict, "unexpected verdict mid-bench");
+        samples.push(ns);
+    }
+    samples.sort_unstable();
+    samples[samples.len() / 2]
+}
+
+/// Production-profile harness: custom-fib, one allowlisted /8, one
+/// resolved single nexthop, egress in the devmap. Mirrors the
+/// reference deployment (single-NH custom-fib, no ECMP / clamp /
+/// block / VLAN).
+fn custom_fib_harness() -> Harness {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.set_custom_fib(true, false);
+    h.add_nexthop_v4(
+        0,
+        LO_IFINDEX,
+        [0x02, 0, 0, 0, 0, 0xee],
+        [0x02, 0, 0, 0, 0, 0xff],
+    );
+    h.add_fib_v4_single("10.0.0.0/8", 0);
+    h.add_devmap_ifindex(LO_IFINDEX);
+    h
+}
+
+fn fwd_packet(tcp_flags: u8) -> Vec<u8> {
+    Ipv4TcpBuilder {
+        ttl: 255, // TTL budget for FWD_REPEAT in-syscall decrements
+        tcp_flags,
+        ..Default::default()
+    }
+    .build()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
+fn bench_custom_fib_forward_established() {
+    let h = custom_fib_harness();
+    let pkt = fwd_packet(TCP_FLAG_ACK);
+
+    let fwd_before = h.stat(StatIdx::FwdOk);
+    let low_ttl_before = h.stat(StatIdx::PassLowTtl);
+
+    let ns = median_ns(&h, &pkt, FWD_REPEAT, FWD_CALLS, xdp_action::XDP_REDIRECT);
+
+    // Every iteration must have forwarded; a TTL-budget bug would
+    // divert iterations to PassLowTtl and quietly bench the wrong path.
+    let executed = (FWD_REPEAT as u64) * (FWD_CALLS as u64);
+    assert_eq!(h.stat(StatIdx::FwdOk) - fwd_before, executed);
+    assert_eq!(h.stat(StatIdx::PassLowTtl), low_ttl_before);
+
+    eprintln!(
+        "bench_custom_fib_forward_established: {ns} ns/pkt (median of {FWD_CALLS} x {FWD_REPEAT})"
+    );
+
+    if let Ok(baseline) = std::env::var("PACKETFRAME_BENCH_BASELINE_NS") {
+        let baseline: u32 = baseline
+            .parse()
+            .expect("PACKETFRAME_BENCH_BASELINE_NS must be an integer ns value");
+        assert!(
+            ns <= baseline,
+            "regression: {ns} ns/pkt exceeds baseline {baseline} ns/pkt"
+        );
+    }
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
+fn bench_custom_fib_forward_syn() {
+    let h = custom_fib_harness();
+    let pkt = fwd_packet(TCP_FLAG_SYN);
+
+    let fwd_before = h.stat(StatIdx::FwdOk);
+    let ns = median_ns(&h, &pkt, FWD_REPEAT, FWD_CALLS, xdp_action::XDP_REDIRECT);
+    let executed = (FWD_REPEAT as u64) * (FWD_CALLS as u64);
+    assert_eq!(h.stat(StatIdx::FwdOk) - fwd_before, executed);
+
+    eprintln!("bench_custom_fib_forward_syn: {ns} ns/pkt (median of {FWD_CALLS} x {FWD_REPEAT})");
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
+fn bench_allowlist_miss() {
+    // No allowlist entries at all: the packet parses, does the two
+    // ALLOW_V4 LPM lookups, misses, and XDP_PASSes without mutation,
+    // so a single syscall can carry a large repeat.
+    let h = Harness::new();
+    let pkt = Ipv4TcpBuilder::default().build();
+
+    let rx_before = h.stat(StatIdx::RxTotal);
+    let ns = median_ns(&h, &pkt, MISS_REPEAT, MISS_CALLS, xdp_action::XDP_PASS);
+    let executed = (MISS_REPEAT as u64) * (MISS_CALLS as u64);
+    assert_eq!(h.stat(StatIdx::RxTotal) - rx_before, executed);
+
+    eprintln!("bench_allowlist_miss: {ns} ns/pkt (median of {MISS_CALLS} x {MISS_REPEAT})");
+}

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -408,12 +408,15 @@ impl Harness {
         test_run_xdp(prog_fd.as_fd().as_raw_fd(), packet)
     }
 
-    /// Aggregate a PerCpuArray stat across all CPUs.
+    /// Aggregate a stat across all CPUs. v0.2.8+ STATS shape: one
+    /// per-CPU entry holding the whole `[u64; STATS_COUNT]` block;
+    /// `StatIdx` discriminants are offsets into it.
     pub fn stat(&self, idx: StatIdx) -> u64 {
         let map = self.bpf.map("STATS").expect("STATS map");
-        let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map).expect("PerCpuArray try_from");
-        let per_cpu = stats.get(&(idx as u32), 0).expect("STATS get");
-        per_cpu.iter().copied().sum()
+        let stats: PerCpuArray<_, [u64; STATS_COUNT as usize]> =
+            PerCpuArray::try_from(map).expect("PerCpuArray try_from");
+        let per_cpu = stats.get(&0, 0).expect("STATS get");
+        per_cpu.iter().map(|block| block[idx as usize]).sum()
     }
 }
 

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -236,6 +236,36 @@ impl Harness {
         trie.insert(&key, 1u8, 0).expect("BLOCK_V4 insert");
     }
 
+    /// Insert an IPv4 mss-clamp prefix rule. `iface_filter` 0 = any
+    /// egress. Callers must also set `FP_CFG_FLAG_MSS_CLAMP_PRESENT`.
+    pub fn add_mss_clamp_v4(&mut self, prefix: &str, mss: u16, iface_filter: u32) {
+        /// Layout mirror of `MssClampValue` in `bpf/src/maps.rs`.
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct MssClampValue {
+            mss: u16,
+            _pad: u16,
+            iface_filter: u32,
+        }
+        unsafe impl Pod for MssClampValue {}
+
+        let (addr, plen) = parse_v4_prefix(prefix);
+        let map = self.bpf.map_mut("MSS_CLAMP_V4").expect("MSS_CLAMP_V4 map");
+        let mut trie: LpmTrie<_, [u8; 4], MssClampValue> =
+            LpmTrie::try_from(map).expect("MSS_CLAMP_V4 try_from");
+        let key = LpmKey::new(u32::from(plen), addr);
+        trie.insert(
+            &key,
+            MssClampValue {
+                mss,
+                _pad: 0,
+                iface_filter,
+            },
+            0,
+        )
+        .expect("MSS_CLAMP_V4 insert");
+    }
+
     /// Insert a VLAN-subif mapping: `subif_ifindex` → (physical parent
     /// ifindex, VID). Callers must also set `FP_CFG_FLAG_VLAN_PRESENT`.
     pub fn add_vlan_resolve(&mut self, subif_ifindex: u32, phys_ifindex: u32, vid: u16) {
@@ -601,6 +631,11 @@ pub struct Ipv4TcpBuilder {
     pub frag_flags: u16, // network byte order: bit 15=res, 14=DF, 13=MF, 12..0=offset
     pub ihl: u8,         // normally 5; set >5 to produce IHL>5 via header option bytes
     pub tcp_flags: u8,   // TCP header byte 13; default SYN (0x02)
+    /// Raw TCP option bytes appended after the fixed 20-byte header.
+    /// Must be a multiple of 4 (padded with NOPs/EOL by the caller);
+    /// data offset is derived. E.g. an MSS option for 1460:
+    /// `vec![2, 4, 0x05, 0xb4]`.
+    pub tcp_options: Vec<u8>,
     pub payload: Vec<u8>,
 }
 
@@ -618,6 +653,7 @@ impl Default for Ipv4TcpBuilder {
             frag_flags: 0,
             ihl: 5,
             tcp_flags: 0x02, // SYN, the historical builder default
+            tcp_options: Vec::new(),
             payload: Vec::new(),
         }
     }
@@ -638,8 +674,13 @@ pub fn insert_vlan_tag(base: &[u8], vid: u16) -> Vec<u8> {
 
 impl Ipv4TcpBuilder {
     pub fn build(&self) -> Vec<u8> {
+        assert!(
+            self.tcp_options.len() % 4 == 0 && self.tcp_options.len() <= 40,
+            "tcp_options must be 4-byte padded and fit the doff field"
+        );
         let ip_header_len = (self.ihl as usize) * 4;
-        let total_len = (ip_header_len + 20 + self.payload.len()) as u16; // +TCP hdr
+        let tcp_header_len = 20 + self.tcp_options.len();
+        let total_len = (ip_header_len + tcp_header_len + self.payload.len()) as u16;
         let mut pkt = Vec::with_capacity(14 + total_len as usize);
 
         // Ethernet
@@ -670,15 +711,18 @@ impl Ipv4TcpBuilder {
         let csum = ipv4_checksum(ip_header);
         pkt[check_offset..check_offset + 2].copy_from_slice(&csum.to_be_bytes());
 
-        // TCP (minimal 20-byte header; flags from `tcp_flags`; no options)
+        // TCP header; flags from `tcp_flags`, options from `tcp_options`.
         pkt.extend_from_slice(&self.src_port.to_be_bytes());
         pkt.extend_from_slice(&self.dst_port.to_be_bytes());
         pkt.extend_from_slice(&[0, 0, 0, 1]); // seq
         pkt.extend_from_slice(&[0, 0, 0, 0]); // ack
-        pkt.push(0x50); // data offset 5 in upper nibble
+        let doff_words = (tcp_header_len / 4) as u8;
+        pkt.push(doff_words << 4); // data offset in upper nibble
         pkt.push(self.tcp_flags);
         pkt.extend_from_slice(&[0xff, 0xff]); // window
-        pkt.extend_from_slice(&[0, 0, 0, 0]); // checksum (zero - bpf doesn't care for fixtures)
+        pkt.extend_from_slice(&[0, 0]); // checksum (zero - bpf recomputes incrementally)
+        pkt.extend_from_slice(&[0, 0]); // urgent pointer
+        pkt.extend_from_slice(&self.tcp_options);
 
         pkt.extend_from_slice(&self.payload);
         pkt

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -65,6 +65,9 @@ pub const FP_CFG_FLAG_IPV6: u8 = 0b0000_0010;
 pub const FP_CFG_FLAG_HEAD_SHIFT_128: u8 = 0b0000_0100;
 pub const FP_CFG_FLAG_CUSTOM_FIB: u8 = 0b0000_1000;
 pub const FP_CFG_FLAG_COMPARE_MODE: u8 = 0b0001_0000;
+pub const FP_CFG_FLAG_BLOCK_PRESENT: u8 = 0b0010_0000;
+pub const FP_CFG_FLAG_VLAN_PRESENT: u8 = 0b0100_0000;
+pub const FP_CFG_FLAG_MSS_CLAMP_PRESENT: u8 = 0b1000_0000;
 
 /// Wire-format counter indices (SPEC.md §4.6). Append-only once v0.1
 /// ships; never renumber.
@@ -207,6 +210,60 @@ impl Harness {
             mss_clamp_global: 0,
             version: FP_CFG_VERSION_V2,
         });
+    }
+
+    /// Write an arbitrary `FpCfg.flags` byte (dry-run off, no global
+    /// clamp). Tests exercising the feature-presence gate bits (5-7)
+    /// compose exactly the flag combination they need.
+    pub fn set_cfg_flags(&mut self, flags: u8) {
+        self.set_cfg(FpCfg {
+            dry_run: 0,
+            flags,
+            mss_clamp_global: 0,
+            version: FP_CFG_VERSION_V2,
+        });
+    }
+
+    /// Insert an IPv4 prefix into the BLOCK_V4 trie. Callers must also
+    /// set `FP_CFG_FLAG_BLOCK_PRESENT` for the XDP program to consult
+    /// it — mirroring the userspace invariant that the bit is derived
+    /// from the same directives that populate the map.
+    pub fn add_block_v4(&mut self, prefix: &str) {
+        let (addr, plen) = parse_v4_prefix(prefix);
+        let map = self.bpf.map_mut("BLOCK_V4").expect("BLOCK_V4 map");
+        let mut trie: LpmTrie<_, [u8; 4], u8> = LpmTrie::try_from(map).expect("LpmTrie try_from");
+        let key = LpmKey::new(u32::from(plen), addr);
+        trie.insert(&key, 1u8, 0).expect("BLOCK_V4 insert");
+    }
+
+    /// Insert a VLAN-subif mapping: `subif_ifindex` → (physical parent
+    /// ifindex, VID). Callers must also set `FP_CFG_FLAG_VLAN_PRESENT`.
+    pub fn add_vlan_resolve(&mut self, subif_ifindex: u32, phys_ifindex: u32, vid: u16) {
+        use aya::maps::HashMap as AyaHashMap;
+
+        /// Layout mirror of `VlanResolve` in `bpf/src/maps.rs`.
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct VlanResolve {
+            phys_ifindex: u32,
+            vid: u16,
+            _pad: u16,
+        }
+        unsafe impl Pod for VlanResolve {}
+
+        let map = self.bpf.map_mut("VLAN_RESOLVE").expect("VLAN_RESOLVE map");
+        let mut hm: AyaHashMap<_, u32, VlanResolve> =
+            AyaHashMap::try_from(map).expect("VLAN_RESOLVE try_from");
+        hm.insert(
+            subif_ifindex,
+            VlanResolve {
+                phys_ifindex,
+                vid,
+                _pad: 0,
+            },
+            0,
+        )
+        .expect("VLAN_RESOLVE insert");
     }
 
     /// Insert an IPv4 prefix into the allowlist. `prefix` is

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -38,18 +38,23 @@ use packetframe_fast_path::{
 /// Layout mirror of `FpCfg` in `bpf/src/maps.rs`. Must track
 /// `linux_impl::FpCfg`, if you change one, change both (and both's
 /// ordering in the StatIdx enum at the same time).
+///
+/// Layout V2 (v0.2.4): the formerly-`_reserved [u8; 2]` slot is
+/// `mss_clamp_global: u16` (0 = unset), matching what production
+/// userspace writes. The pre-fix mirror only worked because both
+/// interpretations were all-zeroes in tests.
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub struct FpCfg {
     pub dry_run: u8,
     pub flags: u8,
-    pub _reserved: [u8; 2],
+    pub mss_clamp_global: u16,
     pub version: u32,
 }
 
 unsafe impl Pod for FpCfg {}
 
-pub const FP_CFG_VERSION_V1: u32 = 0;
+pub const FP_CFG_VERSION_V2: u32 = 1;
 pub const STATS_COUNT: u32 = 38;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
@@ -183,8 +188,8 @@ impl Harness {
         harness.set_cfg(FpCfg {
             dry_run: 0,
             flags: 0b11,
-            _reserved: [0; 2],
-            version: FP_CFG_VERSION_V1,
+            mss_clamp_global: 0,
+            version: FP_CFG_VERSION_V2,
         });
         harness
     }
@@ -199,8 +204,8 @@ impl Harness {
         self.set_cfg(FpCfg {
             dry_run: u8::from(on),
             flags: 0b11,
-            _reserved: [0; 2],
-            version: FP_CFG_VERSION_V1,
+            mss_clamp_global: 0,
+            version: FP_CFG_VERSION_V2,
         });
     }
 
@@ -239,8 +244,8 @@ impl Harness {
         self.set_cfg(FpCfg {
             dry_run: 0,
             flags,
-            _reserved: [0; 2],
-            version: FP_CFG_VERSION_V1,
+            mss_clamp_global: 0,
+            version: FP_CFG_VERSION_V2,
         });
     }
 
@@ -398,6 +403,29 @@ impl Harness {
     /// bytes). The kernel may have mutated the packet (L2 rewrite, TTL
     /// decrement) on XDP_REDIRECT; the output buffer reflects that.
     pub fn run(&self, packet: &[u8]) -> (u32, Vec<u8>) {
+        let (retval, _duration, out) = test_run_xdp_repeat(self.fast_path_fd(), packet, 1);
+        (retval, out)
+    }
+
+    /// Run the BPF program `repeat` times against `packet` in a single
+    /// `BPF_PROG_TEST_RUN` syscall and return `(verdict, avg_ns)`,
+    /// where `avg_ns` is the kernel-reported mean nanoseconds per
+    /// iteration (`bpf_attr.test.duration`). The verdict is from the
+    /// final iteration.
+    ///
+    /// **The kernel reuses one packet buffer across all `repeat`
+    /// iterations within a syscall**, so mutations accumulate: a
+    /// forwarded packet has its TTL decremented every pass. Benchmarks
+    /// of the forward path must build packets with a large TTL (255)
+    /// and keep `repeat` below 253, or later iterations silently
+    /// measure the `PassLowTtl` path instead. Each new syscall starts
+    /// from the pristine `packet` again.
+    pub fn run_timed(&self, packet: &[u8], repeat: u32) -> (u32, u32) {
+        let (retval, duration, _out) = test_run_xdp_repeat(self.fast_path_fd(), packet, repeat);
+        (retval, duration)
+    }
+
+    fn fast_path_fd(&self) -> i32 {
         let prog: &Xdp = self
             .bpf
             .program("fast_path")
@@ -405,7 +433,7 @@ impl Harness {
             .try_into()
             .expect("program is XDP");
         let prog_fd: &ProgramFd = prog.fd().expect("program loaded");
-        test_run_xdp(prog_fd.as_fd().as_raw_fd(), packet)
+        prog_fd.as_fd().as_raw_fd()
     }
 
     /// Aggregate a stat across all CPUs. v0.2.8+ STATS shape: one
@@ -446,7 +474,9 @@ struct TestRunAttr {
 
 const BPF_PROG_TEST_RUN: u32 = 10;
 
-fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
+/// Returns `(retval, duration_ns, data_out)`. `duration_ns` is the
+/// kernel's mean nanoseconds per iteration across `repeat` runs.
+fn test_run_xdp_repeat(prog_fd: i32, packet: &[u8], repeat: u32) -> (u32, u32, Vec<u8>) {
     // XDP programs may grow the packet (VLAN push: +4). Allocate
     // output with headroom so the kernel doesn't truncate.
     let mut data_out = vec![0u8; packet.len() + 256];
@@ -464,7 +494,7 @@ fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
     attr.data_size_out = data_out.len() as u32;
     attr.data_in = packet.as_ptr() as u64;
     attr.data_out = data_out.as_mut_ptr() as u64;
-    attr.repeat = 1;
+    attr.repeat = repeat;
 
     let ret = unsafe {
         libc::syscall(
@@ -481,7 +511,7 @@ fn test_run_xdp(prog_fd: i32, packet: &[u8]) -> (u32, Vec<u8>) {
     }
 
     data_out.truncate(attr.data_size_out as usize);
-    (attr.retval, data_out)
+    (attr.retval, attr.duration, data_out)
 }
 
 // --- Prefix parsing ---------------------------------------------------
@@ -513,6 +543,7 @@ pub struct Ipv4TcpBuilder {
     pub tos: u8,
     pub frag_flags: u16, // network byte order: bit 15=res, 14=DF, 13=MF, 12..0=offset
     pub ihl: u8,         // normally 5; set >5 to produce IHL>5 via header option bytes
+    pub tcp_flags: u8,   // TCP header byte 13; default SYN (0x02)
     pub payload: Vec<u8>,
 }
 
@@ -529,6 +560,7 @@ impl Default for Ipv4TcpBuilder {
             tos: 0,
             frag_flags: 0,
             ihl: 5,
+            tcp_flags: 0x02, // SYN, the historical builder default
             payload: Vec::new(),
         }
     }
@@ -581,13 +613,13 @@ impl Ipv4TcpBuilder {
         let csum = ipv4_checksum(ip_header);
         pkt[check_offset..check_offset + 2].copy_from_slice(&csum.to_be_bytes());
 
-        // TCP (minimal 20-byte header; flags = SYN; no options)
+        // TCP (minimal 20-byte header; flags from `tcp_flags`; no options)
         pkt.extend_from_slice(&self.src_port.to_be_bytes());
         pkt.extend_from_slice(&self.dst_port.to_be_bytes());
         pkt.extend_from_slice(&[0, 0, 0, 1]); // seq
         pkt.extend_from_slice(&[0, 0, 0, 0]); // ack
         pkt.push(0x50); // data offset 5 in upper nibble
-        pkt.push(0x02); // SYN
+        pkt.push(self.tcp_flags);
         pkt.extend_from_slice(&[0xff, 0xff]); // window
         pkt.extend_from_slice(&[0, 0, 0, 0]); // checksum (zero - bpf doesn't care for fixtures)
 

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -55,7 +55,7 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V2: u32 = 1;
-pub const STATS_COUNT: u32 = 38;
+pub const STATS_COUNT: u32 = 40;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.
@@ -113,6 +113,8 @@ pub enum StatIdx {
     ErrTailCall = 35,
     ErrMutationCtx = 36,
     PassNdp = 37,
+    ErrCtxOffsetRange = 38,
+    ErrRedirectFailed = 39,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a

--- a/crates/modules/fast-path/tests/feature_gates.rs
+++ b/crates/modules/fast-path/tests/feature_gates.rs
@@ -1,0 +1,126 @@
+//! Behavioral fixtures for the FpCfg feature-presence gate bits
+//! (5-7): the XDP program skips BLOCK_V4/V6 and VLAN_RESOLVE lookups
+//! when the corresponding bit is clear. These tests prove both
+//! directions — bit set behaves exactly like the pre-gate program,
+//! and bit clear really does bypass the map (by constructing states
+//! where bypassing is observable in the verdict).
+//!
+//! The bit-clear-with-populated-map cases document the userspace
+//! invariant rather than a supported configuration: production always
+//! derives the bits from the same config that populates the maps
+//! (`feature_flags_from_config` + the VLAN RMW fixups), so these
+//! states are unreachable outside a test harness.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::{
+    xdp_action, Harness, Ipv4TcpBuilder, StatIdx, FP_CFG_FLAG_BLOCK_PRESENT,
+    FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_IPV4, FP_CFG_FLAG_IPV6, FP_CFG_FLAG_VLAN_PRESENT,
+};
+
+const LO_IFINDEX: u32 = 1;
+/// A fake VLAN-subif ifindex; deliberately NOT in the devmap so a
+/// bypassed VLAN_RESOLVE lookup is observable as PassNotInDevmap.
+const SUBIF_IFINDEX: u32 = 4242;
+const BASE_FLAGS: u8 = FP_CFG_FLAG_IPV4 | FP_CFG_FLAG_IPV6 | FP_CFG_FLAG_CUSTOM_FIB;
+
+/// Custom-fib forwarding scaffold: allowlisted /8, one resolved
+/// nexthop pointing at `nh_ifindex`, loopback in the devmap.
+fn forwarding_harness(nh_ifindex: u32) -> Harness {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(
+        0,
+        nh_ifindex,
+        [0x02, 0, 0, 0, 0, 0xee],
+        [0x02, 0, 0, 0, 0, 0xff],
+    );
+    h.add_fib_v4_single("10.0.0.0/8", 0);
+    h.add_devmap_ifindex(LO_IFINDEX);
+    h
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn block_gate_set_drops_blocked_dst() {
+    let mut h = forwarding_harness(LO_IFINDEX);
+    h.add_block_v4("10.9.0.0/16");
+    h.set_cfg_flags(BASE_FLAGS | FP_CFG_FLAG_BLOCK_PRESENT);
+
+    let pkt = Ipv4TcpBuilder {
+        dst_ip: [10, 9, 1, 1],
+        ..Default::default()
+    }
+    .build();
+
+    let before = h.stat(StatIdx::BogonDropped);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_DROP);
+    assert_eq!(h.stat(StatIdx::BogonDropped), before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn block_gate_clear_bypasses_lookup() {
+    // Same populated BLOCK_V4 trie, but the presence bit is clear: the
+    // packet must forward as if the trie were empty, proving the gate
+    // really skips the lookup rather than post-filtering its result.
+    let mut h = forwarding_harness(LO_IFINDEX);
+    h.add_block_v4("10.9.0.0/16");
+    h.set_cfg_flags(BASE_FLAGS);
+
+    let pkt = Ipv4TcpBuilder {
+        dst_ip: [10, 9, 1, 1],
+        ..Default::default()
+    }
+    .build();
+
+    let dropped_before = h.stat(StatIdx::BogonDropped);
+    let fwd_before = h.stat(StatIdx::FwdOk);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::BogonDropped), dropped_before);
+    assert_eq!(h.stat(StatIdx::FwdOk), fwd_before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_gate_set_resolves_subif_to_parent() {
+    // Nexthop egress is a VLAN subif; VLAN_RESOLVE maps it to the
+    // loopback parent (which IS in the devmap) with VID 66. With the
+    // bit set, the packet forwards and finalize pushes the tag.
+    let mut h = forwarding_harness(SUBIF_IFINDEX);
+    h.add_vlan_resolve(SUBIF_IFINDEX, LO_IFINDEX, 66);
+    h.set_cfg_flags(BASE_FLAGS | FP_CFG_FLAG_VLAN_PRESENT);
+
+    let pkt = Ipv4TcpBuilder::default().build();
+    let fwd_before = h.stat(StatIdx::FwdOk);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FwdOk), fwd_before + 1);
+    // VLAN push grew the frame by 4 and the 802.1Q TPID sits after
+    // the MAC pair.
+    assert_eq!(out.len(), pkt.len() + 4);
+    assert_eq!(&out[12..14], &[0x81, 0x00]);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn vlan_gate_clear_bypasses_resolve() {
+    // Same VLAN_RESOLVE entry, bit clear: the program must treat the
+    // subif ifindex as the raw egress. It is not in the devmap, so the
+    // pre-check fires and the packet passes to the kernel pristine —
+    // observable proof the map lookup was skipped.
+    let mut h = forwarding_harness(SUBIF_IFINDEX);
+    h.add_vlan_resolve(SUBIF_IFINDEX, LO_IFINDEX, 66);
+    h.set_cfg_flags(BASE_FLAGS);
+
+    let pkt = Ipv4TcpBuilder::default().build();
+    let miss_before = h.stat(StatIdx::PassNotInDevmap);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::PassNotInDevmap), miss_before + 1);
+    assert_eq!(out, pkt, "pass-path packet must be pristine (§11.13)");
+}

--- a/crates/modules/fast-path/tests/fib_fixtures.rs
+++ b/crates/modules/fast-path/tests/fib_fixtures.rs
@@ -349,10 +349,23 @@ fn custom_fib_v4_incomplete_nexthop_returns_noneigh() {
 
     let before_no_neigh = h.stat(StatIdx::CustomFibNoNeigh);
     let before_fwd = h.stat(StatIdx::FwdOk);
+    let before_retry = h.stat(StatIdx::NexthopSeqRetry);
+    let before_cache_miss = h.stat(StatIdx::NeighCacheMiss);
     let (verdict, _) = h.run(&pkt);
     assert_eq!(verdict, xdp_action::XDP_PASS, "incomplete → PASS");
     assert_eq!(h.stat(StatIdx::CustomFibNoNeigh), before_no_neigh + 1);
     assert_eq!(h.stat(StatIdx::FwdOk), before_fwd, "no forward on NoNeigh");
+    // A stably-unresolved entry is NOT a torn read: the seqlock split
+    // must short-circuit without burning the retry budget. Earlier
+    // versions bumped NexthopSeqRetry 4× here, inflating the counter
+    // to ~4× the custom_fib_no_neigh rate in production and masking
+    // genuine churn.
+    assert_eq!(
+        h.stat(StatIdx::NexthopSeqRetry),
+        before_retry,
+        "stable not-Resolved read must not count as a seqlock retry"
+    );
+    assert_eq!(h.stat(StatIdx::NeighCacheMiss), before_cache_miss + 1);
 }
 
 // ========== ECMP distribution =============================================

--- a/crates/modules/fast-path/tests/mss_clamp_gate.rs
+++ b/crates/modules/fast-path/tests/mss_clamp_gate.rs
@@ -1,0 +1,169 @@
+//! Fixtures for the mss-clamp gating changes: the MSS_CLAMP_PRESENT
+//! bit carried across the tail call (finalize skips the whole clamp
+//! chain when clear), the SYN hoist (established TCP skips the clamp
+//! lookups even when configured), and the global-clamp fallback riding
+//! in MutationCtx instead of a finalize-side CFG read.
+//!
+//! Clamp source precedence (prefix > iface > global, SPEC §4.x) is
+//! asserted unchanged.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::{
+    xdp_action, FpCfg, Harness, Ipv4TcpBuilder, StatIdx, FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_IPV4,
+    FP_CFG_FLAG_IPV6, FP_CFG_FLAG_MSS_CLAMP_PRESENT, FP_CFG_VERSION_V2,
+};
+
+const LO_IFINDEX: u32 = 1;
+const BASE_FLAGS: u8 = FP_CFG_FLAG_IPV4 | FP_CFG_FLAG_IPV6 | FP_CFG_FLAG_CUSTOM_FIB;
+
+const TCP_FLAG_SYN: u8 = 0x02;
+const TCP_FLAG_ACK: u8 = 0x10;
+
+/// MSS option bytes for a given value: kind=2, len=4, mss_be.
+fn mss_option(mss: u16) -> Vec<u8> {
+    let be = mss.to_be_bytes();
+    vec![2, 4, be[0], be[1]]
+}
+
+/// Offset of the MSS value bytes within the output frame: eth(14) +
+/// ipv4(20) + tcp fixed(20) + option kind/len(2).
+const MSS_VALUE_OFF: usize = 14 + 20 + 20 + 2;
+
+fn forwarding_harness() -> Harness {
+    let mut h = Harness::new();
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(
+        0,
+        LO_IFINDEX,
+        [0x02, 0, 0, 0, 0, 0xee],
+        [0x02, 0, 0, 0, 0, 0xff],
+    );
+    h.add_fib_v4_single("10.0.0.0/8", 0);
+    h.add_devmap_ifindex(LO_IFINDEX);
+    h
+}
+
+fn set_flags_and_global(h: &mut Harness, flags: u8, mss_clamp_global: u16) {
+    h.set_cfg(FpCfg {
+        dry_run: 0,
+        flags,
+        mss_clamp_global,
+        version: FP_CFG_VERSION_V2,
+    });
+}
+
+fn syn_with_mss(mss: u16) -> Vec<u8> {
+    Ipv4TcpBuilder {
+        tcp_flags: TCP_FLAG_SYN,
+        tcp_options: mss_option(mss),
+        ..Default::default()
+    }
+    .build()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn clamp_unconfigured_syn_forwards_untouched() {
+    // Production profile: no clamp anywhere, presence bit clear. The
+    // SYN must forward with its MSS bytes intact and neither clamp
+    // counter moving.
+    let mut h = forwarding_harness();
+    set_flags_and_global(&mut h, BASE_FLAGS, 0);
+
+    let pkt = syn_with_mss(1460);
+    let applied = h.stat(StatIdx::MssClampApplied);
+    let skipped = h.stat(StatIdx::MssClampSkipped);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[MSS_VALUE_OFF..MSS_VALUE_OFF + 2],
+        &1460u16.to_be_bytes()
+    );
+    assert_eq!(h.stat(StatIdx::MssClampApplied), applied);
+    assert_eq!(h.stat(StatIdx::MssClampSkipped), skipped);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn global_clamp_rides_mutation_ctx() {
+    // Global clamp only (no prefix/iface entries): the value reaches
+    // finalize via MutationCtx.mss_clamp_global — there is no CFG read
+    // in finalize anymore, so a wrong/missing carry would leave the
+    // MSS unclamped and fail this test.
+    let mut h = forwarding_harness();
+    set_flags_and_global(&mut h, BASE_FLAGS | FP_CFG_FLAG_MSS_CLAMP_PRESENT, 1300);
+
+    let pkt = syn_with_mss(1460);
+    let applied = h.stat(StatIdx::MssClampApplied);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[MSS_VALUE_OFF..MSS_VALUE_OFF + 2],
+        &1300u16.to_be_bytes()
+    );
+    assert_eq!(h.stat(StatIdx::MssClampApplied), applied + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn syn_hoist_established_tcp_bumps_nothing() {
+    // Clamp configured, but the packet is an established-flow ACK:
+    // the hoisted SYN test must bail before any clamp bookkeeping.
+    // Same observable outcome as pre-hoist (no counters, no mutation
+    // beyond TTL/L2) — this pins that the hoist didn't change it.
+    let mut h = forwarding_harness();
+    set_flags_and_global(&mut h, BASE_FLAGS | FP_CFG_FLAG_MSS_CLAMP_PRESENT, 1300);
+
+    let pkt = Ipv4TcpBuilder {
+        tcp_flags: TCP_FLAG_ACK,
+        ..Default::default()
+    }
+    .build();
+    let applied = h.stat(StatIdx::MssClampApplied);
+    let skipped = h.stat(StatIdx::MssClampSkipped);
+    let (verdict, _) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::MssClampApplied), applied);
+    assert_eq!(h.stat(StatIdx::MssClampSkipped), skipped);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn prefix_clamp_beats_global() {
+    // SPEC precedence: prefix source wins over the global fallback.
+    let mut h = forwarding_harness();
+    set_flags_and_global(&mut h, BASE_FLAGS | FP_CFG_FLAG_MSS_CLAMP_PRESENT, 1300);
+    h.add_mss_clamp_v4("10.0.0.0/8", 1200, 0);
+
+    let pkt = syn_with_mss(1460);
+    let applied = h.stat(StatIdx::MssClampApplied);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[MSS_VALUE_OFF..MSS_VALUE_OFF + 2],
+        &1200u16.to_be_bytes()
+    );
+    assert_eq!(h.stat(StatIdx::MssClampApplied), applied + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn syn_with_mss_below_clamp_counts_skipped() {
+    // Existing MSS already under the clamp: lower-if-higher semantics
+    // leave it alone and count MssClampSkipped, exactly as before.
+    let mut h = forwarding_harness();
+    set_flags_and_global(&mut h, BASE_FLAGS | FP_CFG_FLAG_MSS_CLAMP_PRESENT, 1300);
+
+    let pkt = syn_with_mss(1200);
+    let skipped = h.stat(StatIdx::MssClampSkipped);
+    let (verdict, out) = h.run(&pkt);
+    assert_eq!(verdict, xdp_action::XDP_REDIRECT);
+    assert_eq!(
+        &out[MSS_VALUE_OFF..MSS_VALUE_OFF + 2],
+        &1200u16.to_be_bytes()
+    );
+    assert_eq!(h.stat(StatIdx::MssClampSkipped), skipped + 1);
+}

--- a/crates/modules/fast-path/tests/netns.rs
+++ b/crates/modules/fast-path/tests/netns.rs
@@ -595,21 +595,21 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
 
 /// Snapshot every counter in the STATS map, indexed by `StatIdx`
 /// discriminant. Length matches `common::STATS_COUNT`. Aggregates
-/// across CPUs via per-CPU sum.
+/// across CPUs via per-CPU sum. v0.2.8+ STATS shape: one per-CPU
+/// entry holding the whole `[u64; STATS_COUNT]` block.
 fn snapshot_all_stats(bpf: &Ebpf) -> Vec<u64> {
     use aya::maps::PerCpuArray;
     let map = bpf.map("STATS").expect("STATS map");
-    let stats: PerCpuArray<_, u64> = PerCpuArray::try_from(map).expect("PerCpuArray::try_from");
-    (0..common::STATS_COUNT)
-        .map(|i| {
-            stats
-                .get(&i, 0)
-                .expect("STATS get")
-                .iter()
-                .copied()
-                .sum::<u64>()
-        })
-        .collect()
+    let stats: PerCpuArray<_, [u64; common::STATS_COUNT as usize]> =
+        PerCpuArray::try_from(map).expect("PerCpuArray::try_from");
+    let per_cpu = stats.get(&0, 0).expect("STATS get");
+    let mut out = vec![0u64; common::STATS_COUNT as usize];
+    for block in per_cpu.iter() {
+        for (slot, v) in out.iter_mut().zip(block.iter()) {
+            *slot += *v;
+        }
+    }
+    out
 }
 
 /// Produce a vec of `(name, delta)` for every counter whose value

--- a/crates/modules/fast-path/tests/netns.rs
+++ b/crates/modules/fast-path/tests/netns.rs
@@ -58,7 +58,7 @@ use packetframe_fast_path::{aligned_bpf_copy, FAST_PATH_BPF_AVAILABLE};
 
 mod common;
 
-use common::{FpCfg, Ipv4TcpBuilder, StatIdx, FP_CFG_VERSION_V1};
+use common::{FpCfg, Ipv4TcpBuilder, StatIdx, FP_CFG_VERSION_V2};
 
 // Names are kept short + PID-suffixed so concurrent test runs don't
 // collide. Linux caps iface names at IFNAMSIZ=16; we stay well under.
@@ -471,8 +471,8 @@ fn pass_path_preserves_packet_bytes_on_devmap_miss() {
             FpCfg {
                 dry_run: 0,
                 flags: 0b11,
-                _reserved: [0; 2],
-                version: FP_CFG_VERSION_V1,
+                mss_clamp_global: 0,
+                version: FP_CFG_VERSION_V2,
             },
             0,
         )

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -1,0 +1,136 @@
+# Generic-mode (xdp-generic) CPU performance
+
+Operational guide for deployments forced onto generic XDP (`attach <iface> generic`,
+or `auto` downgraded by a driver gate such as rvu-nicpf pre-6.8) that are hitting a
+CPU ceiling. Everything here is host tuning and measurement — no PacketFrame config
+change forwards more packets by itself.
+
+## Why generic mode costs so much CPU
+
+Native XDP runs in the driver before an skb exists. Generic XDP runs *after* the
+kernel has built an skb, and pays three extra per-packet costs that dominate the
+profile on a busy box:
+
+1. **Headroom reallocation.** `netif_receive_generic_xdp` requires 256 bytes of skb
+   headroom (`XDP_PACKET_HEADROOM`). Most drivers reserve far less, so the kernel
+   calls `pskb_expand_head` — an allocation plus a full packet copy — for **every
+   packet** the XDP program sees. Community measurements attribute roughly a 2×
+   packets-per-second penalty to this alone.
+2. **Linearization.** If the skb is nonlinear (fragmented data, or a GRO-aggregated
+   super-skb), the kernel linearizes it (another copy) before the program runs.
+3. **Un-bulked redirect.** Native XDP batches redirected frames through the devmap
+   flush. Generic-mode `XDP_REDIRECT` transmits one packet at a time via
+   `generic_xdp_tx` → `netdev_start_xmit`.
+
+The BPF program itself is usually the *smaller* share of per-packet CPU in generic
+mode. Optimize the host first.
+
+## Tuning checklist (ordered by expected payoff)
+
+`packetframe feasibility --config /etc/packetframe/packetframe.conf --human` now
+reports every knob below (`sysctl.net.core.bpf_jit_enable`, `iface.<if>.gro`,
+`iface.<if>.rps`, `kernel.version`).
+
+### 1. Confirm the BPF JIT is on
+
+```sh
+sysctl net.core.bpf_jit_enable   # want 1 (or 2); 0 = interpreter
+sysctl net.core.bpf_jit_harden   # want 0; 1/2 add constant-blinding cost
+```
+
+Interpreted BPF costs several times more CPU per packet than JITed BPF. Kernels
+built with `CONFIG_BPF_JIT_ALWAYS_ON=y` pin `bpf_jit_enable` to 1. If it's 0:
+
+```sh
+sysctl -w net.core.bpf_jit_enable=1
+```
+
+### 2. Spread the work with RPS
+
+Since kernel 5.3, generic XDP runs **after** RPS steering — on the RPS-target CPU,
+not the NIC's IRQ CPU. That means `rps_cpus` spreads the entire generic-XDP
+workload (headroom copy + program + redirect) across cores. On a CPU-limited box
+with all-zero RPS masks this is the highest-leverage free change available.
+
+```sh
+# Report current masks:
+grep . /sys/class/net/eth*/queues/rx-*/rps_cpus
+
+# Example: spread eth0 across CPUs 0-3 (mask f):
+echo f > /sys/class/net/eth0/queues/rx-0/rps_cpus
+```
+
+Guidance:
+- Set the mask to the CPUs you want doing packet work; excluding the CPU that
+  services the NIC IRQ reduces contention on single-queue NICs.
+- Make it persistent (systemd-tmpfiles, udev rule, or an rc script) — sysfs resets
+  on reboot and on some drivers on link bounce.
+- Watch `%soft` per-CPU in `mpstat -P ALL 5` before/after: the win shows up as the
+  hot CPU's softirq share dropping and spreading.
+
+### 3. Decide on GRO
+
+GRO interacts with generic XDP two ways, and the right setting depends on traffic:
+
+- **GRO on:** the kernel aggregates TCP segments into super-skbs *before* generic
+  XDP. Every aggregated skb is nonlinear → linearized (copied) before the program
+  runs. Fewer program invocations, but each one pays a big copy, and the redirect
+  path then transmits the aggregate.
+- **GRO off:** no linearization copies, but the program (and the per-packet 256B
+  headroom copy) runs for every wire packet, and any traffic still handled by the
+  kernel stack (allowlist misses, local traffic) loses GRO's benefit.
+
+For a fast-path box where ~99% of traffic is matched+forwarded, try GRO off on the
+attach interfaces and A/B the CPU numbers:
+
+```sh
+ethtool -K eth0 gro off lro off
+```
+
+Measure before committing — on TCP-heavy links the answer is workload-dependent.
+
+### 4. Verify you're not in a diagnostic mode
+
+- `forwarding-mode compare` runs **both** FIB lookups per packet (documented 2×
+  FIB cost). It's a cutover-validation mode; don't leave it on.
+- `dry-run on` still classifies and FIB-looks-up every matched packet.
+
+## Measuring
+
+### On-box profile (which side is burning CPU?)
+
+```sh
+perf top -e cycles:k
+```
+
+Symbols to read:
+
+| Symbol | Meaning |
+|---|---|
+| `pskb_expand_head` | the generic-XDP 256B-headroom copy (cost #1 above) |
+| `skb_linearize`, `__pskb_pull_tail` | GRO/nonlinear linearization (cost #2) |
+| `bpf_prog_run_generic_xdp`, `bpf_prog_*` | the BPF program itself |
+| `generic_xdp_tx`, `netdev_start_xmit` | generic-mode redirect transmit (cost #3) |
+| `nf_hook_slow`, `__nf_conntrack_find_get` | traffic that is NOT being fast-pathed |
+
+If `pskb_expand_head` + linearization dwarf `bpf_prog_run_generic_xdp`, host tuning
+and datapath placement (not BPF micro-optimization) are where the wins are.
+
+### Program-only microbenchmark
+
+`crates/modules/fast-path/tests/bench.rs` measures ns/packet for the
+`fast_path → finalize` chain via `BPF_PROG_TEST_RUN` (kernel-timed, excludes all
+generic-XDP skb overhead). Run on any Linux host, or cross-build the test binary
+for the router (instructions in the file header). Confirm the JIT is on first —
+otherwise the bench times the interpreter.
+
+### Counters that matter (`packetframe status`)
+
+- `rx_total` vs `fwd_ok`: your fast-path hit rate; the difference is traffic paying
+  full kernel-stack cost.
+- `pass_not_in_devmap`, `err_tail_call`: should be 0; non-zero means matched
+  traffic silently falling back to the slow path.
+- `custom_fib_miss`: destinations the BGP feed doesn't cover (consider
+  `fallback-default`).
+- `nexthop_seq_retry`, `custom_fib_no_neigh`: sustained growth means nexthop churn
+  or unresolved neighbors, each such packet takes the slow path.

--- a/docs/runbooks/tail-call-architecture.md
+++ b/docs/runbooks/tail-call-architecture.md
@@ -60,12 +60,13 @@ pub struct MutationCtx {
     egress_vid: u16,       // VLAN_RESOLVE result; 0 = untagged
     ingress_vid: u16,      // From packet parse; 0 = untagged
     ip_offset: u32,        // Bytes from ctx.data() to IP header
-    is_v4: u8,             // 1 = IPv4, 0 = IPv6
-    _pad: [u8; 3],
+    is_v4: u32,            // 1 = IPv4, 0 = IPv6 (u32: no-padding rule)
+    cfg_flags: u16,        // Low byte = FpCfg.flags at fast_path entry
+    mss_clamp_global: u16, // Global clamp fallback; 0 = unset
 }
 ```
 
-16 bytes, naturally aligned. Per-CPU because the NAPI cycle is single-CPU; the read in finalize sees the most recent write in fast_path with no synchronization.
+20 bytes, naturally aligned, zero padding (compile-time asserted in `bpf/src/maps.rs` — padding would let LLVM merge zero-stores into a `memset` libcall, which becomes a bpf-to-bpf subprogram and trips the tail-call exclusion on UniFi 5.15). `cfg_flags` + `mss_clamp_global` carry fast_path's single CFG read across the tail call so finalize never touches the CFG map. Per-CPU because the NAPI cycle is single-CPU; the read in finalize sees the most recent write in fast_path with no synchronization.
 
 ## MUTATION_PROGS jump table
 


### PR DESCRIPTION
## Context

Production (EFG-class routers: 5.15.72-ui-cn9670 aarch64, rvu-nicpf, 6 ifaces forced to xdp-generic) is CPU-limited. Live counters show 99.91% of rx traffic matches and forwards via custom-fib single-nexthop — and the hot-path inventory found a forwarded TCP packet paying **23 map-helper calls**, of which 5 were reads of the same 8-byte CFG element, 5 were separate STATS lookups for counter bumps, 4 were mss-clamp lookups on a box with no clamp configured, plus unconditional block-prefix/VLAN lookups and dead L4-port parsing.

## Result

**23 → 10 map-helper calls per production forwarded packet (−56%)**, with all 38 counter indices and semantics preserved (append-only contract respected; two flagged bug fixes below). Plus the measurement + operator tooling to quantify it.

| Commit | Change |
|---|---|
| STATS consolidation | `PerCpuArray<u64>`×38 → single `[u64; N]` block: 5 bump lookups → 1 lookup/stage + constant-offset increments; userspace stats read 38 syscalls → 1. Note: raw `bpftool map dump name STATS` shape changes; CLI/Prometheus output byte-identical |
| bench harness | ns/packet microbenchmark via `BPF_PROG_TEST_RUN` repeat+duration (TTL-budget-safe, FwdOk sanity assert); fixes stale test `FpCfg` mirror |
| CFG once + gates | CFG read 4×→1× per packet; new presence bits 5–7 gate BLOCK_V4/V6 and VLAN_RESOLVE lookups when unconfigured. Bits derived via one shared `feature_flags_from_config()` used by populate **and** reconcile (SIGHUP-wipe-proof, unit-tested), VLAN bit RMW-fixed after discovery |
| mss-clamp gating | MutationCtx 16→20B (compile-time no-padding assert) carries cfg_flags + mss_clamp_global across the tail call; whole clamp chain gated off when unconfigured; SYN test hoisted before the 3 clamp lookups; finalize no longer reads CFG |
| FIB micro-fixes | L4 port parse deferred to points of use (zero port work on single-NH path); ECMP double NEXTHOPS read removed; seqlock retry/state split |
| error counters | Appends `err_ctx_offset_range`(38) + `err_redirect_failed`(39) for two previously invisible/mislabeled half-mutated-frame fail-opens |
| probes + runbook | Feasibility probes for `bpf_jit_enable` (kconfig ALWAYS_ON fallback), `bpf_jit_harden`, kernel version, per-iface GRO (ethtool ioctl) + RPS masks; new `docs/runbooks/generic-mode-performance.md` with the generic-XDP cost model and tuning order |

## Flagged counter-behavior changes (bug fixes, no index/name changes)

- **NexthopSeqRetry** no longer 4×-counts stably-unresolved nexthops (production evidence: 10.1M retries ≈ 4 × 2.5M custom_fib_no_neigh — the counter was measuring unresolved-NH traffic, not the seqlock churn it documents). Genuine torn reads count exactly as before.
- **ErrFibOther** no longer absorbs finalize redirect failures; those move to the new `err_redirect_failed`.

## Verifier constraints (the reason CI is the gate)

Every change keeps the UniFi-5.15 rules: two-stage tail-call preserved, everything `#[inline(always)]`, no memset/memcpy libcall bait (MutationCtx stays zero-padding with individual field stores, now compile-time asserted), untouched load-bearing patterns (ip_offset umax clamp, pkt-minus-pkt re-derivation, block-scoped LPM keys, devmap pre-check-before-mutation). The qemu-verifier matrix (5.15 + 6.6) on this PR is the proof; local macOS builds can only type-check the BPF crate.

New sudo-gated fixtures: feature-gate behavior matrices (both bit directions, bypass observability), mss-clamp unconfigured/global-via-ctx/SYN-hoist/precedence/lower-if-higher, seqlock retry-counting assertions.

## After merge

- Run `tests/bench.rs` on the reference EFG for before/after ns/packet (instructions in file header), and record numbers in the runbook.
- Operator quick wins from the runbook need no code: confirm `bpf_jit_enable=1`, set RPS masks (generic XDP runs after RPS on 5.15 — spreads the whole per-packet workload), A/B GRO.
- Next planned phase: TC-ingress datapath variant (avoids generic XDP's per-packet 256B-headroom realloc + linearization entirely; est. 1.5–3×).

🤖 Generated with [Claude Code](https://claude.com/claude-code)