### PR TITLE
feat: tc-ingress datapath (Phase T) — escape generic XDP's per-packet copy tax

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 | `packetframe reconfigure` / `systemctl reload packetframe` | Production (v0.2.4+) |
 | Two-stage BPF datapath (`fast_path` + `finalize` via `bpf_tail_call`) | Production (v0.2.5+); see [docs/runbooks/tail-call-architecture.md](docs/runbooks/tail-call-architecture.md) |
 | `probe` module (diagnostic XDP) | Production |
+| tc-ingress datapath (`attach <iface> tc`, custom-fib only) | Experimental (Phase T); see [docs/runbooks/tc-datapath.md](docs/runbooks/tc-datapath.md) |
 | `ddos` module (XDP-time SYN-flood + amplification filter) | Future; sketched in SPEC §5.2 (priority 0–999, security/admission) |
 | `sampler` module (per-flow ringbuf observability) | Future; sketched in SPEC §5.3 (priority 2000–2999, observation) |
 | `randomizer` module (TC egress jitter for NoiseNet anti-correlation) | Future; sketched in SPEC §5.1 (priority ~3000, egress) |

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -24,6 +24,15 @@ module fast-path
   # Attach native XDP to every interface carrying forwarded traffic we want
   # on the fast path. Omit HA links, out-of-band management, and anything
   # terminating tunnels locally.
+  #
+  # Modes: native | generic | auto | tc.
+  # `tc` (Phase T) runs the datapath as sched_cls classifiers on a
+  # clsact qdisc instead of XDP. On hosts forced into xdp-generic
+  # (e.g. rvu-nicpf kernels < 6.8) it avoids generic XDP's per-packet
+  # headroom copy and GRO linearization. Requires `forwarding-mode
+  # custom-fib`; per-iface opt-in (never chosen by `auto`) so canary
+  # rollouts stay operator-controlled, e.g.:
+  #   attach eth5 tc
   attach eth0 native
   attach eth2 native
   attach eth3 native

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -818,6 +818,18 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
             "pins removed; kernel detached"
         );
 
+        // tc-datapath filters (Phase T) have qdisc lifetime rather
+        // than bpffs pins; tear them down from their own persistence
+        // record. No-op when tc-links.json doesn't exist.
+        #[cfg(target_os = "linux")]
+        {
+            let n = packetframe_fast_path::tc_detach_from_state_dir(&state_dir)
+                .map_err(|e| format!("tc filter teardown: {e}"))?;
+            if n > 0 {
+                tracing::info!(count = n, "tc filters detached");
+            }
+        }
+
         packetframe_fast_path::registry::remove(&state_dir)
             .map_err(|e| format!("registry remove: {e}"))?;
     }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -479,6 +479,14 @@ pub enum AttachMode {
     Native,
     Generic,
     Auto,
+    /// tc-ingress datapath (Phase T): sched_cls classifiers on a
+    /// clsact qdisc instead of XDP. For hosts forced into xdp-generic
+    /// (e.g. rvu-nicpf pre-6.8), this avoids generic XDP's per-packet
+    /// headroom realloc + GRO linearization. Requires
+    /// `forwarding-mode custom-fib` (enforced at attach time); `auto`
+    /// never selects tc — it is an explicit per-iface opt-in so
+    /// canary rollouts stay operator-controlled.
+    Tc,
 }
 
 impl FromStr for AttachMode {
@@ -488,8 +496,9 @@ impl FromStr for AttachMode {
             "native" => Ok(Self::Native),
             "generic" => Ok(Self::Generic),
             "auto" => Ok(Self::Auto),
+            "tc" => Ok(Self::Tc),
             other => Err(format!(
-                "unknown attach mode `{other}` (expected native|generic|auto)"
+                "unknown attach mode `{other}` (expected native|generic|auto|tc)"
             )),
         }
     }
@@ -2361,6 +2370,20 @@ module fast-path
         let s = "module fast-path\n  attach eth0\n";
         let e = Config::parse(s).unwrap_err();
         assert!(matches!(e, ConfigError::Parse { line: 2, .. }));
+    }
+
+    #[test]
+    fn attach_tc_mode_parses() {
+        let s = "module fast-path\n  attach eth5 tc\n";
+        let c = Config::parse(s).unwrap();
+        let d = &c.modules[0].directives[0];
+        match d {
+            ModuleDirective::Attach { iface, mode, .. } => {
+                assert_eq!(iface, "eth5");
+                assert_eq!(*mode, AttachMode::Tc);
+            }
+            other => panic!("expected Attach, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/modules/fast-path/bpf/src/datapath.rs
+++ b/crates/modules/fast-path/bpf/src/datapath.rs
@@ -1,0 +1,266 @@
+//! Context-free datapath helpers shared between hook types (Phase T).
+//!
+//! Everything here is parameterized on `(start, end)` packet-bounds
+//! scalars (from `XdpContext::data()/data_end()` today; from a TC
+//! classifier's `__sk_buff` data pointers in the tc datapath) instead
+//! of a concrete ctx type. Deliberately **no Ctx trait / no generics**:
+//! monomorphized abstraction would likely verify, but this codebase's
+//! verifier history (SPEC "Inline mandate", the `Option<u16>` spill,
+//! the memset-libcall exclusions) argues for the dumbest possible
+//! sharing — scalars in, scalars out, everything `#[inline(always)]`.
+//!
+//! Rules for anything added here:
+//! - `#[inline(always)]` on every fn: bpf-to-bpf calls are mutually
+//!   exclusive with tail calls on the production kernel.
+//! - No map access unless the map is hook-agnostic (STATS via
+//!   [`StatsPtr`] is fine — both hook types share the pinned maps).
+//! - No XDP- or TC-only helper calls (`bpf_xdp_adjust_head`,
+//!   `bpf_skb_vlan_push`, ...); those stay in the per-hook modules.
+
+use network_types::ip::{IpProto, Ipv4Hdr, Ipv6Hdr};
+
+use crate::maps::{bump, StatIdx, StatsPtr};
+
+const PROTO_TCP: u8 = IpProto::Tcp as u8;
+const PROTO_UDP: u8 = IpProto::Udp as u8;
+
+/// SYN flag in TCP header byte 13.
+pub const TCP_FLAG_SYN: u8 = 0x02;
+
+// --- L3 header mutation -------------------------------------------------
+
+/// Decrement IPv4 TTL and patch the header checksum using RFC 1624
+/// incremental update: when TTL decreases by 1, the word at bytes 8-9
+/// (TTL:proto, network order) decreases by 0x0100 → the checksum
+/// increases by 0x0100 in one's-complement arithmetic.
+#[inline(always)]
+pub fn decrement_ipv4_ttl(ip: *mut Ipv4Hdr) {
+    unsafe {
+        (*ip).ttl -= 1;
+        let mut sum = u16::from_be_bytes((*ip).check) as u32;
+        sum = sum.wrapping_add(0x0100);
+        sum = (sum & 0xffff).wrapping_add(sum >> 16);
+        (*ip).check = (sum as u16).to_be_bytes();
+    }
+}
+
+#[inline(always)]
+pub fn decrement_ipv6_hop_limit(ip: *mut Ipv6Hdr) {
+    unsafe {
+        (*ip).hop_limit -= 1;
+    }
+}
+
+// --- Bounds-checked packet readers ---------------------------------------
+
+/// Read sport/dport from the L4 header at `offset`. Returns raw BE
+/// network-order u16 bytes (via `read_unaligned`) matching what the
+/// kernel's `bpf_fib_lookup` expects for its `__be16` sport/dport
+/// fields on an LE host. (0, 0) for ICMP / ICMPv6 or truncated L4.
+#[inline(always)]
+pub fn l4_ports(start: usize, end: usize, offset: usize, proto: u8) -> (u16, u16) {
+    if !matches!(proto, PROTO_TCP | PROTO_UDP) {
+        return (0, 0);
+    }
+    if start + offset + 4 > end {
+        return (0, 0);
+    }
+    unsafe {
+        let p = (start + offset) as *const u8;
+        let sport = core::ptr::read_unaligned(p as *const u16);
+        let dport = core::ptr::read_unaligned(p.add(2) as *const u16);
+        (sport, dport)
+    }
+}
+
+/// Read the ICMPv6 `type` field, the first octet of the ICMPv6 header.
+///
+/// `None` when the read would run past `end`; callers treat that as
+/// "not an NDP message" and fall through to the normal path, which is
+/// fail-safe (a truncated ICMPv6 header can't be a valid NS/NA anyway).
+/// Bounds-check shape mirrors [`l4_ports`].
+#[inline(always)]
+pub fn icmpv6_type(start: usize, end: usize, offset: usize) -> Option<u8> {
+    if start + offset + 1 > end {
+        return None;
+    }
+    Some(unsafe { core::ptr::read_unaligned((start + offset) as *const u8) })
+}
+
+/// Read TCP header byte 13 (flags) at `tcp_offset` and test SYN.
+/// Out-of-bounds → `false` (a truncated TCP header can't be a
+/// clampable SYN). Bounds check uses the accepted
+/// `start + off + k > end` pattern; callers guarantee `tcp_offset`
+/// is `ip_offset + <const HDR>` with `ip_offset` already clamped.
+#[inline(always)]
+pub fn tcp_syn_flag_set(start: usize, end: usize, tcp_offset: usize) -> bool {
+    if start + tcp_offset + 14 > end {
+        return false;
+    }
+    let flags = unsafe { *((start + tcp_offset + 13) as *const u8) };
+    flags & TCP_FLAG_SYN != 0
+}
+
+/// Assemble a `[u8; 16]` IPv6 address into the `[u32; 4]` shape
+/// `bpf_fib_lookup` wants (native-endian word loads of network-order
+/// bytes). Usable from any hook type that calls the FIB helper.
+#[inline(always)]
+pub fn bytes_to_u32x4(b: &[u8; 16]) -> [u32; 4] {
+    [
+        u32::from_ne_bytes([b[0], b[1], b[2], b[3]]),
+        u32::from_ne_bytes([b[4], b[5], b[6], b[7]]),
+        u32::from_ne_bytes([b[8], b[9], b[10], b[11]]),
+        u32::from_ne_bytes([b[12], b[13], b[14], b[15]]),
+    ]
+}
+
+// --- MSS clamp (option walk + checksum patch) -----------------------------
+
+/// Walk the TCP-options block of a matched SYN/SYN-ACK and mutate the MSS
+/// option in place if the existing MSS is greater than the clamp value.
+/// Recomputes the TCP checksum incrementally (RFC 1624). Bumps
+/// `MssClampApplied` on rewrite, `MssClampSkipped` on "policy applies but
+/// no rewrite needed."
+///
+/// Takes a typed `ip_ptr` (already bounds-checked for `ip_hdr_size` bytes)
+/// rather than a raw `tcp_offset` scalar. Inside, we recover ip_offset as
+/// `(ip_ptr as usize) - start`, which the BPF verifier tracks as a `pkt -
+/// pkt` subtraction with `umax = MAX_PACKET_OFF (0xffff)`. That tight bound
+/// is what makes subsequent `start + tcp_offset + N > end` checks
+/// propagate readable-range to the read site (mirrors v0.2.4's working
+/// pattern; passing `tcp_offset` directly as a `usize` from a map read
+/// loses verifier tracking and the post-bound-check pkt pointer ends up
+/// with `r=0`). `start`/`end` must be the same bounds `ip_ptr` was
+/// validated against.
+///
+/// Bounds-checked at every read against `end`. Options walk is
+/// fixed-bound at 8 iterations to keep BPF verifier state-space
+/// exploration tractable (a 40-iteration walk hit the verifier's
+/// 1M-instruction limit during v0.2.4 development).
+#[inline(always)]
+pub fn mss_clamp_tcp(
+    stats: StatsPtr,
+    start: usize,
+    end: usize,
+    ip_ptr: *const u8,
+    ip_hdr_size: usize,
+    clamp: u16,
+) {
+    // pkt-derived scalar; verifier tracks umax tightly.
+    let ip_offset = (ip_ptr as usize) - start;
+    let tcp_offset = ip_offset + ip_hdr_size;
+
+    // Need 20 bytes for the fixed TCP header before walking options.
+    if start + tcp_offset + 20 > end {
+        return;
+    }
+
+    // Bytes 12-13 of TCP header: data_offset:4 | reserved:4 | flags:8.
+    let doff_byte = unsafe { *((start + tcp_offset + 12) as *const u8) };
+    let flags = unsafe { *((start + tcp_offset + 13) as *const u8) };
+    if flags & TCP_FLAG_SYN == 0 {
+        return; // Not SYN/SYN-ACK.
+    }
+    let doff_words = (doff_byte >> 4) as usize;
+    if !(5..=15).contains(&doff_words) {
+        return;
+    }
+    let tcp_hdr_len = doff_words * 4;
+    let opts_len = tcp_hdr_len - 20;
+    if opts_len == 0 {
+        bump(stats, StatIdx::MssClampSkipped);
+        return;
+    }
+    if start + tcp_offset + tcp_hdr_len > end {
+        return;
+    }
+
+    // Walk options. Cap at 8, real SYN packets put MSS in the first
+    // 1-4 options (Linux's tcp_options_write emits MSS very early); 8
+    // is comfortable headroom while keeping verifier state-space bounded.
+    let opts_start_off = tcp_offset + 20;
+    let mut cursor: usize = 0;
+    let mut found = false;
+
+    for _ in 0..8 {
+        if cursor >= opts_len {
+            break;
+        }
+        let p_addr = start + opts_start_off + cursor;
+        if p_addr + 4 > end {
+            break;
+        }
+        let p = p_addr as *const u8;
+        let kind = unsafe { *p };
+        if kind == 0 {
+            break; // EOL.
+        }
+        if kind == 1 {
+            cursor += 1; // NOP.
+            continue;
+        }
+        let length = unsafe { *p.add(1) } as usize;
+        if length < 2 || cursor + length > opts_len {
+            break; // Malformed.
+        }
+        if kind == 2 && length == 4 {
+            // MSS option: [kind=2, length=4, mss_be:2].
+            let mss_be = unsafe { [*p.add(2), *p.add(3)] };
+            let mss = u16::from_be_bytes(mss_be);
+            if mss > clamp {
+                let new_mss_be = clamp.to_be_bytes();
+                unsafe {
+                    let pmut = p as *mut u8;
+                    *pmut.add(2) = new_mss_be[0];
+                    *pmut.add(3) = new_mss_be[1];
+                }
+                // RFC 1624 incremental TCP checksum update.
+                let csum_off = tcp_offset + 16;
+                if start + csum_off + 2 > end {
+                    return;
+                }
+                let csum_p = (start + csum_off) as *mut u8;
+                let old_csum_be = unsafe { [*csum_p, *csum_p.add(1)] };
+                let old_csum = u16::from_be_bytes(old_csum_be);
+                let new_csum = csum_replace_u16(old_csum, mss, clamp);
+                let new_csum_be = new_csum.to_be_bytes();
+                unsafe {
+                    *csum_p = new_csum_be[0];
+                    *csum_p.add(1) = new_csum_be[1];
+                }
+                bump(stats, StatIdx::MssClampApplied);
+            } else {
+                bump(stats, StatIdx::MssClampSkipped);
+            }
+            found = true;
+            break;
+        }
+        cursor += length;
+    }
+
+    if !found {
+        bump(stats, StatIdx::MssClampSkipped);
+    }
+}
+
+#[inline(always)]
+pub fn csum_replace_u16(old_csum: u16, old_val: u16, new_val: u16) -> u16 {
+    let mut sum: u32 = (!old_csum) as u32 + (!old_val) as u32 + new_val as u32;
+    sum = (sum & 0xffff) + (sum >> 16);
+    sum = (sum & 0xffff) + (sum >> 16);
+    !(sum as u16)
+}
+
+// --- Counter bookkeeping ---------------------------------------------------
+
+/// Which side(s) of the allowlist matched. Hook-agnostic: both the XDP
+/// and tc datapaths bump the same shared counters.
+#[inline(always)]
+pub fn bump_match_subset(stats: StatsPtr, src_hit: bool, dst_hit: bool) {
+    match (src_hit, dst_hit) {
+        (true, true) => bump(stats, StatIdx::MatchedBoth),
+        (true, false) => bump(stats, StatIdx::MatchedSrcOnly),
+        (false, true) => bump(stats, StatIdx::MatchedDstOnly),
+        (false, false) => {}
+    }
+}

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -18,9 +18,9 @@
 //! asserts agreement. If the two sides drift, the test fails before
 //! any XDP packet is ever forwarded.
 
-use aya_ebpf::{maps::lpm_trie::Key, programs::XdpContext};
+use aya_ebpf::maps::lpm_trie::Key;
 
-use crate::l4_ports;
+use crate::datapath::l4_ports;
 use crate::maps::{
     bump, EcmpGroup, FibValue, NexthopEntry, StatIdx, StatsPtr, ECMP_GROUPS, FIB_KIND_ECMP,
     FIB_KIND_SINGLE, FIB_V4, FIB_V6, MAX_ECMP_PATHS, NEXTHOPS, NH_STATE_RESOLVED,
@@ -84,16 +84,20 @@ impl CustomFibResult {
 // --- Top-level lookup -------------------------------------------------
 
 /// IPv4 custom-FIB lookup. Caller passes the parsed src/dst/proto plus
-/// the L4 header offset; **port extraction is deferred** into the ECMP
-/// arm (`resolve_fib_value_v4`), because ports feed only the ECMP flow
-/// hash — on the single-nexthop path (the common case on deployments
-/// with no ECMP groups) no port bytes are read at all. Returns a
-/// [`CustomFibResult`] the caller feeds into the existing
-/// `dispatch_fib` success / miss paths in `main.rs`.
+/// the packet bounds and L4 header offset; **port extraction is
+/// deferred** into the ECMP arm (`resolve_fib_value_v4`), because ports
+/// feed only the ECMP flow hash — on the single-nexthop path (the
+/// common case on deployments with no ECMP groups) no port bytes are
+/// read at all. `(start, end)` scalars rather than a ctx type keep the
+/// whole module hook-agnostic (shared with the tc datapath, Phase T).
+/// Returns a [`CustomFibResult`] the caller feeds into its own
+/// dispatch verdict mapping.
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 pub fn lookup_v4(
     stats: StatsPtr,
-    ctx: &XdpContext,
+    start: usize,
+    end: usize,
     l4_off: usize,
     src: [u8; 4],
     dst: [u8; 4],
@@ -108,7 +112,7 @@ pub fn lookup_v4(
         }
     };
 
-    let nh_ptr = match resolve_fib_value_v4(stats, ctx, l4_off, &fib, src, dst, proto) {
+    let nh_ptr = match resolve_fib_value_v4(stats, start, end, l4_off, &fib, src, dst, proto) {
         Some(p) => p,
         None => {
             // ECMP walked every leg and none resolved, or the single
@@ -130,12 +134,14 @@ pub fn lookup_v4(
     }
 }
 
-/// IPv6 custom-FIB lookup. See [`lookup_v4`]; same deferred-port
-/// contract.
+/// IPv6 custom-FIB lookup. See [`lookup_v4`]; same deferred-port and
+/// scalar-bounds contracts.
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 pub fn lookup_v6(
     stats: StatsPtr,
-    ctx: &XdpContext,
+    start: usize,
+    end: usize,
     l4_off: usize,
     src: [u8; 16],
     dst: [u8; 16],
@@ -150,7 +156,7 @@ pub fn lookup_v6(
         }
     };
 
-    let nh_ptr = match resolve_fib_value_v6(stats, ctx, l4_off, &fib, src, dst, proto) {
+    let nh_ptr = match resolve_fib_value_v6(stats, start, end, l4_off, &fib, src, dst, proto) {
         Some(p) => p,
         None => {
             bump(stats, StatIdx::CustomFibNoNeigh);
@@ -173,9 +179,11 @@ pub fn lookup_v6(
 // --- FibValue → NexthopEntry pointer ------------------------------------
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn resolve_fib_value_v4(
     stats: StatsPtr,
-    ctx: &XdpContext,
+    start: usize,
+    end: usize,
     l4_off: usize,
     fib: &FibValue,
     src: [u8; 4],
@@ -192,7 +200,7 @@ fn resolve_fib_value_v4(
             // kernel-FIB `__be16` shape); the hash contract is
             // native-order, so swap here — same values the caller
             // used to compute, just only when actually needed.
-            let (sport_be, dport_be) = l4_ports(ctx, l4_off, proto);
+            let (sport_be, dport_be) = l4_ports(start, end, l4_off, proto);
             let h = hash_v4(
                 src,
                 dst,
@@ -208,9 +216,11 @@ fn resolve_fib_value_v4(
 }
 
 #[inline(always)]
+#[allow(clippy::too_many_arguments)]
 fn resolve_fib_value_v6(
     stats: StatsPtr,
-    ctx: &XdpContext,
+    start: usize,
+    end: usize,
     l4_off: usize,
     fib: &FibValue,
     src: [u8; 16],
@@ -223,7 +233,7 @@ fn resolve_fib_value_v6(
             bump(stats, StatIdx::EcmpHashV6);
             let group = ECMP_GROUPS.get(fib.idx)?;
             // See resolve_fib_value_v4 for the deferred-port rationale.
-            let (sport_be, dport_be) = l4_ports(ctx, l4_off, proto);
+            let (sport_be, dport_be) = l4_ports(start, end, l4_off, proto);
             let h = hash_v6(
                 src,
                 dst,

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -22,6 +22,7 @@ use aya_ebpf::{
 };
 use network_types::ip::{IpProto, Ipv4Hdr, Ipv6Hdr};
 
+use crate::datapath::{mss_clamp_tcp, tcp_syn_flag_set};
 use crate::maps::{
     bump, stats_base, StatIdx, StatsPtr, FP_CFG_FLAG_MSS_CLAMP_PRESENT, MSS_CLAMP_BY_IFACE,
     MSS_CLAMP_V4, MSS_CLAMP_V6, MUTATION_CTX, REDIRECT_DEVMAP,
@@ -33,9 +34,6 @@ const TPID_8021Q: u16 = 0x8100;
 
 /// Sentinel for "no VLAN", mirror of `main::VLAN_NONE`.
 const VLAN_NONE: u16 = 0;
-
-/// SYN flag in TCP byte 13.
-const TCP_FLAG_SYN: u8 = 0x02;
 
 /// IANA TCP protocol number, materialized from `IpProto` (network-types
 /// 0.2 changed `proto`/`next_hdr` to raw `u8`).
@@ -203,7 +201,7 @@ fn mss_clamp_v4(
     if clamp == 0 {
         return;
     }
-    mss_clamp_tcp(ctx, stats, ip as *const u8, Ipv4Hdr::LEN, clamp);
+    mss_clamp_tcp(stats, start, end, ip as *const u8, Ipv4Hdr::LEN, clamp);
 }
 
 /// IPv6 path: same pattern as `mss_clamp_v4` but with a 40-byte bound.
@@ -233,158 +231,7 @@ fn mss_clamp_v6(
     if clamp == 0 {
         return;
     }
-    mss_clamp_tcp(ctx, stats, ip as *const u8, Ipv6Hdr::LEN, clamp);
-}
-
-/// Read TCP header byte 13 (flags) at `tcp_offset` and test SYN.
-/// Out-of-bounds → `false` (a truncated TCP header can't be a
-/// clampable SYN; mirrors the fail-open shape of `icmpv6_type` in
-/// main.rs). Bounds check uses the accepted `start + off + k > end`
-/// pattern; `tcp_offset` is `ip_offset + <const HDR>` where fast_path
-/// already clamped `ip_offset` ≤ MAX_IP_OFFSET.
-#[inline(always)]
-fn tcp_syn_flag_set(start: usize, end: usize, tcp_offset: usize) -> bool {
-    if start + tcp_offset + 14 > end {
-        return false;
-    }
-    let flags = unsafe { *((start + tcp_offset + 13) as *const u8) };
-    flags & TCP_FLAG_SYN != 0
-}
-
-/// Walk the TCP-options block of a matched SYN/SYN-ACK and mutate the MSS
-/// option in place if the existing MSS is greater than the clamp value.
-/// Recomputes the TCP checksum incrementally (RFC 1624). Bumps
-/// `MssClampApplied` on rewrite, `MssClampSkipped` on "policy applies but
-/// no rewrite needed."
-///
-/// Takes a typed `ip_ptr` (already bounds-checked for `ip_hdr_size` bytes)
-/// rather than a raw `tcp_offset` scalar. Inside, we recover ip_offset as
-/// `(ip_ptr as usize) - start`, which the BPF verifier tracks as a `pkt -
-/// pkt` subtraction with `umax = MAX_PACKET_OFF (0xffff)`. That tight bound
-/// is what makes subsequent `start + tcp_offset + N > end` checks
-/// propagate readable-range to the read site (mirrors v0.2.4's working
-/// pattern; passing `tcp_offset` directly as a `usize` from a map read
-/// loses verifier tracking and the post-bound-check pkt pointer ends up
-/// with `r=0`).
-///
-/// Bounds-checked at every read against `ctx.data_end()`. Options walk
-/// is fixed-bound at 8 iterations to keep BPF verifier state-space
-/// exploration tractable (a 40-iteration walk hit the verifier's
-/// 1M-instruction limit during v0.2.4 development).
-#[inline(always)]
-fn mss_clamp_tcp(
-    ctx: &XdpContext,
-    stats: StatsPtr,
-    ip_ptr: *const u8,
-    ip_hdr_size: usize,
-    clamp: u16,
-) {
-    let start = ctx.data();
-    let end = ctx.data_end();
-
-    // pkt-derived scalar; verifier tracks umax tightly.
-    let ip_offset = (ip_ptr as usize) - start;
-    let tcp_offset = ip_offset + ip_hdr_size;
-
-    // Need 20 bytes for the fixed TCP header before walking options.
-    if start + tcp_offset + 20 > end {
-        return;
-    }
-
-    // Bytes 12-13 of TCP header: data_offset:4 | reserved:4 | flags:8.
-    let doff_byte = unsafe { *((start + tcp_offset + 12) as *const u8) };
-    let flags = unsafe { *((start + tcp_offset + 13) as *const u8) };
-    if flags & TCP_FLAG_SYN == 0 {
-        return; // Not SYN/SYN-ACK.
-    }
-    let doff_words = (doff_byte >> 4) as usize;
-    if !(5..=15).contains(&doff_words) {
-        return;
-    }
-    let tcp_hdr_len = doff_words * 4;
-    let opts_len = tcp_hdr_len - 20;
-    if opts_len == 0 {
-        bump(stats, StatIdx::MssClampSkipped);
-        return;
-    }
-    if start + tcp_offset + tcp_hdr_len > end {
-        return;
-    }
-
-    // Walk options. Cap at 8, real SYN packets put MSS in the first
-    // 1-4 options (Linux's tcp_options_write emits MSS very early); 8
-    // is comfortable headroom while keeping verifier state-space bounded.
-    let opts_start_off = tcp_offset + 20;
-    let mut cursor: usize = 0;
-    let mut found = false;
-
-    for _ in 0..8 {
-        if cursor >= opts_len {
-            break;
-        }
-        let p_addr = start + opts_start_off + cursor;
-        if p_addr + 4 > end {
-            break;
-        }
-        let p = p_addr as *const u8;
-        let kind = unsafe { *p };
-        if kind == 0 {
-            break; // EOL.
-        }
-        if kind == 1 {
-            cursor += 1; // NOP.
-            continue;
-        }
-        let length = unsafe { *p.add(1) } as usize;
-        if length < 2 || cursor + length > opts_len {
-            break; // Malformed.
-        }
-        if kind == 2 && length == 4 {
-            // MSS option: [kind=2, length=4, mss_be:2].
-            let mss_be = unsafe { [*p.add(2), *p.add(3)] };
-            let mss = u16::from_be_bytes(mss_be);
-            if mss > clamp {
-                let new_mss_be = clamp.to_be_bytes();
-                unsafe {
-                    let pmut = p as *mut u8;
-                    *pmut.add(2) = new_mss_be[0];
-                    *pmut.add(3) = new_mss_be[1];
-                }
-                // RFC 1624 incremental TCP checksum update.
-                let csum_off = tcp_offset + 16;
-                if start + csum_off + 2 > end {
-                    return;
-                }
-                let csum_p = (start + csum_off) as *mut u8;
-                let old_csum_be = unsafe { [*csum_p, *csum_p.add(1)] };
-                let old_csum = u16::from_be_bytes(old_csum_be);
-                let new_csum = csum_replace_u16(old_csum, mss, clamp);
-                let new_csum_be = new_csum.to_be_bytes();
-                unsafe {
-                    *csum_p = new_csum_be[0];
-                    *csum_p.add(1) = new_csum_be[1];
-                }
-                bump(stats, StatIdx::MssClampApplied);
-            } else {
-                bump(stats, StatIdx::MssClampSkipped);
-            }
-            found = true;
-            break;
-        }
-        cursor += length;
-    }
-
-    if !found {
-        bump(stats, StatIdx::MssClampSkipped);
-    }
-}
-
-#[inline(always)]
-fn csum_replace_u16(old_csum: u16, old_val: u16, new_val: u16) -> u16 {
-    let mut sum: u32 = (!old_csum) as u32 + (!old_val) as u32 + new_val as u32;
-    sum = (sum & 0xffff) + (sum >> 16);
-    sum = (sum & 0xffff) + (sum >> 16);
-    !(sum as u16)
+    mss_clamp_tcp(stats, start, end, ip as *const u8, Ipv6Hdr::LEN, clamp);
 }
 
 #[inline(always)]

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -43,7 +43,7 @@ const PROTO_TCP: u8 = IpProto::Tcp as u8;
 /// verifier a tight `umax` so range propagation through packet-pointer
 /// arithmetic works, see commentary on the `ip_offset > MAX_IP_OFFSET`
 /// check in `finalize`.
-const MAX_IP_OFFSET: usize = 64;
+pub(crate) const MAX_IP_OFFSET: usize = 64;
 
 #[xdp]
 pub fn finalize(ctx: XdpContext) -> u32 {
@@ -235,7 +235,11 @@ fn mss_clamp_v6(
 }
 
 #[inline(always)]
-fn lookup_mss_clamp_v4(ip: *const Ipv4Hdr, egress_ifindex: u32, global_clamp: u16) -> u16 {
+pub(crate) fn lookup_mss_clamp_v4(
+    ip: *const Ipv4Hdr,
+    egress_ifindex: u32,
+    global_clamp: u16,
+) -> u16 {
     {
         let key = Key::new(32, unsafe { (*ip).src_addr });
         if let Some(entry) = MSS_CLAMP_V4.get(&key) {
@@ -265,7 +269,11 @@ fn lookup_mss_clamp_v4(ip: *const Ipv4Hdr, egress_ifindex: u32, global_clamp: u1
 }
 
 #[inline(always)]
-fn lookup_mss_clamp_v6(ip: *const Ipv6Hdr, egress_ifindex: u32, global_clamp: u16) -> u16 {
+pub(crate) fn lookup_mss_clamp_v6(
+    ip: *const Ipv6Hdr,
+    egress_ifindex: u32,
+    global_clamp: u16,
+) -> u16 {
     {
         let key = Key::new(128, unsafe { (*ip).src_addr });
         if let Some(entry) = MSS_CLAMP_V6.get(&key) {

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -32,6 +32,7 @@ mod datapath;
 mod fib;
 mod finalize;
 mod maps;
+mod tc;
 
 use datapath::{
     bump_match_subset, bytes_to_u32x4, decrement_ipv4_ttl, decrement_ipv6_hop_limit, icmpv6_type,

--- a/crates/modules/fast-path/bpf/src/main.rs
+++ b/crates/modules/fast-path/bpf/src/main.rs
@@ -28,10 +28,15 @@ use network_types::{
     ip::{IpProto, Ipv4Hdr, Ipv6Hdr},
 };
 
+mod datapath;
 mod fib;
 mod finalize;
 mod maps;
 
+use datapath::{
+    bump_match_subset, bytes_to_u32x4, decrement_ipv4_ttl, decrement_ipv6_hop_limit, icmpv6_type,
+    l4_ports,
+};
 use maps::{
     bump, stats_base, StatIdx, StatsPtr, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG,
     FIB_LOOKUP_SCRATCH, FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_COMPARE_MODE,
@@ -298,7 +303,15 @@ fn handle_ipv4(
     let l4_off = ip_offset + Ipv4Hdr::LEN;
 
     if use_custom && !compare {
-        let custom = fib::lookup_v4(stats, ctx, l4_off, src_bytes, dst_bytes, proto);
+        let custom = fib::lookup_v4(
+            stats,
+            ctx.data(),
+            ctx.data_end(),
+            l4_off,
+            src_bytes,
+            dst_bytes,
+            proto,
+        );
         return dispatch_custom_fib(
             custom,
             ctx,
@@ -314,7 +327,7 @@ fn handle_ipv4(
 
     // Kernel-FIB path: bpf_fib_lookup wants BE-in-memory `__be16`
     // ports, which is exactly what `l4_ports` returns.
-    let (sport, dport) = l4_ports(ctx, l4_off, proto);
+    let (sport, dport) = l4_ports(ctx.data(), ctx.data_end(), l4_off, proto);
 
     // Use the per-CPU `FIB_LOOKUP_SCRATCH` map for the bpf_fib_lookup
     // struct rather than allocating it on the stack. Per-CPU array
@@ -375,7 +388,15 @@ fn handle_ipv4(
         // the operator managed to set COMPARE without CUSTOM_FIB (bug
         // or manual map poke), the branch above is unreachable and
         // we still do only the kernel lookup here.
-        let custom = fib::lookup_v4(stats, ctx, l4_off, src_bytes, dst_bytes, proto);
+        let custom = fib::lookup_v4(
+            stats,
+            ctx.data(),
+            ctx.data_end(),
+            l4_off,
+            src_bytes,
+            dst_bytes,
+            proto,
+        );
         compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
@@ -435,7 +456,7 @@ fn handle_ipv6(
     // MLD (types 130-132, 143) travels at hop limit 1 and is already
     // caught by the `hop_limit <= 1` check below.
     if next == PROTO_ICMPV6 {
-        if let Some(t) = icmpv6_type(ctx, ip_offset + Ipv6Hdr::LEN) {
+        if let Some(t) = icmpv6_type(ctx.data(), ctx.data_end(), ip_offset + Ipv6Hdr::LEN) {
             if t >= ICMPV6_ND_TYPE_MIN && t <= ICMPV6_ND_TYPE_MAX {
                 bump(stats, StatIdx::PassNdp);
                 return Ok(xdp_action::XDP_PASS);
@@ -483,7 +504,15 @@ fn handle_ipv6(
     let l4_off = ip_offset + Ipv6Hdr::LEN;
 
     if use_custom && !compare {
-        let custom = fib::lookup_v6(stats, ctx, l4_off, src_bytes, dst_bytes, next);
+        let custom = fib::lookup_v6(
+            stats,
+            ctx.data(),
+            ctx.data_end(),
+            l4_off,
+            src_bytes,
+            dst_bytes,
+            next,
+        );
         return dispatch_custom_fib(
             custom,
             ctx,
@@ -497,7 +526,7 @@ fn handle_ipv6(
         );
     }
 
-    let (sport, dport) = l4_ports(ctx, l4_off, next);
+    let (sport, dport) = l4_ports(ctx.data(), ctx.data_end(), l4_off, next);
 
     // See handle_ipv4 for the rationale behind using FIB_LOOKUP_SCRATCH
     // (per-CPU map) instead of stack-allocated bpf_fib_lookup.
@@ -534,7 +563,15 @@ fn handle_ipv6(
     let fib_ref = unsafe { &*fib_ptr };
 
     if compare {
-        let custom = fib::lookup_v6(stats, ctx, l4_off, src_bytes, dst_bytes, next);
+        let custom = fib::lookup_v6(
+            stats,
+            ctx.data(),
+            ctx.data_end(),
+            l4_off,
+            src_bytes,
+            dst_bytes,
+            next,
+        );
         compare_and_bump(stats, ret as u32, fib_ref, &custom);
     }
 
@@ -785,39 +822,12 @@ fn compare_and_bump(
     }
 }
 
-// --- TTL / csum / helpers -------------------------------------------------
-
-/// Decrement IPv4 TTL and patch the header checksum using RFC 1624
-/// incremental update: when TTL decreases by 1, the word at bytes 8-9
-/// (TTL:proto, network order) decreases by 0x0100 → the checksum
-/// increases by 0x0100 in one's-complement arithmetic.
-#[inline(always)]
-fn decrement_ipv4_ttl(ip: *mut Ipv4Hdr) {
-    unsafe {
-        (*ip).ttl -= 1;
-        let mut sum = u16::from_be_bytes((*ip).check) as u32;
-        sum = sum.wrapping_add(0x0100);
-        sum = (sum & 0xffff).wrapping_add(sum >> 16);
-        (*ip).check = (sum as u16).to_be_bytes();
-    }
-}
-
-#[inline(always)]
-fn decrement_ipv6_hop_limit(ip: *mut Ipv6Hdr) {
-    unsafe {
-        (*ip).hop_limit -= 1;
-    }
-}
-
-#[inline(always)]
-fn bump_match_subset(stats: StatsPtr, src_hit: bool, dst_hit: bool) {
-    match (src_hit, dst_hit) {
-        (true, true) => bump(stats, StatIdx::MatchedBoth),
-        (true, false) => bump(stats, StatIdx::MatchedSrcOnly),
-        (false, true) => bump(stats, StatIdx::MatchedDstOnly),
-        (false, false) => {}
-    }
-}
+// --- XDP-ctx-bound helpers -------------------------------------------------
+//
+// The ctx-free packet readers / mutators (TTL decrement, l4_ports,
+// icmpv6_type, mss-clamp walk, match-subset bookkeeping) live in
+// `datapath.rs` so the tc datapath (Phase T) reuses them verbatim.
+// Only the XdpContext-typed accessors stay here.
 
 #[inline(always)]
 fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
@@ -833,54 +843,6 @@ fn ptr_at<T>(ctx: &XdpContext, offset: usize) -> Result<*const T, ()> {
 #[inline(always)]
 fn ptr_mut_at<T>(ctx: &XdpContext, offset: usize) -> Result<*mut T, ()> {
     Ok(ptr_at::<T>(ctx, offset)? as *mut T)
-}
-
-/// Read sport/dport from the L4 header at `offset`. Returns raw BE
-/// network-order u16 bytes (via `read_unaligned`) matching what the
-/// kernel's `bpf_fib_lookup` expects for its `__be16` sport/dport
-/// fields on an LE host. (0, 0) for ICMP / ICMPv6 or truncated L4.
-/// `pub(crate)` so fib.rs's ECMP arm can call it at its point of use.
-#[inline(always)]
-pub(crate) fn l4_ports(ctx: &XdpContext, offset: usize, proto: u8) -> (u16, u16) {
-    if !matches!(proto, PROTO_TCP | PROTO_UDP) {
-        return (0, 0);
-    }
-    let start = ctx.data();
-    let end = ctx.data_end();
-    if start + offset + 4 > end {
-        return (0, 0);
-    }
-    unsafe {
-        let p = (start + offset) as *const u8;
-        let sport = core::ptr::read_unaligned(p as *const u16);
-        let dport = core::ptr::read_unaligned(p.add(2) as *const u16);
-        (sport, dport)
-    }
-}
-
-/// Read the ICMPv6 `type` field, the first octet of the ICMPv6 header.
-///
-/// `None` when the read would run past `data_end`; callers treat that as
-/// "not an NDP message" and fall through to the normal path, which is
-/// fail-safe (a truncated ICMPv6 header can't be a valid NS/NA anyway).
-/// Bounds-check shape mirrors [`l4_ports`].
-#[inline(always)]
-fn icmpv6_type(ctx: &XdpContext, offset: usize) -> Option<u8> {
-    let start = ctx.data();
-    if start + offset + 1 > ctx.data_end() {
-        return None;
-    }
-    Some(unsafe { core::ptr::read_unaligned((start + offset) as *const u8) })
-}
-
-#[inline(always)]
-fn bytes_to_u32x4(b: &[u8; 16]) -> [u32; 4] {
-    [
-        u32::from_ne_bytes([b[0], b[1], b[2], b[3]]),
-        u32::from_ne_bytes([b[4], b[5], b[6], b[7]]),
-        u32::from_ne_bytes([b[8], b[9], b[10], b[11]]),
-        u32::from_ne_bytes([b[12], b[13], b[14], b[15]]),
-    ]
 }
 
 #[cfg(not(test))]

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -175,12 +175,20 @@ pub enum StatIdx {
     /// redirect-time failure indistinguishable from a FIB-lookup
     /// failure.
     ErrRedirectFailed = 39,
+    // --- Phase T: tc-ingress datapath. Append-only. -----------------
+    /// Packet entered `tc_fast_path` (bumped IN ADDITION to `RxTotal`,
+    /// which both datapaths share). During a mixed canary rollout,
+    /// `rx_total - rx_total_tc` attributes traffic to the XDP path.
+    RxTotalTc = 40,
+    /// Packet forwarded by `tc_finalize` via `bpf_redirect` (bumped in
+    /// addition to `FwdOk`). A/B attribution mirror of `RxTotalTc`.
+    FwdOkTc = 41,
 }
 
 /// Total counter count. Sizes the `[u64; N]` value of the single-entry
 /// `STATS` per-CPU map. New counters bump this; dashboards keying on
 /// indices keep working.
-pub const STATS_COUNT: u32 = 40;
+pub const STATS_COUNT: u32 = 42;
 
 /// `STATS_COUNT` as usize, for the array-of-counters value type.
 pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;
@@ -635,6 +643,28 @@ pub static FIB_LOOKUP_SCRATCH: PerCpuArray<bpf_fib_lookup> = PerCpuArray::with_m
 /// fails open to kernel slow-path rather than getting blackholed.
 #[map]
 pub static MUTATION_PROGS: ProgramArray = ProgramArray::with_max_entries(8, 0);
+
+// --- tc-ingress datapath maps (Phase T) ---------------------------------
+
+/// Tail-call table for the tc datapath. Separate from MUTATION_PROGS
+/// because the kernel binds a PROG_ARRAY to one owner program type on
+/// first use — sched_cls cannot tail-call through the XDP-owned array.
+/// Slot 0 holds `tc_finalize`; same fail-open contract as the XDP
+/// table (empty slot → `ErrTailCall` + TC_ACT_OK to kernel slow path).
+#[map]
+pub static TC_MUTATION_PROGS: ProgramArray = ProgramArray::with_max_entries(8, 0);
+
+/// Redirect-target membership for the tc datapath: keyed and valued by
+/// ifindex, mirroring REDIRECT_DEVMAP (devmap types are XDP-only and
+/// unusable from sched_cls). Load-bearing for the §11.13 pristine-
+/// packet invariant: `bpf_redirect()` cannot pre-check — it always
+/// "succeeds" in-program and a bad ifindex DROPS the skb after return
+/// — so tc_fast_path consults this map BEFORE any mutation, exactly
+/// like the XDP devmap pre-check. Userspace populates it from the same
+/// `enumerate_redirect_targets()` walk that fills REDIRECT_DEVMAP.
+#[map]
+pub static TC_REDIRECT_TARGETS: HashMap<u32, u32> =
+    HashMap::with_max_entries(REDIRECT_DEVMAP_MAX_ENTRIES, 0);
 
 // --- Custom-FIB maps (Option F, Phase 1) -------------------------------
 //

--- a/crates/modules/fast-path/bpf/src/tc.rs
+++ b/crates/modules/fast-path/bpf/src/tc.rs
@@ -1,0 +1,601 @@
+//! tc-ingress datapath (Phase T): `tc_fast_path` + `tc_finalize`
+//! sched_cls programs, attached via clsact with direct-action.
+//!
+//! Same forwarding semantics as the XDP pair in `main.rs`/`finalize.rs`
+//! — same maps, same counters, same classification and custom-FIB
+//! logic (shared via `datapath.rs` and `fib.rs`) — but running on the
+//! skb path, which on generic-XDP-only hardware (rvu-nicpf pre-6.8)
+//! avoids generic XDP's three per-packet taxes: the 256-byte-headroom
+//! `pskb_expand_head` copy, GRO-skb linearization, and the un-bulked
+//! `generic_xdp_tx` transmit. GRO super-skbs forward as single units
+//! (GSO segmentation happens on egress in `validate_xmit_skb`).
+//!
+//! The per-hook differences, and only these, live here:
+//!
+//! - **VLAN ingress is metadata-first.** By clsact time the kernel has
+//!   usually untagged the frame into `skb->vlan_tci` (hw offload or
+//!   `skb_vlan_untag`); the inline-tag parse is kept as a fallback
+//!   because `BPF_PROG_TEST_RUN` does not untag.
+//! - **Redirect pre-check is a plain map.** `bpf_redirect()` cannot
+//!   pre-check — it always "succeeds" in-program and an invalid target
+//!   drops the skb after return — so the §11.13 mutate-only-if-
+//!   forwardable invariant is upheld by consulting
+//!   `TC_REDIRECT_TARGETS` (a devmap-membership mirror) BEFORE any
+//!   mutation.
+//! - **MTU is checked pre-mutation.** `dev_queue_xmit` via
+//!   `skb_do_redirect` has no `is_skb_forwardable` MTU check, so an
+//!   oversize non-GSO packet would reach the driver silently.
+//!   `bpf_check_mtu(BPF_MTU_CHK_SEGS)` runs in stage 1, before TTL/L2
+//!   rewrite, and exceeds return TC_ACT_OK pristine so the kernel
+//!   emits FRAG_NEEDED — which also gives custom-fib mode the
+//!   FRAG_NEEDED parity it lacks under XDP.
+//! - **Egress VLAN uses the skb helpers.** Manual byte-shifting at TC
+//!   would desync `skb->mac_len`/`skb->protocol`, which
+//!   `dev_queue_xmit`/GSO rely on; `bpf_skb_vlan_push/pop` keep the
+//!   metadata coherent. They invalidate packet pointers, so they run
+//!   after every direct packet write, immediately before redirect.
+//! - **Separate tail-call table.** PROG_ARRAYs bind to one owner
+//!   program type; sched_cls jumps through `TC_MUTATION_PROGS`.
+//!
+//! Verifier constraints are prog-type-independent and all apply here:
+//! everything `#[inline(always)]`, no memset/memcpy bait, two-stage
+//! split for the same 512-byte stack budget.
+
+use aya_ebpf::{
+    bindings::{bpf_check_mtu_flags::BPF_MTU_CHK_SEGS, TC_ACT_OK, TC_ACT_SHOT},
+    helpers::{bpf_check_mtu, bpf_redirect, bpf_skb_vlan_pop, bpf_skb_vlan_push},
+    macros::classifier,
+    maps::lpm_trie::Key,
+    programs::TcContext,
+};
+use network_types::{
+    eth::{EthHdr, EtherType},
+    ip::{Ipv4Hdr, Ipv6Hdr},
+};
+
+use crate::datapath::{
+    bump_match_subset, decrement_ipv4_ttl, decrement_ipv6_hop_limit, icmpv6_type, mss_clamp_tcp,
+    tcp_syn_flag_set,
+};
+use crate::maps::{
+    bump, stats_base, StatIdx, StatsPtr, ALLOW_V4, ALLOW_V6, BLOCK_V4, BLOCK_V6, CFG,
+    FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+    FP_CFG_FLAG_VLAN_PRESENT, MUTATION_CTX, TC_MUTATION_PROGS, TC_REDIRECT_TARGETS, VLAN_RESOLVE,
+};
+use crate::{
+    fib, ICMPV6_ND_TYPE_MAX, ICMPV6_ND_TYPE_MIN, PROTO_ICMPV6, PROTO_TCP, PROTO_UDP, VLAN_HDR_LEN,
+    VLAN_NONE,
+};
+
+/// `bpf_redirect()`'s success return (uapi TC_ACT_REDIRECT). Returned
+/// verbatim from the classifier so the kernel performs the redirect.
+const TC_ACT_REDIRECT: i32 = 7;
+
+/// 802.1Q TPID for `bpf_skb_vlan_push`'s `__be16 vlan_proto` argument.
+const ETH_P_8021Q_BE: u16 = 0x8100u16.to_be();
+
+#[classifier]
+pub fn tc_fast_path(ctx: TcContext) -> i32 {
+    // Same single-lookup STATS + CFG pattern as the XDP stage; see
+    // main.rs. TC additionally bumps the A/B attribution counter.
+    let stats = match stats_base() {
+        Some(s) => s,
+        None => return TC_ACT_OK as i32,
+    };
+    bump(stats, StatIdx::RxTotal);
+    bump(stats, StatIdx::RxTotalTc);
+
+    let (cfg_flags, dry_run, mss_clamp_global) = match CFG.get(0) {
+        Some(c) => (c.flags, c.dry_run != 0, c.mss_clamp_global),
+        None => (0u8, false, 0u16),
+    };
+    // No head-shift here: the rvu-nicpf xdp_buff mis-sizing bug lives
+    // in the driver's XDP path; by clsact time the skb is normalized.
+
+    match tc_try_fast_path(&ctx, stats, cfg_flags, dry_run, mss_clamp_global) {
+        Ok(verdict) => verdict,
+        Err(()) => {
+            bump(stats, StatIdx::ErrParse);
+            TC_ACT_OK as i32
+        }
+    }
+}
+
+#[inline(always)]
+fn tc_try_fast_path(
+    ctx: &TcContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
+    mss_clamp_global: u16,
+) -> Result<i32, ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + EthHdr::LEN > end {
+        return Err(());
+    }
+    let eth = start as *mut EthHdr;
+    let outer_ether = unsafe { (*eth).ether_type };
+
+    // VLAN ingress: metadata first. cls_bpf runs with `data` pushed
+    // back to the MAC header, but the 802.1Q tag itself has usually
+    // been lifted into skb metadata (`vlan_tci`) by hw offload or
+    // `skb_vlan_untag` before clsact — the inline bytes then hold the
+    // untagged frame. The inline parse below only fires when the tag
+    // is still in-band (BPF_PROG_TEST_RUN, exotic drivers).
+    let skb = ctx.skb.skb;
+    let meta_present = unsafe { (*skb).vlan_present } != 0;
+    let (inner_ether, ip_offset, ingress_vid) = if meta_present {
+        let vid = (unsafe { (*skb).vlan_tci } & 0x0fff) as u16;
+        (outer_ether, EthHdr::LEN, vid)
+    } else if outer_ether == EtherType::Ieee8021q as u16
+        || outer_ether == EtherType::Ieee8021ad as u16
+    {
+        // Inline-tag fallback; mirrors main.rs's parse (one tag, QinQ
+        // out of scope, VID 0 treated as absent).
+        if start + EthHdr::LEN + VLAN_HDR_LEN > end {
+            return Err(());
+        }
+        let tci_hi = unsafe { *((start + EthHdr::LEN) as *const u8) };
+        let tci_lo = unsafe { *((start + EthHdr::LEN + 1) as *const u8) };
+        let vid = u16::from_be_bytes([tci_hi, tci_lo]) & 0x0fff;
+        let inner = unsafe { core::ptr::read_unaligned((start + EthHdr::LEN + 2) as *const u16) };
+        (inner, EthHdr::LEN + VLAN_HDR_LEN, vid)
+    } else {
+        (outer_ether, EthHdr::LEN, VLAN_NONE)
+    };
+
+    if inner_ether == EtherType::Ipv4 as u16 {
+        tc_handle_ipv4(
+            ctx,
+            stats,
+            cfg_flags,
+            dry_run,
+            mss_clamp_global,
+            eth,
+            ip_offset,
+            ingress_vid,
+        )
+    } else if inner_ether == EtherType::Ipv6 as u16 {
+        tc_handle_ipv6(
+            ctx,
+            stats,
+            cfg_flags,
+            dry_run,
+            mss_clamp_global,
+            eth,
+            ip_offset,
+            ingress_vid,
+        )
+    } else {
+        bump(stats, StatIdx::PassNotIp);
+        Ok(TC_ACT_OK as i32)
+    }
+}
+
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn tc_handle_ipv4(
+    ctx: &TcContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
+    mss_clamp_global: u16,
+    eth: *mut EthHdr,
+    ip_offset: usize,
+    ingress_vid: u16,
+) -> Result<i32, ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + ip_offset + Ipv4Hdr::LEN > end {
+        return Err(());
+    }
+    let ip = (start + ip_offset) as *mut Ipv4Hdr;
+
+    // Classification identical to main.rs::handle_ipv4 — same order,
+    // same counters, same gates.
+    let ihl_bytes = unsafe { (*ip).ihl() };
+    if ihl_bytes != 20 {
+        bump(stats, StatIdx::PassComplexHeader);
+        return Ok(TC_ACT_OK as i32);
+    }
+    let frags_be = u16::from_be_bytes(unsafe { (*ip).frags });
+    if (frags_be & 0x3fff) != 0 {
+        bump(stats, StatIdx::PassFragment);
+        return Ok(TC_ACT_OK as i32);
+    }
+    let ttl = unsafe { (*ip).ttl };
+    if ttl <= 1 {
+        bump(stats, StatIdx::PassLowTtl);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    let src_bytes = unsafe { (*ip).src_addr };
+    let dst_bytes = unsafe { (*ip).dst_addr };
+    let proto = unsafe { (*ip).proto };
+
+    let src_key = Key::new(32, src_bytes);
+    let dst_key = Key::new(32, dst_bytes);
+    let src_hit = ALLOW_V4.get(&src_key).is_some();
+    let dst_hit = ALLOW_V4.get(&dst_key).is_some();
+    if !(src_hit || dst_hit) {
+        return Ok(TC_ACT_OK as i32);
+    }
+    bump(stats, StatIdx::MatchedV4);
+    bump_match_subset(stats, src_hit, dst_hit);
+
+    if cfg_flags & FP_CFG_FLAG_BLOCK_PRESENT != 0 && BLOCK_V4.get(&dst_key).is_some() {
+        bump(stats, StatIdx::BogonDropped);
+        return Ok(TC_ACT_SHOT as i32);
+    }
+    if dry_run {
+        bump(stats, StatIdx::FwdDryRun);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    // tc datapath is custom-fib only (Phase T scope): kernel-fib
+    // deployments have no reason to leave XDP, and skipping the
+    // bpf_fib_lookup arm keeps this program's verifier footprint
+    // small. Userspace enforces the pairing (attach `tc` requires
+    // `forwarding-mode custom-fib`); if the flag is somehow clear,
+    // fail open to the kernel path rather than guess.
+    if cfg_flags & FP_CFG_FLAG_CUSTOM_FIB == 0 {
+        return Ok(TC_ACT_OK as i32);
+    }
+    let l4_off = ip_offset + Ipv4Hdr::LEN;
+    let custom = fib::lookup_v4(stats, start, end, l4_off, src_bytes, dst_bytes, proto);
+    tc_dispatch_custom_fib(
+        custom,
+        ctx,
+        stats,
+        cfg_flags,
+        mss_clamp_global,
+        eth,
+        ip as *mut u8,
+        true,
+        ingress_vid,
+    )
+}
+
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn tc_handle_ipv6(
+    ctx: &TcContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    dry_run: bool,
+    mss_clamp_global: u16,
+    eth: *mut EthHdr,
+    ip_offset: usize,
+    ingress_vid: u16,
+) -> Result<i32, ()> {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if start + ip_offset + Ipv6Hdr::LEN > end {
+        return Err(());
+    }
+    let ip = (start + ip_offset) as *mut Ipv6Hdr;
+
+    let next = unsafe { (*ip).next_hdr };
+    match next {
+        PROTO_TCP | PROTO_UDP | PROTO_ICMPV6 => {}
+        _ => {
+            bump(stats, StatIdx::PassComplexHeader);
+            return Ok(TC_ACT_OK as i32);
+        }
+    }
+    // NDP gate: identical rationale to main.rs (RFC 4861 hop-limit-255
+    // messages must never be forwarded with a decremented hop limit).
+    if next == PROTO_ICMPV6 {
+        if let Some(t) = icmpv6_type(start, end, ip_offset + Ipv6Hdr::LEN) {
+            if t >= ICMPV6_ND_TYPE_MIN && t <= ICMPV6_ND_TYPE_MAX {
+                bump(stats, StatIdx::PassNdp);
+                return Ok(TC_ACT_OK as i32);
+            }
+        }
+    }
+    let hop_limit = unsafe { (*ip).hop_limit };
+    if hop_limit <= 1 {
+        bump(stats, StatIdx::PassLowTtl);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    let src_bytes = unsafe { (*ip).src_addr };
+    let dst_bytes = unsafe { (*ip).dst_addr };
+    let src_key = Key::new(128, src_bytes);
+    let dst_key = Key::new(128, dst_bytes);
+    let src_hit = ALLOW_V6.get(&src_key).is_some();
+    let dst_hit = ALLOW_V6.get(&dst_key).is_some();
+    if !(src_hit || dst_hit) {
+        return Ok(TC_ACT_OK as i32);
+    }
+    bump(stats, StatIdx::MatchedV6);
+    bump_match_subset(stats, src_hit, dst_hit);
+
+    if cfg_flags & FP_CFG_FLAG_BLOCK_PRESENT != 0 && BLOCK_V6.get(&dst_key).is_some() {
+        bump(stats, StatIdx::BogonDropped);
+        return Ok(TC_ACT_SHOT as i32);
+    }
+    if dry_run {
+        bump(stats, StatIdx::FwdDryRun);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    // Custom-fib only; see tc_handle_ipv4.
+    if cfg_flags & FP_CFG_FLAG_CUSTOM_FIB == 0 {
+        return Ok(TC_ACT_OK as i32);
+    }
+    let l4_off = ip_offset + Ipv6Hdr::LEN;
+    let custom = fib::lookup_v6(stats, start, end, l4_off, src_bytes, dst_bytes, next);
+    tc_dispatch_custom_fib(
+        custom,
+        ctx,
+        stats,
+        cfg_flags,
+        mss_clamp_global,
+        eth,
+        ip as *mut u8,
+        false,
+        ingress_vid,
+    )
+}
+
+/// TC verdict mapping for a [`fib::CustomFibResult`]: same shape as
+/// main.rs::dispatch_custom_fib with XDP verdicts swapped for TC
+/// actions (PASS→OK, DROP→SHOT).
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn tc_dispatch_custom_fib(
+    result: fib::CustomFibResult,
+    ctx: &TcContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    mss_clamp_global: u16,
+    eth: *mut EthHdr,
+    ip: *mut u8,
+    is_v4: bool,
+    ingress_vid: u16,
+) -> Result<i32, ()> {
+    match result.action {
+        fib::FIB_ACTION_FORWARD => tc_forward_success(
+            ctx,
+            stats,
+            cfg_flags,
+            mss_clamp_global,
+            eth,
+            ip,
+            is_v4,
+            result.egress_ifindex,
+            result.smac,
+            result.dmac,
+            ingress_vid,
+        ),
+        fib::FIB_ACTION_NO_NEIGH => {
+            bump(stats, StatIdx::PassNoNeigh);
+            Ok(TC_ACT_OK as i32)
+        }
+        fib::FIB_ACTION_DROP => {
+            bump(stats, StatIdx::DropUnreachable);
+            Ok(TC_ACT_SHOT as i32)
+        }
+        _ => Ok(TC_ACT_OK as i32),
+    }
+}
+
+/// Success path: VLAN-resolve gate, targets pre-check, MTU pre-check,
+/// TTL + L2 rewrite, MUTATION_CTX handoff, tail-call into tc_finalize.
+/// The two pre-checks run BEFORE any packet mutation, upholding the
+/// §11.13 pristine-pass invariant (the 2026-04-21 outage lesson) —
+/// mandatory at TC because a failed `bpf_redirect` DROPS the skb
+/// rather than passing it.
+#[inline(always)]
+#[allow(clippy::too_many_arguments)]
+fn tc_forward_success(
+    ctx: &TcContext,
+    stats: StatsPtr,
+    cfg_flags: u8,
+    mss_clamp_global: u16,
+    eth: *mut EthHdr,
+    ip: *mut u8,
+    is_v4: bool,
+    ifindex: u32,
+    smac: [u8; 6],
+    dmac: [u8; 6],
+    ingress_vid: u16,
+) -> Result<i32, ()> {
+    let (egress_ifindex, egress_vid) = if cfg_flags & FP_CFG_FLAG_VLAN_PRESENT != 0 {
+        match unsafe { VLAN_RESOLVE.get(&ifindex) } {
+            Some(vi) => (vi.phys_ifindex, vi.vid),
+            None => (ifindex, VLAN_NONE),
+        }
+    } else {
+        (ifindex, VLAN_NONE)
+    };
+
+    if unsafe { TC_REDIRECT_TARGETS.get(&egress_ifindex) }.is_none() {
+        bump(stats, StatIdx::PassNotInDevmap);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    // MTU pre-check, segment-aware: a GSO super-skb passes if its
+    // segments fit. Exceeds return the packet PRISTINE so the kernel
+    // slow path emits FRAG_NEEDED (custom-fib gets FRAG_NEEDED parity
+    // XDP never had). `skb_do_redirect → dev_queue_xmit` performs no
+    // MTU check of its own.
+    let mut mtu_len: u32 = 0;
+    let mtu_rc = unsafe {
+        bpf_check_mtu(
+            ctx.skb.skb as *mut core::ffi::c_void,
+            egress_ifindex,
+            &mut mtu_len,
+            0,
+            BPF_MTU_CHK_SEGS as u64,
+        )
+    };
+    if mtu_rc != 0 {
+        bump(stats, StatIdx::PassFragNeeded);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    // Direct packet writes; sched_cls supports them and the verifier
+    // has the ranges from the callers' bounds checks.
+    if is_v4 {
+        decrement_ipv4_ttl(ip as *mut Ipv4Hdr);
+    } else {
+        decrement_ipv6_hop_limit(ip as *mut Ipv6Hdr);
+    }
+    unsafe {
+        (*eth).dst_addr = dmac;
+        (*eth).src_addr = smac;
+    }
+
+    let ip_offset = (ip as usize) - ctx.data();
+    if let Some(mctx_ptr) = MUTATION_CTX.get_ptr_mut(0) {
+        // Same field-by-field store discipline as main.rs (no memset
+        // bait). Sharing MUTATION_CTX with the XDP chain is safe: BPF
+        // programs run to completion per CPU, so each chain's
+        // write→tail_call→read is atomic with respect to the other
+        // datapath.
+        unsafe {
+            (*mctx_ptr).egress_ifindex = egress_ifindex;
+            (*mctx_ptr).egress_vid = egress_vid;
+            (*mctx_ptr).ingress_vid = ingress_vid;
+            (*mctx_ptr).ip_offset = ip_offset as u32;
+            (*mctx_ptr).is_v4 = u32::from(u8::from(is_v4));
+            (*mctx_ptr).cfg_flags = u16::from(cfg_flags);
+            (*mctx_ptr).mss_clamp_global = mss_clamp_global;
+        }
+    } else {
+        bump(stats, StatIdx::ErrMutationCtx);
+        return Ok(TC_ACT_OK as i32);
+    }
+
+    let _ = unsafe { TC_MUTATION_PROGS.tail_call(ctx, 0) };
+    bump(stats, StatIdx::ErrTailCall);
+    Ok(TC_ACT_OK as i32)
+}
+
+#[classifier]
+pub fn tc_finalize(ctx: TcContext) -> i32 {
+    let stats = match stats_base() {
+        Some(s) => s,
+        None => return TC_ACT_OK as i32,
+    };
+    let mctx = match unsafe { MUTATION_CTX.get(0) } {
+        Some(c) => *c,
+        None => {
+            bump(stats, StatIdx::ErrMutationCtx);
+            return TC_ACT_OK as i32;
+        }
+    };
+
+    let egress_ifindex = mctx.egress_ifindex;
+    let egress_vid = mctx.egress_vid;
+    let ingress_vid = mctx.ingress_vid;
+    let is_v4 = mctx.is_v4 != 0;
+
+    // Same verifier-mandated umax clamp as finalize.rs; same counter.
+    let ip_offset = mctx.ip_offset as usize;
+    if ip_offset > crate::finalize::MAX_IP_OFFSET {
+        bump(stats, StatIdx::ErrCtxOffsetRange);
+        return TC_ACT_OK as i32;
+    }
+
+    // mss-clamp before the VLAN helpers (which invalidate packet
+    // pointers). Gated identically to finalize.rs.
+    if mctx.cfg_flags & u16::from(FP_CFG_FLAG_MSS_CLAMP_PRESENT) != 0 {
+        tc_mss_clamp_inline(
+            &ctx,
+            stats,
+            ip_offset,
+            is_v4,
+            egress_ifindex,
+            mctx.mss_clamp_global,
+        );
+    }
+
+    // VLAN egress choreography via the skb helpers, which keep
+    // `skb->mac_len`/`skb->protocol` coherent for dev_queue_xmit/GSO.
+    // Same-VID passthrough needs nothing: a metadata tag is reinserted
+    // by validate_xmit_skb on the egress dev. These calls invalidate
+    // every packet pointer — nothing below touches packet data.
+    if ingress_vid != egress_vid {
+        if ingress_vid != VLAN_NONE {
+            let rc = unsafe { bpf_skb_vlan_pop(ctx.skb.skb) };
+            if rc != 0 {
+                bump(stats, StatIdx::ErrVlan);
+                return TC_ACT_SHOT as i32;
+            }
+        }
+        if egress_vid != VLAN_NONE {
+            let rc = unsafe { bpf_skb_vlan_push(ctx.skb.skb, ETH_P_8021Q_BE, egress_vid) };
+            if rc != 0 {
+                bump(stats, StatIdx::ErrVlan);
+                return TC_ACT_SHOT as i32;
+            }
+        }
+    }
+
+    // bpf_redirect always "succeeds" from the program's perspective;
+    // the actual redirect happens after return via skb_do_redirect.
+    // TC_ACT_REDIRECT is the only success value; anything else means
+    // the helper rejected the call itself.
+    let ret = unsafe { bpf_redirect(egress_ifindex, 0) } as i32;
+    if ret == TC_ACT_REDIRECT {
+        bump(stats, StatIdx::FwdOk);
+        bump(stats, StatIdx::FwdOkTc);
+    } else {
+        bump(stats, StatIdx::ErrRedirectFailed);
+    }
+    ret
+}
+
+/// TC twin of finalize.rs::mss_clamp_inline: same dispatch, same
+/// shared option-walk (`datapath::mss_clamp_tcp`), same clamp-source
+/// lookups (`finalize::lookup_mss_clamp_v4/v6` — ip-pointer-based and
+/// ctx-free, so shared directly).
+#[inline(always)]
+fn tc_mss_clamp_inline(
+    ctx: &TcContext,
+    stats: StatsPtr,
+    ip_offset: usize,
+    is_v4: bool,
+    egress_ifindex: u32,
+    global_clamp: u16,
+) {
+    let start = ctx.data();
+    let end = ctx.data_end();
+    if is_v4 {
+        if start + ip_offset + Ipv4Hdr::LEN > end {
+            return;
+        }
+        let ip = (start + ip_offset) as *const Ipv4Hdr;
+        if unsafe { (*ip).proto } != PROTO_TCP {
+            return;
+        }
+        if !tcp_syn_flag_set(start, end, ip_offset + Ipv4Hdr::LEN) {
+            return;
+        }
+        let clamp = crate::finalize::lookup_mss_clamp_v4(ip, egress_ifindex, global_clamp);
+        if clamp == 0 {
+            return;
+        }
+        mss_clamp_tcp(stats, start, end, ip as *const u8, Ipv4Hdr::LEN, clamp);
+    } else {
+        if start + ip_offset + Ipv6Hdr::LEN > end {
+            return;
+        }
+        let ip = (start + ip_offset) as *const Ipv6Hdr;
+        if unsafe { (*ip).next_hdr } != PROTO_TCP {
+            return;
+        }
+        if !tcp_syn_flag_set(start, end, ip_offset + Ipv6Hdr::LEN) {
+            return;
+        }
+        let clamp = crate::finalize::lookup_mss_clamp_v6(ip, egress_ifindex, global_clamp);
+        if clamp == 0 {
+            return;
+        }
+        mss_clamp_tcp(stats, start, end, ip as *const u8, Ipv6Hdr::LEN, clamp);
+    }
+}

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -20,6 +20,7 @@ pub mod fib;
 pub mod metrics;
 pub mod pin;
 pub mod registry;
+pub mod tc_links;
 
 #[cfg(target_os = "linux")]
 pub mod linux_impl;
@@ -29,8 +30,8 @@ pub mod reconcile;
 
 #[cfg(target_os = "linux")]
 pub use linux_impl::{
-    fib_status_from_pin, stats_from_pin, tail_call_chain_from_pin, trial_attach_native,
-    FibStatusSnapshot, TrialResult,
+    fib_status_from_pin, stats_from_pin, tail_call_chain_from_pin, tc_attach_iface,
+    tc_detach_from_state_dir, trial_attach_native, FibStatusSnapshot, TrialResult,
 };
 
 pub const MODULE_NAME: &str = "fast-path";

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -977,6 +977,20 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 priority,
                 handle,
             });
+            // Persist IMMEDIATELY, not after the loop: the aya link
+            // for this filter is already forgotten, so if a later
+            // attach in this loop fails and aborts startup, this
+            // record is the ONLY way `packetframe detach` can find
+            // the live filter. A post-loop save would strand every
+            // earlier filter as an invisible orphan (review finding,
+            // PR #75).
+            crate::tc_links::save(
+                &state.state_dir,
+                &crate::tc_links::TcLinksFile {
+                    links: tc_records.clone(),
+                },
+            )
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json save: {e}")))?;
             state.links.push(LinkRecord {
                 iface: iface.clone(),
                 ifindex: *ifindex,
@@ -992,11 +1006,6 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 "fast-path attached (tc-ingress datapath)"
             );
         }
-        crate::tc_links::save(
-            &state.state_dir,
-            &crate::tc_links::TcLinksFile { links: tc_records },
-        )
-        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json save: {e}")))?;
     }
 
     // Detect buggy-kernel rvu-nicpf native XDP delivery and flip the
@@ -1684,42 +1693,104 @@ pub fn tc_attach_iface(ebpf: &mut Ebpf, iface: &str) -> ModuleResult<(u16, u32)>
     Ok((priority, handle))
 }
 
-/// Detach one recorded tc filter. Best-effort building block for both
-/// the in-process (`detach(state)`) and out-of-process
-/// ([`tc_detach_from_state_dir`]) teardown paths.
-fn tc_detach_one(iface: &str, priority: u16, handle: u32) -> Result<(), String> {
-    use aya::programs::tc::{SchedClassifierLink, TcAttachType};
-    use aya::programs::Link as _;
-    let link = SchedClassifierLink::attached(iface, TcAttachType::Ingress, priority, handle)
-        .map_err(|e| format!("reconstruct tc link on {iface}: {e}"))?;
-    link.detach()
-        .map_err(|e| format!("tc detach on {iface} (prio {priority}, handle {handle}): {e}"))
+/// Outcome of one tc-filter detach attempt. The distinction decides
+/// whether the filter's `tc-links.json` record may be dropped — that
+/// record is the ONLY teardown metadata for a live filter (review
+/// finding, PR #75), so it must survive any failure that leaves the
+/// filter plausibly attached.
+enum TcDetachOutcome {
+    /// Goal state reached: the filter was detached, or is provably
+    /// gone already (iface no longer resolvable — the qdisc and its
+    /// filters died with the device — or the netlink delete reported
+    /// ENOENT/EINVAL, i.e. no such filter/qdisc). Record droppable.
+    Cleared,
+    /// The delete failed with the filter plausibly still live
+    /// (transient netlink error, EPERM, ...). Record must be retained
+    /// for retry.
+    Failed(String),
 }
 
-/// Tear down every tc filter recorded in `<state-dir>/tc-links.json`
-/// and remove the file. Used by `packetframe detach` (no live loader
-/// required — the filters have qdisc lifetime). Returns the number of
-/// filters detached; per-filter failures are logged and skipped so a
-/// vanished iface doesn't wedge the teardown (the qdisc died with it).
+/// Detach one recorded tc filter. Building block for both the
+/// in-process (`detach(state)`) and out-of-process
+/// ([`tc_detach_from_state_dir`]) teardown paths.
+fn tc_detach_one(iface: &str, priority: u16, handle: u32) -> TcDetachOutcome {
+    use aya::programs::tc::{SchedClassifierLink, TcAttachType, TcError};
+    use aya::programs::{Link as _, ProgramError};
+
+    // `attached()` only resolves the ifindex; failure means the iface
+    // is gone, and qdisc-lifetime filters go with their device.
+    let link = match SchedClassifierLink::attached(iface, TcAttachType::Ingress, priority, handle) {
+        Ok(l) => l,
+        Err(e) => {
+            info!(iface, error = %e, "iface gone; tc filter died with it");
+            return TcDetachOutcome::Cleared;
+        }
+    };
+    match link.detach() {
+        Ok(()) => TcDetachOutcome::Cleared,
+        // ENOENT: no such filter; EINVAL: no such qdisc. Either way
+        // nothing of ours is attached anymore — goal state.
+        Err(ProgramError::TcError(TcError::NetlinkError { io_error }))
+            if matches!(
+                io_error.raw_os_error(),
+                Some(libc::ENOENT) | Some(libc::EINVAL)
+            ) =>
+        {
+            info!(iface, priority, handle, "tc filter already absent");
+            TcDetachOutcome::Cleared
+        }
+        Err(e) => TcDetachOutcome::Failed(format!(
+            "tc detach on {iface} (prio {priority}, handle {handle}): {e}"
+        )),
+    }
+}
+
+/// Tear down every tc filter recorded in `<state-dir>/tc-links.json`.
+/// Used by `packetframe detach` (no live loader required — the
+/// filters have qdisc lifetime). Returns the number of filters
+/// cleared.
+///
+/// Records whose detach FAILED with the filter plausibly still live
+/// are written back to tc-links.json and the call errors: deleting
+/// their only teardown metadata would orphan active classifiers while
+/// reporting success (review finding, PR #75). Records for vanished
+/// ifaces / already-absent filters are dropped normally.
 pub fn tc_detach_from_state_dir(state_dir: &Path) -> ModuleResult<usize> {
     let Some(file) = crate::tc_links::load(state_dir)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json read: {e}")))?
     else {
         return Ok(0);
     };
-    let mut detached = 0usize;
-    for rec in &file.links {
+    let mut cleared = 0usize;
+    let mut retained = Vec::new();
+    for rec in file.links {
         match tc_detach_one(&rec.iface, rec.priority, rec.handle) {
-            Ok(()) => {
-                info!(iface = %rec.iface, rec.priority, rec.handle, "tc filter detached");
-                detached += 1;
+            TcDetachOutcome::Cleared => {
+                info!(iface = %rec.iface, rec.priority, rec.handle, "tc filter cleared");
+                cleared += 1;
             }
-            Err(e) => warn!(iface = %rec.iface, error = %e, "tc filter detach skipped"),
+            TcDetachOutcome::Failed(e) => {
+                warn!(iface = %rec.iface, error = %e, "tc filter detach failed; record retained");
+                retained.push(rec);
+            }
         }
     }
-    crate::tc_links::remove(state_dir)
-        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json remove: {e}")))?;
-    Ok(detached)
+    if retained.is_empty() {
+        crate::tc_links::remove(state_dir)
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json remove: {e}")))?;
+        return Ok(cleared);
+    }
+    let file = crate::tc_links::TcLinksFile { links: retained };
+    crate::tc_links::save(state_dir, &file)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json rewrite: {e}")))?;
+    let names: Vec<&str> = file.links.iter().map(|r| r.iface.as_str()).collect();
+    Err(ModuleError::other(
+        MODULE_NAME,
+        format!(
+            "tc filters still attached on {names:?}; records kept in tc-links.json — \
+             rerun `packetframe detach` (or `tc filter del dev <iface> ingress`) to retry"
+        ),
+    ))
 }
 
 /// §2.3: per-interface trial-attach. `Native` and `Generic` are explicit
@@ -1999,22 +2070,49 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
     // Drop every PinnedLink next: this closes our userspace FDs but
     // the kernel keeps the attach alive via the bpffs inodes. tc
     // records hold no FD at all — detach them explicitly via their
-    // recorded (priority, handle), best-effort (a vanished iface took
-    // its qdisc and filter with it). Drain in reverse attach order.
+    // recorded (priority, handle). Drain in reverse attach order.
+    //
+    // tc failures must not abort the rest of the teardown (a breaker
+    // trip still has to detach XDP + remove pins), but a filter whose
+    // delete failed with the iface still alive keeps its record in
+    // tc-links.json: that record is the only metadata a later
+    // `packetframe detach` retry has (review finding, PR #75).
     let mut had_tc = false;
+    let mut tc_retained: Vec<crate::tc_links::TcLinkRecord> = Vec::new();
     while let Some(record) = state.links.pop() {
         info!(iface = %record.iface, "fast-path detaching");
         if let LinkHandle::Tc { priority, handle } = record.link {
             had_tc = true;
-            if let Err(e) = tc_detach_one(&record.iface, priority, handle) {
-                warn!(iface = %record.iface, error = %e, "tc filter detach skipped");
+            match tc_detach_one(&record.iface, priority, handle) {
+                TcDetachOutcome::Cleared => {}
+                TcDetachOutcome::Failed(e) => {
+                    warn!(iface = %record.iface, error = %e, "tc filter detach failed; record retained");
+                    tc_retained.push(crate::tc_links::TcLinkRecord {
+                        iface: record.iface.clone(),
+                        priority,
+                        handle,
+                    });
+                }
             }
         }
         drop(record);
     }
     if had_tc {
-        if let Err(e) = crate::tc_links::remove(&state.state_dir) {
-            warn!(error = %e, "tc-links.json remove failed");
+        if tc_retained.is_empty() {
+            if let Err(e) = crate::tc_links::remove(&state.state_dir) {
+                warn!(error = %e, "tc-links.json remove failed");
+            }
+        } else {
+            warn!(
+                count = tc_retained.len(),
+                "tc filters still attached; records kept in tc-links.json for `packetframe detach` retry"
+            );
+            if let Err(e) = crate::tc_links::save(
+                &state.state_dir,
+                &crate::tc_links::TcLinksFile { links: tc_retained },
+            ) {
+                warn!(error = %e, "tc-links.json rewrite failed");
+            }
         }
     }
 

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -255,11 +255,29 @@ pub struct LinkRecord {
 pub enum LinkHandle {
     Pinned(PinnedLink),
     Transient(FdLink),
+    /// tc datapath (Phase T): a netlink cls_bpf filter on the iface's
+    /// clsact ingress. No FD is held — the aya link was deliberately
+    /// forgotten after reading the kernel-assigned identifiers (a held
+    /// link would detach on Drop), so the kernel attach has qdisc
+    /// lifetime and survives process exit, like `Pinned`. Teardown
+    /// reconstructs the filter from `(priority, handle)` via
+    /// `SchedClassifierLink::attached()`; the same pair is persisted
+    /// in `<state-dir>/tc-links.json` for out-of-process `detach`.
+    Tc {
+        priority: u16,
+        handle: u32,
+    },
 }
 
 impl LinkHandle {
     pub fn is_pinned(&self) -> bool {
         matches!(self, LinkHandle::Pinned(_))
+    }
+
+    /// Whether the kernel-side attach outlives this process (bpffs pin
+    /// for XDP, qdisc-lifetime filter for tc).
+    pub fn persists_across_exit(&self) -> bool {
+        matches!(self, LinkHandle::Pinned(_) | LinkHandle::Tc { .. })
     }
 }
 
@@ -879,9 +897,34 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // `attach_settle_time` between attaches so each link stabilizes
     // before the next touches the driver. 0s disables (useful on
     // non-bridge topologies).
+    // Split tc-datapath attaches from the XDP ones: they use a
+    // different program pair, a different attach mechanism (netlink
+    // cls_bpf on clsact), and must run after the XDP loop because
+    // `prog` mutably borrows `state.ebpf` until its last use here.
+    let (tc_dirs, xdp_dirs): (Vec<_>, Vec<_>) = attach_dirs
+        .into_iter()
+        .partition(|(_, mode, _)| matches!(mode, AttachMode::Tc));
+
+    // The tc datapath is custom-fib only (the classifiers have no
+    // kernel-FIB arm; see bpf/src/tc.rs). Reject the pairing up front
+    // rather than silently passing all matched traffic to the kernel.
+    if !tc_dirs.is_empty()
+        && !matches!(
+            forwarding_mode_from_cfg(cfg),
+            packetframe_common::config::ForwardingMode::CustomFib
+        )
+    {
+        return Err(ModuleError::other(
+            MODULE_NAME,
+            "`attach <iface> tc` requires `forwarding-mode custom-fib` \
+             (the tc datapath has no kernel-fib/compare arm)",
+        ));
+    }
+
     let settle_time = cfg.global.attach_settle_time;
-    for (idx, (iface, mode, ifindex)) in attach_dirs.iter().enumerate() {
-        if idx > 0 && !settle_time.is_zero() {
+    let mut attach_count = 0usize;
+    for (iface, mode, ifindex) in xdp_dirs.iter() {
+        if attach_count > 0 && !settle_time.is_zero() {
             info!(
                 settle_secs = settle_time.as_secs_f64(),
                 next_iface = %iface,
@@ -889,9 +932,10 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
             );
             std::thread::sleep(settle_time);
         }
+        attach_count += 1;
         let (effective_mode, link) =
             try_attach_with_fallback(prog, *ifindex, iface, *mode, &state.bpffs_root)?;
-        let persist = link.is_pinned();
+        let persist = link.persists_across_exit();
         state.links.push(LinkRecord {
             iface: iface.clone(),
             ifindex: *ifindex,
@@ -905,6 +949,54 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
             persists_across_exit = persist,
             "fast-path attached"
         );
+    }
+
+    // tc-datapath attaches. Load + wire the classifier pair first so
+    // tc_fast_path's tail_call into TC_MUTATION_PROGS[0] succeeds from
+    // the first packet (same ordering contract as finalize above);
+    // aya loads programs lazily, so XDP-only deployments never pay
+    // for the classifiers.
+    if !tc_dirs.is_empty() {
+        load_tc_programs(&mut state.ebpf)?;
+        populate_tc_mutation_progs(&mut state.ebpf)?;
+
+        let mut tc_records = Vec::with_capacity(tc_dirs.len());
+        for (iface, _mode, ifindex) in tc_dirs.iter() {
+            if attach_count > 0 && !settle_time.is_zero() {
+                info!(
+                    settle_secs = settle_time.as_secs_f64(),
+                    next_iface = %iface,
+                    "waiting for link to settle before next attach (§11.8)"
+                );
+                std::thread::sleep(settle_time);
+            }
+            attach_count += 1;
+            let (priority, handle) = tc_attach_iface(&mut state.ebpf, iface)?;
+            tc_records.push(crate::tc_links::TcLinkRecord {
+                iface: iface.clone(),
+                priority,
+                handle,
+            });
+            state.links.push(LinkRecord {
+                iface: iface.clone(),
+                ifindex: *ifindex,
+                effective_mode: AttachMode::Tc,
+                link: LinkHandle::Tc { priority, handle },
+            });
+            info!(
+                iface,
+                ifindex,
+                priority,
+                handle,
+                persists_across_exit = true,
+                "fast-path attached (tc-ingress datapath)"
+            );
+        }
+        crate::tc_links::save(
+            &state.state_dir,
+            &crate::tc_links::TcLinksFile { links: tc_records },
+        )
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json save: {e}")))?;
     }
 
     // Detect buggy-kernel rvu-nicpf native XDP delivery and flip the
@@ -952,6 +1044,25 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         "REDIRECT_DEVMAP populated from /sys/class/net (Ethernet-type, UP)"
     );
 
+    // Mirror the same membership into TC_REDIRECT_TARGETS (Phase T).
+    // Devmap types are XDP-only, so the tc datapath's pristine-packet
+    // pre-check consults this plain hash map instead. Populated
+    // unconditionally — it's a handful of entries and keeps reconcile
+    // symmetric whether or not any `attach <iface> tc` exists yet.
+    {
+        let map = state.ebpf.map_mut("TC_REDIRECT_TARGETS").ok_or_else(|| {
+            ModuleError::other(MODULE_NAME, "TC_REDIRECT_TARGETS map missing from ELF")
+        })?;
+        let mut hm: AyaHashMap<_, u32, u32> = AyaHashMap::try_from(map).map_err(|e| {
+            ModuleError::other(MODULE_NAME, format!("TC_REDIRECT_TARGETS try_from: {e}"))
+        })?;
+        for (iface, ifindex) in &targets {
+            if let Err(e) = hm.insert(*ifindex, *ifindex, 0) {
+                warn!(iface = %iface, ifindex, error = %e, "TC_REDIRECT_TARGETS insert skipped");
+            }
+        }
+    }
+
     populate_vlan_resolve(state)?;
 
     // Pin program + every §4.5 map so `packetframe status` can read
@@ -965,15 +1076,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
     // custom FIB path. Uses `MapData::from_pin` internally, so it
     // must run after `pin_program_and_maps`. Kernel-fib mode skips
     // this entirely and pays nothing for the feature.
-    let forwarding = cfg
-        .section
-        .directives
-        .iter()
-        .find_map(|d| match d {
-            ModuleDirective::ForwardingMode(m) => Some(*m),
-            _ => None,
-        })
-        .unwrap_or_default();
+    let forwarding = forwarding_mode_from_cfg(cfg);
     if matches!(
         forwarding,
         packetframe_common::config::ForwardingMode::CustomFib
@@ -1141,9 +1244,15 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
                 AttachMode::Native => HookType::NativeXdp,
                 AttachMode::Generic => HookType::GenericXdp,
                 AttachMode::Auto => HookType::NativeXdp, // already resolved
+                AttachMode::Tc => HookType::TcIngress,
             },
             prog_id,
-            pinned_path: pin::link_path(&state.bpffs_root, &l.iface),
+            // tc attaches have no bpffs link pin; their persistent
+            // record is tc-links.json, so point the registry there.
+            pinned_path: match l.effective_mode {
+                AttachMode::Tc => crate::tc_links::file_path(&state.state_dir),
+                _ => pin::link_path(&state.bpffs_root, &l.iface),
+            },
         })
         .collect())
 }
@@ -1336,7 +1445,9 @@ fn rvu_nicpf_version_gate(
                 );
                 out.push((iface, AttachMode::Generic, ifindex));
             }
-            AttachMode::Generic => unreachable!("filtered by wants_native check above"),
+            AttachMode::Generic | AttachMode::Tc => {
+                unreachable!("filtered by wants_native check above")
+            }
         }
     }
     Ok(out)
@@ -1439,6 +1550,178 @@ fn populate_mutation_progs(ebpf: &mut Ebpf) -> ModuleResult<()> {
     Ok(())
 }
 
+/// The parsed `forwarding-mode` directive (default `kernel-fib`).
+fn forwarding_mode_from_cfg(cfg: &ModuleConfig<'_>) -> packetframe_common::config::ForwardingMode {
+    cfg.section
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::ForwardingMode(m) => Some(*m),
+            _ => None,
+        })
+        .unwrap_or_default()
+}
+
+/// tc-datapath program names in the shared BPF ELF (Phase T).
+const TC_FAST_PATH_PROGRAM_NAME: &str = "tc_fast_path";
+const TC_FINALIZE_PROGRAM_NAME: &str = "tc_finalize";
+
+/// Load the sched_cls pair. `tc_finalize` first, its FD feeds the
+/// TC_MUTATION_PROGS population before any tc filter attaches — the
+/// same contract as the XDP finalize/MUTATION_PROGS ordering.
+fn load_tc_programs(ebpf: &mut Ebpf) -> ModuleResult<()> {
+    use aya::programs::tc::SchedClassifier;
+    for name in [TC_FINALIZE_PROGRAM_NAME, TC_FAST_PATH_PROGRAM_NAME] {
+        let prog: &mut SchedClassifier = ebpf
+            .program_mut(name)
+            .ok_or_else(|| ModuleError::other(MODULE_NAME, format!("{name} missing from ELF")))?
+            .try_into()
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("{name} not sched_cls: {e}")))?;
+        prog.load().map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("SchedClassifier::load({name}) failed (verifier rejection?): {e}"),
+            )
+        })?;
+    }
+    Ok(())
+}
+
+/// Populate TC_MUTATION_PROGS[0] with tc_finalize (mirror of
+/// `populate_mutation_progs`; PROG_ARRAYs bind to one owner program
+/// type, so the tc chain needs its own jump table).
+fn populate_tc_mutation_progs(ebpf: &mut Ebpf) -> ModuleResult<()> {
+    use aya::maps::ProgramArray;
+    use aya::programs::tc::SchedClassifier;
+    use aya::programs::ProgramFd;
+
+    let tc_finalize_fd: ProgramFd = {
+        let prog: &SchedClassifier = ebpf
+            .program(TC_FINALIZE_PROGRAM_NAME)
+            .ok_or_else(|| ModuleError::other(MODULE_NAME, "tc_finalize missing post-load"))?
+            .try_into()
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc_finalize type: {e}")))?;
+        prog.fd()
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc_finalize fd: {e}")))?
+            .try_clone()
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc_finalize fd clone: {e}")))?
+    };
+
+    let map = ebpf
+        .map_mut("TC_MUTATION_PROGS")
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "TC_MUTATION_PROGS map missing"))?;
+    let mut prog_array: ProgramArray<_> = ProgramArray::try_from(map)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("TC_MUTATION_PROGS try_from: {e}")))?;
+    prog_array.set(0, &tc_finalize_fd, 0).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("TC_MUTATION_PROGS.set(0, tc_finalize): {e}"),
+        )
+    })?;
+    info!("TC_MUTATION_PROGS[0] populated with tc_finalize program FD");
+    Ok(())
+}
+
+/// Attach `tc_fast_path` to `iface`'s clsact ingress and return the
+/// kernel-assigned `(priority, handle)` identifying the filter.
+///
+/// **Explicitly netlink cls_bpf on every kernel** (not aya's
+/// version-picked TCX path): netlink filters have qdisc lifetime —
+/// the kernel attach survives process exit, matching the pinned-XDP
+/// posture — and yield the `(priority, handle)` pair that
+/// `SchedClassifierLink::attached()` needs for out-of-process detach.
+/// TCX (≥6.6) would hand us an FD-lifetime link that dies with the
+/// process; migrating to pinned TCX links is future work once the
+/// fleet baseline moves past 6.6.
+///
+/// The returned aya link is deliberately `mem::forget`-ed: dropping
+/// it would detach the filter.
+pub fn tc_attach_iface(ebpf: &mut Ebpf, iface: &str) -> ModuleResult<(u16, u32)> {
+    use aya::programs::tc::{
+        qdisc_add_clsact, NlOptions, SchedClassifier, TcAttachOptions, TcAttachType,
+    };
+
+    match qdisc_add_clsact(iface) {
+        Ok(()) => info!(iface, "clsact qdisc added"),
+        // Already present (another tool, a prior run): attaching a
+        // filter to the existing clsact is exactly what we want.
+        Err(e) if e.raw_os_error() == Some(libc::EEXIST) => {
+            info!(iface, "clsact qdisc already present");
+        }
+        Err(e) => {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!("qdisc_add_clsact({iface}): {e}"),
+            ));
+        }
+    }
+
+    let prog: &mut SchedClassifier = ebpf
+        .program_mut(TC_FAST_PATH_PROGRAM_NAME)
+        .ok_or_else(|| ModuleError::other(MODULE_NAME, "tc_fast_path missing post-load"))?
+        .try_into()
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc_fast_path type: {e}")))?;
+    let link_id = prog
+        .attach_with_options(
+            iface,
+            TcAttachType::Ingress,
+            TcAttachOptions::Netlink(NlOptions::default()),
+        )
+        .map_err(|e| {
+            ModuleError::other(MODULE_NAME, format!("tc attach on {iface} failed: {e}"))
+        })?;
+    let link = prog
+        .take_link(link_id)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc take_link({iface}): {e}")))?;
+    let priority = link
+        .priority()
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc link priority({iface}): {e}")))?;
+    let handle = link
+        .handle()
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc link handle({iface}): {e}")))?;
+    // Keep the kernel attach alive past this scope; see fn docs.
+    std::mem::forget(link);
+    Ok((priority, handle))
+}
+
+/// Detach one recorded tc filter. Best-effort building block for both
+/// the in-process (`detach(state)`) and out-of-process
+/// ([`tc_detach_from_state_dir`]) teardown paths.
+fn tc_detach_one(iface: &str, priority: u16, handle: u32) -> Result<(), String> {
+    use aya::programs::tc::{SchedClassifierLink, TcAttachType};
+    use aya::programs::Link as _;
+    let link = SchedClassifierLink::attached(iface, TcAttachType::Ingress, priority, handle)
+        .map_err(|e| format!("reconstruct tc link on {iface}: {e}"))?;
+    link.detach()
+        .map_err(|e| format!("tc detach on {iface} (prio {priority}, handle {handle}): {e}"))
+}
+
+/// Tear down every tc filter recorded in `<state-dir>/tc-links.json`
+/// and remove the file. Used by `packetframe detach` (no live loader
+/// required — the filters have qdisc lifetime). Returns the number of
+/// filters detached; per-filter failures are logged and skipped so a
+/// vanished iface doesn't wedge the teardown (the qdisc died with it).
+pub fn tc_detach_from_state_dir(state_dir: &Path) -> ModuleResult<usize> {
+    let Some(file) = crate::tc_links::load(state_dir)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json read: {e}")))?
+    else {
+        return Ok(0);
+    };
+    let mut detached = 0usize;
+    for rec in &file.links {
+        match tc_detach_one(&rec.iface, rec.priority, rec.handle) {
+            Ok(()) => {
+                info!(iface = %rec.iface, rec.priority, rec.handle, "tc filter detached");
+                detached += 1;
+            }
+            Err(e) => warn!(iface = %rec.iface, error = %e, "tc filter detach skipped"),
+        }
+    }
+    crate::tc_links::remove(state_dir)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json remove: {e}")))?;
+    Ok(detached)
+}
+
 /// §2.3: per-interface trial-attach. `Native` and `Generic` are explicit
 /// (no fallback); `Auto` tries native first, falls back to generic on
 /// any error. The spec calls out that `bpftool feature probe` is
@@ -1454,6 +1737,12 @@ fn try_attach_with_fallback(
     bpffs_root: &Path,
 ) -> ModuleResult<(AttachMode, LinkHandle)> {
     match mode {
+        // tc attaches are partitioned out before the XDP loop and go
+        // through `tc_attach_iface`; reaching here is a caller bug.
+        AttachMode::Tc => Err(ModuleError::other(
+            MODULE_NAME,
+            format!("internal: tc attach for `{iface}` routed to the XDP attach path"),
+        )),
         AttachMode::Native => attach_and_pin(
             prog,
             ifindex,
@@ -1708,12 +1997,25 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
     }
 
     // Drop every PinnedLink next: this closes our userspace FDs but
-    // the kernel keeps the attach alive via the bpffs inodes. Drain
-    // in reverse attach order, no practical consequence here, matches
-    // typical lifecycle expectations.
-    while let Some(link) = state.links.pop() {
-        info!(iface = %link.iface, "fast-path detaching");
-        drop(link);
+    // the kernel keeps the attach alive via the bpffs inodes. tc
+    // records hold no FD at all — detach them explicitly via their
+    // recorded (priority, handle), best-effort (a vanished iface took
+    // its qdisc and filter with it). Drain in reverse attach order.
+    let mut had_tc = false;
+    while let Some(record) = state.links.pop() {
+        info!(iface = %record.iface, "fast-path detaching");
+        if let LinkHandle::Tc { priority, handle } = record.link {
+            had_tc = true;
+            if let Err(e) = tc_detach_one(&record.iface, priority, handle) {
+                warn!(iface = %record.iface, error = %e, "tc filter detach skipped");
+            }
+        }
+        drop(record);
+    }
+    if had_tc {
+        if let Err(e) = crate::tc_links::remove(&state.state_dir) {
+            warn!(error = %e, "tc-links.json remove failed");
+        }
     }
 
     // Unlink every pin under the module's pin root. Pace the link-pin

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -31,7 +31,7 @@ use std::fmt::Write as _;
 /// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
 /// tail-call diagnostics from the Prometheus export; a separate
 /// hardcoded 37 hid `pass_ndp` from `packetframe status`).
-pub const COUNTER_NAMES: [&str; 40] = [
+pub const COUNTER_NAMES: [&str; 42] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -77,6 +77,9 @@ pub const COUNTER_NAMES: [&str; 40] = [
     // --- v0.2.8: finalize error-path visibility ---
     "err_ctx_offset_range",
     "err_redirect_failed",
+    // --- Phase T: tc-ingress datapath A/B attribution ---
+    "rx_total_tc",
+    "fwd_ok_tc",
 ];
 
 /// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
@@ -228,12 +231,12 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 40);
+        assert_eq!(COUNTER_NAMES.len(), 42);
         assert_eq!(COUNTER_NAMES.len(), COUNTER_COUNT);
         // The newest counters, as a canary that the tail of the list
         // stayed aligned with the `StatIdx` discriminants.
-        assert_eq!(COUNTER_NAMES[38], "err_ctx_offset_range");
-        assert_eq!(COUNTER_NAMES[39], "err_redirect_failed");
+        assert_eq!(COUNTER_NAMES[40], "rx_total_tc");
+        assert_eq!(COUNTER_NAMES[41], "fwd_ok_tc");
     }
 
     #[test]

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -356,6 +356,36 @@ fn reconcile_devmap(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
             Err(e) => warn!(ifindex, error = %e, "REDIRECT_DEVMAP remove failed"),
         }
     }
+
+    // Converge the tc datapath's membership mirror against the same
+    // desired set (Phase T; devmaps are XDP-only so tc_fast_path's
+    // pristine-packet pre-check reads this plain hash map instead).
+    // Same stale-purge policy; deltas fold into the devmap's counts.
+    {
+        let map = state
+            .ebpf
+            .map_mut("TC_REDIRECT_TARGETS")
+            .ok_or_else(|| ModuleError::other(MODULE_NAME, "TC_REDIRECT_TARGETS missing"))?;
+        let mut hm: AyaHashMap<_, u32, u32> = AyaHashMap::try_from(map).map_err(|e| {
+            ModuleError::other(MODULE_NAME, format!("TC_REDIRECT_TARGETS try_from: {e}"))
+        })?;
+        let tc_current: HashSet<u32> = hm.keys().filter_map(Result::ok).collect();
+        for ifindex in desired.difference(&tc_current) {
+            match hm.insert(*ifindex, *ifindex, 0) {
+                Ok(()) => info!(ifindex, "TC_REDIRECT_TARGETS added (iface came up)"),
+                Err(e) => warn!(ifindex, error = %e, "TC_REDIRECT_TARGETS insert failed"),
+            }
+        }
+        for ifindex in tc_current.difference(&desired) {
+            if ifindex_exists(*ifindex) {
+                continue;
+            }
+            match hm.remove(ifindex) {
+                Ok(()) => info!(ifindex, "TC_REDIRECT_TARGETS stale entry purged"),
+                Err(e) => warn!(ifindex, error = %e, "TC_REDIRECT_TARGETS remove failed"),
+            }
+        }
+    }
     Ok(delta)
 }
 

--- a/crates/modules/fast-path/src/tc_links.rs
+++ b/crates/modules/fast-path/src/tc_links.rs
@@ -1,0 +1,125 @@
+//! Persistence for tc-datapath filter attachments (Phase T).
+//!
+//! Netlink cls_bpf filters cannot be pinned as bpf_links: their
+//! lifetime is the clsact qdisc's, so the kernel attach survives
+//! process exit inherently (the filter holds its own reference to the
+//! program). What does NOT survive is aya's in-process
+//! `SchedClassifierLink` — it detaches on Drop — so the attach path
+//! reads the kernel-assigned `(priority, handle)` pair, persists it
+//! here, and forgets the link. `packetframe detach` reconstructs each
+//! filter via `SchedClassifierLink::attached()` and detaches it.
+//!
+//! Sibling of `registry.rs` (`<state-dir>/tc-links.json` next to
+//! `attachments.json`); same atomic write-then-rename discipline.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const TC_LINKS_FILENAME: &str = "tc-links.json";
+
+#[derive(Debug, Error)]
+pub enum TcLinksError {
+    #[error("I/O error on {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("JSON error on {path:?}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TcLinksFile {
+    pub links: Vec<TcLinkRecord>,
+}
+
+/// One attached cls_bpf filter: the tuple
+/// `SchedClassifierLink::attached()` needs to reconstruct it
+/// (attach type is always ingress for the fast-path datapath).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TcLinkRecord {
+    pub iface: String,
+    pub priority: u16,
+    pub handle: u32,
+}
+
+pub fn file_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(TC_LINKS_FILENAME)
+}
+
+/// Atomic write-then-rename, mirroring `registry::save`.
+pub fn save(state_dir: &Path, file: &TcLinksFile) -> Result<(), TcLinksError> {
+    let path = file_path(state_dir);
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(file).map_err(|source| TcLinksError::Json {
+        path: path.clone(),
+        source,
+    })?;
+    std::fs::create_dir_all(state_dir).map_err(|source| TcLinksError::Io {
+        path: state_dir.to_path_buf(),
+        source,
+    })?;
+    std::fs::write(&tmp, json).map_err(|source| TcLinksError::Io {
+        path: tmp.clone(),
+        source,
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|source| TcLinksError::Io { path, source })
+}
+
+/// `Ok(None)` when the file doesn't exist (no tc attaches recorded).
+pub fn load(state_dir: &Path) -> Result<Option<TcLinksFile>, TcLinksError> {
+    let path = file_path(state_dir);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(TcLinksError::Io { path, source }),
+    };
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|source| TcLinksError::Json { path, source })
+}
+
+/// Missing file is fine (idempotent teardown).
+pub fn remove(state_dir: &Path) -> Result<(), TcLinksError> {
+    let path = file_path(state_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(TcLinksError::Io { path, source }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_and_idempotent_remove() {
+        let dir = std::env::temp_dir().join(format!("pf-tc-links-{}", std::process::id()));
+        let file = TcLinksFile {
+            links: vec![TcLinkRecord {
+                iface: "eth5".into(),
+                priority: 49152,
+                handle: 1,
+            }],
+        };
+        save(&dir, &file).unwrap();
+        let loaded = load(&dir).unwrap().expect("file present");
+        assert_eq!(loaded.links.len(), 1);
+        assert_eq!(loaded.links[0].iface, "eth5");
+        assert_eq!(loaded.links[0].priority, 49152);
+        assert_eq!(loaded.links[0].handle, 1);
+        remove(&dir).unwrap();
+        assert!(load(&dir).unwrap().is_none());
+        remove(&dir).unwrap(); // second remove is a no-op
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -55,7 +55,7 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V2: u32 = 1;
-pub const STATS_COUNT: u32 = 40;
+pub const STATS_COUNT: u32 = 42;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.
@@ -115,6 +115,8 @@ pub enum StatIdx {
     PassNdp = 37,
     ErrCtxOffsetRange = 38,
     ErrRedirectFailed = 39,
+    RxTotalTc = 40,
+    FwdOkTc = 41,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a
@@ -125,6 +127,15 @@ pub mod xdp_action {
     pub const XDP_PASS: u32 = 2;
     pub const XDP_TX: u32 = 3;
     pub const XDP_REDIRECT: u32 = 4;
+}
+
+/// TC action constants (uapi pkt_cls.h) for the tc datapath fixtures.
+pub mod tc_action {
+    pub const TC_ACT_OK: u32 = 0;
+    pub const TC_ACT_SHOT: u32 = 2;
+    /// `bpf_redirect()`'s success return, passed through as the
+    /// classifier verdict.
+    pub const TC_ACT_REDIRECT: u32 = 7;
 }
 
 pub struct Harness {
@@ -186,6 +197,49 @@ impl Harness {
             prog_array
                 .set(0, &finalize_fd, 0)
                 .expect("MUTATION_PROGS.set(0, finalize)");
+        }
+
+        // tc datapath (Phase T): load both classifiers and populate
+        // TC_MUTATION_PROGS[0], mirroring the XDP chain setup, so every
+        // harness run also verifier-gates the sched_cls programs and
+        // `run_tc` exercises the full tc_fast_path → tc_finalize chain.
+        {
+            use aya::programs::tc::SchedClassifier;
+            {
+                let prog: &mut SchedClassifier = bpf
+                    .program_mut("tc_finalize")
+                    .expect("tc_finalize program present")
+                    .try_into()
+                    .expect("tc_finalize is sched_cls-typed");
+                prog.load().expect("verifier accepts tc_finalize");
+            }
+            {
+                let prog: &mut SchedClassifier = bpf
+                    .program_mut("tc_fast_path")
+                    .expect("tc_fast_path program present")
+                    .try_into()
+                    .expect("tc_fast_path is sched_cls-typed");
+                prog.load().expect("verifier accepts tc_fast_path");
+            }
+            let tc_finalize_fd: ProgramFd = {
+                let prog: &SchedClassifier = bpf
+                    .program("tc_finalize")
+                    .expect("tc_finalize present")
+                    .try_into()
+                    .expect("tc_finalize is sched_cls-typed");
+                prog.fd()
+                    .expect("tc_finalize loaded")
+                    .try_clone()
+                    .expect("tc_finalize fd dup")
+            };
+            let map = bpf
+                .map_mut("TC_MUTATION_PROGS")
+                .expect("TC_MUTATION_PROGS map");
+            let mut prog_array: ProgramArray<_> =
+                ProgramArray::try_from(map).expect("ProgramArray try_from");
+            prog_array
+                .set(0, &tc_finalize_fd, 0)
+                .expect("TC_MUTATION_PROGS.set(0, tc_finalize)");
         }
 
         // Set a default cfg with dry_run=off and both families enabled.
@@ -494,6 +548,43 @@ impl Harness {
     pub fn run(&self, packet: &[u8]) -> (u32, Vec<u8>) {
         let (retval, _duration, out) = test_run_xdp_repeat(self.fast_path_fd(), packet, 1);
         (retval, out)
+    }
+
+    /// Run the tc datapath (`tc_fast_path` → `tc_finalize` via the
+    /// TC_MUTATION_PROGS tail call) against `packet`. Returns
+    /// (tc action, output bytes). `BPF_PROG_TEST_RUN` for sched_cls
+    /// builds a real skb from the bytes (data at the MAC header, same
+    /// offsets as live clsact ingress) and does NOT lift an inline
+    /// 802.1Q tag into skb metadata — which is exactly why the program
+    /// keeps its inline-tag fallback parse.
+    pub fn run_tc(&self, packet: &[u8]) -> (u32, Vec<u8>) {
+        use aya::programs::tc::SchedClassifier;
+        let prog: &SchedClassifier = self
+            .bpf
+            .program("tc_fast_path")
+            .expect("tc_fast_path present")
+            .try_into()
+            .expect("program is sched_cls");
+        let prog_fd: &ProgramFd = prog.fd().expect("program loaded");
+        let (retval, _duration, out) = test_run_xdp_repeat(prog_fd.as_fd().as_raw_fd(), packet, 1);
+        (retval, out)
+    }
+
+    /// Insert an ifindex into `TC_REDIRECT_TARGETS` (the tc datapath's
+    /// devmap-membership mirror) so tc_forward_success's pre-check
+    /// passes. Tests use a REAL ifindex (loopback): unlike the XDP
+    /// path, tc's `bpf_check_mtu` resolves the ifindex against the
+    /// netns even under TEST_RUN, and a fake one fails the MTU check.
+    pub fn add_tc_redirect_target(&mut self, ifindex: u32) {
+        use aya::maps::HashMap as AyaHashMap;
+        let map = self
+            .bpf
+            .map_mut("TC_REDIRECT_TARGETS")
+            .expect("TC_REDIRECT_TARGETS map");
+        let mut hm: AyaHashMap<_, u32, u32> =
+            AyaHashMap::try_from(map).expect("TC_REDIRECT_TARGETS try_from");
+        hm.insert(ifindex, ifindex, 0)
+            .expect("TC_REDIRECT_TARGETS insert");
     }
 
     /// Run the BPF program `repeat` times against `packet` in a single

--- a/crates/modules/fast-path/tests/tc_attach.rs
+++ b/crates/modules/fast-path/tests/tc_attach.rs
@@ -1,0 +1,140 @@
+// aya is Linux-only.
+#![cfg(target_os = "linux")]
+
+//! Integration test for the tc-datapath attach lifecycle (Phase T,
+//! T3): load the shared ELF, create a veth pair, attach `tc_fast_path`
+//! to one end via the production helper (`tc_attach_iface`: clsact +
+//! netlink cls_bpf, link forgotten), persist the record, then prove
+//! the two properties the design depends on:
+//!
+//! 1. **The filter outlives the attaching context.** The aya link was
+//!    forgotten, so nothing in-process holds it; `tc filter show`
+//!    still lists the bpf filter afterwards.
+//! 2. **Out-of-process teardown works from the persisted record.**
+//!    `tc_detach_from_state_dir` reconstructs the filter purely from
+//!    tc-links.json `(iface, priority, handle)` and detaches it.
+//!
+//! Full end-to-end tc forwarding (packet in → bpf_redirect → packet
+//! out the peer) needs a netns + AF_PACKET harness like netns.rs and
+//! is tracked as Phase T follow-up work.
+//!
+//! Requires CAP_NET_ADMIN + CAP_BPF; CI runs this under `sudo`.
+
+use std::process::Command;
+
+use packetframe_fast_path::{
+    aligned_bpf_copy, tc_attach_iface, tc_detach_from_state_dir, tc_links, FAST_PATH_BPF_AVAILABLE,
+};
+
+const PEER_A: &str = "pf-tcv0";
+const PEER_B: &str = "pf-tcv1";
+
+struct Cleanup {
+    state_dir: std::path::PathBuf,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        let _ = Command::new("ip").args(["link", "del", PEER_A]).status();
+        let _ = std::fs::remove_dir_all(&self.state_dir);
+    }
+}
+
+fn run(cmd: &[&str]) {
+    let status = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("spawning `{}`: {e}", cmd.join(" ")));
+    assert!(status.success(), "`{}` failed: {status}", cmd.join(" "));
+}
+
+fn tc_filter_listing(iface: &str) -> String {
+    let out = Command::new("tc")
+        .args(["filter", "show", "dev", iface, "ingress"])
+        .output()
+        .expect("spawn tc");
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_attach_persists_and_detaches_from_state_dir() {
+    if !FAST_PATH_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping tc attach test.");
+        return;
+    }
+
+    // Clean any leftover from a prior aborted run. Idempotent.
+    let _ = Command::new("ip").args(["link", "del", PEER_A]).status();
+
+    run(&[
+        "ip", "link", "add", PEER_A, "type", "veth", "peer", "name", PEER_B,
+    ]);
+    run(&["ip", "link", "set", PEER_A, "up"]);
+    run(&["ip", "link", "set", PEER_B, "up"]);
+
+    let state_dir = std::env::temp_dir().join(format!("pf-tc-attach-test-{}", std::process::id()));
+    let _cleanup = Cleanup {
+        state_dir: state_dir.clone(),
+    };
+
+    // Load the ELF and the classifier pair the same way attach() does:
+    // tc_finalize first (its FD feeds the tail-call table).
+    let bytes = aligned_bpf_copy();
+    let mut bpf = aya::Ebpf::load(&bytes).expect("aya::Ebpf::load");
+    for name in ["tc_finalize", "tc_fast_path"] {
+        let prog: &mut aya::programs::tc::SchedClassifier = bpf
+            .program_mut(name)
+            .unwrap_or_else(|| panic!("{name} present"))
+            .try_into()
+            .unwrap_or_else(|_| panic!("{name} is sched_cls"));
+        prog.load().expect("verifier accepts classifier");
+    }
+
+    // Production attach helper: clsact (tolerating pre-existing) +
+    // netlink cls_bpf + forget, returning kernel-assigned identifiers.
+    let (priority, handle) = tc_attach_iface(&mut bpf, PEER_A).expect("tc attach");
+    assert!(priority > 0, "kernel-assigned priority expected");
+
+    // Persist the record exactly as attach() does.
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: PEER_A.to_string(),
+                priority,
+                handle,
+            }],
+        },
+    )
+    .expect("tc-links.json save");
+
+    // Property 1: the filter is live and held by nothing in-process
+    // (the aya link was forgotten inside tc_attach_iface). Dropping
+    // the whole Ebpf object must NOT detach it either: the cls_bpf
+    // filter holds its own program reference.
+    let listing = tc_filter_listing(PEER_A);
+    assert!(
+        listing.contains("bpf"),
+        "expected a bpf filter on {PEER_A} ingress, got:\n{listing}"
+    );
+    drop(bpf);
+    let listing = tc_filter_listing(PEER_A);
+    assert!(
+        listing.contains("bpf"),
+        "filter must survive Ebpf drop (qdisc lifetime), got:\n{listing}"
+    );
+
+    // Property 2: out-of-process-style teardown from the persisted
+    // record alone.
+    let n = tc_detach_from_state_dir(&state_dir).expect("teardown from state dir");
+    assert_eq!(n, 1, "one recorded filter should have been detached");
+    let listing = tc_filter_listing(PEER_A);
+    assert!(
+        !listing.contains("bpf"),
+        "filter should be gone after detach, got:\n{listing}"
+    );
+    // Record file removed; a second teardown is a clean no-op.
+    assert!(tc_links::load(&state_dir).expect("load").is_none());
+    assert_eq!(tc_detach_from_state_dir(&state_dir).expect("idempotent"), 0);
+}

--- a/crates/modules/fast-path/tests/tc_attach.rs
+++ b/crates/modules/fast-path/tests/tc_attach.rs
@@ -138,3 +138,39 @@ fn tc_attach_persists_and_detaches_from_state_dir() {
     assert!(tc_links::load(&state_dir).expect("load").is_none());
     assert_eq!(tc_detach_from_state_dir(&state_dir).expect("idempotent"), 0);
 }
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_detach_clears_records_for_vanished_ifaces() {
+    // A recorded filter whose iface no longer exists died with the
+    // device (qdisc lifetime): teardown must classify it as cleared —
+    // dropping the record and removing the file — rather than either
+    // erroring out or, worse, retaining a dead record forever. The
+    // opposite case (detach FAILS with the iface alive) retains the
+    // record; that branch needs an induced netlink failure and is
+    // covered by review-level reasoning rather than a fixture.
+    let state_dir =
+        std::env::temp_dir().join(format!("pf-tc-vanished-test-{}", std::process::id()));
+    let _cleanup = Cleanup {
+        state_dir: state_dir.clone(),
+    };
+
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: "pf-gone0".to_string(), // never created
+                priority: 49152,
+                handle: 1,
+            }],
+        },
+    )
+    .expect("tc-links.json save");
+
+    let n = tc_detach_from_state_dir(&state_dir).expect("vanished iface must not error");
+    assert_eq!(n, 1, "vanished-iface record counts as cleared");
+    assert!(
+        tc_links::load(&state_dir).expect("load").is_none(),
+        "file must be removed once every record is cleared"
+    );
+}

--- a/crates/modules/fast-path/tests/tc_attach.rs
+++ b/crates/modules/fast-path/tests/tc_attach.rs
@@ -149,11 +149,20 @@ fn tc_detach_clears_records_for_vanished_ifaces() {
     // opposite case (detach FAILS with the iface alive) retains the
     // record; that branch needs an induced netlink failure and is
     // covered by review-level reasoning rather than a fixture.
+    //
+    // State-dir-only guard, NOT the shared `Cleanup`: that one also
+    // deletes PEER_A, and cargo runs tests in parallel — this test
+    // finishing first would yank the veth out from under
+    // `tc_attach_persists_and_detaches_from_state_dir` mid-setup.
+    struct DirCleanup(std::path::PathBuf);
+    impl Drop for DirCleanup {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
     let state_dir =
         std::env::temp_dir().join(format!("pf-tc-vanished-test-{}", std::process::id()));
-    let _cleanup = Cleanup {
-        state_dir: state_dir.clone(),
-    };
+    let _cleanup = DirCleanup(state_dir.clone());
 
     tc_links::save(
         &state_dir,

--- a/crates/modules/fast-path/tests/tc_fixtures.rs
+++ b/crates/modules/fast-path/tests/tc_fixtures.rs
@@ -1,0 +1,174 @@
+//! Packet-level fixtures for the tc-ingress datapath (Phase T) via
+//! sched_cls `BPF_PROG_TEST_RUN`: verdict mapping (OK/SHOT/REDIRECT),
+//! shared-counter parity with the XDP path plus the A/B attribution
+//! counters, the TC_REDIRECT_TARGETS pristine-packet pre-check, and
+//! the inline-VLAN-tag fallback parse.
+//!
+//! The tc datapath is custom-fib only; kernel-fib/compare stay on XDP.
+//! Real clsact attach, metadata-VLAN round-trip, and MTU/GSO behavior
+//! need a netns + veth (T3's integration test) — TEST_RUN neither
+//! untags inline 802.1Q into skb metadata nor executes the redirect.
+//!
+//! Every test is `#[ignore]`: CAP_BPF + BPF build required; CI runs
+//! them under sudo.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use common::{
+    tc_action, FpCfg, Harness, Ipv4TcpBuilder, StatIdx, FP_CFG_FLAG_BLOCK_PRESENT,
+    FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_IPV4, FP_CFG_FLAG_IPV6, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+    FP_CFG_VERSION_V2,
+};
+
+/// Real ifindex required: tc's bpf_check_mtu resolves it against the
+/// netns even under TEST_RUN (see add_tc_redirect_target docs).
+const LO_IFINDEX: u32 = 1;
+const EGRESS_MAC: [u8; 6] = [0xde, 0xad, 0xbe, 0xef, 0, 0x01];
+const NEXTHOP_MAC: [u8; 6] = [0xde, 0xad, 0xbe, 0xef, 0, 0x02];
+const BASE_FLAGS: u8 = FP_CFG_FLAG_IPV4 | FP_CFG_FLAG_IPV6 | FP_CFG_FLAG_CUSTOM_FIB;
+
+fn tc_forwarding_harness() -> Harness {
+    let mut h = Harness::new();
+    h.set_custom_fib(true, /*compare=*/ false);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+    h.add_tc_redirect_target(LO_IFINDEX);
+    h
+}
+
+fn matched_pkt() -> Vec<u8> {
+    Ipv4TcpBuilder {
+        src_ip: [10, 0, 0, 5],
+        dst_ip: [10, 0, 0, 42],
+        ..Default::default()
+    }
+    .build()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_allowlist_miss_returns_ok_and_attributes_rx() {
+    let mut h = Harness::new();
+    h.set_custom_fib(true, false);
+    // No allowlist entries: everything misses.
+    let pkt = Ipv4TcpBuilder::default().build();
+
+    let rx_before = h.stat(StatIdx::RxTotal);
+    let rx_tc_before = h.stat(StatIdx::RxTotalTc);
+    let (verdict, out) = h.run_tc(&pkt);
+    assert_eq!(verdict, tc_action::TC_ACT_OK);
+    assert_eq!(out, pkt, "miss path must leave the packet pristine");
+    // Both the shared counter and the tc attribution counter move.
+    assert_eq!(h.stat(StatIdx::RxTotal), rx_before + 1);
+    assert_eq!(h.stat(StatIdx::RxTotalTc), rx_tc_before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_custom_fib_hit_redirects_with_rewrites() {
+    let h = tc_forwarding_harness();
+    let pkt = matched_pkt();
+
+    let fwd_before = h.stat(StatIdx::FwdOk);
+    let fwd_tc_before = h.stat(StatIdx::FwdOkTc);
+    let hit_before = h.stat(StatIdx::CustomFibHit);
+    let (verdict, out) = h.run_tc(&pkt);
+    assert_eq!(verdict, tc_action::TC_ACT_REDIRECT);
+    assert_eq!(h.stat(StatIdx::CustomFibHit), hit_before + 1);
+    assert_eq!(h.stat(StatIdx::FwdOk), fwd_before + 1);
+    assert_eq!(h.stat(StatIdx::FwdOkTc), fwd_tc_before + 1);
+    // Same mutations as the XDP path: L2 rewrite + TTL decrement.
+    assert_eq!(&out[0..6], &NEXTHOP_MAC, "dst MAC not rewritten");
+    assert_eq!(&out[6..12], &EGRESS_MAC, "src MAC not rewritten");
+    assert_eq!(out[14 + 8], pkt[14 + 8] - 1, "TTL not decremented");
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_targets_miss_passes_pristine() {
+    // Same forwarding state but TC_REDIRECT_TARGETS left empty: the
+    // pre-check must fire BEFORE any mutation (a bpf_redirect to an
+    // unchecked ifindex would DROP the skb after return, and a
+    // mutated pass-through would be the §11.13 hazard).
+    let mut h = Harness::new();
+    h.set_custom_fib(true, false);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+    let pkt = matched_pkt();
+
+    let miss_before = h.stat(StatIdx::PassNotInDevmap);
+    let (verdict, out) = h.run_tc(&pkt);
+    assert_eq!(verdict, tc_action::TC_ACT_OK);
+    assert_eq!(h.stat(StatIdx::PassNotInDevmap), miss_before + 1);
+    assert_eq!(out, pkt, "pass-path packet must be pristine (§11.13)");
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_block_gate_drops_with_shot() {
+    let mut h = tc_forwarding_harness();
+    h.add_block_v4("10.0.0.0/24");
+    h.set_cfg(FpCfg {
+        dry_run: 0,
+        flags: BASE_FLAGS | FP_CFG_FLAG_BLOCK_PRESENT,
+        mss_clamp_global: 0,
+        version: FP_CFG_VERSION_V2,
+    });
+    let pkt = matched_pkt();
+
+    let dropped_before = h.stat(StatIdx::BogonDropped);
+    let (verdict, _) = h.run_tc(&pkt);
+    assert_eq!(verdict, tc_action::TC_ACT_SHOT);
+    assert_eq!(h.stat(StatIdx::BogonDropped), dropped_before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_inline_vlan_tag_parse_matches() {
+    // TEST_RUN delivers the 802.1Q tag inline (no skb-metadata lift),
+    // exercising exactly the fallback parse. The tagged matched packet
+    // must classify and forward; egress is untagged (VLAN_RESOLVE
+    // empty ⇒ egress_vid none ⇒ ingress tag popped by tc_finalize).
+    let h = tc_forwarding_harness();
+    let base = matched_pkt();
+    let tagged = common::insert_vlan_tag(&base, 66);
+
+    let matched_before = h.stat(StatIdx::MatchedV4);
+    let (verdict, _out) = h.run_tc(&tagged);
+    assert_eq!(verdict, tc_action::TC_ACT_REDIRECT);
+    assert_eq!(h.stat(StatIdx::MatchedV4), matched_before + 1);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_mss_clamp_parity_with_xdp() {
+    // The tc finalize stage shares the clamp walk + source lookups
+    // with XDP; a global clamp must rewrite a SYN's MSS identically.
+    let mut h = tc_forwarding_harness();
+    h.set_cfg(FpCfg {
+        dry_run: 0,
+        flags: BASE_FLAGS | FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+        mss_clamp_global: 1300,
+        version: FP_CFG_VERSION_V2,
+    });
+    let pkt = Ipv4TcpBuilder {
+        src_ip: [10, 0, 0, 5],
+        dst_ip: [10, 0, 0, 42],
+        tcp_flags: 0x02,                     // SYN
+        tcp_options: vec![2, 4, 0x05, 0xb4], // MSS 1460
+        ..Default::default()
+    }
+    .build();
+
+    let applied_before = h.stat(StatIdx::MssClampApplied);
+    let (verdict, out) = h.run_tc(&pkt);
+    assert_eq!(verdict, tc_action::TC_ACT_REDIRECT);
+    assert_eq!(h.stat(StatIdx::MssClampApplied), applied_before + 1);
+    // eth(14) + ipv4(20) + tcp fixed(20) + option kind/len(2).
+    let mss_off = 14 + 20 + 20 + 2;
+    assert_eq!(&out[mss_off..mss_off + 2], &1300u16.to_be_bytes());
+}

--- a/docs/runbooks/tc-datapath.md
+++ b/docs/runbooks/tc-datapath.md
@@ -1,0 +1,103 @@
+# tc-ingress datapath (Phase T)
+
+Operational guide for `attach <iface> tc`: running the fast-path as
+sched_cls classifiers on a clsact qdisc instead of XDP.
+
+## When to use it
+
+On hosts forced into `xdp-generic` (e.g. rvu-nicpf kernels < 6.8), the
+dominant per-packet CPU costs are outside the BPF program: the kernel
+copies every packet to guarantee 256 bytes of headroom
+(`pskb_expand_head`), linearizes GRO super-skbs, and transmits
+redirects one at a time. The tc datapath runs the same forwarding
+logic after normal skb receive and avoids all three; GRO aggregates
+forward as single units and segment on egress. Expected win vs generic
+XDP: substantial for TCP-heavy traffic (GRO amortization), meaningful
+for small-packet floods. It is strictly slower than *native* XDP —
+hosts that can run native should.
+
+`auto` never selects tc. It is a per-interface, explicit opt-in so
+canary rollouts stay operator-controlled.
+
+## Prerequisites
+
+- `forwarding-mode custom-fib` with a live `route-source`. The tc
+  classifiers have no kernel-fib arm; the loader refuses the pairing
+  otherwise.
+- Kernel: `CONFIG_NET_SCH_INGRESS` + `CONFIG_NET_CLS_BPF` (verified
+  `=y` on the reference EFG's 5.15.72-ui-cn9670).
+- No conflicting `ingress` qdisc: `tc qdisc show dev <iface>` must not
+  list `qdisc ingress ffff:` from another tool (clsact and the legacy
+  ingress qdisc occupy the same handle). A plain `mq`/`fq` root — the
+  EFG default — is fine; packetframe adds `clsact` itself and
+  tolerates one that already exists.
+
+## Semantics vs the XDP datapath
+
+Identical: allowlist match, custom-FIB lookup (shared code), counters
+(same indices), block-prefix (drop is `TC_ACT_SHOT`), dry-run, NDP
+gate, mss-clamp, VLAN-subif egress resolution, the
+mutate-only-if-forwardable invariant (via `TC_REDIRECT_TARGETS`, the
+devmap-membership mirror).
+
+Different, deliberately:
+
+| Aspect | XDP datapath | tc datapath |
+|---|---|---|
+| Oversize packets | pass, kernel decides | `bpf_check_mtu` pre-check → pristine pass, kernel emits FRAG_NEEDED (parity custom-fib never had under XDP) |
+| Egress path | `generic_xdp_tx` direct xmit | `dev_queue_xmit` — traverses the egress qdisc, so `fq` pacing/shaping still applies |
+| tcpdump on ingress | blind (XDP runs before taps) | sees ingress traffic again |
+| VLAN ingress | inline tag parse | skb metadata first, inline fallback |
+| Attach persistence | bpffs-pinned bpf_link | netlink cls_bpf filter (qdisc lifetime), recorded in `<state-dir>/tc-links.json` |
+
+## Canary rollout
+
+1. Pick the quietest attached interface. Change its attach line:
+
+   ```
+   attach eth5 tc
+   ```
+
+   Attach-set changes are **restart-only** (not SIGHUP-reloadable):
+   `systemctl restart packetframe`.
+
+2. Confirm: `packetframe status` shows `eth5 [tc-ingress]`, and
+   `tc filter show dev eth5 ingress` lists a `bpf` filter running
+   `tc_fast_path`.
+
+3. Watch, comparing against the XDP interfaces:
+   - `rx_total_tc` / `fwd_ok_tc`: the tc datapath's share. During a
+     mixed rollout, `fwd_ok - fwd_ok_tc` is the XDP share.
+   - `mpstat -P ALL 10 1` `%soft`: the actual CPU verdict.
+   - `pass_not_in_devmap`, `err_tail_call`, `err_redirect_failed`,
+     `err_vlan`: should stay flat at their pre-canary rates.
+   - End-to-end: latency/loss through the canary interface,
+     especially VLAN-tagged and near-MTU flows.
+
+4. Expand interface by interface as the numbers hold.
+
+## Rollback
+
+Config revert (`attach eth5 generic`) + restart. `packetframe detach
+--all` tears down tc filters from `tc-links.json` alongside the XDP
+pins; if the state file is ever lost, the manual fallback is:
+
+```sh
+tc filter del dev eth5 ingress
+```
+
+(The clsact qdisc itself is harmless to leave in place.)
+
+Failure posture mirrors XDP: SIGTERM leaves filters attached
+(§8.5 parity — the filter holds its own program reference); a circuit
+breaker trip detaches everything explicitly.
+
+## Known gaps
+
+- Hardware validation pending for: VLAN metadata round-trip on tagged
+  trunks, egress-qdisc (`fq`) lock cost under load, and real GSO
+  forwarding throughput. The canary steps above are the validation.
+- No netns end-to-end forwarding test yet (TEST_RUN can't execute the
+  redirect); tracked as Phase T follow-up.
+- Migrating from netlink cls_bpf to pinned TCX links is future work
+  once the fleet baseline is ≥ 6.6.


### PR DESCRIPTION
## What

Stacked on #74 (base is that branch; will retarget to main when it merges). Adds the tc-ingress datapath: `attach <iface> tc` runs the fast-path as sched_cls classifiers on clsact instead of XDP.

**Why:** on the production EFG class (rvu-nicpf, 5.15-ui, native XDP unsafe), generic XDP pays three kernel-side taxes per packet — the 256B-headroom `pskb_expand_head` copy, GRO linearization, and un-bulked `generic_xdp_tx`. The tc datapath avoids all three and forwards GRO super-skbs whole (GSO segmentation on egress). Estimated 1.5–3× effective forwarded throughput for TCP-heavy traffic vs generic XDP; strictly below native XDP, which this hardware can't use.

## Commits (T1–T4)

1. **T1 — shared helpers:** behavior-neutral extraction of ctx-free packet helpers into `bpf/src/datapath.rs` (scalars-only, no Ctx trait per this repo's verifier history); `fib.rs` becomes fully hook-agnostic.
2. **T2 — classifiers:** `tc_fast_path` + `tc_finalize` reuse the shared classification/custom-FIB/clamp logic. Hook deltas only: metadata-first VLAN parse, `TC_REDIRECT_TARGETS` pre-mutation pre-check (`bpf_redirect` can't pre-check and drops on bad targets), pre-mutation `bpf_check_mtu(SEGS)` (custom-fib gains FRAG_NEEDED parity), skb-helper VLAN push/pop, separate `TC_MUTATION_PROGS`. Counters `rx_total_tc`/`fwd_ok_tc` (40/41) for mixed-rollout A/B attribution. **custom-fib only** — kernel-fib/compare stay on XDP; userspace enforces the pairing.
3. **T3 — userspace lifecycle:** `AttachMode::Tc` (explicit opt-in, never chosen by `auto`); attach is deliberately netlink cls_bpf on every kernel (qdisc-lifetime persistence + `(priority, handle)` for out-of-process detach; TCX migration deferred to a ≥6.6 baseline); `tc-links.json` persistence; `packetframe detach` handles filters with or without a live loader; SIGTERM preserves attach (§8.5 parity), breaker trip detaches. veth integration test proves persistence-past-Ebpf-drop and teardown-from-record.
4. **T4 — runbook:** `docs/runbooks/tc-datapath.md` — prerequisites, semantic deltas table, per-interface canary procedure, rollback (one-line config revert; manual `tc filter del` fallback).

## Validation state

- Every fixture run now verifier-gates the classifiers (harness loads them in `Harness::new`); six new sched_cls TEST_RUN fixtures + the veth lifecycle test run in the qemu matrix.
- On-hardware gates already cleared on the reference EFG: no conflicting ingress qdisc (plain mq/fq), `CONFIG_NET_SCH_INGRESS=y` + `CONFIG_NET_CLS_BPF=y`.
- Remaining validation is the canary itself: VLAN-trunk metadata round-trip, fq egress lock cost, real GSO forwarding throughput (runbook §Known gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)