### PR TITLE
feat(fast-path): bridge egress short-circuit — skip the software bridge stack on egress

### DIFF
--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -164,7 +164,7 @@ jobs:
               --memory 4096 \
               --disable-kvm \
               --verbose \
-              -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
+              -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; export PACKETFRAME_BENCH_QUICK=1; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
           }
           # Retry policy: virtme-ng propagates the guest command's exit
           # status, so a genuine test failure arrives as cargo's 101

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -152,16 +152,20 @@ jobs:
           # (only the listed overlay paths are writable). Point
           # HOME/CARGO_HOME/RUSTUP_HOME at the /home overlay so rustup
           # can write its state without going read-only.
-          # --memory 4096 (up from 1024): virtme-ng sizes the in-VM
-          # tmpfs against RAM, and the Option F dep graph (tokio +
-          # rtnetlink + netlink-packet-route + futures) pushes
-          # incremental-relink tmpfs usage past the old ~500 MB.
-          # 4 GB RAM ⇒ ~2 GB writable tmpfs, comfortable headroom.
+          # --memory 6144 (1024 → 4096 → here): virtme-ng sizes the
+          # in-VM tmpfs against RAM, and the in-VM incremental relink
+          # of the test binaries is what fills it. 4 GB (~2 GB tmpfs)
+          # was sized for the Option F dep graph; the v0.2.8 fib-cache
+          # branch's grown fast-path test set pushed the subsequent
+          # probe-crate relink over the edge — `ld terminated with
+          # signal 7 [Bus error]` twice in a row on the 6.6 leg, at
+          # the same link. 6 GB ⇒ ~3 GB tmpfs restores the margin;
+          # hosted runners have 16 GB, so TCG + 6 GB guest is fine.
           run_vm() {
             virtme-ng \
               --run "${KERNEL_IMG}" \
               --pwd \
-              --memory 4096 \
+              --memory 6144 \
               --disable-kvm \
               --verbose \
               -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; export PACKETFRAME_BENCH_QUICK=1; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -96,6 +96,12 @@ module fast-path
   #   on:    synonym for auto (nothing to force; unprovable
   #          topologies stay on the kernel path).
   #   off:   never install — the SIGHUP-able rollback.
+  # Assumes 802.1Q (the datapath tags TPID 0x8100, as the whole
+  # VLAN_RESOLVE mechanism does); 802.1ad deployments should set off.
+  # An `mss-clamp via <bridge>` rule will not match while a bridge is
+  # collapsed — scope it via the underlying device instead (warned at
+  # attach). Bridges with MTU below their underlying device never
+  # qualify.
   # bridge-resolve auto
 
   # --- Option F custom FIB. Cutting over to `custom-fib` requires

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -84,6 +84,20 @@ module fast-path
   #          kernel with the fix backported).
   # driver-workaround rvu-nicpf-head-shift auto
 
+  # Bridge egress short-circuit. When a nexthop's egress device is a
+  # Linux bridge whose single forwarding member is a VLAN subif
+  # (br1337 -> switch0.1337 -> switch0, the UniFi gateway shape), the
+  # loader installs a VLAN_RESOLVE entry keyed on the bridge ifindex
+  # so forwarded packets are tagged and redirected straight to the
+  # underlying device, skipping the software bridge traversal (and
+  # its ebtables walk). The wire frame is identical to what the
+  # bridge would emit. Multi-member bridges never qualify. Values:
+  #   auto:  (default) install wherever sysfs proves the shape.
+  #   on:    synonym for auto (nothing to force; unprovable
+  #          topologies stay on the kernel path).
+  #   off:   never install — the SIGHUP-able rollback.
+  # bridge-resolve auto
+
   # --- Option F custom FIB. Cutting over to `custom-fib` requires
   # bird's BMP protocol dialing this station AND bird's kernel
   # export dropping BGP routes. See docs/runbooks/custom-fib.md for

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -252,6 +252,21 @@ pub enum ModuleDirective {
         line: usize,
     },
     DryRun(bool),
+    /// `bridge-resolve auto|on|off` — bridge egress short-circuit
+    /// (SPEC §4.7 extension). When the FIB resolves a nexthop whose
+    /// egress device is a Linux bridge whose **single forwarding
+    /// member** is a VLAN subinterface (`br1337` → `switch0.1337` →
+    /// `switch0`), the loader installs a `VLAN_RESOLVE` entry keyed on
+    /// the *bridge* ifindex so the datapath tags and redirects straight
+    /// to the underlying device, skipping the software bridge traversal
+    /// and the subif device. The wire frame is identical to what the
+    /// bridge stack would emit; multi-member bridges never qualify
+    /// (picking a port needs the FDB, which the datapath can't consult).
+    /// `Auto` (default) installs wherever discovery proves the shape;
+    /// `On` is accepted as a synonym for `Auto` (there is nothing to
+    /// force — an unprovable topology stays on the kernel path);
+    /// `Off` disables installation and is the SIGHUP-able rollback.
+    BridgeResolve(ToggleAutoOnOff),
     CircuitBreaker(CircuitBreakerSpec),
     /// Operator override for a driver-specific workaround. Currently
     /// the only defined knob is `rvu-nicpf-head-shift` (SPEC
@@ -1573,6 +1588,10 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             Ok(ModuleDirective::DryRun(on))
         }
         "circuit-breaker" => parse_circuit_breaker(line, rest),
+        "bridge-resolve" => parse_single_arg(line, rest, "bridge-resolve", |t| {
+            let v: ToggleAutoOnOff = t.parse().map_err(|e: String| e)?;
+            Ok(ModuleDirective::BridgeResolve(v))
+        }),
         "driver-workaround" => parse_driver_workaround(line, rest),
         "forwarding-mode" => parse_single_arg(line, rest, "forwarding-mode", |t| {
             let mode: ForwardingMode = t.parse().map_err(|e: String| e)?;
@@ -2384,6 +2403,25 @@ module fast-path
             }
             other => panic!("expected Attach, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn bridge_resolve_parses() {
+        for (tok, want) in [
+            ("auto", ToggleAutoOnOff::Auto),
+            ("on", ToggleAutoOnOff::On),
+            ("off", ToggleAutoOnOff::Off),
+        ] {
+            let s = format!("module fast-path\n  bridge-resolve {tok}\n");
+            let c = Config::parse(&s).unwrap();
+            match &c.modules[0].directives[0] {
+                ModuleDirective::BridgeResolve(v) => assert_eq!(*v, want),
+                other => panic!("expected BridgeResolve, got {other:?}"),
+            }
+        }
+        assert!(Config::parse("module fast-path\n  bridge-resolve maybe\n").is_err());
+        assert!(Config::parse("module fast-path\n  bridge-resolve\n").is_err());
+        assert!(Config::parse("module fast-path\n  bridge-resolve on extra\n").is_err());
     }
 
     #[test]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -134,6 +134,130 @@ pub(crate) fn vlan_subifs_present() -> bool {
     read_vlan_config().map(|v| !v.is_empty()).unwrap_or(false)
 }
 
+/// Whether the `bridge-resolve` directive enables the bridge egress
+/// short-circuit. Default (no directive) is `Auto` = enabled; `On` is
+/// a documented synonym for `Auto` (there is nothing to force — an
+/// unprovable topology stays on the kernel path either way).
+pub(crate) fn bridge_resolve_enabled(directives: &[ModuleDirective]) -> bool {
+    let toggle = directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::BridgeResolve(v) => Some(*v),
+            _ => None,
+        })
+        .unwrap_or_default();
+    !matches!(toggle, ToggleAutoOnOff::Off)
+}
+
+/// One collapsed bridge egress chain: a bridge whose single forwarding
+/// member is a VLAN subif, resolved down to (bridge, underlying device,
+/// VID). `br1337` over `switch0.1337` over `switch0` yields
+/// `("br1337", "switch0", 1337)`.
+pub(crate) type BridgeChain = (String, String, u16);
+
+/// One bridge port as discovery sees it: (member name, is_forwarding).
+pub(crate) type BridgeMember = (String, bool);
+
+/// Host bridge topology: each bridge with its member ports.
+pub(crate) type BridgeTopology = Vec<(String, Vec<BridgeMember>)>;
+
+/// Pure core of bridge-chain discovery: which bridges collapse to a
+/// (underlying device, VID) pair the datapath can redirect to directly?
+///
+/// A bridge qualifies iff it has **exactly one member in total** and
+/// that member (a) is in bridge-port state *forwarding* and (b) is a
+/// VLAN subinterface. "Exactly one member, counting non-forwarding
+/// ones" is deliberate: a second member in STP blocking state can
+/// transition to forwarding at any moment, at which point port choice
+/// requires the bridge FDB — which the BPF side cannot consult. A
+/// bridge that doesn't qualify simply keeps today's kernel path.
+///
+/// `bridges`: (bridge name, members as (name, is_forwarding)).
+/// `vlans`: `/proc/net/vlan/config` rows as (subif, vid, parent).
+pub(crate) fn bridge_vlan_chains(
+    bridges: &[(String, Vec<BridgeMember>)],
+    vlans: &[(String, u16, String)],
+) -> Vec<BridgeChain> {
+    let mut out = Vec::new();
+    for (bridge, members) in bridges {
+        let [(member, forwarding)] = members.as_slice() else {
+            continue; // zero or multiple members: not provably collapsible
+        };
+        if !*forwarding {
+            continue;
+        }
+        if let Some((_, vid, parent)) = vlans.iter().find(|(subif, _, _)| subif == member) {
+            out.push((bridge.clone(), parent.clone(), *vid));
+        }
+    }
+    out
+}
+
+/// Bridge-port STP state "forwarding" (`net/bridge/br_private.h`
+/// BR_STATE_FORWARDING). `/sys/class/net/<member>/brport/state` holds
+/// the numeric state.
+const BR_STATE_FORWARDING: &str = "3";
+
+/// Enumerate every bridge on the host with its members and their
+/// forwarding state. A device is a bridge iff
+/// `/sys/class/net/<dev>/bridge` exists; members are the entries of
+/// `<dev>/brif/`. Per-device read failures are skipped (the sysfs tree
+/// is a live snapshot — a device can vanish mid-walk, same tolerance
+/// as `enumerate_redirect_targets`); only a failure to list
+/// `/sys/class/net` itself is an error.
+fn read_bridge_topology() -> std::io::Result<BridgeTopology> {
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir("/sys/class/net")? {
+        let Ok(entry) = entry else { continue };
+        let Ok(name) = entry.file_name().into_string() else {
+            continue;
+        };
+        let base = format!("/sys/class/net/{name}");
+        if !std::path::Path::new(&format!("{base}/bridge")).is_dir() {
+            continue;
+        }
+        let Ok(ports) = std::fs::read_dir(format!("{base}/brif")) else {
+            continue;
+        };
+        let mut members = Vec::new();
+        for port in ports.flatten() {
+            let Ok(member) = port.file_name().into_string() else {
+                continue;
+            };
+            let state = std::fs::read_to_string(format!("/sys/class/net/{member}/brport/state"))
+                .map(|s| s.trim() == BR_STATE_FORWARDING)
+                .unwrap_or(false);
+            members.push((member, state));
+        }
+        out.push((name, members));
+    }
+    Ok(out)
+}
+
+/// Discover the currently collapsible bridge chains, or an empty list
+/// when the directive disables the feature. VLAN-config NotFound means
+/// no 8021q subifs exist, so no chain can terminate in one — empty.
+/// Other IO errors propagate (same policy as the VLAN path: a broken
+/// sysfs/procfs read must not silently produce "no entries" while the
+/// gate bit logic runs on).
+pub(crate) fn discover_bridge_chains(
+    directives: &[ModuleDirective],
+) -> std::io::Result<Vec<BridgeChain>> {
+    if !bridge_resolve_enabled(directives) {
+        return Ok(Vec::new());
+    }
+    let vlans = match read_vlan_config() {
+        Ok(v) => v,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    if vlans.is_empty() {
+        return Ok(Vec::new());
+    }
+    let bridges = read_bridge_topology()?;
+    Ok(bridge_vlan_chains(&bridges, &vlans))
+}
+
 /// Read-modify-write one `FpCfg.flags` bit on the live CFG map.
 /// Same pattern as `apply_driver_quirks_cfg`'s head-shift OR: preserve
 /// every other bit and field.
@@ -389,9 +513,21 @@ fn populate_cfg(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<()> {
         // bits 5-7: feature-presence gates (block / vlan / mss-clamp).
         // bit 2 (HEAD_SHIFT_128) is OR'd on later in
         // apply_driver_quirks_cfg for rvu-nicpf attaches.
+        // The VLAN/bridge presence input is an initial seed only:
+        // `populate_vlan_resolve` re-asserts the bit after it actually
+        // inserts entries (subifs and bridge chains share bit 6).
+        // `discover_bridge_chains` errors count as "none" here for the
+        // same reason a vlan read error does in `vlan_subifs_present` —
+        // the authoritative pass in populate_vlan_resolve fails loud.
         flags: 0b11
             | fib_flags
-            | feature_flags_from_config(&mcfg.section.directives, vlan_subifs_present()),
+            | feature_flags_from_config(
+                &mcfg.section.directives,
+                vlan_subifs_present()
+                    || discover_bridge_chains(&mcfg.section.directives)
+                        .map(|c| !c.is_empty())
+                        .unwrap_or(false),
+            ),
         mss_clamp_global,
         version: FP_CFG_VERSION_V2,
     };
@@ -1072,7 +1208,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         }
     }
 
-    populate_vlan_resolve(state)?;
+    populate_vlan_resolve(state, &cfg.section.directives)?;
 
     // Pin program + every §4.5 map so `packetframe status` can read
     // counters from a separate process and `packetframe detach` can
@@ -1961,17 +2097,26 @@ fn format_error_chain(err: &dyn std::error::Error) -> String {
     out
 }
 
-/// Populate `vlan_resolve` from `/proc/net/vlan/config`. Each VLAN
-/// subinterface maps its ifindex → (physical parent ifindex, VID) so
-/// the BPF program can push/pop/rewrite per SPEC §4.7 when the FIB
-/// resolves to a subif. Missing `/proc/net/vlan/config` (no 8021q
-/// kernel module loaded) is not an error, we just insert nothing.
-fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
+/// Populate `vlan_resolve` from `/proc/net/vlan/config`, plus — when
+/// `bridge-resolve` allows — the collapsed bridge egress chains from
+/// [`discover_bridge_chains`]. Each VLAN subinterface maps its ifindex
+/// → (physical parent ifindex, VID) so the BPF program can
+/// push/pop/rewrite per SPEC §4.7 when the FIB resolves to a subif;
+/// each qualifying bridge maps its ifindex → (underlying device, VID)
+/// so the datapath skips the software bridge traversal entirely (the
+/// wire frame is identical to what the bridge would emit). Missing
+/// `/proc/net/vlan/config` (no 8021q kernel module loaded) is not an
+/// error — and with no VLAN subifs there can be no bridge chains
+/// either, so both sets are empty together.
+fn populate_vlan_resolve(
+    state: &mut ActiveState,
+    directives: &[ModuleDirective],
+) -> ModuleResult<()> {
     let entries = match read_vlan_config() {
         Ok(e) => e,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
             info!("/proc/net/vlan/config missing, no VLAN subifs to resolve");
-            return Ok(());
+            Vec::new()
         }
         Err(e) => {
             return Err(ModuleError::other(
@@ -1980,9 +2125,11 @@ fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
             ));
         }
     };
+    let chains = discover_bridge_chains(directives)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("bridge topology read: {e}")))?;
 
-    if entries.is_empty() {
-        info!("/proc/net/vlan/config empty, no VLAN subifs configured");
+    if entries.is_empty() && chains.is_empty() {
+        info!("no VLAN subifs and no collapsible bridges, VLAN_RESOLVE left empty");
         return Ok(());
     }
 
@@ -2014,6 +2161,30 @@ fn populate_vlan_resolve(state: &mut ActiveState) -> ModuleResult<()> {
             phys_idx,
             vid,
             "vlan_resolve populated"
+        );
+    }
+
+    for (bridge_name, phys_name, vid) in chains {
+        let bridge_idx = if_nametoindex(&bridge_name)?;
+        let phys_idx = if_nametoindex(&phys_name)?;
+        let value = VlanResolve {
+            phys_ifindex: phys_idx,
+            vid,
+            _pad: 0,
+        };
+        hm.insert(bridge_idx, value, 0).map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("VLAN_RESOLVE insert {bridge_name}: {e}"),
+            )
+        })?;
+        info!(
+            bridge = %bridge_name,
+            bridge_idx,
+            phys = %phys_name,
+            phys_idx,
+            vid,
+            "bridge egress short-circuit installed"
         );
     }
 
@@ -2595,10 +2766,13 @@ pub fn state_dir(state: &ActiveState) -> &Path {
 mod tests {
     use super::gc_thresh3_capacity_warning;
     use super::{
-        feature_flags_from_config, FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
+        bridge_resolve_enabled, bridge_vlan_chains, discover_bridge_chains,
+        feature_flags_from_config, if_nametoindex, populate_vlan_resolve, ActiveState, FpCfg,
+        VlanResolve, FP_CFG_FLAG_BLOCK_PRESENT, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
         FP_CFG_FLAG_VLAN_PRESENT,
     };
-    use packetframe_common::config::ModuleDirective;
+    use aya::maps::Array;
+    use packetframe_common::config::{ModuleDirective, ToggleAutoOnOff};
 
     #[test]
     fn feature_flags_truth_table() {
@@ -2639,6 +2813,78 @@ mod tests {
         );
     }
 
+    /// The pure core of bridge-chain discovery: only a bridge with
+    /// exactly one member, that member forwarding, that member a VLAN
+    /// subif, collapses. Everything else stays on the kernel path.
+    #[test]
+    fn bridge_vlan_chains_truth_table() {
+        let vlans = vec![
+            ("switch0.1337".to_string(), 1337u16, "switch0".to_string()),
+            ("switch0.88".to_string(), 88u16, "switch0".to_string()),
+        ];
+        let m = |name: &str, fwd: bool| (name.to_string(), fwd);
+
+        // Single forwarding member that is a VLAN subif → collapses.
+        let bridges = vec![("br1337".to_string(), vec![m("switch0.1337", true)])];
+        assert_eq!(
+            bridge_vlan_chains(&bridges, &vlans),
+            vec![("br1337".to_string(), "switch0".to_string(), 1337)]
+        );
+
+        // Two members — even with one blocked — never collapses: the
+        // blocked port can transition to forwarding, and then port
+        // choice needs the FDB.
+        let bridges = vec![(
+            "br1337".to_string(),
+            vec![m("switch0.1337", true), m("eth9", false)],
+        )];
+        assert!(bridge_vlan_chains(&bridges, &vlans).is_empty());
+
+        // Single member but not forwarding (STP blocking/disabled).
+        let bridges = vec![("br1337".to_string(), vec![m("switch0.1337", false)])];
+        assert!(bridge_vlan_chains(&bridges, &vlans).is_empty());
+
+        // Single forwarding member that is NOT a VLAN subif.
+        let bridges = vec![("br0".to_string(), vec![m("eth7", true)])];
+        assert!(bridge_vlan_chains(&bridges, &vlans).is_empty());
+
+        // Zero members.
+        let bridges = vec![("brempty".to_string(), vec![])];
+        assert!(bridge_vlan_chains(&bridges, &vlans).is_empty());
+
+        // Mixed host: qualifying and non-qualifying bridges coexist.
+        let bridges = vec![
+            ("br1337".to_string(), vec![m("switch0.1337", true)]),
+            ("br88".to_string(), vec![m("switch0.88", true)]),
+            ("br0".to_string(), vec![m("switch0.1", true)]), // .1 not in vlans
+            (
+                "brmulti".to_string(),
+                vec![m("switch0.88", true), m("switch0.1337", true)],
+            ),
+        ];
+        assert_eq!(
+            bridge_vlan_chains(&bridges, &vlans),
+            vec![
+                ("br1337".to_string(), "switch0".to_string(), 1337),
+                ("br88".to_string(), "switch0".to_string(), 88),
+            ]
+        );
+    }
+
+    /// Directive semantics: absent/auto/on enable, off disables.
+    #[test]
+    fn bridge_resolve_directive_semantics() {
+        assert!(bridge_resolve_enabled(&[]), "default is auto = enabled");
+        for (toggle, want) in [
+            (ToggleAutoOnOff::Auto, true),
+            (ToggleAutoOnOff::On, true),
+            (ToggleAutoOnOff::Off, false),
+        ] {
+            let d = ModuleDirective::BridgeResolve(toggle);
+            assert_eq!(bridge_resolve_enabled(std::slice::from_ref(&d)), want);
+        }
+    }
+
     /// Bits 5-7 must never collide with the established bits 0-4.
     #[test]
     fn presence_bits_are_disjoint_from_legacy_bits() {
@@ -2659,6 +2905,164 @@ mod tests {
             gc_thresh3_capacity_warning(Some(1024), Some(1024), 8192),
             None
         );
+    }
+
+    /// End-to-end bridge short-circuit against a real topology:
+    /// veth → 802.1Q subif → single-member bridge, then
+    /// populate/reconcile against a genuinely loaded BPF object.
+    /// Proves the sysfs reader (bridge dir, brif members, brport
+    /// state), the VLAN_RESOLVE keying on the bridge ifindex, the
+    /// `bridge-resolve off` rollback purge, and re-enable convergence.
+    ///
+    /// Requires CAP_NET_ADMIN + CAP_BPF + the 8021q module; CI runs it
+    /// under sudo in the qemu matrix.
+    #[test]
+    #[ignore = "needs CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+    fn bridge_short_circuit_populate_and_reconcile() {
+        use aya::maps::HashMap as AyaHashMap;
+
+        if !crate::FAST_PATH_BPF_AVAILABLE {
+            eprintln!("BPF stub in effect (no rustup); skipping bridge-resolve test.");
+            return;
+        }
+
+        const VETH_A: &str = "pf-brv0";
+        const VETH_B: &str = "pf-brv1";
+        const SUBIF: &str = "pf-brv0.42";
+        const BRIDGE: &str = "pf-brtst";
+        const VID: u16 = 42;
+
+        struct Cleanup;
+        impl Drop for Cleanup {
+            fn drop(&mut self) {
+                // veth del removes the pair + the subif riding on it.
+                let _ = std::process::Command::new("ip")
+                    .args(["link", "del", VETH_A])
+                    .status();
+                let _ = std::process::Command::new("ip")
+                    .args(["link", "del", BRIDGE])
+                    .status();
+            }
+        }
+        fn run(cmd: &[&str]) {
+            let st = std::process::Command::new(cmd[0])
+                .args(&cmd[1..])
+                .status()
+                .unwrap_or_else(|e| panic!("spawn `{}`: {e}", cmd.join(" ")));
+            assert!(st.success(), "`{}` failed: {st}", cmd.join(" "));
+        }
+
+        // Idempotent pre-clean, then build the topology.
+        let _ = std::process::Command::new("ip")
+            .args(["link", "del", VETH_A])
+            .status();
+        let _ = std::process::Command::new("ip")
+            .args(["link", "del", BRIDGE])
+            .status();
+        run(&[
+            "ip", "link", "add", VETH_A, "type", "veth", "peer", "name", VETH_B,
+        ]);
+        let _cleanup = Cleanup;
+        run(&[
+            "ip", "link", "add", "link", VETH_A, "name", SUBIF, "type", "vlan", "id", "42",
+        ]);
+        // STP off (default) → the port enters forwarding as soon as
+        // the link is up.
+        run(&["ip", "link", "add", BRIDGE, "type", "bridge"]);
+        run(&["ip", "link", "set", SUBIF, "master", BRIDGE]);
+        for dev in [VETH_A, VETH_B, SUBIF, BRIDGE] {
+            run(&["ip", "link", "set", dev, "up"]);
+        }
+        // brport/state flips to forwarding asynchronously; poll briefly.
+        let state_path = format!("/sys/class/net/{SUBIF}/brport/state");
+        for _ in 0..50 {
+            if std::fs::read_to_string(&state_path).is_ok_and(|s| s.trim() == "3") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+
+        // Discovery alone must find exactly our chain (the host may
+        // have other bridges; filter to ours).
+        let auto_cfg =
+            packetframe_common::config::Config::parse("module fast-path\n  bridge-resolve auto\n")
+                .unwrap();
+        let chains =
+            discover_bridge_chains(&auto_cfg.modules[0].directives).expect("bridge topology read");
+        assert!(
+            chains.contains(&(BRIDGE.to_string(), VETH_A.to_string(), VID)),
+            "expected {BRIDGE} → ({VETH_A}, {VID}) in {chains:?}"
+        );
+
+        // Full populate + reconcile against a real BPF object.
+        let bytes = crate::aligned_bpf_copy();
+        let ebpf = aya::Ebpf::load(&bytes).expect("Ebpf::load");
+        let tmp = std::env::temp_dir().join(format!("pf-brtest-{}", std::process::id()));
+        let mut state = ActiveState {
+            ebpf,
+            links: Vec::new(),
+            state_dir: tmp.clone(),
+            bpffs_root: tmp,
+            route_controller: None,
+            attach_settle_time: std::time::Duration::ZERO,
+        };
+
+        let bridge_idx = if_nametoindex(BRIDGE).unwrap();
+        let veth_idx = if_nametoindex(VETH_A).unwrap();
+        let read_entry = |state: &mut ActiveState| -> Option<(u32, u16)> {
+            let map = state.ebpf.map_mut("VLAN_RESOLVE").unwrap();
+            let hm: AyaHashMap<_, u32, VlanResolve> = AyaHashMap::try_from(map).unwrap();
+            hm.get(&bridge_idx, 0).ok().map(|v| (v.phys_ifindex, v.vid))
+        };
+        let flag_set = |state: &mut ActiveState| -> bool {
+            let map = state.ebpf.map_mut("CFG").unwrap();
+            let arr: Array<_, FpCfg> = Array::try_from(map).unwrap();
+            arr.get(&0, 0).unwrap().flags & FP_CFG_FLAG_VLAN_PRESENT != 0
+        };
+
+        populate_vlan_resolve(&mut state, &auto_cfg.modules[0].directives)
+            .expect("populate with bridge-resolve auto");
+        assert_eq!(
+            read_entry(&mut state),
+            Some((veth_idx, VID)),
+            "bridge key must map to (underlying device, VID)"
+        );
+        assert!(flag_set(&mut state), "bit 6 must be set after populate");
+
+        // SIGHUP rollback: bridge-resolve off purges the bridge key but
+        // keeps the plain subif entry (it's a normal 8021q resolve).
+        let off_cfg =
+            packetframe_common::config::Config::parse("module fast-path\n  bridge-resolve off\n")
+                .unwrap();
+        let mcfg =
+            packetframe_common::module::ModuleConfig::new(&off_cfg.modules[0], &off_cfg.global);
+        crate::reconcile::reconcile_vlan_resolve(&mut state, &mcfg)
+            .expect("reconcile with bridge-resolve off");
+        assert_eq!(
+            read_entry(&mut state),
+            None,
+            "bridge key must be purged when the directive is off"
+        );
+        {
+            let map = state.ebpf.map_mut("VLAN_RESOLVE").unwrap();
+            let hm: AyaHashMap<_, u32, VlanResolve> = AyaHashMap::try_from(map).unwrap();
+            let subif_idx = if_nametoindex(SUBIF).unwrap();
+            assert!(
+                hm.get(&subif_idx, 0).is_ok(),
+                "plain 8021q subif entry must survive bridge-resolve off"
+            );
+        }
+        assert!(
+            flag_set(&mut state),
+            "bit 6 stays set — the subif entries still exist"
+        );
+
+        // Re-enable converges the key back.
+        let mcfg =
+            packetframe_common::module::ModuleConfig::new(&auto_cfg.modules[0], &auto_cfg.global);
+        crate::reconcile::reconcile_vlan_resolve(&mut state, &mcfg)
+            .expect("reconcile with bridge-resolve auto");
+        assert_eq!(read_entry(&mut state), Some((veth_idx, VID)));
     }
 
     #[test]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -25,7 +25,7 @@ use packetframe_common::{
     },
     module::{Attachment, HookType, LoaderCtx, ModuleConfig, ModuleError, ModuleResult},
 };
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::{aligned_bpf_copy, pin, FAST_PATH_BPF_AVAILABLE, MODULE_NAME};
 
@@ -199,7 +199,16 @@ pub(crate) fn bridge_vlan_chains(
 const BR_STATE_FORWARDING: &str = "3";
 
 /// Enumerate every bridge on the host with its members and their
-/// forwarding state. A device is a bridge iff
+/// forwarding state.
+///
+/// This is a point-in-time sysfs snapshot, converged at attach and on
+/// every SIGHUP — deliberately the same convergence model as every
+/// other discovery-populated map here (`/proc/net/vlan/config` entries,
+/// redirect-target membership). There is no live topology watcher;
+/// membership or STP changes between reconciles keep the previously
+/// proven chain until the next `packetframe reconfigure`. Documented
+/// in the runbook; a netlink link-watcher would introduce a second
+/// writer domain for VLAN_RESOLVE and is out of scope for this slice. A device is a bridge iff
 /// `/sys/class/net/<dev>/bridge` exists; members are the entries of
 /// `<dev>/brif/`. Per-device read failures are skipped (the sysfs tree
 /// is a live snapshot — a device can vanish mid-walk, same tolerance
@@ -214,6 +223,21 @@ fn read_bridge_topology() -> std::io::Result<BridgeTopology> {
         };
         let base = format!("/sys/class/net/{name}");
         if !std::path::Path::new(&format!("{base}/bridge")).is_dir() {
+            continue;
+        }
+        // A VLAN-filtering bridge consults its per-port VLAN table on
+        // every forward — it can drop, retag, or untag before the
+        // member's own 8021q encapsulation. A single forwarding member
+        // is NOT wire-equivalence proof under filtering, so such
+        // bridges never qualify. (The UniFi brXXXX shape this feature
+        // targets is a classic non-filtering bridge; the VLAN work is
+        // the subif's.) Unreadable counts as filtering-on: refuse
+        // rather than assume.
+        let filtering_off = std::fs::read_to_string(format!("{base}/bridge/vlan_filtering"))
+            .map(|s| s.trim() == "0")
+            .unwrap_or(false);
+        if !filtering_off {
+            debug!(bridge = %name, "bridge skipped: vlan_filtering enabled (or unreadable)");
             continue;
         }
         let Ok(ports) = std::fs::read_dir(format!("{base}/brif")) else {
@@ -3063,6 +3087,60 @@ mod tests {
         crate::reconcile::reconcile_vlan_resolve(&mut state, &mcfg)
             .expect("reconcile with bridge-resolve auto");
         assert_eq!(read_entry(&mut state), Some((veth_idx, VID)));
+
+        // Same-key value change must converge in ONE reconcile: swap
+        // the bridge's member for a different-VID subif. The bridge
+        // keeps its ifindex, so the full-tuple diff sees an add and a
+        // remove under one key — the remove pass must not delete the
+        // freshly written value (the Codex-found off-by-one-reconcile).
+        run(&["ip", "link", "del", SUBIF]);
+        run(&[
+            "ip",
+            "link",
+            "add",
+            "link",
+            VETH_A,
+            "name",
+            "pf-brv0.43",
+            "type",
+            "vlan",
+            "id",
+            "43",
+        ]);
+        run(&["ip", "link", "set", "pf-brv0.43", "master", BRIDGE]);
+        run(&["ip", "link", "set", "pf-brv0.43", "up"]);
+        let state43 = "/sys/class/net/pf-brv0.43/brport/state";
+        for _ in 0..50 {
+            if std::fs::read_to_string(state43).is_ok_and(|s| s.trim() == "3") {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        crate::reconcile::reconcile_vlan_resolve(&mut state, &mcfg)
+            .expect("reconcile after member swap");
+        assert_eq!(
+            read_entry(&mut state),
+            Some((veth_idx, 43)),
+            "value change under a stable bridge key must survive one reconcile"
+        );
+
+        // A VLAN-filtering bridge must never qualify.
+        run(&[
+            "ip",
+            "link",
+            "set",
+            BRIDGE,
+            "type",
+            "bridge",
+            "vlan_filtering",
+            "1",
+        ]);
+        let chains =
+            discover_bridge_chains(&auto_cfg.modules[0].directives).expect("bridge topology read");
+        assert!(
+            !chains.iter().any(|(b, _, _)| b == BRIDGE),
+            "vlan_filtering bridge must be excluded, got {chains:?}"
+        );
     }
 
     #[test]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -267,7 +267,32 @@ fn read_bridge_topology() -> std::io::Result<BridgeTopology> {
             let unicast_flood = std::fs::read_to_string(format!("{brport}/unicast_flood"))
                 .map(|s| s.trim() == "1")
                 .unwrap_or(false);
-            members.push((member, forwarding && unicast_flood));
+            // A VLAN member with a non-default egress-qos-map encodes
+            // the mapped PCP into the tag it emits; the datapath's
+            // vlan push writes PCP/DEI 0, so collapsing such a member
+            // would silently flatten wire priority. The map is visible
+            // in /proc/net/vlan/<member> ("EGRESS priority mappings:"
+            // is empty by default) — require it empty. NotFound means
+            // the member isn't a VLAN device at all, which is fine
+            // (such members never match the VLAN join anyway); any
+            // other read failure refuses.
+            let egress_qos_default =
+                match std::fs::read_to_string(format!("/proc/net/vlan/{member}")) {
+                    Ok(content) => content
+                        .lines()
+                        .find(|l| l.contains("EGRESS priority mappings:"))
+                        .map(|l| {
+                            l.split("EGRESS priority mappings:")
+                                .nth(1)
+                                .unwrap_or("")
+                                .trim()
+                                .is_empty()
+                        })
+                        .unwrap_or(false),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+                    Err(_) => false,
+                };
+            members.push((member, forwarding && unicast_flood && egress_qos_default));
         }
         out.push((name, members));
     }

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -279,7 +279,42 @@ pub(crate) fn discover_bridge_chains(
         return Ok(Vec::new());
     }
     let bridges = read_bridge_topology()?;
-    Ok(bridge_vlan_chains(&bridges, &vlans))
+    let mut chains = bridge_vlan_chains(&bridges, &vlans);
+    // Wire-equivalence also needs the MTU relation: the uncollapsed
+    // path enforces the BRIDGE's MTU (a packet over it gets dropped /
+    // PTB'd by the bridge layer, and the tc datapath's bpf_check_mtu
+    // would test the bridge device). The short-circuit tests the
+    // underlying device instead, so a bridge with a SMALLER MTU than
+    // its underlying device would silently forward packets the bridge
+    // would have refused. Require mtu(bridge) >= mtu(underlying);
+    // anything else keeps the kernel path. Unreadable → refuse.
+    chains.retain(|(bridge, phys, _)| {
+        let mtu = |dev: &str| -> Option<u32> {
+            std::fs::read_to_string(format!("/sys/class/net/{dev}/mtu"))
+                .ok()?
+                .trim()
+                .parse()
+                .ok()
+        };
+        match (mtu(bridge), mtu(phys)) {
+            (Some(b), Some(p)) if b >= p => true,
+            (Some(b), Some(p)) => {
+                info!(
+                    bridge = %bridge,
+                    bridge_mtu = b,
+                    underlying = %phys,
+                    underlying_mtu = p,
+                    "bridge egress short-circuit skipped: bridge MTU below underlying device"
+                );
+                false
+            }
+            _ => {
+                warn!(bridge = %bridge, underlying = %phys, "bridge short-circuit skipped: MTU unreadable");
+                false
+            }
+        }
+    });
+    Ok(chains)
 }
 
 /// Read-modify-write one `FpCfg.flags` bit on the live CFG map.
@@ -2188,20 +2223,33 @@ fn populate_vlan_resolve(
         );
     }
 
+    // Bridge entries are an optional optimization: failure to install
+    // one (map at capacity, iface vanished mid-walk) must degrade to
+    // "that bridge keeps the kernel path", never abort attach — unlike
+    // the subif entries above, whose absence would mistag real subif
+    // egress. Warn-and-continue per entry.
     for (bridge_name, phys_name, vid) in chains {
-        let bridge_idx = if_nametoindex(&bridge_name)?;
-        let phys_idx = if_nametoindex(&phys_name)?;
+        let (bridge_idx, phys_idx) =
+            match (if_nametoindex(&bridge_name), if_nametoindex(&phys_name)) {
+                (Ok(b), Ok(p)) => (b, p),
+                _ => {
+                    warn!(bridge = %bridge_name, "bridge short-circuit skipped: iface vanished");
+                    continue;
+                }
+            };
         let value = VlanResolve {
             phys_ifindex: phys_idx,
             vid,
             _pad: 0,
         };
-        hm.insert(bridge_idx, value, 0).map_err(|e| {
-            ModuleError::other(
-                MODULE_NAME,
-                format!("VLAN_RESOLVE insert {bridge_name}: {e}"),
-            )
-        })?;
+        if let Err(e) = hm.insert(bridge_idx, value, 0) {
+            warn!(
+                bridge = %bridge_name,
+                error = %e,
+                "bridge short-circuit skipped: VLAN_RESOLVE insert failed (bridge keeps the kernel path)"
+            );
+            continue;
+        }
         info!(
             bridge = %bridge_name,
             bridge_idx,
@@ -2210,6 +2258,25 @@ fn populate_vlan_resolve(
             vid,
             "bridge egress short-circuit installed"
         );
+        // `mss-clamp via <this bridge>` can no longer match: the clamp
+        // lookup keys on the POST-resolve egress ifindex (identical
+        // pre-existing semantics for plain VLAN subifs). Detectable
+        // here, so say it loudly with the fix.
+        for d in directives {
+            if let ModuleDirective::MssClamp {
+                iface: Some(clamp_iface),
+                ..
+            } = d
+            {
+                if *clamp_iface == bridge_name {
+                    warn!(
+                        bridge = %bridge_name,
+                        underlying = %phys_name,
+                        "mss-clamp `via {bridge_name}` will NOT match while the bridge                          egress short-circuit is installed (clamp matching keys on the                          resolved egress ifindex). Scope the clamp `via {phys_name}` or                          set `bridge-resolve off`."
+                    );
+                }
+            }
+        }
     }
 
     // Entries landed → make sure the VLAN_PRESENT gate bit is on, even

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -155,7 +155,10 @@ pub(crate) fn bridge_resolve_enabled(directives: &[ModuleDirective]) -> bool {
 /// `("br1337", "switch0", 1337)`.
 pub(crate) type BridgeChain = (String, String, u16);
 
-/// One bridge port as discovery sees it: (member name, is_forwarding).
+/// One bridge port as discovery sees it: (member name, eligible).
+/// "Eligible" = brport state forwarding AND unicast flooding enabled —
+/// both are preconditions for the wire-equivalence argument (see
+/// `read_bridge_topology`).
 pub(crate) type BridgeMember = (String, bool);
 
 /// Host bridge topology: each bridge with its member ports.
@@ -248,10 +251,23 @@ fn read_bridge_topology() -> std::io::Result<BridgeTopology> {
             let Ok(member) = port.file_name().into_string() else {
                 continue;
             };
-            let state = std::fs::read_to_string(format!("/sys/class/net/{member}/brport/state"))
+            let brport = format!("/sys/class/net/{member}/brport");
+            let forwarding = std::fs::read_to_string(format!("{brport}/state"))
                 .map(|s| s.trim() == BR_STATE_FORWARDING)
                 .unwrap_or(false);
-            members.push((member, state));
+            // With unicast flooding off, a destination MAC absent from
+            // the FDB (e.g. a silent host behind a static neighbor, or
+            // right after an FDB flush) is DROPPED by the bridge rather
+            // than emitted through the sole port — so "single member"
+            // stops implying "the bridge would have sent this frame
+            // there". Forwarded frames always carry a resolved unicast
+            // dst MAC, so unicast_flood is the only flood control that
+            // participates in the equivalence; require it on
+            // (unreadable → refuse).
+            let unicast_flood = std::fs::read_to_string(format!("{brport}/unicast_flood"))
+                .map(|s| s.trim() == "1")
+                .unwrap_or(false);
+            members.push((member, forwarding && unicast_flood));
         }
         out.push((name, members));
     }

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -307,7 +307,18 @@ pub(crate) fn reconcile_vlan_resolve(
             Err(e) => warn!(subif_idx, error = %e, "VLAN_RESOLVE insert failed"),
         }
     }
+    // The diff is over full (key, value) tuples but the map is keyed
+    // on ifindex alone, so a key whose VALUE changed (same bridge,
+    // re-parented member or new VID) appears in both differences: the
+    // add pass above already wrote the new value under the key, and
+    // removing the old tuple here would delete that fresh entry —
+    // one SIGHUP would leave the key absent until the next reconcile.
+    // Skip removals for keys the desired set still contains.
+    let desired_keys: HashSet<u32> = desired.iter().map(|(k, _, _)| *k).collect();
     for (subif_idx, _, _) in current.difference(&desired) {
+        if desired_keys.contains(subif_idx) {
+            continue; // value updated in place by the add pass
+        }
         match hm.remove(subif_idx) {
             Ok(()) => {
                 delta.removed += 1;

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -261,7 +261,7 @@ pub(crate) fn reconcile_vlan_resolve(
     let chains = discover_bridge_chains(&cfg.section.directives)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("bridge topology read: {e}")))?;
 
-    let desired: HashSet<(u32, u32, u16)> = vlan_entries
+    let desired_subifs: HashSet<(u32, u32, u16)> = vlan_entries
         .iter()
         .filter_map(|(subif, vid, parent)| {
             // Skip entries whose ifindexes don't resolve, the proc
@@ -271,12 +271,22 @@ pub(crate) fn reconcile_vlan_resolve(
             let phys_idx = if_nametoindex(parent).ok()?;
             Some((subif_idx, phys_idx, *vid))
         })
-        .chain(chains.iter().filter_map(|(bridge, phys, vid)| {
+        .collect();
+    let desired_bridges: HashSet<(u32, u32, u16)> = chains
+        .iter()
+        .filter_map(|(bridge, phys, vid)| {
             let bridge_idx = if_nametoindex(bridge).ok()?;
             let phys_idx = if_nametoindex(phys).ok()?;
             Some((bridge_idx, phys_idx, *vid))
-        }))
+        })
         .collect();
+    // Union for the diff/removal/gate logic; the ADD pass below runs
+    // subif entries before bridge aliases so that under map-capacity
+    // pressure the slot that runs out is always the optional
+    // optimization's, never a required subif entry (mirrors the
+    // attach-time population order).
+    let desired: HashSet<(u32, u32, u16)> =
+        desired_subifs.union(&desired_bridges).copied().collect();
 
     let map = state
         .ebpf
@@ -293,7 +303,14 @@ pub(crate) fn reconcile_vlan_resolve(
         .collect();
 
     let mut delta = DeltaCount::default();
-    for (subif_idx, phys_idx, vid) in desired.difference(&current) {
+    let mut to_add: Vec<&(u32, u32, u16)> = desired.difference(&current).collect();
+    to_add.sort_by_key(|t| {
+        (
+            desired_bridges.contains(t) && !desired_subifs.contains(t),
+            t.0,
+        )
+    });
+    for (subif_idx, phys_idx, vid) in to_add.into_iter() {
         let value = VlanResolve {
             phys_ifindex: *phys_idx,
             vid: *vid,

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -23,9 +23,10 @@ use packetframe_common::{
 use tracing::{info, warn};
 
 use crate::linux_impl::{
-    feature_flags_from_config, fib_flags_from_forwarding_mode, if_nametoindex,
-    mss_clamp_global_value, read_vlan_config, set_cfg_flag, ActiveState, FpCfg, MssClampValue,
-    VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT, FP_CFG_VERSION_V2,
+    discover_bridge_chains, feature_flags_from_config, fib_flags_from_forwarding_mode,
+    if_nametoindex, mss_clamp_global_value, read_vlan_config, set_cfg_flag, ActiveState, FpCfg,
+    MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT,
+    FP_CFG_VERSION_V2,
 };
 use crate::MODULE_NAME;
 
@@ -43,7 +44,7 @@ pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
     let block_v4 = reconcile_block_v4(state, cfg)?;
     let block_v6 = reconcile_block_v6(state, cfg)?;
     let mss_clamp = reconcile_mss_clamp(state, cfg)?;
-    let vlan = reconcile_vlan_resolve(state)?;
+    let vlan = reconcile_vlan_resolve(state, cfg)?;
     let devmap = reconcile_devmap(state)?;
 
     info!(
@@ -231,7 +232,10 @@ where
     Ok(delta)
 }
 
-fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
+pub(crate) fn reconcile_vlan_resolve(
+    state: &mut ActiveState,
+    cfg: &ModuleConfig<'_>,
+) -> ModuleResult<DeltaCount> {
     // Rebuild the desired set from /proc/net/vlan/config. Missing file
     // means no VLAN subifs, desired is empty, which will remove any
     // stale entries.
@@ -246,6 +250,17 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
         }
     };
 
+    // Bridge egress short-circuits share this map and bit 6: the
+    // desired set is the UNION of both sources, and only the single
+    // set_cfg_flag below writes the gate. `bridge-resolve off` yields
+    // an empty chain set, which purges any previously installed bridge
+    // keys via the normal diff — the SIGHUP rollback path. Read errors
+    // abort before the flag RMW, same policy as the vlan read above
+    // (never clear the gate on a transient failure while the map still
+    // holds entries).
+    let chains = discover_bridge_chains(&cfg.section.directives)
+        .map_err(|e| ModuleError::other(MODULE_NAME, format!("bridge topology read: {e}")))?;
+
     let desired: HashSet<(u32, u32, u16)> = vlan_entries
         .iter()
         .filter_map(|(subif, vid, parent)| {
@@ -256,6 +271,11 @@ fn reconcile_vlan_resolve(state: &mut ActiveState) -> ModuleResult<DeltaCount> {
             let phys_idx = if_nametoindex(parent).ok()?;
             Some((subif_idx, phys_idx, *vid))
         })
+        .chain(chains.iter().filter_map(|(bridge, phys, vid)| {
+            let bridge_idx = if_nametoindex(bridge).ok()?;
+            let phys_idx = if_nametoindex(phys).ok()?;
+            Some((bridge_idx, phys_idx, *vid))
+        }))
         .collect();
 
     let map = state

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -261,6 +261,32 @@ pub(crate) fn reconcile_vlan_resolve(
     let chains = discover_bridge_chains(&cfg.section.directives)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("bridge topology read: {e}")))?;
 
+    // Same clamp-scoping warning the attach-time population emits: an
+    // `mss-clamp via <bridge>` cannot match while that bridge is
+    // collapsed (matching keys on the post-resolve egress ifindex).
+    // A SIGHUP can introduce either half of the collision — the clamp
+    // rule or the alias — so the check has to live here too.
+    for (bridge_name, phys_name, _) in &chains {
+        for d in &cfg.section.directives {
+            if let ModuleDirective::MssClamp {
+                iface: Some(clamp_iface),
+                ..
+            } = d
+            {
+                if clamp_iface == bridge_name {
+                    warn!(
+                        bridge = %bridge_name,
+                        underlying = %phys_name,
+                        "mss-clamp `via {bridge_name}` will NOT match while the bridge \
+                         egress short-circuit is installed (clamp matching keys on the \
+                         resolved egress ifindex). Scope the clamp `via {phys_name}` or \
+                         set `bridge-resolve off`."
+                    );
+                }
+            }
+        }
+    }
+
     let desired_subifs: HashSet<(u32, u32, u16)> = vlan_entries
         .iter()
         .filter_map(|(subif, vid, parent)| {

--- a/crates/modules/fast-path/tests/bench.rs
+++ b/crates/modules/fast-path/tests/bench.rs
@@ -55,6 +55,23 @@ use common::{xdp_action, Harness, Ipv4TcpBuilder, StatIdx};
 /// devmap pre-check needs a real entry.
 const LO_IFINDEX: u32 = 1;
 
+/// Quick mode for CI under emulation. The statistics only matter on
+/// real hardware; under qemu TCG the full 1M-execution forward loops
+/// (a) take double-digit minutes and (b) trip the kernel's 22-second
+/// soft-lockup watchdog inside `bpf_test_run`, whose per-fire ~35-line
+/// splat to the emulated serial console compounds the slowdown until
+/// the job times out (observed on the v0.2.8 fib-cache PR: 5.15 qemu
+/// job dead at 20 min with bench still running). CI's question is
+/// "does the bench run and do its sanity asserts hold", which 1/25th
+/// of the iterations answers identically.
+fn bench_calls(full: usize) -> usize {
+    if std::env::var_os("PACKETFRAME_BENCH_QUICK").is_some() {
+        (full / 25).max(8)
+    } else {
+        full
+    }
+}
+
 /// Iterations per syscall on paths that mutate TTL (must stay < 253
 /// with ttl=255; see module docs).
 const FWD_REPEAT: u32 = 200;
@@ -120,16 +137,17 @@ fn bench_custom_fib_forward_established() {
     let fwd_before = h.stat(StatIdx::FwdOk);
     let low_ttl_before = h.stat(StatIdx::PassLowTtl);
 
-    let ns = median_ns(&h, &pkt, FWD_REPEAT, FWD_CALLS, xdp_action::XDP_REDIRECT);
+    let calls = bench_calls(FWD_CALLS);
+    let ns = median_ns(&h, &pkt, FWD_REPEAT, calls, xdp_action::XDP_REDIRECT);
 
     // Every iteration must have forwarded; a TTL-budget bug would
     // divert iterations to PassLowTtl and quietly bench the wrong path.
-    let executed = (FWD_REPEAT as u64) * (FWD_CALLS as u64);
+    let executed = (FWD_REPEAT as u64) * (calls as u64);
     assert_eq!(h.stat(StatIdx::FwdOk) - fwd_before, executed);
     assert_eq!(h.stat(StatIdx::PassLowTtl), low_ttl_before);
 
     eprintln!(
-        "bench_custom_fib_forward_established: {ns} ns/pkt (median of {FWD_CALLS} x {FWD_REPEAT})"
+        "bench_custom_fib_forward_established: {ns} ns/pkt (median of {calls} x {FWD_REPEAT})"
     );
 
     if let Ok(baseline) = std::env::var("PACKETFRAME_BENCH_BASELINE_NS") {
@@ -150,11 +168,12 @@ fn bench_custom_fib_forward_syn() {
     let pkt = fwd_packet(TCP_FLAG_SYN);
 
     let fwd_before = h.stat(StatIdx::FwdOk);
-    let ns = median_ns(&h, &pkt, FWD_REPEAT, FWD_CALLS, xdp_action::XDP_REDIRECT);
-    let executed = (FWD_REPEAT as u64) * (FWD_CALLS as u64);
+    let calls = bench_calls(FWD_CALLS);
+    let ns = median_ns(&h, &pkt, FWD_REPEAT, calls, xdp_action::XDP_REDIRECT);
+    let executed = (FWD_REPEAT as u64) * (calls as u64);
     assert_eq!(h.stat(StatIdx::FwdOk) - fwd_before, executed);
 
-    eprintln!("bench_custom_fib_forward_syn: {ns} ns/pkt (median of {FWD_CALLS} x {FWD_REPEAT})");
+    eprintln!("bench_custom_fib_forward_syn: {ns} ns/pkt (median of {calls} x {FWD_REPEAT})");
 }
 
 #[test]
@@ -167,9 +186,10 @@ fn bench_allowlist_miss() {
     let pkt = Ipv4TcpBuilder::default().build();
 
     let rx_before = h.stat(StatIdx::RxTotal);
-    let ns = median_ns(&h, &pkt, MISS_REPEAT, MISS_CALLS, xdp_action::XDP_PASS);
-    let executed = (MISS_REPEAT as u64) * (MISS_CALLS as u64);
+    let calls = bench_calls(MISS_CALLS);
+    let ns = median_ns(&h, &pkt, MISS_REPEAT, calls, xdp_action::XDP_PASS);
+    let executed = (MISS_REPEAT as u64) * (calls as u64);
     assert_eq!(h.stat(StatIdx::RxTotal) - rx_before, executed);
 
-    eprintln!("bench_allowlist_miss: {ns} ns/pkt (median of {MISS_CALLS} x {MISS_REPEAT})");
+    eprintln!("bench_allowlist_miss: {ns} ns/pkt (median of {calls} x {MISS_REPEAT})");
 }

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -414,6 +414,16 @@ layer's ebtables hooks for forwarded traffic — consistent with the fast path's
 existing netfilter bypass on ingress, but worth knowing if ebtables rules
 target forwarded traffic on the bridge.
 
+**Convergence model — same as every discovery-populated map.** Chains are
+discovered at attach and re-verified on every `packetframe reconfigure`
+(SIGHUP); there is no live topology watcher, exactly as with plain VLAN-subif
+entries and redirect-target membership. If you change bridge membership (enslave
+a second port, move the subif) or flip `vlan_filtering` on a bridge that has a
+short-circuit installed, run `packetframe reconfigure` afterwards — until then
+the datapath keeps using the previously proven chain. Bridges with
+`vlan_filtering=1` never qualify at all (the per-port VLAN table can drop or
+retag in ways a static entry can't reproduce).
+
 Rollback is SIGHUP-cheap, no restart and no traffic blip:
 
 ```text

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -377,3 +377,59 @@ removed — budget for them instead of chasing them:
   udapi polling target forever after. That trade is usually right (fast-pathing a
   host saves far more than its poll costs) but it belongs in capacity planning,
   not in a surprised `ss --packet` session at 3am.
+
+## Bridge egress short-circuit (`bridge-resolve`)
+
+On gateway-shaped hosts, a routed egress interface is often a Linux bridge whose
+only member is a VLAN subif of a lower device (`br1337` → `switch0.1337` →
+`switch0`). Nexthops learned there carry the *bridge's* ifindex, so every
+forwarded packet the fast path redirects into `br1337` then traverses the
+software bridge (FDB lookup, ebtables), the 8021q device (tag insert), and only
+then the lower device — three `dev_queue_xmit` layers plus a per-layer AF_PACKET
+tap walk, all in softirq. On a live EFG this stack was measured carrying ~53% of
+forwarded traffic.
+
+With `bridge-resolve auto` (the default), the loader collapses that chain at
+attach/reconcile time: for every bridge whose **single forwarding member** is a
+VLAN subif, it installs a `VLAN_RESOLVE` entry keyed on the bridge ifindex, so
+the datapath pushes the 802.1Q tag itself and redirects straight to the lower
+device. No BPF code changes — the same mechanism that handles plain VLAN subif
+egress does the work.
+
+Why this is safe, and when it refuses:
+
+- The wire frame is byte-identical to what the bridge stack emits: same source
+  MAC (the bridge's — on UniFi hardware all these devices share one MAC), same
+  802.1Q VID, destination MAC from the resolved neighbor entry.
+- A single-member bridge has no port choice to make: its FDB could only ever
+  pick that member, and unknown-unicast flooding reaches exactly the same port.
+- A bridge with **two or more members — even if all but one are blocked by
+  STP** — never qualifies: a blocked port can transition to forwarding at any
+  time, and then port selection needs the FDB, which the datapath cannot
+  consult. Those bridges keep today's kernel path, automatically.
+- Member port must be in bridge state *forwarding* (`brport/state == 3`).
+
+Note what is *not* skipped: packets that egress this way bypass the bridge
+layer's ebtables hooks for forwarded traffic — consistent with the fast path's
+existing netfilter bypass on ingress, but worth knowing if ebtables rules
+target forwarded traffic on the bridge.
+
+Rollback is SIGHUP-cheap, no restart and no traffic blip:
+
+```text
+bridge-resolve off
+```
+
+then `packetframe reconfigure`. The bridge keys are purged from `VLAN_RESOLVE`
+on the spot; plain VLAN subif entries are untouched.
+
+What to watch after enabling (canary):
+
+- `/proc/net/dev`: the bridge and subif tx packet counters should collapse to
+  ~0 for fast-pathed traffic while the lower device's tx holds steady.
+- `mpstat -P ALL 10` `%soft`: the win.
+- `packetframe status`: `pass_not_in_devmap` must stay flat (the lower device
+  is enumerated into the redirect maps the same way as everything else).
+- Attach/reconcile logs: one `bridge egress short-circuit installed` line per
+  collapsed chain says discovery proved the shape; absence means the topology
+  didn't qualify and nothing changed.

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -431,6 +431,17 @@ Three scoping caveats, stated precisely:
 - **MTU relation is enforced:** a bridge whose MTU is smaller than its
   underlying device's is skipped (the bridge would have refused packets the
   short-circuit would forward). Equal MTUs — the normal case — qualify.
+- **Egress qdiscs on the bridge or subif are bypassed** — collapsed traffic
+  traverses only the underlying device's qdisc. This is the standing semantic
+  of `VLAN_RESOLVE` (plain subif entries have always redirected to the parent,
+  skipping the subif's own qdisc); shape or police on the underlying device,
+  or set `bridge-resolve off` for bridges carrying their own qdisc policy.
+  (These virtual devices are `noqueue` by default; a configured qdisc on one
+  is an operator choice this feature cannot see from procfs/sysfs.)
+- **Unicast flooding must be on** (`brport/unicast_flood == 1`, the kernel
+  default): with it off, a destination MAC absent from the FDB is dropped by
+  the bridge rather than emitted through the sole port, so "single member" no
+  longer predicts the bridge's decision. Discovery refuses such ports.
 
 **Convergence model — same as every discovery-populated map.** Chains are
 discovered at attach and re-verified on every `packetframe reconfigure`

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -414,6 +414,24 @@ layer's ebtables hooks for forwarded traffic — consistent with the fast path's
 existing netfilter bypass on ingress, but worth knowing if ebtables rules
 target forwarded traffic on the bridge.
 
+Three scoping caveats, stated precisely:
+
+- **802.1Q only.** `/proc/net/vlan/config` lists 802.1ad (QinQ) subifs
+  indistinguishably from 802.1Q ones, and the datapath's VLAN push always
+  writes TPID 0x8100 — this is a standing assumption of the whole
+  `VLAN_RESOLVE` mechanism (plain subif entries included), not something the
+  bridge feature adds. On an 802.1ad deployment set `bridge-resolve off` and
+  don't rely on subif egress resolution either; protocol-aware resolution is
+  a named follow-up for the subsystem.
+- **`mss-clamp via <bridge>` will not match** while a short-circuit is
+  installed: clamp matching keys on the resolved egress ifindex (identical
+  pre-existing behavior for `via <subif>` under plain VLAN resolution). The
+  loader warns at attach/reconcile with the fix: scope the clamp `via` the
+  underlying device, or set `bridge-resolve off`.
+- **MTU relation is enforced:** a bridge whose MTU is smaller than its
+  underlying device's is skipped (the bridge would have refused packets the
+  short-circuit would forward). Equal MTUs — the normal case — qualify.
+
 **Convergence model — same as every discovery-populated map.** Chains are
 discovered at attach and re-verified on every `packetframe reconfigure`
 (SIGHUP); there is no live topology watcher, exactly as with plain VLAN-subif


### PR DESCRIPTION
Phase-2 perf, PR 1 of 2 (plan: bridge short-circuit now, FIB dest cache next). Follows from the on-hardware profiling session: ~53% of forwarded traffic on the reference EFG egresses through `br1337 → switch0.1337 → switch0`, paying three `dev_queue_xmit` layers, the bridge FDB walk, ebtables, and a per-layer tap walk — all softirq. Estimated recovery: 4–8% of busy CPU.

## Mechanism — zero BPF changes

`VLAN_RESOLVE` is keyed on whatever ifindex the FIB resolves (`main.rs:674`, `tc.rs:406`), and nexthops learned on a bridge carry the bridge's ifindex. So for every bridge whose **single forwarding member** is a VLAN subif, the loader installs `bridge_ifindex → (underlying device, VID)` and both datapaths tag + redirect straight to the underlying device. The BPF side cannot tell these entries apart from plain subif entries — which is the point.

Equivalence argument, stated rather than assumed:
- wire frame is byte-identical to what the bridge emits (same src MAC — these devices share one on UniFi hardware; same 802.1Q VID; dst MAC from the resolved neighbor);
- a single-member bridge has no port choice its FDB could have made differently, and unknown-unicast flooding reaches exactly the same port;
- **multi-member bridges never qualify, even with all-but-one port STP-blocked** — a blocked port can start forwarding at any moment, and then port selection needs the FDB, which the datapath can't consult. Those bridges keep today's kernel path automatically.

One behavior note (documented in the runbook): collapsed egress bypasses the bridge layer's ebtables hooks for forwarded traffic — consistent with the fast path's existing ingress netfilter bypass.

## Config + reconcile

- New module directive `bridge-resolve auto|on|off`, default `auto` (`ToggleAutoOnOff`, the `driver-workaround` precedent; `on` is a documented synonym for `auto` — an unprovable topology can't be forced). `off` is the SIGHUP-able rollback.
- Reconcile computes the desired set as the **union** of 8021q subifs and bridge chains, so `off` purges bridge keys via the normal diff while plain subif entries survive. Bit-6 ownership rules are preserved exactly: `reconcile_cfg` still carries the live bit, and the single post-convergence RMW in `reconcile_vlan_resolve` remains the only writer, now computed from the union.
- Discovery: `/sys/class/net/<dev>/bridge` (is-bridge) + `brif/` members + `brport/state == 3` (forwarding), joined against `/proc/net/vlan/config`. Pure decision function is separated from the sysfs reader for unit testing.

## Tests

- Truth table for the pure function: single-member ✓, multi-member ✗ (incl. one-blocked), non-forwarding ✗, member-not-a-VLAN ✗, zero members ✗, mixed hosts.
- Directive semantics + config parse (`auto|on|off`, arity, garbage).
- Sudo/qemu end-to-end (`bridge_short_circuit_populate_and_reconcile`): builds veth → 8021q subif → single-member bridge on the real kernel, loads the real ELF, asserts the map key is `(underlying_dev, vid)`, bit 6 set, `bridge-resolve off` purges the bridge key but not the subif entry, re-enable converges it back.
- BPF side needs no new tests — the resolve-hit path is already covered by `fixtures`/`tc_fixtures`; nothing BPF-side changed.

## Notes for review

- Based on `main` (`63e81ab`); no overlap with #77's files. The aarch64 clippy failure that exists on `main` (`uname_release` cast, `probe/mod.rs:285`) is pre-existing and fixed by #77 — after both merge, #77's new per-triple clippy gate covers this branch's code too (it's clean on all four triples locally, modulo that one inherited error).
- Hardware canary plan (runbook §"Bridge egress short-circuit"): watch `/proc/net/dev` (bridge + subif tx → ~0, lower device tx holds), `mpstat` `%soft`, `pass_not_in_devmap` flat. Rollback: `bridge-resolve off` + `packetframe reconfigure`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)