### PR TITLE
ci: installable on-router test bundles + keep the test tree cross-buildable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,8 @@ jobs:
 
       - name: Install Rust (stable + target)
         run: |
-          rustup toolchain install ${{ env.RUST_STABLE }} --profile minimal
+          rustup toolchain install ${{ env.RUST_STABLE }} \
+            --profile minimal --component clippy
           rustup default ${{ env.RUST_STABLE }}
           rustup target add ${{ matrix.target }}
 
@@ -130,6 +131,20 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-${{ matrix.target }}-
+
+      # `cross build` below covers lib + bins only, and the `check` job's
+      # clippy run sees just the host triple, so *test* code that doesn't
+      # compile for a release target slipped through both. It bit us
+      # twice: `libc::ioctl`'s request argument is `c_ulong` on glibc but
+      # `c_int` on musl, and `c_char` is signed on x86_64 but unsigned on
+      # aarch64 — neither is visible from an x86_64-gnu lint of the
+      # workspace. Clippy doesn't link, so `--all-targets` per triple is
+      # cheap insurance, and it's what keeps the test tree cross-buildable
+      # for `hardware-artifacts.yml`.
+      - name: cargo clippy --all-targets
+        run: |
+          cargo clippy --workspace --all-targets --all-features \
+            --target ${{ matrix.target }} -- -D warnings
 
       - name: Install cross
         run: |

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -61,7 +61,15 @@ jobs:
     env:
       PACKETFRAME_BPF_REQUIRED: "1"
     steps:
+      # Check out the PR head rather than the default merge ref. This
+      # workflow's output is an artifact someone installs on a router, so
+      # the revision it was built from has to be a commit that exists:
+      # stamping a package with a sha that isn't what was compiled is
+      # worse than no sha at all. Correctness gating against the merge
+      # result is ci.yml's and qemu-verifier.yml's job, not this one's.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install Rust (stable + nightly for BPF)
         run: |
@@ -145,13 +153,22 @@ jobs:
       # out to be older than the cross image's: a static musl build has no
       # runtime libc dependency to satisfy, at the cost of no .deb.
       TARGET: ${{ inputs.target || 'aarch64-unknown-linux-gnu' }}
-      # On a pull_request run, GITHUB_SHA (and the checked-out HEAD) is the
-      # synthetic merge commit, which exists in nobody's clone. Stamp the
-      # package version with the PR head instead, so the sha an operator
-      # reads out of `dpkg -l` is one they can actually `git show`.
+      # The revision stamped into the package version. Must stay identical
+      # to the checkout `ref` below, so the sha an operator reads out of
+      # `dpkg -l` names the commit that was actually compiled — on a
+      # pull_request run GITHUB_SHA alone would be the synthetic merge
+      # commit, which exists in nobody's clone.
       PF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
+      # Check out the PR head rather than the default merge ref. This
+      # workflow's output is an artifact someone installs on a router, so
+      # the revision it was built from has to be a commit that exists:
+      # stamping a package with a sha that isn't what was compiled is
+      # worse than no sha at all. Correctness gating against the merge
+      # result is ci.yml's and qemu-verifier.yml's job, not this one's.
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Install Rust (stable + target)
         run: |
@@ -376,14 +393,26 @@ jobs:
 
           suite="${*:-${SAFE}}"
           rc=0
+          ran=0
           for t in ${suite}; do
+            # A missing binary is a failure, not a skip. Silently passing
+            # here would let a typo, or a staging bug that dropped a
+            # target, report a clean pre-canary validation that in fact
+            # exercised nothing.
             if [ ! -x "./${t}" ]; then
-              echo "== skip ${t} (not in this bundle)"
+              echo "!! ${t}: not in this bundle (run --list to see what is)" >&2
+              rc=1
               continue
             fi
             echo "== ${t}"
+            ran=$((ran + 1))
             ./"${t}" --ignored --nocapture || rc=1
           done
+          if [ "${ran}" -eq 0 ]; then
+            echo "!! no tests ran" >&2
+            rc=1
+          fi
+          echo "== ${ran} test binaries ran, exit ${rc}"
           exit "${rc}"
           SH
           chmod +x "dist/packetframe-hwtest-${TARGET}/run-tests.sh"

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -426,7 +426,13 @@ jobs:
             fi
             echo "== ${t}"
             ran=$((ran + 1))
-            ./"${t}" --ignored --nocapture || rc=1
+            # --include-ignored, not --ignored: the *-unittests
+            # harnesses staged here hold mostly ORDINARY tests, and
+            # --ignored would filter every one of them out — zero
+            # tests, exit 0, a silent fake pass. For the integration
+            # binaries the two flags are equivalent (every test there
+            # is #[ignore]-gated), so one flag serves all binaries.
+            ./"${t}" --include-ignored --nocapture || rc=1
           done
           if [ "${ran}" -eq 0 ]; then
             echo "!! no tests ran" >&2

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -272,9 +272,15 @@ jobs:
           # Every test binary here is #[ignore]d by default (they need
           # CAP_BPF/CAP_NET_ADMIN), so the driver passes --ignored.
           #
-          # SAFE BY DEFAULT: the default suite only uses BPF_PROG_TEST_RUN
-          # — programs are loaded and fed synthetic packets in-kernel;
-          # nothing is attached to a live NIC and no traffic is affected.
+          # SAFE BY DEFAULT, including on a forwarding production router:
+          # the default suite only uses BPF_PROG_TEST_RUN — programs are
+          # loaded and fed synthetic packets in-kernel. Nothing is
+          # attached to a NIC, no route/neighbour/sysctl state is touched,
+          # and no live traffic is affected. `fib_comparison` is the only
+          # one that writes anything outside its own process: it pins maps
+          # under a unique /sys/fs/bpf/pftestcmp-<pid>-<n> scratch dir and
+          # removes it on exit, never the running instance's pins.
+          #
           # `attach`, `tc_attach`, `netns`, `local_prefix_netns` and
           # `neigh_resolver_netns` create interfaces or network
           # namespaces; they clean up after themselves but are excluded

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -19,6 +19,14 @@ name: Hardware test artifacts
 on:
   push:
     branches: [main]
+  # Self-test: a PR that touches this workflow runs it, so a broken
+  # cross-build or staging step is caught by the PR that introduced it
+  # rather than after merge. Path-filtered, so ordinary PRs don't pay for
+  # a second BPF build. It also means the bundle is downloadable from the
+  # PR run — handy when the change being reviewed is the bundle itself.
+  pull_request:
+    paths:
+      - '.github/workflows/hardware-artifacts.yml'
   workflow_dispatch:
     inputs:
       target:

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -145,6 +145,11 @@ jobs:
       # out to be older than the cross image's: a static musl build has no
       # runtime libc dependency to satisfy, at the cost of no .deb.
       TARGET: ${{ inputs.target || 'aarch64-unknown-linux-gnu' }}
+      # On a pull_request run, GITHUB_SHA (and the checked-out HEAD) is the
+      # synthetic merge commit, which exists in nobody's clone. Stamp the
+      # package version with the PR head instead, so the sha an operator
+      # reads out of `dpkg -l` is one they can actually `git show`.
+      PF_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - uses: actions/checkout@v7
 
@@ -305,7 +310,7 @@ jobs:
           cargo deb --no-build --no-strip \
             --target "${TARGET}" \
             -p packetframe-cli \
-            --deb-version "$(cat VERSION)~hwtest$(git rev-parse --short HEAD)" \
+            --deb-version "$(cat VERSION)~hwtest${PF_SHA:0:7}" \
             --output "dist/packetframe-hwtest-${TARGET}/"
           ls -la "dist/packetframe-hwtest-${TARGET}"/*.deb
 

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -295,22 +295,24 @@ jobs:
           # CAP_BPF/CAP_NET_ADMIN), so the driver passes --ignored.
           #
           # SAFE BY DEFAULT, including on a forwarding production router:
-          # the default suite only uses BPF_PROG_TEST_RUN — programs are
-          # loaded and fed synthetic packets in-kernel. Nothing is
-          # attached to a NIC, no route/neighbour/sysctl state is touched,
-          # and no live traffic is affected. `fib_comparison` is the only
-          # one that writes anything outside its own process: it pins maps
-          # under a unique /sys/fs/bpf/pftestcmp-<pid>-<n> scratch dir and
-          # removes it on exit, never the running instance's pins.
+          # every test in the default suite only uses BPF_PROG_TEST_RUN —
+          # programs are loaded and fed synthetic packets in-kernel.
+          # Nothing is attached to a NIC, no route/neighbour/sysctl state
+          # is touched, nothing is written outside the test process, and no
+          # live traffic is affected.
           #
-          # `attach`, `tc_attach`, `netns`, `local_prefix_netns` and
-          # `neigh_resolver_netns` create interfaces or network
-          # namespaces; they clean up after themselves but are excluded
-          # from the default run. Name them explicitly if you want them.
+          # Excluded from the default run, name them explicitly to opt in:
+          #   attach, tc_attach, netns, local_prefix_netns,
+          #   neigh_resolver_netns  — create interfaces or netns
+          #   fib_comparison, fib_programmer_integration — pin maps into a
+          #     scratch /sys/fs/bpf/pftestcmp-<pid>-<n> dir (removed on
+          #     exit) and mount bpffs if it isn't already mounted
+          # All of them clean up after themselves; they're excluded so the
+          # default run's "writes nothing" property holds without caveats.
           set -u
           cd "$(dirname "$0")/tests" || exit 1
 
-          SAFE="verifier fixtures tc_fixtures feature_gates mss_clamp_gate fib_fixtures fib_hash_vectors fib_comparison bench"
+          SAFE="verifier fixtures tc_fixtures feature_gates mss_clamp_gate fib_fixtures fib_hash_vectors bench"
 
           if [ "${1:-}" = "--list" ]; then
             ls -1

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -30,14 +30,14 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: 'Target triple to cross-build the test binaries for'
+        description: 'Target triple to cross-build for (gnu targets also get a .deb)'
         type: choice
-        default: aarch64-unknown-linux-musl
+        default: aarch64-unknown-linux-gnu
         options:
-          - aarch64-unknown-linux-musl
           - aarch64-unknown-linux-gnu
-          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
           - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
 
 permissions:
   contents: read
@@ -131,15 +131,20 @@ jobs:
           if-no-files-found: error
 
   tests:
-    name: test binaries (${{ inputs.target || 'aarch64-unknown-linux-musl' }})
+    name: test binaries (${{ inputs.target || 'aarch64-unknown-linux-gnu' }})
     needs: bpf
     runs-on: ubuntu-latest
     env:
-      # Default target is the production fleet's: aarch64 + musl.
-      # Static-musl matters here — these binaries run on UniFi OS, whose
-      # glibc version we don't control, and a statically linked test ELF
-      # has no runtime dependency to satisfy.
-      TARGET: ${{ inputs.target || 'aarch64-unknown-linux-musl' }}
+      # Default target matches the production fleet: aarch64 UniFi OS,
+      # which is Debian-family glibc. That's also what makes a .deb
+      # possible — dpkg packages are for glibc distros, so the `-gnu`
+      # targets are the ones that get one, and `dpkg -i` is how this
+      # actually gets onto a test router.
+      #
+      # The musl options remain for the case where a target's glibc turns
+      # out to be older than the cross image's: a static musl build has no
+      # runtime libc dependency to satisfy, at the cost of no .deb.
+      TARGET: ${{ inputs.target || 'aarch64-unknown-linux-gnu' }}
     steps:
       - uses: actions/checkout@v7
 
@@ -157,9 +162,9 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-gnu' }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}-
+            ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-gnu' }}-
 
       - name: Install cross
         run: |
@@ -274,6 +279,36 @@ jobs:
              docs/runbooks/generic-mode-performance.md \
              "dist/packetframe-hwtest-${TARGET}/"
 
+      # An installable package, not just loose binaries: `dpkg -i` is how
+      # this reaches a test router, and it brings the systemd unit and
+      # /etc/packetframe along with the binary. Only the `-gnu` targets get
+      # one — a .deb targets glibc Debian-family systems, which is what
+      # UniFi OS is; musl builds are static ELFs with no package.
+      #
+      # release.yml stays the authority for PUBLISHED packages
+      # (reproducible SOURCE_DATE_EPOCH, combined + signed SHA256SUMS).
+      # This one is deliberately versioned `<VERSION>~hwtest<sha>` so it
+      # sorts below any real release, can never be mistaken for one, and is
+      # trivially visible in `dpkg -l`.
+      - name: Build .deb (gnu targets only)
+        if: contains(inputs.target || 'aarch64-unknown-linux-gnu', '-gnu')
+        run: |
+          set -euo pipefail
+          if ! command -v cargo-deb >/dev/null 2>&1 || \
+             [ "$(cargo deb --version 2>/dev/null | awk '{print $2}')" != "2.7.0" ]; then
+            cargo install --locked --force cargo-deb --version 2.7.0
+          fi
+          # --no-build: cross already produced the binary at
+          # target/<triple>/release/packetframe. --no-strip: the release
+          # profile strips, and the host's `strip` can't read a cross-built
+          # arm64 ELF anyway.
+          cargo deb --no-build --no-strip \
+            --target "${TARGET}" \
+            -p packetframe-cli \
+            --deb-version "$(cat VERSION)~hwtest$(git rev-parse --short HEAD)" \
+            --output "dist/packetframe-hwtest-${TARGET}/"
+          ls -la "dist/packetframe-hwtest-${TARGET}"/*.deb
+
       # Default suite is BPF_PROG_TEST_RUN-only: it loads programs and
       # runs packets through them in-kernel without attaching anything to
       # a live interface, so it is safe on a forwarding router. The tests
@@ -359,7 +394,7 @@ jobs:
 
       - uses: actions/upload-artifact@v7
         with:
-          name: hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}
+          name: hwtest-${{ inputs.target || 'aarch64-unknown-linux-gnu' }}
           path: |
             dist/*.tar.gz
             dist/*.sha256

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -381,6 +381,26 @@ jobs:
             exit 1
           fi
 
+          # Detect a noexec mount before reporting anything as missing.
+          # Every binary here is staged 0755, and Linux access(X_OK) —
+          # which `test -x` uses — honours mount flags, so on a noexec
+          # filesystem a perfectly good binary tests as non-executable.
+          # /tmp is noexec on UniFi OS, so unpacking there makes the whole
+          # suite look absent, which is a maddening thing to debug from a
+          # "not in this bundle" message. Diagnose it once, properly.
+          for probe in ${SAFE}; do
+            if [ -f "./${probe}" ] && [ ! -x "./${probe}" ]; then
+              bundle=$(dirname "$(pwd)")
+              echo "error: ./${probe} exists but is not executable." >&2
+              echo "  cwd:            $(pwd)" >&2
+              echo "  mount options:  $(findmnt -no OPTIONS -T . 2>/dev/null || echo 'unknown (no findmnt)')" >&2
+              echo "  A noexec mount makes every test look missing. /tmp is noexec on" >&2
+              echo "  UniFi OS — copy the bundle somewhere exec-capable and rerun:" >&2
+              echo "    cp -r ${bundle} /root/ && /root/$(basename "${bundle}")/run-tests.sh" >&2
+              exit 1
+            fi
+          done
+
           # The microbenchmark times the JIT-compiled program; with the
           # JIT off it would time the interpreter and the numbers would be
           # meaningless. Warn rather than refuse: correctness tests are

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -208,6 +208,22 @@ jobs:
           root = os.path.join("dist", f"packetframe-hwtest-{target}")
           tests_dir = os.path.join(root, "tests")
           os.makedirs(tests_dir, exist_ok=True)
+          cwd = os.getcwd()
+
+          def host_path(p):
+              """Translate a cross-container path to its host equivalent.
+
+              cargo ran inside cross's Docker container, which mounts the
+              workspace at /project and the target dir at /target, so every
+              `executable` in build.json is a container path that does not
+              exist out here. Map the two mount points back onto the
+              workspace. A plain (non-cross) build reports host paths
+              already and falls through unchanged.
+              """
+              for prefix, rel in (("/target/", "target/"), ("/project/", "")):
+                  if p.startswith(prefix):
+                      return os.path.join(cwd, rel + p[len(prefix):])
+              return p
 
           staged_tests, staged_bins = [], []
           for line in open("build.json"):
@@ -237,7 +253,13 @@ jobs:
                   staged_bins.append(name)
               if os.path.exists(dest):
                   sys.exit(f"refusing to overwrite staged {dest} (target name collision)")
-              shutil.copy2(exe, dest)
+              src = host_path(exe)
+              if not os.path.exists(src):
+                  sys.exit(
+                      f"cargo reported {exe} but it is not readable at {src} — "
+                      "cross's container mount layout has changed, fix host_path()"
+                  )
+              shutil.copy2(src, dest)
               os.chmod(dest, 0o755)
 
           if not staged_tests:

--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -1,0 +1,329 @@
+name: Hardware test artifacts
+
+# Produces a downloadable bundle for running PacketFrame's integration
+# tests and the ns/packet microbenchmark ON A ROUTER, rather than on a
+# CI runner or in qemu.
+#
+# Why this exists: `ci.yml` and `qemu-verifier.yml` prove correctness on
+# x86_64 (host + 5.15/6.6 VMs) but neither produces an artifact you can
+# copy to an aarch64 EFG, and the release tarballs ship only the
+# `packetframe` binary — no test binaries, and only on a tag. Numbers
+# that matter for the generic-XDP-vs-tc work (ns/packet on cn9670 cores)
+# can only be measured on the real hardware, so the test ELFs have to be
+# cross-built somewhere that has both the BPF toolchain and the cross
+# targets. That's here.
+#
+# Runs on every push to main so there is always a current bundle, and on
+# demand for other targets. Never publishes anything.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: 'Target triple to cross-build the test binaries for'
+        type: choice
+        default: aarch64-unknown-linux-musl
+        options:
+          - aarch64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - x86_64-unknown-linux-gnu
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_STABLE: "1.95.0"
+  RUST_NIGHTLY: "nightly-2026-04-14"
+  BPF_LINKER_VERSION: "0.10.3"
+
+jobs:
+  # Same shape as release.yml's `bpf` job, and for the same reason:
+  # cross's Docker images have no rustup, so they cannot nest-build the
+  # BPF crate. Build the ELF once here (host has nightly + bpf-linker),
+  # hand it to the cross job via PACKETFRAME_BPF_OBJ_PATH. Test binaries
+  # must embed the REAL bytecode — a stub ELF makes every BPF-loading
+  # test early-return "BPF stub in effect" and report ok.
+  bpf:
+    name: build BPF ELF
+    runs-on: ubuntu-latest
+    env:
+      PACKETFRAME_BPF_REQUIRED: "1"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable + nightly for BPF)
+        run: |
+          rustup toolchain install ${{ env.RUST_STABLE }} --profile minimal
+          rustup default ${{ env.RUST_STABLE }}
+          rustup toolchain install ${{ env.RUST_NIGHTLY }} \
+            --profile minimal --component rust-src,llvm-tools-preview
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            crates/modules/fast-path/bpf/target/
+            crates/modules/probe/bpf/target/
+          key: ${{ runner.os }}-hwtest-bpf-${{ hashFiles('crates/modules/fast-path/bpf/**', 'crates/modules/probe/bpf/**') }}
+
+      - name: Install bpf-linker
+        run: |
+          if ! command -v bpf-linker >/dev/null 2>&1 || \
+             [ "$(bpf-linker --version 2>/dev/null | awk '{print $2}')" != "${{ env.BPF_LINKER_VERSION }}" ]; then
+            cargo install --locked --force bpf-linker \
+              --version ${{ env.BPF_LINKER_VERSION }}
+          fi
+
+      - name: Build BPF ELFs
+        run: |
+          set -eux
+          build_one() {
+            local bpf_dir="$1"
+            local bin_name="$2"
+            local out_name="$3"
+            ( cd "${bpf_dir}" && cargo build --release --message-format=json ) \
+              | tee "${out_name}.json" >/dev/null
+            local elf
+            elf=$(python3 -c "
+          import json, sys
+          for line in open('${out_name}.json'):
+              try:
+                  msg = json.loads(line)
+              except Exception:
+                  continue
+              if msg.get('reason') == 'compiler-artifact' and msg.get('target', {}).get('name') == '${bin_name}':
+                  print(msg['filenames'][0])
+                  sys.exit(0)
+          sys.exit(1)
+          ")
+            test -n "${elf}" && test -e "${elf}"
+            head -c 4 "${elf}" | od -An -c | grep -q 'E   L   F' || \
+              (echo "BPF output is not an ELF at ${elf}" >&2; exit 1)
+            cp "${elf}" "dist/${out_name}"
+          }
+          mkdir -p dist
+          build_one crates/modules/fast-path/bpf fast-path fast-path.bpf.o
+          build_one crates/modules/probe/bpf     probe     probe.bpf.o
+          ls -la dist/*.bpf.o
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: bpf-elf
+          path: |
+            dist/fast-path.bpf.o
+            dist/probe.bpf.o
+          retention-days: 14
+          if-no-files-found: error
+
+  tests:
+    name: test binaries (${{ inputs.target || 'aarch64-unknown-linux-musl' }})
+    needs: bpf
+    runs-on: ubuntu-latest
+    env:
+      # Default target is the production fleet's: aarch64 + musl.
+      # Static-musl matters here — these binaries run on UniFi OS, whose
+      # glibc version we don't control, and a statically linked test ELF
+      # has no runtime dependency to satisfy.
+      TARGET: ${{ inputs.target || 'aarch64-unknown-linux-musl' }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust (stable + target)
+        run: |
+          rustup toolchain install ${{ env.RUST_STABLE }} --profile minimal
+          rustup default ${{ env.RUST_STABLE }}
+          rustup target add "${TARGET}"
+
+      - uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}-
+
+      - name: Install cross
+        run: |
+          if ! command -v cross >/dev/null 2>&1; then
+            cargo install --locked cross
+          fi
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: bpf-elf
+          path: prebuilt-bpf
+
+      - name: Point build.rs at the prebuilt BPF ELFs
+        run: |
+          set -eux
+          FAST="$(pwd)/prebuilt-bpf/fast-path.bpf.o"
+          PROBE="$(pwd)/prebuilt-bpf/probe.bpf.o"
+          head -c 4 "${FAST}"  | od -An -c | grep -q 'E   L   F'
+          head -c 4 "${PROBE}" | od -An -c | grep -q 'E   L   F'
+          # Cross.toml's passthrough list doesn't cover these, so forward
+          # them with explicit -e, using the container's mount point for
+          # the workspace (/project). Same approach as release.yml.
+          echo "CROSS_CONTAINER_OPTS=-e PACKETFRAME_BPF_OBJ_PATH=/project/prebuilt-bpf/fast-path.bpf.o -e PACKETFRAME_PROBE_BPF_OBJ_PATH=/project/prebuilt-bpf/probe.bpf.o" >> "${GITHUB_ENV}"
+
+      # `--tests` is the point of this job and is NOT covered by
+      # ci.yml's cross matrix (which builds `--release --workspace`
+      # only). Test code has its own cross-compilation hazards — the
+      # SIOCGIFHWADDR ioctl request type differs between glibc and musl
+      # — so this job is also the gate that keeps the test tree
+      # cross-buildable.
+      - name: Cross-build test binaries + CLI
+        run: |
+          set -euo pipefail
+          cross build --release --target "${TARGET}" \
+            --tests --bins \
+            -p packetframe-fast-path -p packetframe-probe -p packetframe-cli \
+            --message-format=json | tee build.json >/dev/null
+
+      - name: Stage bundle
+        run: |
+          set -euo pipefail
+          python3 - "$TARGET" <<'PY'
+          import json, os, shutil, sys
+
+          target = sys.argv[1]
+          root = os.path.join("dist", f"packetframe-hwtest-{target}")
+          tests_dir = os.path.join(root, "tests")
+          os.makedirs(tests_dir, exist_ok=True)
+
+          staged_tests, staged_bins = [], []
+          for line in open("build.json"):
+              try:
+                  msg = json.loads(line)
+              except Exception:
+                  continue
+              if msg.get("reason") != "compiler-artifact":
+                  continue
+              exe = msg.get("executable")
+              if not exe:
+                  continue
+              tgt = msg["target"]
+              name = tgt["name"]
+              kinds = tgt.get("kind", [])
+              if msg.get("profile", {}).get("test"):
+                  # A lib's or bin's own #[test] harness shares its
+                  # target name with the library/binary itself; suffix so
+                  # the real `packetframe` binary and the test harness
+                  # compiled from src/main.rs don't collide.
+                  if "test" not in kinds:
+                      name = f"{name}-unittests"
+                  dest = os.path.join(tests_dir, name)
+                  staged_tests.append(name)
+              else:
+                  dest = os.path.join(root, name)
+                  staged_bins.append(name)
+              if os.path.exists(dest):
+                  sys.exit(f"refusing to overwrite staged {dest} (target name collision)")
+              shutil.copy2(exe, dest)
+              os.chmod(dest, 0o755)
+
+          if not staged_tests:
+              sys.exit("no test executables found in build.json")
+          if "packetframe" not in staged_bins:
+              sys.exit("packetframe CLI binary missing from build.json")
+          print("tests:", " ".join(sorted(staged_tests)))
+          print("bins: ", " ".join(sorted(staged_bins)))
+          PY
+          cp conf/example.conf "dist/packetframe-hwtest-${TARGET}/"
+          cp docs/runbooks/tc-datapath.md \
+             docs/runbooks/generic-mode-performance.md \
+             "dist/packetframe-hwtest-${TARGET}/"
+
+      # Default suite is BPF_PROG_TEST_RUN-only: it loads programs and
+      # runs packets through them in-kernel without attaching anything to
+      # a live interface, so it is safe on a forwarding router. The tests
+      # that create veths/netns or attach to devices must be named
+      # explicitly — hence the split.
+      - name: Write on-router driver script
+        run: |
+          set -euo pipefail
+          cat > "dist/packetframe-hwtest-${TARGET}/run-tests.sh" <<'SH'
+          #!/bin/sh
+          # On-router driver for PacketFrame's staged test binaries.
+          #
+          #   ./run-tests.sh              # safe suite: no interface is touched
+          #   ./run-tests.sh bench        # just the ns/packet microbenchmark
+          #   ./run-tests.sh tc_attach    # invasive: creates veths (see below)
+          #   ./run-tests.sh --list       # what is in this bundle
+          #
+          # Every test binary here is #[ignore]d by default (they need
+          # CAP_BPF/CAP_NET_ADMIN), so the driver passes --ignored.
+          #
+          # SAFE BY DEFAULT: the default suite only uses BPF_PROG_TEST_RUN
+          # — programs are loaded and fed synthetic packets in-kernel;
+          # nothing is attached to a live NIC and no traffic is affected.
+          # `attach`, `tc_attach`, `netns`, `local_prefix_netns` and
+          # `neigh_resolver_netns` create interfaces or network
+          # namespaces; they clean up after themselves but are excluded
+          # from the default run. Name them explicitly if you want them.
+          set -u
+          cd "$(dirname "$0")/tests" || exit 1
+
+          SAFE="verifier fixtures tc_fixtures feature_gates mss_clamp_gate fib_fixtures fib_hash_vectors fib_comparison bench"
+
+          if [ "${1:-}" = "--list" ]; then
+            ls -1
+            exit 0
+          fi
+
+          if [ "$(id -u)" != 0 ]; then
+            echo "error: run as root — these tests need CAP_BPF + CAP_NET_ADMIN" >&2
+            exit 1
+          fi
+
+          # The microbenchmark times the JIT-compiled program; with the
+          # JIT off it would time the interpreter and the numbers would be
+          # meaningless. Warn rather than refuse: correctness tests are
+          # unaffected.
+          if [ -r /proc/sys/net/core/bpf_jit_enable ]; then
+            jit=$(cat /proc/sys/net/core/bpf_jit_enable)
+            [ "${jit}" = "0" ] && \
+              echo "WARNING: net.core.bpf_jit_enable=0 — bench numbers would measure the BPF interpreter" >&2
+          fi
+
+          suite="${*:-${SAFE}}"
+          rc=0
+          for t in ${suite}; do
+            if [ ! -x "./${t}" ]; then
+              echo "== skip ${t} (not in this bundle)"
+              continue
+            fi
+            echo "== ${t}"
+            ./"${t}" --ignored --nocapture || rc=1
+          done
+          exit "${rc}"
+          SH
+          chmod +x "dist/packetframe-hwtest-${TARGET}/run-tests.sh"
+
+      - name: Bundle
+        run: |
+          set -euo pipefail
+          STEM="packetframe-hwtest-${TARGET}"
+          ( cd dist && tar czf "${STEM}.tar.gz" "${STEM}" )
+          ( cd dist && sha256sum "${STEM}.tar.gz" > "${STEM}.tar.gz.sha256" )
+          ls -la "dist/${STEM}"/ "dist/${STEM}/tests"/
+          du -sh "dist/${STEM}.tar.gz"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: hwtest-${{ inputs.target || 'aarch64-unknown-linux-musl' }}
+          path: |
+            dist/*.tar.gz
+            dist/*.sha256
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,11 +127,21 @@ jobs:
       # both rustc-embedded timestamps and the .deb archive's file mtimes
       # are deterministic. Same value across all matrix legs ensures the
       # binary contents (and the .deb wrapping it) match across runners.
-      - name: Set SOURCE_DATE_EPOCH from tag commit
+      - name: Set SOURCE_DATE_EPOCH and artifact label from the ref
         run: |
           set -euo pipefail
           SDE=$(git log -1 --pretty=%ct "${GITHUB_REF_NAME}")
           echo "SOURCE_DATE_EPOCH=${SDE}" >> "${GITHUB_ENV}"
+          # Artifacts are named after the ref. Publishing only ever happens
+          # for tags, but a workflow_dispatch validation run is on a branch,
+          # and a branch name may contain `/` — which would turn the tar and
+          # .deb output paths into directories that don't exist. Flatten
+          # anything that isn't a tag; leave tags exactly as written.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "PF_REF_LABEL=${GITHUB_REF_NAME}" >> "${GITHUB_ENV}"
+          else
+            echo "PF_REF_LABEL=${GITHUB_REF_NAME//[^a-zA-Z0-9._-]/-}" >> "${GITHUB_ENV}"
+          fi
 
       - name: Install Rust (stable + target)
         run: |
@@ -186,8 +196,9 @@ jobs:
       - name: Stage tarball contents
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME}"
-          STEM="packetframe-${VERSION}-${{ matrix.target }}"
+          # PF_REF_LABEL is the tag verbatim, or a flattened branch name for
+          # a dispatch validation run (a `/` here would break tar's paths).
+          STEM="packetframe-${PF_REF_LABEL}-${{ matrix.target }}"
           STAGE="dist/${STEM}"
           mkdir -p "${STAGE}/conf"
           cp "target/${{ matrix.target }}/release/packetframe" "${STAGE}/"
@@ -211,19 +222,22 @@ jobs:
         if: contains(matrix.target, '-gnu')
         run: |
           set -euo pipefail
-          # Strip the leading `v` so the .deb version is plain semver (e.g.
-          # 0.2.2), matching what `dpkg -s packetframe` will report.
-          DEB_VERSION="${GITHUB_REF_NAME#v}"
-          # A workflow_dispatch pre-release validation run has a branch
-          # name here, not a tag, and dpkg requires an upstream version
-          # starting with a digit — `main` makes cargo-deb fail, which
-          # used to sink both gnu legs of the very dry run that exists to
-          # de-risk a release. Synthesize a valid throwaway version.
-          case "${DEB_VERSION}" in
-            [0-9]*) ;;
-            *) DEB_VERSION="$(cat VERSION)~${DEB_VERSION//[^a-zA-Z0-9]/}$(git rev-parse --short HEAD)" ;;
-          esac
-          STEM="packetframe-${GITHUB_REF_NAME}-${{ matrix.target }}"
+          # For a tag, strip the leading `v` so the .deb version is plain
+          # semver (e.g. 0.2.2), matching what `dpkg -s packetframe` reports.
+          #
+          # A workflow_dispatch pre-release validation run has a BRANCH name
+          # here, and dpkg requires an upstream version that starts with a
+          # digit and contains no `/`, so both `main` and `123/feature` make
+          # cargo-deb fail — sinking both gnu legs of the very dry run that
+          # exists to de-risk a release. Decide on the ref TYPE rather than
+          # the string's shape (a digit-led branch name looks like a version
+          # but isn't one) and synthesize a throwaway version for branches.
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            DEB_VERSION="${GITHUB_REF_NAME#v}"
+          else
+            DEB_VERSION="$(cat VERSION)~${GITHUB_REF_NAME//[^a-zA-Z0-9]/}$(git rev-parse --short HEAD)"
+          fi
+          STEM="packetframe-${PF_REF_LABEL}-${{ matrix.target }}"
           # SOURCE_DATE_EPOCH is already in GITHUB_ENV from the earlier
           # step; cargo-deb honors it for archive mtimes and the
           # changelog Date field. --no-build because cross already

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,6 +214,15 @@ jobs:
           # Strip the leading `v` so the .deb version is plain semver (e.g.
           # 0.2.2), matching what `dpkg -s packetframe` will report.
           DEB_VERSION="${GITHUB_REF_NAME#v}"
+          # A workflow_dispatch pre-release validation run has a branch
+          # name here, not a tag, and dpkg requires an upstream version
+          # starting with a digit — `main` makes cargo-deb fail, which
+          # used to sink both gnu legs of the very dry run that exists to
+          # de-risk a release. Synthesize a valid throwaway version.
+          case "${DEB_VERSION}" in
+            [0-9]*) ;;
+            *) DEB_VERSION="$(cat VERSION)~${DEB_VERSION//[^a-zA-Z0-9]/}$(git rev-parse --short HEAD)" ;;
+          esac
           STEM="packetframe-${GITHUB_REF_NAME}-${{ matrix.target }}"
           # SOURCE_DATE_EPOCH is already in GITHUB_ENV from the earlier
           # step; cargo-deb honors it for archive mtimes and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ PacketFrame is a modular eBPF data plane written in pure Rust (aya + aya-ebpf). 
 - `crates/modules/fast-path/`: fast-path module including the custom-FIB control plane under `src/fib/`
 - `conf/example.conf`: reference config per SPEC.md §4.8
 - `docs/runbooks/custom-fib.md`: Option F operations runbook (healthy state, triage by symptom, cutover + rollback, Phase 4 config snippets)
-- `.github/workflows/`: `ci.yml` (fmt/clippy/test + 4× cross-build), `qemu-verifier.yml` (integration tests on 5.15 + 6.6 kernels), `release.yml` (tag-triggered tarballs)
+- `.github/workflows/`: `ci.yml` (fmt/clippy/test + 4× cross-build), `qemu-verifier.yml` (integration tests on 5.15 + 6.6 kernels), `release.yml` (tag-triggered tarballs), `hardware-artifacts.yml` (per-main-push aarch64 test-binary + CLI bundle for on-router runs)
 
 ## Build & test
 

--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -282,6 +282,11 @@ fn uname_release() -> std::io::Result<String> {
         .iter()
         .position(|&c| c == 0)
         .unwrap_or(release.len());
+    // `c_char` is signed on x86_64 but unsigned on aarch64, so this cast
+    // is load-bearing on the dev/CI architecture and a no-op on the
+    // production one. Clippy only ever sees one of the two. Same
+    // targeted-allow pattern as `statfs.f_type` in probe_bpffs.
+    #[allow(clippy::unnecessary_cast)]
     let bytes: Vec<u8> = release[..end].iter().map(|&c| c as u8).collect();
     String::from_utf8(bytes).map_err(|e| {
         std::io::Error::new(

--- a/crates/modules/fast-path/tests/bench.rs
+++ b/crates/modules/fast-path/tests/bench.rs
@@ -15,12 +15,12 @@
 //! ```
 //!
 //! Run on the reference EFG (or any aarch64 router): download the
-//! `hwtest-aarch64-unknown-linux-musl` artifact from the
+//! `hwtest-aarch64-unknown-linux-gnu` artifact from the
 //! `hardware-artifacts` workflow — it cross-builds this test binary with
-//! the real BPF ELF embedded and stages it with a driver script — then
-//! on the router:
+//! the real BPF ELF embedded and stages it alongside an installable .deb
+//! and a driver script — then on the router:
 //! ```sh
-//! sudo ./packetframe-hwtest-aarch64-unknown-linux-musl/run-tests.sh bench
+//! sudo ./packetframe-hwtest-aarch64-unknown-linux-gnu/run-tests.sh bench
 //! ```
 //! `docs/runbooks/generic-mode-performance.md` has the download
 //! commands. Cross-building by hand needs the BPF toolchain (nightly +

--- a/crates/modules/fast-path/tests/bench.rs
+++ b/crates/modules/fast-path/tests/bench.rs
@@ -14,13 +14,20 @@
 //! sudo -E cargo test --test bench -- --ignored --nocapture
 //! ```
 //!
-//! Run on the reference EFG (or any aarch64 router):
+//! Run on the reference EFG (or any aarch64 router): download the
+//! `hwtest-aarch64-unknown-linux-musl` artifact from the
+//! `hardware-artifacts` workflow — it cross-builds this test binary with
+//! the real BPF ELF embedded and stages it with a driver script — then
+//! on the router:
 //! ```sh
-//! cross build --target aarch64-unknown-linux-gnu --tests --release
-//! # find the bench binary under target/aarch64-unknown-linux-gnu/release/deps/bench-<hash>
-//! scp target/aarch64-unknown-linux-gnu/release/deps/bench-* router:/tmp/
-//! ssh router 'sudo /tmp/bench-<hash> --ignored --nocapture'
+//! sudo ./packetframe-hwtest-aarch64-unknown-linux-musl/run-tests.sh bench
 //! ```
+//! `docs/runbooks/generic-mode-performance.md` has the download
+//! commands. Cross-building by hand needs the BPF toolchain (nightly +
+//! bpf-linker) in the same place as the cross target, which is why the
+//! workflow splits the two: a macOS dev box can't build the ELF at all
+//! and would silently embed a stub, making every bench here early-return.
+//!
 //! Confirm `net.core.bpf_jit_enable=1` on the target first (see
 //! `packetframe feasibility`), otherwise the numbers measure the BPF
 //! interpreter, not what production runs.

--- a/crates/modules/fast-path/tests/fib_comparison.rs
+++ b/crates/modules/fast-path/tests/fib_comparison.rs
@@ -60,8 +60,38 @@ struct PinDirs {
     dir: PathBuf,
 }
 
+/// bpffs superblock magic (`include/uapi/linux/magic.h`).
+const BPF_FS_MAGIC: i64 = 0xcafe_4a11;
+
+fn bpffs_already_mounted() -> bool {
+    let path = match std::ffi::CString::new(BPFFS_ROOT) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let mut st: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut st) } != 0 {
+        return false;
+    }
+    // `f_type` differs in width and signedness across libc/arch, so
+    // normalize before comparing. Same targeted-allow pattern as
+    // `probe_bpffs` in packetframe_common.
+    #[allow(clippy::unnecessary_cast)]
+    let f_type = st.f_type as i64;
+    f_type == BPF_FS_MAGIC
+}
+
 fn ensure_bpffs_mounted() {
     BPFFS_MOUNT.call_once(|| {
+        // Never stack a second bpffs. Linux happily mounts one filesystem
+        // over another on the same mountpoint, so on a host already
+        // running packetframe — where /sys/fs/bpf is mounted and holds the
+        // live pinned maps — an unconditional `mount -t bpf` would shadow
+        // the production pins with an empty instance for the rest of the
+        // boot. Mount only when bpffs genuinely isn't there (bare
+        // containers, a fresh netns).
+        if bpffs_already_mounted() {
+            return;
+        }
         let _ = std::fs::create_dir_all(BPFFS_ROOT);
         let _ = std::process::Command::new("mount")
             .args(["-t", "bpf", "bpf", BPFFS_ROOT])

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -49,13 +49,43 @@ struct PinDirs {
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 static BPFFS_MOUNT: Once = Once::new();
 
+/// bpffs superblock magic (`include/uapi/linux/magic.h`).
+const BPF_FS_MAGIC: i64 = 0xcafe_4a11;
+
+fn bpffs_already_mounted() -> bool {
+    let path = match std::ffi::CString::new(BPFFS_ROOT) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let mut st: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut st) } != 0 {
+        return false;
+    }
+    // `f_type` differs in width and signedness across libc/arch.
+    #[allow(clippy::unnecessary_cast)]
+    let f_type = st.f_type as i64;
+    f_type == BPF_FS_MAGIC
+}
+
 /// Ensure `/sys/fs/bpf` exists and has bpffs mounted on it. GitHub's
 /// hosted Ubuntu runner already has this; virtme-ng's VM does not, so
 /// we mount it ourselves. Best-effort: errors are tolerated, the
 /// subsequent `create_dir_all` / `pin` call will surface the real
 /// problem with a clearer message.
+///
+/// Only mounts when bpffs genuinely isn't there. Linux stacks mounts on
+/// the same mountpoint, so mounting unconditionally would shadow a live
+/// packetframe's pinned maps with an empty instance for the rest of the
+/// boot — this test binary ships in the on-router bundle, where that
+/// would be a production incident rather than a test failure. Same guard
+/// in `fib_comparison.rs` and `route_source_bgp_addpath.rs`; each
+/// `tests/*.rs` is its own crate, so the helper can't be shared without
+/// the `tests/common/` refactor noted below.
 fn ensure_bpffs_mounted() {
     BPFFS_MOUNT.call_once(|| {
+        if bpffs_already_mounted() {
+            return;
+        }
         let _ = std::fs::create_dir_all(BPFFS_ROOT);
         let _ = std::process::Command::new("mount")
             .args(["-t", "bpf", "bpf", BPFFS_ROOT])

--- a/crates/modules/fast-path/tests/neigh_resolver_netns.rs
+++ b/crates/modules/fast-path/tests/neigh_resolver_netns.rs
@@ -184,7 +184,9 @@ fn if_nametoindex(name: &str) -> u32 {
 /// it goes through a socket (sysfs is not reliably remounted per-netns
 /// on every distro).
 fn mac_of(iface: &str) -> [u8; 6] {
-    const SIOCGIFHWADDR: libc::c_ulong = 0x8927;
+    // u32 + `as _`: ioctl's request parameter is `c_ulong` on glibc,
+    // `c_int` on musl. See the same constant in `netns.rs`.
+    const SIOCGIFHWADDR: u32 = 0x8927;
 
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     assert!(
@@ -199,7 +201,8 @@ fn mac_of(iface: &str) -> [u8; 6] {
         ifr.ifr_name[i] = b as libc::c_char;
     }
 
-    let rc = unsafe { libc::ioctl(sock, SIOCGIFHWADDR, &mut ifr as *mut libc::ifreq) };
+    #[allow(clippy::unnecessary_cast)]
+    let rc = unsafe { libc::ioctl(sock, SIOCGIFHWADDR as _, &mut ifr as *mut libc::ifreq) };
     assert_eq!(
         rc,
         0,

--- a/crates/modules/fast-path/tests/netns.rs
+++ b/crates/modules/fast-path/tests/netns.rs
@@ -251,7 +251,12 @@ fn if_nametoindex(name: &str) -> u32 {
 /// whichever netns held it at mount time, which is usually init. The
 /// ioctl goes through a socket and so is properly netns-scoped.
 fn mac_of(iface: &str) -> [u8; 6] {
-    const SIOCGIFHWADDR: libc::c_ulong = 0x8927;
+    // Plain u32 + `as _` at the call site: libc declares ioctl's
+    // request parameter as `c_ulong` on glibc but `c_int` on musl, and
+    // these tests get cross-built for the routers (aarch64 musl) to run
+    // on hardware. Same pattern as `SIOCETHTOOL` in
+    // `packetframe_common::probe`.
+    const SIOCGIFHWADDR: u32 = 0x8927;
 
     let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
     assert!(
@@ -272,7 +277,8 @@ fn mac_of(iface: &str) -> [u8; 6] {
         ifr.ifr_name[i] = b as libc::c_char;
     }
 
-    let rc = unsafe { libc::ioctl(sock, SIOCGIFHWADDR, &mut ifr as *mut libc::ifreq) };
+    #[allow(clippy::unnecessary_cast)]
+    let rc = unsafe { libc::ioctl(sock, SIOCGIFHWADDR as _, &mut ifr as *mut libc::ifreq) };
     assert_eq!(
         rc,
         0,

--- a/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
+++ b/crates/modules/fast-path/tests/route_source_bgp_addpath.rs
@@ -44,8 +44,35 @@ struct PinDirs {
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 static BPFFS_MOUNT: Once = Once::new();
 
+/// bpffs superblock magic (`include/uapi/linux/magic.h`).
+const BPF_FS_MAGIC: i64 = 0xcafe_4a11;
+
+fn bpffs_already_mounted() -> bool {
+    let path = match std::ffi::CString::new(BPFFS_ROOT) {
+        Ok(p) => p,
+        Err(_) => return false,
+    };
+    let mut st: libc::statfs = unsafe { std::mem::zeroed() };
+    if unsafe { libc::statfs(path.as_ptr(), &mut st) } != 0 {
+        return false;
+    }
+    // `f_type` differs in width and signedness across libc/arch.
+    #[allow(clippy::unnecessary_cast)]
+    let f_type = st.f_type as i64;
+    f_type == BPF_FS_MAGIC
+}
+
+/// Mount bpffs only when it genuinely isn't mounted. Linux stacks mounts
+/// on the same mountpoint, so an unconditional mount would shadow a live
+/// packetframe's pinned maps with an empty instance for the rest of the
+/// boot — and this test binary ships in the on-router bundle. Same guard
+/// in `fib_comparison.rs` and `fib_programmer_integration.rs`; each
+/// `tests/*.rs` is its own crate so it can't be shared today.
 fn ensure_bpffs_mounted() {
     BPFFS_MOUNT.call_once(|| {
+        if bpffs_already_mounted() {
+            return;
+        }
         let _ = std::fs::create_dir_all(BPFFS_ROOT);
         let _ = std::process::Command::new("mount")
             .args(["-t", "bpf", "bpf", BPFFS_ROOT])

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -116,42 +116,63 @@ Symbols to read:
 If `pskb_expand_head` + linearization dwarf `bpf_prog_run_generic_xdp`, host tuning
 and datapath placement (not BPF micro-optimization) are where the wins are.
 
-### Getting binaries onto the router
+### Getting a build onto a test router
 
 Neither the release tarballs nor the CI test runs give you what an on-hardware
-measurement session needs: releases ship only the `packetframe` binary and only on
-a tag, and the test suites run on x86_64 runners and in qemu. The
-`hardware-artifacts` workflow closes that gap. It runs on every push to `main` and
-publishes a `hwtest-aarch64-unknown-linux-musl` artifact containing the
-cross-built test binaries, the matching `packetframe` CLI, both runbooks, and a
-driver script — all statically linked and carrying the real BPF ELF (the same
-bytecode a release would ship, not a stub).
+session needs: releases only exist for tags, and the test suites run on x86_64
+runners and in qemu. The `hardware-artifacts` workflow closes that gap. It runs on
+every push to `main` and publishes a `hwtest-aarch64-unknown-linux-gnu` artifact
+containing:
+
+- `packetframe_<version>~hwtest<sha>_arm64.deb` — an installable package, same
+  contents as a release .deb (binary, systemd unit, `/etc/packetframe`)
+- `tests/` — the cross-built test binaries, including `bench`
+- `run-tests.sh`, `example.conf`, and both perf runbooks
+
+Everything carries the real BPF ELF — the same bytecode a release would ship, not
+a stub.
 
 Download the bundle from the newest `main` run (`gh run download` needs an
 explicit run id or it prompts, hence the subshell):
 
 ```sh
-gh run download -R unredacted/packetframe -n hwtest-aarch64-unknown-linux-musl -D /tmp/hw "$(gh run list -R unredacted/packetframe -w 'Hardware test artifacts' -b main -s success --limit 1 --json databaseId --jq '.[0].databaseId')"
+gh run download -R unredacted/packetframe -n hwtest-aarch64-unknown-linux-gnu -D /tmp/hw "$(gh run list -R unredacted/packetframe -w 'Hardware test artifacts' -b main -s success --limit 1 --json databaseId --jq '.[0].databaseId')"
 ```
 
 Unpack and copy to the router (swap `router` for the target host):
 
 ```sh
-tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl router:/tmp/
+tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu router:/tmp/
 ```
 
-To take a bundle from a PR instead of `main` — the workflow also runs on PRs
-that change it — pass `-b <branch>` in place of `-b main`.
-
-For a target other than the fleet default (aarch64 + musl), dispatch it manually:
+Install it, then run the tests from the same directory:
 
 ```sh
-gh workflow run hardware-artifacts.yml --repo unredacted/packetframe -f target=aarch64-unknown-linux-gnu
+dpkg -i /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/packetframe_*_arm64.deb
 ```
 
-A tagged release remains the way to get a *signed, versioned* package. To build
-release tarballs from an untagged `main` without publishing anything, dispatch
-`release.yml` — its `dry_run` input defaults to true and skips the publish job:
+The `~hwtest<sha>` version sorts below every real release and is visible in
+`dpkg -l`, so a validation build can't be mistaken for one — and `apt install
+packetframe` later upgrades cleanly over it. To go back, `dpkg -r packetframe` or
+install a release .deb over the top.
+
+To take a bundle from a PR instead of `main` — the workflow also runs on PRs that
+change it — pass `-b <branch>` in place of `-b main`. For a different target,
+dispatch it:
+
+```sh
+gh workflow run hardware-artifacts.yml --repo unredacted/packetframe -f target=aarch64-unknown-linux-musl
+```
+
+The musl variants are statically linked and produce **no .deb** (dpkg packages
+target glibc distros). They exist as an escape hatch: if a router's glibc turns
+out to be older than the cross image's and the gnu binaries won't start, a static
+musl build has no libc dependency to satisfy.
+
+For a *signed, versioned* package, cut a tag — `release.yml` publishes tarballs
+and .debs for all four targets with reproducible timestamps and a signed
+`SHA256SUMS`. To rehearse that without publishing, dispatch it; `dry_run` defaults
+to true and skips the publish job:
 
 ```sh
 gh workflow run release.yml --repo unredacted/packetframe --ref main

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -211,6 +211,42 @@ Confirm `net.core.bpf_jit_enable=1` first (`packetframe feasibility` reports it,
 and the driver script warns) — otherwise the bench times the BPF interpreter
 rather than what production runs.
 
+#### Reference figures (cn9670)
+
+Measured 2026-07-31 on an EFG-class box (`5.15.72-ui-cn9670`, aarch64, JIT on,
+`bpf_jit_harden=0`), build `0.2.7~hwtestdd33ae7` — i.e. with the hot-path map-op
+reduction and the tc datapath in place:
+
+| Bench | ns/packet |
+|---|---|
+| `bench_allowlist_miss` | 85 |
+| `bench_custom_fib_forward_syn` | 278 |
+| `bench_custom_fib_forward_established` | 282 |
+
+Two things to read off these:
+
+- **~24 ns per map-helper call.** The forward path does 8 more map operations than
+  the miss path plus TTL/L2 mutation and a tail call; `(282 − 85) / 8 ≈ 24 ns`
+  lands inside the 20–40 ns per `bpf_map_lookup_elem` the optimization work
+  assumed, so the cost model the hot-path reduction was designed against holds on
+  this silicon.
+- **SYN and established cost the same** (278 vs 282 ns, ~1% apart — noise). With no
+  `mss-clamp` configured, the clamp lookups are gated out entirely rather than
+  being paid and discarded.
+
+Note what these figures are *not*: no pre-reduction baseline was ever captured on
+this hardware, so the 23→10 map-op change cannot be quantified from them. Scaling
+the measured per-op cost suggests roughly 13 × 24 ≈ 310 ns saved, which would put
+the old path near 590 ns — but that is arithmetic on one measurement, not a
+before/after. Capturing a real baseline means building `bench` from `83badca` (the
+commit before the reduction landed) with this workflow grafted on, and is worth
+doing before quoting any improvement figure.
+
+At 282 ns of program time, one core sustains ~3.5 Mpps of pure BPF work. On a box
+that is CPU-saturated in generic mode, that is the *small* share of per-packet
+cost — use `perf top` above to size the kernel-side share before concluding the
+program is what needs optimizing.
+
 `run-tests.sh` with no arguments runs the wider correctness suite, which is worth
 doing on the box before a tc canary — it proves this kernel's verifier accepts the
 classifiers and that the fixtures produce the expected verdicts.

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -116,13 +116,63 @@ Symbols to read:
 If `pskb_expand_head` + linearization dwarf `bpf_prog_run_generic_xdp`, host tuning
 and datapath placement (not BPF micro-optimization) are where the wins are.
 
+### Getting binaries onto the router
+
+Neither the release tarballs nor the CI test runs give you what an on-hardware
+measurement session needs: releases ship only the `packetframe` binary and only on
+a tag, and the test suites run on x86_64 runners and in qemu. The
+`hardware-artifacts` workflow closes that gap. It runs on every push to `main` and
+publishes a `hwtest-aarch64-unknown-linux-musl` artifact containing the
+cross-built test binaries, the matching `packetframe` CLI, both runbooks, and a
+driver script — all statically linked and carrying the real BPF ELF (the same
+bytecode a release would ship, not a stub).
+
+Download the bundle from the newest run and copy it to the router:
+
+```sh
+gh run download --repo unredacted/packetframe --name hwtest-aarch64-unknown-linux-musl --dir /tmp/hw
+```
+
+```sh
+tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl router:/tmp/
+```
+
+For a target other than the fleet default (aarch64 + musl), dispatch it manually:
+
+```sh
+gh workflow run hardware-artifacts.yml --repo unredacted/packetframe -f target=aarch64-unknown-linux-gnu
+```
+
+A tagged release remains the way to get a *signed, versioned* package. To build
+release tarballs from an untagged `main` without publishing anything, dispatch
+`release.yml` — its `dry_run` input defaults to true and skips the publish job:
+
+```sh
+gh workflow run release.yml --repo unredacted/packetframe --ref main
+```
+
 ### Program-only microbenchmark
 
 `crates/modules/fast-path/tests/bench.rs` measures ns/packet for the
 `fast_path → finalize` chain via `BPF_PROG_TEST_RUN` (kernel-timed, excludes all
-generic-XDP skb overhead). Run on any Linux host, or cross-build the test binary
-for the router (instructions in the file header). Confirm the JIT is on first —
-otherwise the bench times the interpreter.
+generic-XDP skb overhead). It runs on any Linux host, but a number from a CI
+runner tells you nothing about cn9670 cores — take the reference figures on the
+router itself, from the bundle above:
+
+```sh
+sudo /tmp/packetframe-hwtest-aarch64-unknown-linux-musl/run-tests.sh bench
+```
+
+Confirm `net.core.bpf_jit_enable=1` first (`packetframe feasibility` reports it,
+and the driver script warns) — otherwise the bench times the BPF interpreter
+rather than what production runs.
+
+`run-tests.sh` with no arguments runs the wider correctness suite. Its default
+selection is deliberately limited to tests that only use `BPF_PROG_TEST_RUN`:
+programs are loaded and fed synthetic packets in-kernel, nothing is attached to a
+live NIC, so it is safe to run on a forwarding router. The tests that create
+veths or network namespaces (`attach`, `tc_attach`, `netns`,
+`local_prefix_netns`, `neigh_resolver_netns`) have to be named explicitly.
 
 ### Counters that matter (`packetframe status`)
 

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -301,6 +301,15 @@ Two things to read off these:
   `mss-clamp` configured, the clamp lookups are gated out entirely rather than
   being paid and discarded.
 
+**These are cache-hot, small-table numbers.** The bench populates a handful of
+FIB entries, so every LPM walk hits L1. On the reference box under live load with
+a full BGP-fed FIB, the same perf profile that produced the table above puts the
+map lookups alone (`trie_lookup_elem` + `longest_prefix_match`) at ~1.2 µs/packet
+and the program bodies at ~0.5 µs — roughly 6× the bench total, almost all of it
+LPM-walk cache misses that a small table never pays. Use the bench for
+before/after comparisons of code changes (both sides mis-cache equally); use
+`kernel.bpf_stats_enabled` + `bpftool` (above) for the absolute live cost.
+
 Note what these figures are *not*: no pre-reduction baseline was ever captured on
 this hardware, so the 23→10 map-op change cannot be quantified from them. Scaling
 the measured per-op cost suggests roughly 13 × 24 ≈ 310 ns saved, which would put

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -127,15 +127,21 @@ cross-built test binaries, the matching `packetframe` CLI, both runbooks, and a
 driver script — all statically linked and carrying the real BPF ELF (the same
 bytecode a release would ship, not a stub).
 
-Download the bundle from the newest run and copy it to the router:
+Download the bundle from the newest `main` run (`gh run download` needs an
+explicit run id or it prompts, hence the subshell):
 
 ```sh
-gh run download --repo unredacted/packetframe --name hwtest-aarch64-unknown-linux-musl --dir /tmp/hw
+gh run download -R unredacted/packetframe -n hwtest-aarch64-unknown-linux-musl -D /tmp/hw "$(gh run list -R unredacted/packetframe -w 'Hardware test artifacts' -b main -s success --limit 1 --json databaseId --jq '.[0].databaseId')"
 ```
+
+Unpack and copy to the router (swap `router` for the target host):
 
 ```sh
 tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-musl router:/tmp/
 ```
+
+To take a bundle from a PR instead of `main` — the workflow also runs on PRs
+that change it — pass `-b <branch>` in place of `-b main`.
 
 For a target other than the fleet default (aarch64 + musl), dispatch it manually:
 

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -148,13 +148,26 @@ tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu.tar.gz -C /tmp/hw &
 Install it, then run the tests from the same directory:
 
 ```sh
-dpkg -i /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/packetframe_*_arm64.deb
+dpkg -i /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/packetframe_*_arm64.deb && systemctl daemon-reload
 ```
+
+The `daemon-reload` is not optional: the package ships
+`/lib/systemd/system/packetframe.service` but carries **no maintainer scripts**, so
+nothing reloads systemd for you and `systemctl start packetframe` can otherwise
+fail with "Unit packetframe.service not found". This is true of the release .debs
+as well — `[package.metadata.deb.systemd-units]` is configured in
+`crates/cli/Cargo.toml`, but the built package contains only `control`,
+`conffiles` and `sha256sums`.
+
+The package declares `Depends: libc6 (>= 2.31)`. If the target's libc6 is older,
+`dpkg -i` refuses; check with `dpkg -s libc6 | grep ^Version`. That's the case the
+musl variant below exists for.
 
 The `~hwtest<sha>` version sorts below every real release and is visible in
 `dpkg -l`, so a validation build can't be mistaken for one — and `apt install
-packetframe` later upgrades cleanly over it. To go back, `dpkg -r packetframe` or
-install a release .deb over the top.
+packetframe` later upgrades cleanly over it. The sha is the commit the bundle was
+built from, so `git show <sha>` tells you exactly what is on the box. To go back,
+`dpkg -r packetframe` or install a release .deb over the top.
 
 To take a bundle from a PR instead of `main` — the workflow also runs on PRs that
 change it — pass `-b <branch>` in place of `-b main`. For a different target,

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -173,12 +173,19 @@ Confirm `net.core.bpf_jit_enable=1` first (`packetframe feasibility` reports it,
 and the driver script warns) — otherwise the bench times the BPF interpreter
 rather than what production runs.
 
-`run-tests.sh` with no arguments runs the wider correctness suite. Its default
-selection is deliberately limited to tests that only use `BPF_PROG_TEST_RUN`:
-programs are loaded and fed synthetic packets in-kernel, nothing is attached to a
-live NIC, so it is safe to run on a forwarding router. The tests that create
-veths or network namespaces (`attach`, `tc_attach`, `netns`,
-`local_prefix_netns`, `neigh_resolver_netns`) have to be named explicitly.
+`run-tests.sh` with no arguments runs the wider correctness suite, which is worth
+doing on the box before a tc canary — it proves this kernel's verifier accepts the
+classifiers and that the fixtures produce the expected verdicts.
+
+That default selection is deliberately limited to tests that only use
+`BPF_PROG_TEST_RUN`: programs are loaded and fed synthetic packets in-kernel,
+nothing is attached to a NIC, and no route, neighbour or sysctl state is touched,
+so it is safe on a forwarding router. The one exception to "writes nothing" is
+`fib_comparison`, which pins maps under a unique
+`/sys/fs/bpf/pftestcmp-<pid>-<n>` scratch directory and removes it on exit — never
+the running instance's pins. The tests that create veths or network namespaces
+(`attach`, `tc_attach`, `netns`, `local_prefix_netns`, `neigh_resolver_netns`)
+have to be named explicitly.
 
 ### Counters that matter (`packetframe status`)
 

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -139,16 +139,20 @@ explicit run id or it prompts, hence the subshell):
 gh run download -R unredacted/packetframe -n hwtest-aarch64-unknown-linux-gnu -D /tmp/hw "$(gh run list -R unredacted/packetframe -w 'Hardware test artifacts' -b main -s success --limit 1 --json databaseId --jq '.[0].databaseId')"
 ```
 
-Unpack and copy to the router (swap `router` for the target host):
+Unpack and copy to the router (swap `router` for the target host). **Not `/tmp`** —
+UniFi OS mounts it `noexec`, and since Linux `access(X_OK)` honours mount flags, a
+0755 test binary there tests as non-executable and the whole suite looks absent
+(`sudo …/run-tests.sh` reports "command not found" for a file that plainly exists).
+`run-tests.sh` detects that case and says so, but `/root` avoids it:
 
 ```sh
-tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu router:/tmp/
+tar xzf /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu.tar.gz -C /tmp/hw && scp -r /tmp/hw/packetframe-hwtest-aarch64-unknown-linux-gnu router:/root/
 ```
 
 Install it, then run the tests from the same directory:
 
 ```sh
-dpkg -i /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/packetframe_*_arm64.deb && systemctl daemon-reload
+dpkg -i /root/packetframe-hwtest-aarch64-unknown-linux-gnu/packetframe_*_arm64.deb && systemctl daemon-reload
 ```
 
 The `daemon-reload` is not optional: the package ships
@@ -200,7 +204,7 @@ runner tells you nothing about cn9670 cores — take the reference figures on th
 router itself, from the bundle above:
 
 ```sh
-sudo /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/run-tests.sh bench
+/root/packetframe-hwtest-aarch64-unknown-linux-gnu/run-tests.sh bench
 ```
 
 Confirm `net.core.bpf_jit_enable=1` first (`packetframe feasibility` reports it,

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -200,7 +200,7 @@ runner tells you nothing about cn9670 cores — take the reference figures on th
 router itself, from the bundle above:
 
 ```sh
-sudo /tmp/packetframe-hwtest-aarch64-unknown-linux-musl/run-tests.sh bench
+sudo /tmp/packetframe-hwtest-aarch64-unknown-linux-gnu/run-tests.sh bench
 ```
 
 Confirm `net.core.bpf_jit_enable=1` first (`packetframe feasibility` reports it,

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -179,13 +179,21 @@ classifiers and that the fixtures produce the expected verdicts.
 
 That default selection is deliberately limited to tests that only use
 `BPF_PROG_TEST_RUN`: programs are loaded and fed synthetic packets in-kernel,
-nothing is attached to a NIC, and no route, neighbour or sysctl state is touched,
-so it is safe on a forwarding router. The one exception to "writes nothing" is
-`fib_comparison`, which pins maps under a unique
-`/sys/fs/bpf/pftestcmp-<pid>-<n>` scratch directory and removes it on exit — never
-the running instance's pins. The tests that create veths or network namespaces
-(`attach`, `tc_attach`, `netns`, `local_prefix_netns`, `neigh_resolver_netns`)
-have to be named explicitly.
+nothing is attached to a NIC, no route/neighbour/sysctl state is touched, and
+nothing is written outside the test process — so it is safe on a forwarding
+router. Two groups are excluded and must be named explicitly:
+
+- `attach`, `tc_attach`, `netns`, `local_prefix_netns`, `neigh_resolver_netns` —
+  create interfaces or network namespaces.
+- `fib_comparison`, `fib_programmer_integration` — pin maps into a scratch
+  `/sys/fs/bpf/pftestcmp-<pid>-<n>` directory (removed on exit) and will mount
+  bpffs if it isn't already mounted.
+
+All of them clean up after themselves; they're excluded so the default run's
+"writes nothing" property holds without caveats. On a box already running
+packetframe, bpffs is of course already mounted and the tests leave it alone —
+they check before mounting, precisely so a second bpffs can never get stacked
+over the live pins.
 
 ### Counters that matter (`packetframe status`)
 

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -116,6 +116,40 @@ Symbols to read:
 If `pskb_expand_head` + linearization dwarf `bpf_prog_run_generic_xdp`, host tuning
 and datapath placement (not BPF micro-optimization) are where the wins are.
 
+#### Measured profile on cn9670 / otx2 (2026-07-31)
+
+`perf record -F 499 -a -e cycles:k` for 10s on a live EFG at ~640 kpps, 30.6%
+idle. Aggregated by area, as a share of *busy* CPU:
+
+| Area | % of busy CPU |
+|---|---|
+| Marvell driver (`otx2_nix_cq_op_status`, `otx2_napi_handler`, `otx2_sq_append_skb`) | 11.2 |
+| **AF_PACKET tap** (`packet_rcv`, `dev_queue_xmit_nit`) | **9.1** |
+| skb alloc/free churn (`__kmalloc_node_track_caller`, `kfree`, `kmem_cache_*`) | 6.9 |
+| BPF map lookups (`trie_lookup_elem`, `longest_prefix_match`) | 5.9 |
+| Transmit (`__dev_queue_xmit`, `skb_push`, `memmove`) | 3.4 |
+| BPF programs (`fast_path`, `finalize`) | 2.6 |
+| ebtables (`ebt_do_table`) | 1.6 |
+
+**`pskb_expand_head` and `skb_linearize` do not appear at all** (below the 0.5%
+cutoff). The generic-XDP headroom-copy cost that the tc-datapath work was designed
+to escape is *not being paid* on this driver — otx2 evidently reserves enough
+headroom that `netif_receive_generic_xdp` never reallocates. Do not assume the
+generic-XDP cost model applies to your hardware without checking this first; on
+this fleet it does not, and the expected tc win is correspondingly much smaller
+than the 1.5–3× estimated from the model.
+
+Two other things worth acting on before any datapath change:
+
+- **An AF_PACKET tap costs more than the entire BPF datapath.** `packet_rcv` plus
+  `dev_queue_xmit_nit` (the transmit-side hook that feeds packet sockets) is 9.1%
+  of busy CPU. `dev_queue_xmit_nit` only runs when a tap exists. Find it with
+  `ss --packet --processes` and stop it if it isn't needed — a leftover `tcpdump`
+  or a monitoring daemon is pure overhead.
+- **Inside BPF, the map lookups cost 2.3× the program bodies.** The LPM tries
+  dominate: a forwarded packet does three (`ALLOW` src, `ALLOW` dst, `FIB`). Any
+  further BPF optimization should target lookup *count*, not instruction count.
+
 **`perf` is not available on UniFi OS.** There is no `perf` package; Debian
 bullseye ships `linux-perf` built for its own 5.10 kernel while these boxes run a
 UniFi 5.15, so `/usr/bin/perf` fails looking for `perf_5.15`. `apt install

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -116,6 +116,39 @@ Symbols to read:
 If `pskb_expand_head` + linearization dwarf `bpf_prog_run_generic_xdp`, host tuning
 and datapath placement (not BPF micro-optimization) are where the wins are.
 
+**`perf` is not available on UniFi OS.** There is no `perf` package; Debian
+bullseye ships `linux-perf` built for its own 5.10 kernel while these boxes run a
+UniFi 5.15, so `/usr/bin/perf` fails looking for `perf_5.15`. `apt install
+linux-perf` then invoking `perf_5.10` directly works (minor skew is fine for cycle
+sampling), but installing it on a forwarding router may not be worth it — the
+split below needs nothing that isn't already present.
+
+### Splitting program cost from kernel cost without perf
+
+The microbenchmark gives program ns/packet directly. Total per-packet CPU comes
+from `/proc/stat` and the module's own counters, so the kernel-side share is the
+difference. Run on a box that is actually forwarding:
+
+```sh
+S1=$(awk '/^cpu /{print $8}' /proc/stat); R1=$(packetframe status | awk '/^[[:space:]]*rx_total/{print $2}'); sleep 10; S2=$(awk '/^cpu /{print $8}' /proc/stat); R2=$(packetframe status | awk '/^[[:space:]]*rx_total/{print $2}'); echo "rx pps: $(( (R2-R1)/10 ))"; echo "softirq ns per rx packet: $(( (S2-S1)*10000000 / (R2-R1) ))"
+```
+
+Field 8 of `/proc/stat`'s `cpu` line is softirq in USER_HZ, which is always 100 Hz,
+so one tick is 10 ms — hence `10000000` ns. Subtract the measured program time
+(see the reference figures below) to get the kernel-side share. Softirq covers all
+softirq work on the box, not only the XDP receive path, so read it as an upper
+bound.
+
+A direct cross-check of program time under live traffic, if `bpftool` is installed
+(it is not a PacketFrame dependency):
+
+```sh
+sysctl -w kernel.bpf_stats_enabled=1 && sleep 10 && bpftool prog show name fast_path; sysctl -w kernel.bpf_stats_enabled=0
+```
+
+`run_time_ns / run_cnt` is the real per-invocation cost. Enabling the stats adds
+two timestamp reads per invocation (a few percent), so turn it off afterwards.
+
 ### Getting a build onto a test router
 
 Neither the release tarballs nor the CI test runs give you what an on-hardware

--- a/docs/runbooks/tc-datapath.md
+++ b/docs/runbooks/tc-datapath.md
@@ -52,6 +52,16 @@ Different, deliberately:
 
 ## Canary rollout
 
+0. Get a build that has the tc datapath onto the box. The
+   `hardware-artifacts` workflow publishes a statically linked aarch64
+   bundle (`packetframe` CLI + test binaries + this runbook) for every
+   push to `main`; `docs/runbooks/generic-mode-performance.md` §"Getting
+   binaries onto the router" has the `gh run download` commands. Before
+   touching the attach set, run the safe test suite on the router —
+   `sudo ./run-tests.sh` — which proves this kernel's verifier accepts
+   the tc classifiers and that the fixtures produce the expected
+   verdicts, without attaching anything to a live interface.
+
 1. Pick the quietest attached interface. Change its attach line:
 
    ```


### PR DESCRIPTION
Prep for the on-hardware phase of the generic-XDP/tc performance work: the tc datapath is merged (#75) but nothing in the repo produced anything you could install or run on an EFG.

## Why

- Releases only exist for tags, and ship the `packetframe` binary — no test binaries.
- `ci.yml` and `qemu-verifier.yml` prove correctness on x86_64 runners and 5.15/6.6 VMs, and upload no artifacts.
- `bench.rs` told you to cross-build the test binary by hand, which can't work from a macOS dev box (no bpf-linker → stub ELF → every BPF-loading test early-returns "ok"), and couldn't work anywhere: **the test tree did not compile for any musl target.**

So the number that decides whether tc is worth rolling out — ns/packet on cn9670 cores — had no path to being measured, and no way to get a build onto a test router.

## What's here

**`hardware-artifacts.yml`** (new) — runs on every push to `main`, plus manual dispatch for other triples, and self-tests on PRs that change it. Builds the BPF ELF once on the host runner (nightly + bpf-linker) and hands it to a cross job via `PACKETFRAME_BPF_OBJ_PATH`, the same split `release.yml` uses, so everything embeds the bytecode a release would ship rather than a stub. Publishes nothing.

The `hwtest-aarch64-unknown-linux-gnu` artifact contains:

- `packetframe_<version>~hwtest<sha>_arm64.deb` — installable, same contents as a release .deb (binary, systemd unit, `/etc/packetframe`). Versioned so it sorts below every real release and is obvious in `dpkg -l`.
- `tests/` — 20 cross-built test binaries including `bench`
- `run-tests.sh`, `example.conf`, both perf runbooks

Target defaults to `-gnu` because the fleet is Debian-family UniFi OS and `dpkg -i` is how a build reaches a router; musl variants remain as a documented escape hatch (static, no .deb) for a router whose glibc predates the cross image's.

`run-tests.sh` defaults to the `BPF_PROG_TEST_RUN`-only suite — programs are loaded and fed synthetic packets in-kernel, nothing attaches to a NIC, no route/neighbour/sysctl state is touched and nothing is written outside the process — which is what makes it safe on a forwarding router. Tests that create interfaces/netns, or that pin into the shared bpffs, must be named explicitly.

**Three real bugs, none of which CI could see:**
- `libc::ioctl`'s request parameter is `c_ulong` on glibc but `c_int` on musl → the typed `SIOCGIFHWADDR` in `netns.rs`/`neigh_resolver_netns.rs` was a hard `E0308` for every musl target.
- `c_char` is unsigned on aarch64, signed on x86_64 → `uname_release()`'s cast tripped `clippy::unnecessary_cast` there.
- `fib_comparison`'s `ensure_bpffs_mounted` ran `mount -t bpf bpf /sys/fs/bpf` unconditionally with the result discarded. Linux stacks mounts on the same mountpoint, so on a host already running packetframe this would shadow the live pinned maps with an empty bpffs for the rest of the boot. Now statfs-checks for `BPF_FS_MAGIC` first. (Caught by Codex review.)

**The gate that would have caught the first two:** `cargo clippy --workspace --all-targets` per release triple in the cross-build jobs. `cross build --release --workspace` never compiled test targets and the `check` job's clippy only saw the host triple. Clippy doesn't link, so it's cheap.

**`release.yml` dry run** — dispatching on a branch put a branch name in `GITHUB_REF_NAME`; dpkg needs an upstream version starting with a digit and containing no `/`, so `cargo-deb` sank both gnu legs of the run that exists to de-risk a release. Now keyed off `GITHUB_REF_TYPE` rather than the string's shape (a digit-led branch name like `123/feature` looks like a version but isn't), and the tarball `STEM` — which had the identical latent bug — is sanitized too. Tag pushes produce byte-identical names.

## Verification

- `clippy --workspace --all-targets --all-features` clean for all four release triples; was failing on both aarch64 triples (`c_char`) and both musl triples (`E0308`) before the fixes.
- Bundle downloaded from the PR run and inspected: binaries are genuine aarch64 ELFs, and the embedded BPF object is real — `TC_REDIRECT_TARGETS`, `TC_MUTATION_PROGS`, `FIB_V4`, `STATS` present as maps and `tc_fast_path`/`tc_finalize` as programs, so a stub can't silently no-op an on-router run.
- Staging script exercised against real `cargo --message-format=json` output, including the container paths that broke the first run, plus the lib/bin/test-harness naming disambiguation and the collision guard.
- `run-tests.sh` extracted and exercised: `sh -n` clean, `--list` works, non-root refuses.
- Version/label derivation checked across `v0.2.8`, `main`, `123/feature`, `fix/foo_bar`.
- Release test binaries link despite `panic = "abort"` (cargo overrides it for test targets) and still enumerate tests under `strip = true`.

## After merge

The push to `main` produces the first bundle; `docs/runbooks/generic-mode-performance.md` §"Getting a build onto a test router" has the download, install and run commands, and `docs/runbooks/tc-datapath.md` gains a step 0 that runs the safe suite on the box before any attach-set change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)