### PR TITLE
feat(fast-path): FIB destination cache — default-off experiment with a kill criterion

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -104,6 +104,19 @@ module fast-path
   # qualify.
   # bridge-resolve auto
 
+  # Destination cache in front of the custom-FIB LPM lookups
+  # (EXPERIMENT, default off). A full BGP table makes each LPM lookup
+  # a deep DRAM-bound trie walk; the cache converts repeat
+  # destinations into one per-CPU array probe. Cached entries hold the
+  # FIB decision (not the resolved neighbor), so nexthop churn needs no
+  # invalidation and ECMP flow placement is unchanged; any route change
+  # invalidates the whole cache via a generation counter. Only
+  # meaningful under `forwarding-mode custom-fib`. Enable on a canary
+  # and decide by measurement: fib_cache_hit / (hit+miss+stale) below
+  # ~70% means your destination diversity defeats the cache — leave it
+  # off. SIGHUP-reloadable.
+  # fib-cache off
+
   # --- Option F custom FIB. Cutting over to `custom-fib` requires
   # bird's BMP protocol dialing this station AND bird's kernel
   # export dropping BGP routes. See docs/runbooks/custom-fib.md for

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -252,6 +252,14 @@ pub enum ModuleDirective {
         line: usize,
     },
     DryRun(bool),
+    /// `fib-cache on|off` — destination cache in front of the custom
+    /// FIB LPM lookups (default off; an experiment with an explicit
+    /// kill criterion, see docs). Caches the FibValue keyed on the
+    /// full destination address; invalidated globally on every route
+    /// change via a generation counter owned by the FibProgrammer.
+    /// Only meaningful under `forwarding-mode custom-fib`; parsed and
+    /// inert otherwise (warned at apply time). SIGHUP-reconcilable.
+    FibCache(bool),
     /// `bridge-resolve auto|on|off` — bridge egress short-circuit
     /// (SPEC §4.7 extension). When the FIB resolves a nexthop whose
     /// egress device is a Linux bridge whose **single forwarding
@@ -1588,6 +1596,25 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             Ok(ModuleDirective::DryRun(on))
         }
         "circuit-breaker" => parse_circuit_breaker(line, rest),
+        "fib-cache" => {
+            let v = rest
+                .next()
+                .ok_or_else(|| ConfigError::parse(line, "fib-cache requires on|off"))?;
+            if rest.next().is_some() {
+                return Err(ConfigError::parse(line, "fib-cache takes one argument"));
+            }
+            let on = match v {
+                "on" => true,
+                "off" => false,
+                other => {
+                    return Err(ConfigError::parse(
+                        line,
+                        format!("fib-cache expects on|off, got `{other}`"),
+                    ))
+                }
+            };
+            Ok(ModuleDirective::FibCache(on))
+        }
         "bridge-resolve" => parse_single_arg(line, rest, "bridge-resolve", |t| {
             let v: ToggleAutoOnOff = t.parse().map_err(|e: String| e)?;
             Ok(ModuleDirective::BridgeResolve(v))
@@ -2403,6 +2430,21 @@ module fast-path
             }
             other => panic!("expected Attach, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn fib_cache_parses() {
+        for (tok, want) in [("on", true), ("off", false)] {
+            let s = format!("module fast-path\n  fib-cache {tok}\n");
+            let c = Config::parse(&s).unwrap();
+            match &c.modules[0].directives[0] {
+                ModuleDirective::FibCache(v) => assert_eq!(*v, want),
+                other => panic!("expected FibCache, got {other:?}"),
+            }
+        }
+        assert!(Config::parse("module fast-path\n  fib-cache auto\n").is_err());
+        assert!(Config::parse("module fast-path\n  fib-cache\n").is_err());
+        assert!(Config::parse("module fast-path\n  fib-cache on off\n").is_err());
     }
 
     #[test]

--- a/crates/modules/fast-path/bpf/src/datapath.rs
+++ b/crates/modules/fast-path/bpf/src/datapath.rs
@@ -81,21 +81,25 @@ pub fn l4_ports(start: usize, end: usize, offset: usize, proto: u8) -> (u16, u16
 /// Bounds-check shape mirrors [`l4_ports`].
 #[inline(always)]
 pub fn icmpv6_type(start: usize, end: usize, offset: usize) -> Option<u8> {
-    // `p >= end` rather than the file's usual `start + off + k > end`:
-    // mathematically identical for k = 1, but it pins the packet
-    // pointer on the LEFT of the comparison. The 5.15-ui verifier
-    // failed this exact read when LLVM (under register pressure from
-    // the v0.2.8 FIB-cache inlining) emitted the reversed form
-    // `if pkt_end > pkt+off goto read` with `off` reloaded from a
-    // stack spill — range propagation stopped at r=off and the
-    // 1-byte read at `off` was rejected ("R2 offset is outside of
-    // the packet"). The `p >= end → bail` shape compiles to the
-    // canonical JGE-pointer-left compare that every kernel tracks.
-    let p = start + offset;
-    if p >= end {
+    // Bounds-check 4 bytes even though only 1 is read, and the 4 is
+    // load-bearing — do not "fix" it back to 1. Verifier history
+    // (v0.2.8 FIB-cache PR, two failed qemu-5.15 rounds): with k = 1,
+    // LLVM strength-reduces `p + 1 > end` (and the equivalent
+    // `p >= end`) into the reversed strict compare
+    // `if pkt_end > pkt+off goto read`, and the 5.15 verifier's range
+    // propagation for exactly that arm is off by one — the taken
+    // branch keeps r = off where off+1 is provable, and the 1-byte
+    // read at `off` is rejected ("R2 offset is outside of the
+    // packet"). `p + 4 > end` cannot collapse into a >= form, so LLVM
+    // emits the pkt-on-the-left shape (`if pkt+off+4 > pkt_end goto
+    // bail`) whose fall-through range every kernel tracks correctly.
+    // Semantically free: 4 bytes (type, code, checksum) is the ICMPv6
+    // header minimum, and a message truncated below that cannot be a
+    // valid NS/NA — "not NDP" is already the fail-safe answer.
+    if start + offset + 4 > end {
         return None;
     }
-    Some(unsafe { core::ptr::read_unaligned(p as *const u8) })
+    Some(unsafe { core::ptr::read_unaligned((start + offset) as *const u8) })
 }
 
 /// Read TCP header byte 13 (flags) at `tcp_offset` and test SYN.

--- a/crates/modules/fast-path/bpf/src/datapath.rs
+++ b/crates/modules/fast-path/bpf/src/datapath.rs
@@ -81,10 +81,21 @@ pub fn l4_ports(start: usize, end: usize, offset: usize, proto: u8) -> (u16, u16
 /// Bounds-check shape mirrors [`l4_ports`].
 #[inline(always)]
 pub fn icmpv6_type(start: usize, end: usize, offset: usize) -> Option<u8> {
-    if start + offset + 1 > end {
+    // `p >= end` rather than the file's usual `start + off + k > end`:
+    // mathematically identical for k = 1, but it pins the packet
+    // pointer on the LEFT of the comparison. The 5.15-ui verifier
+    // failed this exact read when LLVM (under register pressure from
+    // the v0.2.8 FIB-cache inlining) emitted the reversed form
+    // `if pkt_end > pkt+off goto read` with `off` reloaded from a
+    // stack spill — range propagation stopped at r=off and the
+    // 1-byte read at `off` was rejected ("R2 offset is outside of
+    // the packet"). The `p >= end → bail` shape compiles to the
+    // canonical JGE-pointer-left compare that every kernel tracks.
+    let p = start + offset;
+    if p >= end {
         return None;
     }
-    Some(unsafe { core::ptr::read_unaligned((start + offset) as *const u8) })
+    Some(unsafe { core::ptr::read_unaligned(p as *const u8) })
 }
 
 /// Read TCP header byte 13 (flags) at `tcp_offset` and test SYN.

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -135,8 +135,14 @@ pub fn lookup_v4(
     // gen check, a just-invalidated entry can produce a spurious
     // CompareDisagree blip under BGP churn — compare is a temporary
     // validation mode; tolerated and documented.
+    // Register-pressure note: only `cache_gen` + the 8-byte `fib` +
+    // `cached` stay live across the LPM call. The dst word and slot
+    // index are recomputed at the fill site rather than carried — the
+    // first CI round carried them, LLVM spilled the v6 parse's L4
+    // offset to make room, and the 5.15-ui verifier rejected the
+    // NDP-gate byte read it restructured around the reload (see
+    // datapath::icmpv6_type). Cheap ALU beats live registers here.
     let cache_gen = cache_generation();
-    let dst_w = u32::from_ne_bytes(dst);
     let mut fib = FibValue {
         kind: FIB_KIND_SINGLE,
         _pad: [0; 3],
@@ -144,6 +150,7 @@ pub fn lookup_v4(
     };
     let mut cached = false;
     if cache_gen != 0 {
+        let dst_w = u32::from_ne_bytes(dst);
         if let Some(e) = FIB_CACHE_V4.get_ptr_mut(cache_slot(dst_w, FIB_CACHE_V4_ENTRIES)) {
             // SAFETY: bounds-checked map value pointer; per-CPU, and
             // XDP/tc programs run to completion on their CPU, so no
@@ -177,6 +184,7 @@ pub fn lookup_v4(
             }
         };
         if cache_gen != 0 {
+            let dst_w = u32::from_ne_bytes(dst);
             if let Some(e) = FIB_CACHE_V4.get_ptr_mut(cache_slot(dst_w, FIB_CACHE_V4_ENTRIES)) {
                 // Field-by-field stores (anti-memset discipline).
                 // Ordering within the entry is irrelevant: the sole
@@ -226,13 +234,11 @@ pub fn lookup_v6(
     dst: [u8; 16],
     proto: u8,
 ) -> CustomFibResult {
-    // Destination-cache probe; see the v4 twin for the full contract.
+    // Destination-cache probe; see the v4 twin for the full contract
+    // and the register-pressure note (nothing but `cache_gen`, `fib`,
+    // `cached` may live across the LPM call — the dst words and slot
+    // are recomputed per block from `dst`, which is live regardless).
     let cache_gen = cache_generation();
-    let d0 = u32::from_ne_bytes([dst[0], dst[1], dst[2], dst[3]]);
-    let d1 = u32::from_ne_bytes([dst[4], dst[5], dst[6], dst[7]]);
-    let d2 = u32::from_ne_bytes([dst[8], dst[9], dst[10], dst[11]]);
-    let d3 = u32::from_ne_bytes([dst[12], dst[13], dst[14], dst[15]]);
-    let slot_word = d0 ^ d1 ^ d2 ^ d3;
     let mut fib = FibValue {
         kind: FIB_KIND_SINGLE,
         _pad: [0; 3],
@@ -240,7 +246,13 @@ pub fn lookup_v6(
     };
     let mut cached = false;
     if cache_gen != 0 {
-        if let Some(e) = FIB_CACHE_V6.get_ptr_mut(cache_slot(slot_word, FIB_CACHE_V6_ENTRIES)) {
+        let d0 = u32::from_ne_bytes([dst[0], dst[1], dst[2], dst[3]]);
+        let d1 = u32::from_ne_bytes([dst[4], dst[5], dst[6], dst[7]]);
+        let d2 = u32::from_ne_bytes([dst[8], dst[9], dst[10], dst[11]]);
+        let d3 = u32::from_ne_bytes([dst[12], dst[13], dst[14], dst[15]]);
+        if let Some(e) =
+            FIB_CACHE_V6.get_ptr_mut(cache_slot(d0 ^ d1 ^ d2 ^ d3, FIB_CACHE_V6_ENTRIES))
+        {
             // SAFETY: as in the v4 twin.
             unsafe {
                 if (*e).dst[0] == d0 && (*e).dst[1] == d1 && (*e).dst[2] == d2 && (*e).dst[3] == d3
@@ -269,7 +281,13 @@ pub fn lookup_v6(
             }
         };
         if cache_gen != 0 {
-            if let Some(e) = FIB_CACHE_V6.get_ptr_mut(cache_slot(slot_word, FIB_CACHE_V6_ENTRIES)) {
+            let d0 = u32::from_ne_bytes([dst[0], dst[1], dst[2], dst[3]]);
+            let d1 = u32::from_ne_bytes([dst[4], dst[5], dst[6], dst[7]]);
+            let d2 = u32::from_ne_bytes([dst[8], dst[9], dst[10], dst[11]]);
+            let d3 = u32::from_ne_bytes([dst[12], dst[13], dst[14], dst[15]]);
+            if let Some(e) =
+                FIB_CACHE_V6.get_ptr_mut(cache_slot(d0 ^ d1 ^ d2 ^ d3, FIB_CACHE_V6_ENTRIES))
+            {
                 // Field-by-field stores; see the v4 twin.
                 unsafe {
                     (*e).dst[0] = d0;

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -33,7 +33,7 @@ use crate::maps::{
 /// reserved generation the programmer never issues, so "disabled" and
 /// "no valid entry can match" collapse into one sentinel).
 #[inline(always)]
-fn cache_generation() -> u32 {
+fn cache_generation() -> u64 {
     match FIB_CACHE_CFG.get(0) {
         Some(cc) if cc.enabled != 0 => cc.generation,
         _ => 0,
@@ -193,6 +193,7 @@ pub fn lookup_v4(
                     (*e).dst = dst_w;
                     (*e).kind = fib.kind as u32;
                     (*e).idx = fib.idx;
+                    (*e)._pad = 0;
                     (*e).generation = cache_gen;
                 }
             }

--- a/crates/modules/fast-path/bpf/src/fib.rs
+++ b/crates/modules/fast-path/bpf/src/fib.rs
@@ -22,9 +22,32 @@ use aya_ebpf::maps::lpm_trie::Key;
 
 use crate::datapath::l4_ports;
 use crate::maps::{
-    bump, EcmpGroup, FibValue, NexthopEntry, StatIdx, StatsPtr, ECMP_GROUPS, FIB_KIND_ECMP,
+    bump, EcmpGroup, FibValue, NexthopEntry, StatIdx, StatsPtr, ECMP_GROUPS, FIB_CACHE_CFG,
+    FIB_CACHE_V4, FIB_CACHE_V4_ENTRIES, FIB_CACHE_V6, FIB_CACHE_V6_ENTRIES, FIB_KIND_ECMP,
     FIB_KIND_SINGLE, FIB_V4, FIB_V6, MAX_ECMP_PATHS, NEXTHOPS, NH_STATE_RESOLVED,
 };
+
+// --- FIB destination cache probe ---------------------------------------
+
+/// Current cache generation, or 0 when the cache is disabled (0 is a
+/// reserved generation the programmer never issues, so "disabled" and
+/// "no valid entry can match" collapse into one sentinel).
+#[inline(always)]
+fn cache_generation() -> u32 {
+    match FIB_CACHE_CFG.get(0) {
+        Some(cc) if cc.enabled != 0 => cc.generation,
+        _ => 0,
+    }
+}
+
+/// Fibonacci multiplicative hash → slot index. Two ALU ops. This hash
+/// is BPF-internal only (cache entries never cross the BPF/userspace
+/// boundary), so unlike the ECMP flow hash it deliberately has no
+/// userspace mirror in `fib_hash_vectors.rs`.
+#[inline(always)]
+fn cache_slot(word: u32, entries: u32) -> u32 {
+    (word.wrapping_mul(0x9E37_79B1) >> 16) & (entries - 1)
+}
 
 // --- Action codes -----------------------------------------------------
 //
@@ -103,14 +126,70 @@ pub fn lookup_v4(
     dst: [u8; 4],
     proto: u8,
 ) -> CustomFibResult {
-    let key = Key::new(32, dst);
-    let fib = match FIB_V4.get(&key) {
-        Some(v) => *v,
-        None => {
-            bump(stats, StatIdx::CustomFibMiss);
-            return CustomFibResult::miss();
-        }
+    // Destination-cache probe (gated; generation 0 = disabled). On a
+    // hit the LPM walk is skipped entirely; the FibValue still resolves
+    // through NEXTHOPS/ECMP_GROUPS below, so the seqlock read and the
+    // per-flow ECMP hash are identical cached or not. Compare-mode
+    // caveat: this lookup also serves the compare arm, so during the
+    // microscopic window between a generation bump and the packet's
+    // gen check, a just-invalidated entry can produce a spurious
+    // CompareDisagree blip under BGP churn — compare is a temporary
+    // validation mode; tolerated and documented.
+    let cache_gen = cache_generation();
+    let dst_w = u32::from_ne_bytes(dst);
+    let mut fib = FibValue {
+        kind: FIB_KIND_SINGLE,
+        _pad: [0; 3],
+        idx: 0,
     };
+    let mut cached = false;
+    if cache_gen != 0 {
+        if let Some(e) = FIB_CACHE_V4.get_ptr_mut(cache_slot(dst_w, FIB_CACHE_V4_ENTRIES)) {
+            // SAFETY: bounds-checked map value pointer; per-CPU, and
+            // XDP/tc programs run to completion on their CPU, so no
+            // concurrent writer exists for this slot.
+            unsafe {
+                if (*e).dst == dst_w {
+                    if (*e).generation == cache_gen {
+                        bump(stats, StatIdx::FibCacheHit);
+                        fib.kind = (*e).kind as u8;
+                        fib.idx = (*e).idx;
+                        cached = true;
+                    } else {
+                        bump(stats, StatIdx::FibCacheStale);
+                    }
+                } else {
+                    bump(stats, StatIdx::FibCacheMiss);
+                }
+            }
+        }
+    }
+    if !cached {
+        let key = Key::new(32, dst);
+        fib = match FIB_V4.get(&key) {
+            Some(v) => *v,
+            None => {
+                // No negative caching: a stale "no route" entry is a
+                // blackhole-shaped bug, and true misses are rare under
+                // a full table.
+                bump(stats, StatIdx::CustomFibMiss);
+                return CustomFibResult::miss();
+            }
+        };
+        if cache_gen != 0 {
+            if let Some(e) = FIB_CACHE_V4.get_ptr_mut(cache_slot(dst_w, FIB_CACHE_V4_ENTRIES)) {
+                // Field-by-field stores (anti-memset discipline).
+                // Ordering within the entry is irrelevant: the sole
+                // reader is this CPU's own later invocations.
+                unsafe {
+                    (*e).dst = dst_w;
+                    (*e).kind = fib.kind as u32;
+                    (*e).idx = fib.idx;
+                    (*e).generation = cache_gen;
+                }
+            }
+        }
+    }
 
     let nh_ptr = match resolve_fib_value_v4(stats, start, end, l4_off, &fib, src, dst, proto) {
         Some(p) => p,
@@ -147,14 +226,63 @@ pub fn lookup_v6(
     dst: [u8; 16],
     proto: u8,
 ) -> CustomFibResult {
-    let key = Key::new(128, dst);
-    let fib = match FIB_V6.get(&key) {
-        Some(v) => *v,
-        None => {
-            bump(stats, StatIdx::CustomFibMiss);
-            return CustomFibResult::miss();
-        }
+    // Destination-cache probe; see the v4 twin for the full contract.
+    let cache_gen = cache_generation();
+    let d0 = u32::from_ne_bytes([dst[0], dst[1], dst[2], dst[3]]);
+    let d1 = u32::from_ne_bytes([dst[4], dst[5], dst[6], dst[7]]);
+    let d2 = u32::from_ne_bytes([dst[8], dst[9], dst[10], dst[11]]);
+    let d3 = u32::from_ne_bytes([dst[12], dst[13], dst[14], dst[15]]);
+    let slot_word = d0 ^ d1 ^ d2 ^ d3;
+    let mut fib = FibValue {
+        kind: FIB_KIND_SINGLE,
+        _pad: [0; 3],
+        idx: 0,
     };
+    let mut cached = false;
+    if cache_gen != 0 {
+        if let Some(e) = FIB_CACHE_V6.get_ptr_mut(cache_slot(slot_word, FIB_CACHE_V6_ENTRIES)) {
+            // SAFETY: as in the v4 twin.
+            unsafe {
+                if (*e).dst[0] == d0 && (*e).dst[1] == d1 && (*e).dst[2] == d2 && (*e).dst[3] == d3
+                {
+                    if (*e).generation == cache_gen {
+                        bump(stats, StatIdx::FibCacheHit);
+                        fib.kind = (*e).kind as u8;
+                        fib.idx = (*e).idx;
+                        cached = true;
+                    } else {
+                        bump(stats, StatIdx::FibCacheStale);
+                    }
+                } else {
+                    bump(stats, StatIdx::FibCacheMiss);
+                }
+            }
+        }
+    }
+    if !cached {
+        let key = Key::new(128, dst);
+        fib = match FIB_V6.get(&key) {
+            Some(v) => *v,
+            None => {
+                bump(stats, StatIdx::CustomFibMiss);
+                return CustomFibResult::miss();
+            }
+        };
+        if cache_gen != 0 {
+            if let Some(e) = FIB_CACHE_V6.get_ptr_mut(cache_slot(slot_word, FIB_CACHE_V6_ENTRIES)) {
+                // Field-by-field stores; see the v4 twin.
+                unsafe {
+                    (*e).dst[0] = d0;
+                    (*e).dst[1] = d1;
+                    (*e).dst[2] = d2;
+                    (*e).dst[3] = d3;
+                    (*e).kind = fib.kind as u32;
+                    (*e).idx = fib.idx;
+                    (*e).generation = cache_gen;
+                }
+            }
+        }
+    }
 
     let nh_ptr = match resolve_fib_value_v6(stats, start, end, l4_off, &fib, src, dst, proto) {
         Some(p) => p,

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -752,32 +752,40 @@ pub static FIB_CONFIG: Array<FpFibCfg> = Array::with_max_entries(1, 0);
 // All-u32 fields: zero padding by construction (compile-time asserted)
 // and field-by-field stores — the MutationCtx anti-memset discipline.
 
-/// v4 cache entry. 16 bytes.
+/// v4 cache entry. 24 bytes, zero padding (the `_pad` field is
+/// explicit and stored, keeping the anti-memset discipline intact
+/// under the u64 alignment).
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct FibCacheEntryV4 {
     /// Destination address, native-endian word of the wire bytes.
     pub dst: u32,
-    /// `FIB_CACHE_CFG.generation` at fill time. 0 = never filled.
-    pub generation: u32,
     /// `FibValue.kind` widened to u32 (avoids u8-plus-padding stores).
     pub kind: u32,
     /// `FibValue.idx`.
     pub idx: u32,
+    /// Explicit padding; always stored as 0.
+    pub _pad: u32,
+    /// `FIB_CACHE_CFG.generation` at fill time. 0 = never filled.
+    /// u64: at one bump per route mutation, wrap is unreachable in any
+    /// deployment lifetime, so a slot never revisited across a full
+    /// generation cycle can never see its stale stamp become live
+    /// again (the u32 flaw review round 3 caught).
+    pub generation: u64,
 }
-const _: () = assert!(core::mem::size_of::<FibCacheEntryV4>() == 16);
+const _: () = assert!(core::mem::size_of::<FibCacheEntryV4>() == 24);
 
-/// v6 cache entry. 28 bytes.
+/// v6 cache entry. 32 bytes, zero padding by construction.
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub struct FibCacheEntryV6 {
     /// Destination address as 4 native-endian words of the wire bytes.
     pub dst: [u32; 4],
-    pub generation: u32,
     pub kind: u32,
     pub idx: u32,
+    pub generation: u64,
 }
-const _: () = assert!(core::mem::size_of::<FibCacheEntryV6>() == 28);
+const _: () = assert!(core::mem::size_of::<FibCacheEntryV6>() == 32);
 
 /// Cache control: enable flag + current generation. One entry, sole
 /// writer is the userspace FibProgrammer task (the enable directive
@@ -789,19 +797,21 @@ const _: () = assert!(core::mem::size_of::<FibCacheEntryV6>() == 28);
 pub struct FibCacheCfg {
     /// 0 = off (default), 1 = on.
     pub enabled: u32,
-    /// Current generation. 0 reserved — the programmer starts at 1
-    /// and skips 0 on wrap, so a zeroed entry can never match.
-    pub generation: u32,
+    /// Explicit padding; always written as 0.
+    pub _pad: u32,
+    /// Current generation. 0 reserved (never issued), so a zeroed
+    /// entry can never match. u64 — see `FibCacheEntryV4::generation`.
+    pub generation: u64,
 }
-const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 8);
+const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 16);
 
 /// v4 slot count. Power of two (the probe masks with N-1). Memory:
-/// 65_536 × 16 B × nr_cpus (≈19 MB on an 18-core cn9670) — sized so a
+/// 65_536 × 24 B × nr_cpus (≈28 MB on an 18-core cn9670) — sized so a
 /// per-CPU working set in the tens of thousands of destinations keeps
 /// collision churn low at ~36 kpps/CPU.
 pub const FIB_CACHE_V4_ENTRIES: u32 = 65_536;
 /// v6 slot count. Smaller: v6 traffic share is materially lower on the
-/// target deployments. 16_384 × 28 B × nr_cpus ≈ 8 MB.
+/// target deployments. 16_384 × 32 B × nr_cpus ≈ 9 MB.
 pub const FIB_CACHE_V6_ENTRIES: u32 = 16_384;
 
 #[map]

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -183,12 +183,32 @@ pub enum StatIdx {
     /// Packet forwarded by `tc_finalize` via `bpf_redirect` (bumped in
     /// addition to `FwdOk`). A/B attribution mirror of `RxTotalTc`.
     FwdOkTc = 41,
+    // --- FIB destination cache (default-off experiment). Append-only.
+    //
+    // The three probe outcomes are mutually exclusive per packet, so
+    // hit rate = hit / (hit + miss + stale). They are a layer ON TOP
+    // of the route-decision counters: a cache-hit packet still bumps
+    // `CustomFibHit` (it IS a FIB hit) and `EcmpHashV4/V6` where
+    // applicable — cache counters describe the probe, not the verdict.
+    /// Cache probe matched (dst equal, generation current); the LPM
+    /// walk was skipped.
+    FibCacheHit = 42,
+    /// Cache enabled but the slot was empty or held a different dst
+    /// (collision / cold working set). The LPM walk ran and the slot
+    /// was refilled.
+    FibCacheMiss = 43,
+    /// Slot held the right dst but a stale generation — a route change
+    /// invalidated it since fill. Distinct from Miss because the two
+    /// have opposite remedies: sustained Stale means BGP churn defeats
+    /// the global-generation invalidation; sustained Miss means the
+    /// working set outsizes the table (or collisions dominate).
+    FibCacheStale = 44,
 }
 
 /// Total counter count. Sizes the `[u64; N]` value of the single-entry
 /// `STATS` per-CPU map. New counters bump this; dashboards keying on
 /// indices keep working.
-pub const STATS_COUNT: u32 = 42;
+pub const STATS_COUNT: u32 = 45;
 
 /// `STATS_COUNT` as usize, for the array-of-counters value type.
 pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;
@@ -699,6 +719,101 @@ pub static ECMP_GROUPS: Array<EcmpGroup> = Array::with_max_entries(ECMP_GROUPS_M
 /// index 0. Separate from `CFG` to avoid evolving `FpCfg`.
 #[map]
 pub static FIB_CONFIG: Array<FpFibCfg> = Array::with_max_entries(1, 0);
+
+// --- FIB destination cache (default-off experiment) ----------------------
+//
+// A direct-mapped per-CPU cache in front of the FIB LPM tries. The
+// tries hold a full BGP table, so a production lookup is a deep
+// DRAM-bound walk (~1.2 µs/pkt measured on cn9670); the cache converts
+// repeat destinations into one array probe. Design constraints:
+//
+// - The cached value is the FibValue (kind + idx), NEVER the resolved
+//   nexthop tuple: the per-packet seqlock read and the ECMP 5-tuple
+//   hash run unchanged on hits, so neighbor churn requires no
+//   invalidation and per-flow ECMP placement is preserved bit-for-bit.
+// - Key is the full /32 (v4) or /128 (v6) destination — FibValue does
+//   not record the matched prefix length, so no coarser key is sound.
+// - Direct-mapped PerCpuArray, not an LRU map: no LRU type is proven
+//   on the 5.15-ui verifier, LRU insert is an alloc-under-spinlock
+//   helper call per miss, and under adversarial dst spray LRU degrades
+//   to eviction-list thrash (the failure mode that killed the Linux
+//   route cache) while direct-mapped degrades to baseline-plus-two-
+//   helper-calls. Collisions simply overwrite.
+// - Invalidation is a global generation stamped into each entry at
+//   fill: the FibProgrammer bumps `FIB_CACHE_CFG.generation` on every
+//   LPM mutation, logically flushing the whole cache; it refills at
+//   line rate. Generation 0 is RESERVED (never valid): kernel
+//   zero-init means an untouched slot is `{dst:0, generation:0}`, so
+//   no false hit is possible for any dst under any live generation —
+//   no init pass needed.
+// - No negative caching: LPM misses are not cached (rare under a full
+//   table, and a stale negative entry is a blackhole-shaped bug).
+//
+// All-u32 fields: zero padding by construction (compile-time asserted)
+// and field-by-field stores — the MutationCtx anti-memset discipline.
+
+/// v4 cache entry. 16 bytes.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FibCacheEntryV4 {
+    /// Destination address, native-endian word of the wire bytes.
+    pub dst: u32,
+    /// `FIB_CACHE_CFG.generation` at fill time. 0 = never filled.
+    pub generation: u32,
+    /// `FibValue.kind` widened to u32 (avoids u8-plus-padding stores).
+    pub kind: u32,
+    /// `FibValue.idx`.
+    pub idx: u32,
+}
+const _: () = assert!(core::mem::size_of::<FibCacheEntryV4>() == 16);
+
+/// v6 cache entry. 28 bytes.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FibCacheEntryV6 {
+    /// Destination address as 4 native-endian words of the wire bytes.
+    pub dst: [u32; 4],
+    pub generation: u32,
+    pub kind: u32,
+    pub idx: u32,
+}
+const _: () = assert!(core::mem::size_of::<FibCacheEntryV6>() == 28);
+
+/// Cache control: enable flag + current generation. One entry, sole
+/// writer is the userspace FibProgrammer task (the enable directive
+/// travels to it over the programmer's command channel — reconcile
+/// never touches this map, keeping the programmer/reconcile writer
+/// domains disjoint). Kernel zero-init = disabled.
+#[repr(C)]
+#[derive(Copy, Clone)]
+pub struct FibCacheCfg {
+    /// 0 = off (default), 1 = on.
+    pub enabled: u32,
+    /// Current generation. 0 reserved — the programmer starts at 1
+    /// and skips 0 on wrap, so a zeroed entry can never match.
+    pub generation: u32,
+}
+const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 8);
+
+/// v4 slot count. Power of two (the probe masks with N-1). Memory:
+/// 65_536 × 16 B × nr_cpus (≈19 MB on an 18-core cn9670) — sized so a
+/// per-CPU working set in the tens of thousands of destinations keeps
+/// collision churn low at ~36 kpps/CPU.
+pub const FIB_CACHE_V4_ENTRIES: u32 = 65_536;
+/// v6 slot count. Smaller: v6 traffic share is materially lower on the
+/// target deployments. 16_384 × 28 B × nr_cpus ≈ 8 MB.
+pub const FIB_CACHE_V6_ENTRIES: u32 = 16_384;
+
+#[map]
+pub static FIB_CACHE_V4: PerCpuArray<FibCacheEntryV4> =
+    PerCpuArray::with_max_entries(FIB_CACHE_V4_ENTRIES, 0);
+
+#[map]
+pub static FIB_CACHE_V6: PerCpuArray<FibCacheEntryV6> =
+    PerCpuArray::with_max_entries(FIB_CACHE_V6_ENTRIES, 0);
+
+#[map]
+pub static FIB_CACHE_CFG: Array<FibCacheCfg> = Array::with_max_entries(1, 0);
 
 // --- Stat increment helpers ----------------------------------------------
 

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -147,6 +147,7 @@ impl RouteController {
         let fib_v4 = FibProgrammer::open_fib_v4(bpffs_root)?;
         let fib_v6 = FibProgrammer::open_fib_v6(bpffs_root)?;
         let ecmp_groups = FibProgrammer::open_ecmp_groups(bpffs_root)?;
+        let cache_cfg = FibProgrammer::open_fib_cache_cfg(bpffs_root)?;
 
         let (resolver, events_rx, neigh_handle) =
             NetlinkNeighborResolver::new(shutdown_token.clone());
@@ -160,6 +161,7 @@ impl RouteController {
             fib_v4,
             fib_v6,
             ecmp_groups,
+            Some(cache_cfg),
             events_rx,
             shutdown_token.clone(),
             Some(neigh_handle.clone()),

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -805,6 +805,21 @@ impl FibProgrammer {
     /// resends the directive unconditionally) retries the toggle.
     fn set_cache_enabled(&mut self, on: bool) {
         if on == self.cache_enabled {
+            // Same-value commands arrive on every SIGHUP reconcile,
+            // which makes them the natural retry hook for a wedged
+            // publication: if the LAST route mutation was the one
+            // whose publish failed and churn then stopped, nothing
+            // else would ever retry, and the frozen reclaim queue
+            // would hold its slots forever while reconcile claimed
+            // convergence. Publishing the current (enabled,
+            // generation) pair is idempotent; success unfreezes.
+            if self.cache_publish_wedged && self.cache_enabled && self.write_cache_cfg() {
+                info!(
+                    generation = self.cache_generation,
+                    "FIB_CACHE_CFG publish recovered on reconcile retry; resuming reclamation"
+                );
+                self.cache_publish_wedged = false;
+            }
             return;
         }
         self.advance_generation();

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -698,32 +698,64 @@ impl FibProgrammer {
     }
 
     // --- Destination cache control ---
+    //
+    // Invariant: `self.cache_enabled` must mirror what a SUCCESSFUL
+    // write last put in the kernel map, because it gates whether
+    // generation bumps are published. If internal state said
+    // "disabled" while the map still said "enabled" (a failed disable
+    // write), route mutations would stop publishing generations and
+    // stale cached FibValues would stay valid past nexthop reclaim —
+    // the exact hazard the generation exists to prevent. Hence:
+    // toggle transitions only commit internal state after the write
+    // succeeds, and a failed publish during a bump is retried once
+    // then escalated loudly (an 8-byte Array::set on a pinned map has
+    // no expected failure mode; if it fails persistently the map is
+    // unwritable and the operator must restart).
 
-    /// Write the current (enabled, generation) pair to FIB_CACHE_CFG.
-    fn write_cache_cfg(&mut self) {
+    /// Write the (enabled, generation) pair to FIB_CACHE_CFG. Returns
+    /// whether the write succeeded (vacuously true with no handle —
+    /// harness-only construction, where there is no kernel state to
+    /// diverge from).
+    fn write_cache_cfg(&mut self) -> bool {
         let value = FibCacheCfg {
             enabled: u32::from(self.cache_enabled),
             generation: self.cache_generation,
         };
-        if let Some(map) = &mut self.cache_cfg {
-            if let Err(e) = map.set(0, value, 0) {
-                warn!(error = %e, "FIB_CACHE_CFG write failed");
-            }
+        match &mut self.cache_cfg {
+            Some(map) => match map.set(0, value, 0) {
+                Ok(()) => true,
+                Err(e) => {
+                    warn!(error = %e, "FIB_CACHE_CFG write failed");
+                    false
+                }
+            },
+            None => true,
         }
     }
 
-    /// Advance the generation (skipping the reserved 0) and, when the
-    /// cache is live, publish it — logically flushing every cached
-    /// entry. Called on every successful FIB LPM mutation; skipping
-    /// the syscall while disabled keeps route churn free when the
-    /// experiment is off.
-    fn bump_cache_generation(&mut self) {
+    /// Advance the generation, skipping the reserved 0.
+    fn advance_generation(&mut self) {
         self.cache_generation = self.cache_generation.wrapping_add(1);
         if self.cache_generation == 0 {
             self.cache_generation = 1;
         }
-        if self.cache_enabled {
-            self.write_cache_cfg();
+    }
+
+    /// Advance the generation and, when the cache is live, publish it
+    /// — logically flushing every cached entry. Called on every
+    /// successful FIB LPM mutation; skipping the syscall while
+    /// disabled keeps route churn free when the experiment is off.
+    /// A failed publish is retried once, then escalated: an
+    /// unpublished bump leaves previously cached FibValues validating
+    /// against the old generation until the next successful publish,
+    /// which reopens the reclaim window the generation closes.
+    fn bump_cache_generation(&mut self) {
+        self.advance_generation();
+        if self.cache_enabled && !self.write_cache_cfg() && !self.write_cache_cfg() {
+            tracing::error!(
+                generation = self.cache_generation,
+                "FIB_CACHE_CFG generation publish failed twice; cached FIB entries                  cannot be invalidated — disable fib-cache and restart packetframe"
+            );
         }
     }
 
@@ -732,21 +764,33 @@ impl FibProgrammer {
     /// publishing, so disable→enable can never resurrect entries
     /// filled under an earlier enable epoch; disable publishes
     /// `enabled = 0`, stopping the BPF probe on the next packet.
+    ///
+    /// Internal state commits ONLY on a successful map write: on
+    /// failure the kernel map is unchanged (map array updates are
+    /// atomic), so keeping the previous `cache_enabled` keeps the
+    /// generation-publication policy consistent with what the BPF
+    /// side actually sees, and the next SIGHUP reconcile (which
+    /// resends the directive unconditionally) retries the toggle.
     fn set_cache_enabled(&mut self, on: bool) {
         if on == self.cache_enabled {
             return;
         }
-        self.cache_generation = self.cache_generation.wrapping_add(1);
-        if self.cache_generation == 0 {
-            self.cache_generation = 1;
-        }
+        self.advance_generation();
+        let prev = self.cache_enabled;
         self.cache_enabled = on;
-        self.write_cache_cfg();
-        info!(
-            enabled = on,
-            generation = self.cache_generation,
-            "fib-cache toggled"
-        );
+        if self.write_cache_cfg() {
+            info!(
+                enabled = on,
+                generation = self.cache_generation,
+                "fib-cache toggled"
+            );
+        } else {
+            self.cache_enabled = prev;
+            warn!(
+                requested = on,
+                "fib-cache toggle NOT applied (map write failed); kernel state                  unchanged, will retry on next reconcile"
+            );
+        }
     }
 
     fn register(&mut self, ip: IpAddr) -> Result<NexthopId, ProgrammerError> {

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -485,10 +485,19 @@ pub struct FibProgrammer {
     /// Mirrors FIB_CACHE_CFG.enabled. Toggled only via
     /// `Command::SetCacheEnabled`.
     cache_enabled: bool,
-    /// Current generation. Starts at 1 and skips 0 on wrap — 0 is the
-    /// reserved never-valid generation that makes kernel-zeroed cache
-    /// slots unable to false-hit.
-    cache_generation: u32,
+    /// Current generation. Starts at 1; 0 is the reserved never-valid
+    /// generation that makes kernel-zeroed cache slots unable to
+    /// false-hit. u64: wrap (and therefore stamp reuse against
+    /// never-cleared slots) is unreachable in any deployment lifetime.
+    cache_generation: u64,
+    /// True while a generation publish has failed and no later write
+    /// has succeeded. While wedged (and enabled), the reclaim queue is
+    /// frozen: the kernel may still be validating cached entries
+    /// against the last published generation, so freeing the nexthop /
+    /// ECMP slots those entries reference would convert an unpublished
+    /// bump into a use-after-reclaim misroute. Slots leak (bounded by
+    /// churn during the wedge) instead — strictly the safer failure.
+    cache_publish_wedged: bool,
 
     // --- Proactive resolve (Phase 3.9 fix) ---
     /// Handle to the NeighborResolver. Every newly-allocated nexthop
@@ -635,6 +644,7 @@ impl FibProgrammer {
                 cache_cfg,
                 cache_enabled: false,
                 cache_generation: 1,
+                cache_publish_wedged: false,
                 neigh_handle,
             },
             FibProgrammerHandle { tx: cmd_tx },
@@ -719,6 +729,7 @@ impl FibProgrammer {
     fn write_cache_cfg(&mut self) -> bool {
         let value = FibCacheCfg {
             enabled: u32::from(self.cache_enabled),
+            _pad: 0,
             generation: self.cache_generation,
         };
         match &mut self.cache_cfg {
@@ -751,12 +762,33 @@ impl FibProgrammer {
     /// which reopens the reclaim window the generation closes.
     fn bump_cache_generation(&mut self) {
         self.advance_generation();
-        if self.cache_enabled && !self.write_cache_cfg() && !self.write_cache_cfg() {
-            tracing::error!(
-                generation = self.cache_generation,
-                "FIB_CACHE_CFG generation publish failed twice; cached FIB entries                  cannot be invalidated — disable fib-cache and restart packetframe"
-            );
+        if !self.cache_enabled {
+            return;
         }
+        if self.write_cache_cfg() || self.write_cache_cfg() {
+            if self.cache_publish_wedged {
+                info!(
+                    generation = self.cache_generation,
+                    "FIB_CACHE_CFG publish recovered; resuming reclamation"
+                );
+                self.cache_publish_wedged = false;
+            }
+            return;
+        }
+        // Publish failed twice: the kernel keeps validating cached
+        // entries against the LAST PUBLISHED generation, so entries
+        // stamped with it stay live. Freeze reclamation (see
+        // drain_reclaim_queue) until a later publish succeeds —
+        // generations are monotonic, so any successful publish
+        // invalidates everything stamped earlier and the queue becomes
+        // safe to drain again.
+        self.cache_publish_wedged = true;
+        tracing::error!(
+            generation = self.cache_generation,
+            "FIB_CACHE_CFG generation publish failed twice; cached FIB entries cannot \
+             be invalidated — reclamation FROZEN (slots will not be reused) until a \
+             publish succeeds. Disable fib-cache and restart packetframe if this persists"
+        );
     }
 
     /// Handle a `SetCacheEnabled` transition. Same-value commands are
@@ -1655,6 +1687,13 @@ impl FibProgrammer {
     // --- Reclaim queue drain (grace-period release) ---
 
     fn drain_reclaim_queue(&mut self) {
+        // While a generation publish is wedged, cached entries stamped
+        // with the last published generation are still being honored by
+        // the BPF side; releasing the slots they point at would be a
+        // use-after-reclaim. Hold everything until a publish succeeds.
+        if self.cache_publish_wedged && self.cache_enabled {
+            return;
+        }
         let now = Instant::now();
         while let Some(entry) = self.reclaim_queue.front() {
             if entry.release_at > now {

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -59,8 +59,8 @@ use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, RouteEvent};
 
 use crate::fib::netlink_neigh::NeighborResolveHandle;
 use crate::fib::types::{
-    EcmpGroup, FibValue, NexthopEntry, ECMP_NH_UNUSED, FIB_KIND_ECMP, MAX_ECMP_PATHS, NH_FAMILY_V4,
-    NH_FAMILY_V6, NH_STATE_FAILED, NH_STATE_INCOMPLETE, NH_STATE_RESOLVED,
+    EcmpGroup, FibCacheCfg, FibValue, NexthopEntry, ECMP_NH_UNUSED, FIB_KIND_ECMP, MAX_ECMP_PATHS,
+    NH_FAMILY_V4, NH_FAMILY_V6, NH_STATE_FAILED, NH_STATE_INCOMPLETE, NH_STATE_RESOLVED,
 };
 use crate::pin;
 
@@ -147,6 +147,18 @@ impl FibProgrammerHandle {
     /// can `unregister` at its own cadence.
     ///
     /// Non-`Send` callers use the blocking `_sync` variant below.
+    /// Flip the destination cache. Synchronous and runtime-agnostic
+    /// (`try_send`): safe from both tokio (SIGHUP reconcile runs on
+    /// the signal thread) and non-tokio contexts, unlike
+    /// `blocking_send`, which panics inside a runtime. The command
+    /// queue holds 8192 entries; if it is genuinely full the flip is
+    /// dropped with a warning and the next reconcile retries.
+    pub fn set_cache_enabled_nowait(&self, on: bool) {
+        if let Err(e) = self.tx.try_send(Command::SetCacheEnabled { on }) {
+            warn!(on, error = %e, "fib-cache toggle dropped (command queue full or shut down)");
+        }
+    }
+
     pub async fn register_nexthop(&self, ip: IpAddr) -> Result<NexthopId, ProgrammerError> {
         let (tx, rx) = oneshot::channel();
         self.tx
@@ -269,6 +281,8 @@ pub fn recording_handle() -> (FibProgrammerHandle, RouteEventLog) {
                 Command::MirrorCounts { reply } => {
                     let _ = reply.send((0, 0));
                 }
+                // Fire-and-forget; nothing to record or reply to.
+                Command::SetCacheEnabled { .. } => {}
             }
         }
     });
@@ -296,6 +310,12 @@ enum Command {
     MirrorCounts {
         reply: oneshot::Sender<(usize, usize)>,
     },
+    /// Flip the destination cache on or off. Fire-and-forget: config
+    /// apply and SIGHUP reconcile send this instead of touching
+    /// FIB_CACHE_CFG themselves — the programmer is the map's sole
+    /// writer, which serializes enable flips against generation bumps
+    /// by construction.
+    SetCacheEnabled { on: bool },
 }
 
 /// Per-nexthop state tracked in userspace. Refcount lets multiple
@@ -457,6 +477,19 @@ pub struct FibProgrammer {
     // --- Default-route reclaim queue (Phase 3) ---
     reclaim_queue: VecDeque<PendingReclaim>,
 
+    // --- Destination cache (v0.2.8, default-off experiment) ---
+    /// FIB_CACHE_CFG handle. `None` in harnesses that don't exercise
+    /// the cache; production (RouteController) always passes `Some`.
+    /// This task is the map's SOLE writer.
+    cache_cfg: Option<Array<MapData, FibCacheCfg>>,
+    /// Mirrors FIB_CACHE_CFG.enabled. Toggled only via
+    /// `Command::SetCacheEnabled`.
+    cache_enabled: bool,
+    /// Current generation. Starts at 1 and skips 0 on wrap — 0 is the
+    /// reserved never-valid generation that makes kernel-zeroed cache
+    /// slots unable to false-hit.
+    cache_generation: u32,
+
     // --- Proactive resolve (Phase 3.9 fix) ---
     /// Handle to the NeighborResolver. Every newly-allocated nexthop
     /// fires `request_resolve(ip)`. The resolver consults its seeded
@@ -523,6 +556,18 @@ impl FibProgrammer {
             .map_err(|e| ProgrammerError::MapOpen(format!("Array::try_from(ECMP_GROUPS): {e}")))
     }
 
+    /// Open the `FIB_CACHE_CFG` single-entry array from its bpffs pin.
+    pub fn open_fib_cache_cfg(
+        bpffs_root: &Path,
+    ) -> Result<Array<MapData, FibCacheCfg>, ProgrammerError> {
+        let pin_path = pin::map_path(bpffs_root, "FIB_CACHE_CFG");
+        let map_data = MapData::from_pin(&pin_path)
+            .map_err(|e| ProgrammerError::MapOpen(format!("FIB_CACHE_CFG pin open: {e}")))?;
+        let map = Map::Array(map_data);
+        Array::try_from(map)
+            .map_err(|e| ProgrammerError::MapOpen(format!("Array::try_from(FIB_CACHE_CFG): {e}")))
+    }
+
     /// Construct the programmer with all four BPF map handles. Opens
     /// are done by the caller (via [`open_nexthops`](Self::open_nexthops) etc.)
     /// so test harnesses can pass synthetic maps. `events_rx` is the
@@ -540,6 +585,7 @@ impl FibProgrammer {
             fib_v4,
             fib_v6,
             ecmp_groups,
+            None,
             events_rx,
             shutdown,
             None,
@@ -552,11 +598,13 @@ impl FibProgrammer {
     /// this with `None`, leaving resolution to multicast events
     /// only. Production callers (RouteController) MUST pass `Some`
     /// or BGP nexthops will not resolve cleanly.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_with_resolver(
         nexthops: Array<MapData, NexthopEntry>,
         fib_v4: LpmTrie<MapData, [u8; 4], FibValue>,
         fib_v6: LpmTrie<MapData, [u8; 16], FibValue>,
         ecmp_groups: Array<MapData, EcmpGroup>,
+        cache_cfg: Option<Array<MapData, FibCacheCfg>>,
         events_rx: mpsc::Receiver<NeighEvent>,
         shutdown: CancellationToken,
         neigh_handle: Option<NeighborResolveHandle>,
@@ -584,6 +632,9 @@ impl FibProgrammer {
                 free_ecmp_ids: Vec::new(),
                 next_ecmp_id: 0,
                 reclaim_queue: VecDeque::new(),
+                cache_cfg,
+                cache_enabled: false,
+                cache_generation: 1,
                 neigh_handle,
             },
             FibProgrammerHandle { tx: cmd_tx },
@@ -642,7 +693,60 @@ impl FibProgrammer {
             Command::MirrorCounts { reply } => {
                 let _ = reply.send((self.routes_v4.len(), self.routes_v6.len()));
             }
+            Command::SetCacheEnabled { on } => self.set_cache_enabled(on),
         }
+    }
+
+    // --- Destination cache control ---
+
+    /// Write the current (enabled, generation) pair to FIB_CACHE_CFG.
+    fn write_cache_cfg(&mut self) {
+        let value = FibCacheCfg {
+            enabled: u32::from(self.cache_enabled),
+            generation: self.cache_generation,
+        };
+        if let Some(map) = &mut self.cache_cfg {
+            if let Err(e) = map.set(0, value, 0) {
+                warn!(error = %e, "FIB_CACHE_CFG write failed");
+            }
+        }
+    }
+
+    /// Advance the generation (skipping the reserved 0) and, when the
+    /// cache is live, publish it — logically flushing every cached
+    /// entry. Called on every successful FIB LPM mutation; skipping
+    /// the syscall while disabled keeps route churn free when the
+    /// experiment is off.
+    fn bump_cache_generation(&mut self) {
+        self.cache_generation = self.cache_generation.wrapping_add(1);
+        if self.cache_generation == 0 {
+            self.cache_generation = 1;
+        }
+        if self.cache_enabled {
+            self.write_cache_cfg();
+        }
+    }
+
+    /// Handle a `SetCacheEnabled` transition. Same-value commands are
+    /// no-ops. A transition always advances the generation before
+    /// publishing, so disable→enable can never resurrect entries
+    /// filled under an earlier enable epoch; disable publishes
+    /// `enabled = 0`, stopping the BPF probe on the next packet.
+    fn set_cache_enabled(&mut self, on: bool) {
+        if on == self.cache_enabled {
+            return;
+        }
+        self.cache_generation = self.cache_generation.wrapping_add(1);
+        if self.cache_generation == 0 {
+            self.cache_generation = 1;
+        }
+        self.cache_enabled = on;
+        self.write_cache_cfg();
+        info!(
+            enabled = on,
+            generation = self.cache_generation,
+            "fib-cache toggled"
+        );
     }
 
     fn register(&mut self, ip: IpAddr) -> Result<NexthopId, ProgrammerError> {
@@ -1171,7 +1275,16 @@ impl FibProgrammer {
                 None => return Ok(()),
             };
             self.delete_fib_entry(&prefix)?;
-            self.reclaim_immediate(rec.fib_value, rec.nexthop_ips);
+            // Grace-deferred even though the LPM entry is gone: with
+            // the destination cache, an in-flight invocation that
+            // passed its generation check microseconds before the
+            // delete's bump can still dereference the cached FibValue.
+            // Freeing the IDs instantly would let `register` reuse the
+            // slot for a different neighbor inside that window
+            // (misroute); 100 ms of slot residency is the entire cost
+            // of closing it, so the deferral is unconditional rather
+            // than cache-gated — one lifecycle, strictly safer.
+            self.reclaim_prior(Some(rec.fib_value), rec.nexthop_ips);
             return Ok(());
         }
 
@@ -1268,19 +1381,6 @@ impl FibProgrammer {
         }
     }
 
-    /// Free a torn-down prefix's resources immediately. Safe because
-    /// the BPF LPM entry has already been removed; lookups return
-    /// no-match right away, so no in-flight reader can dereference
-    /// these IDs after the deletion.
-    fn reclaim_immediate(&mut self, fib: FibValue, nh_ips: Vec<IpAddr>) {
-        if fib.kind == FIB_KIND_ECMP {
-            self.free_ecmp_group(fib.idx);
-        }
-        for ip in nh_ips {
-            let _ = self.unregister(ip);
-        }
-    }
-
     // --- Mirror ops ---
 
     fn lookup_mirror(&self, prefix: &IpPrefix) -> Option<&RouteRecord> {
@@ -1345,12 +1445,20 @@ impl FibProgrammer {
 
     // --- FIB map ops ---
 
+    // The two functions below are the ONLY places the FIB LPM tries
+    // are mutated, which makes them the destination cache's generation
+    // choke points: every successful insert/remove bumps the global
+    // generation (invalidating all cached entries) BEFORE any caller
+    // reclaims nexthop IDs. recompute_fib_entry's no-change shortcut
+    // returns before reaching either, so no-op recomputes during BGP
+    // churn don't flush the cache.
+
     fn write_fib_entry(
         &mut self,
         prefix: &IpPrefix,
         value: FibValue,
     ) -> Result<(), ProgrammerError> {
-        match prefix {
+        let result = match prefix {
             IpPrefix::V4 { addr, prefix_len } => {
                 if self.routes_v4.len() as u32 >= FIB_V4_CAP
                     && !self.routes_v4.contains_key(&(*addr, *prefix_len))
@@ -1373,11 +1481,15 @@ impl FibProgrammer {
                     .insert(&key, value, 0)
                     .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V6 insert: {e}")))
             }
+        };
+        if result.is_ok() {
+            self.bump_cache_generation();
         }
+        result
     }
 
     fn delete_fib_entry(&mut self, prefix: &IpPrefix) -> Result<(), ProgrammerError> {
-        match prefix {
+        let result = match prefix {
             IpPrefix::V4 { addr, prefix_len } => {
                 let key = LpmKey::new(u32::from(*prefix_len), *addr);
                 self.fib_v4
@@ -1390,7 +1502,11 @@ impl FibProgrammer {
                     .remove(&key)
                     .map_err(|e| ProgrammerError::MapWrite(format!("FIB_V6 remove: {e}")))
             }
+        };
+        if result.is_ok() {
+            self.bump_cache_generation();
         }
+        result
     }
 
     // --- ECMP group ops ---

--- a/crates/modules/fast-path/src/fib/types.rs
+++ b/crates/modules/fast-path/src/fib/types.rs
@@ -182,9 +182,13 @@ unsafe impl aya::Pod for FpFibCfg {}
 pub struct FibCacheCfg {
     /// 0 = off (default; kernel zero-init), 1 = on.
     pub enabled: u32,
+    /// Explicit padding; always written as 0.
+    pub _pad: u32,
     /// Current generation. 0 is reserved (never issued): a zeroed
     /// cache slot can then never compare equal to a live generation.
-    pub generation: u32,
+    /// u64 so wrap-reuse against never-cleared slots is unreachable
+    /// in any deployment lifetime.
+    pub generation: u64,
 }
 
 // SAFETY: repr(C), two u32s, every bit pattern valid.
@@ -209,8 +213,8 @@ const _: () = assert!(core::mem::align_of::<EcmpGroup>() == 4);
 const _: () = assert!(core::mem::size_of::<FpFibCfg>() == 8);
 const _: () = assert!(core::mem::align_of::<FpFibCfg>() == 4);
 
-const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 8);
-const _: () = assert!(core::mem::align_of::<FibCacheCfg>() == 4);
+const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 16);
+const _: () = assert!(core::mem::align_of::<FibCacheCfg>() == 8);
 
 #[cfg(test)]
 mod tests {

--- a/crates/modules/fast-path/src/fib/types.rs
+++ b/crates/modules/fast-path/src/fib/types.rs
@@ -169,6 +169,28 @@ impl FpFibCfg {
 #[cfg(target_os = "linux")]
 unsafe impl aya::Pod for FpFibCfg {}
 
+// --- FibCacheCfg --------------------------------------------------------
+
+/// Userspace mirror of `maps::FibCacheCfg`: the destination-cache
+/// enable flag + global generation. 8 bytes. Sole writer is the
+/// FibProgrammer task (reconcile talks to it over the command channel
+/// instead of touching the map — the programmer/reconcile writer
+/// domains stay disjoint). The cache *entry* structs deliberately have
+/// no userspace mirror: userspace never reads or writes cache slots.
+#[repr(C)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct FibCacheCfg {
+    /// 0 = off (default; kernel zero-init), 1 = on.
+    pub enabled: u32,
+    /// Current generation. 0 is reserved (never issued): a zeroed
+    /// cache slot can then never compare equal to a live generation.
+    pub generation: u32,
+}
+
+// SAFETY: repr(C), two u32s, every bit pattern valid.
+#[cfg(target_os = "linux")]
+unsafe impl aya::Pod for FibCacheCfg {}
+
 // --- Layout assertions -------------------------------------------------
 //
 // These match the layouts declared in `bpf/src/maps.rs`. Any drift on
@@ -186,6 +208,9 @@ const _: () = assert!(core::mem::align_of::<EcmpGroup>() == 4);
 
 const _: () = assert!(core::mem::size_of::<FpFibCfg>() == 8);
 const _: () = assert!(core::mem::align_of::<FpFibCfg>() == 4);
+
+const _: () = assert!(core::mem::size_of::<FibCacheCfg>() == 8);
+const _: () = assert!(core::mem::align_of::<FibCacheCfg>() == 4);
 
 #[cfg(test)]
 mod tests {

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -134,6 +134,18 @@ pub(crate) fn vlan_subifs_present() -> bool {
     read_vlan_config().map(|v| !v.is_empty()).unwrap_or(false)
 }
 
+/// The `fib-cache` directive value; absent = off (the experiment is
+/// opt-in).
+pub(crate) fn fib_cache_enabled(directives: &[ModuleDirective]) -> bool {
+    directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::FibCache(v) => Some(*v),
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
 /// Whether the `bridge-resolve` directive enables the bridge egress
 /// short-circuit. Default (no directive) is `Auto` = enabled; `On` is
 /// a documented synonym for `Auto` (there is nothing to force — an
@@ -1464,12 +1476,24 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
         .map_err(|e| {
             ModuleError::other(MODULE_NAME, format!("RouteController start failed: {e}"))
         })?;
+        // The destination cache rides the programmer's command
+        // channel: the programmer is FIB_CACHE_CFG's sole writer, so
+        // config apply (here) and SIGHUP reconcile both just send the
+        // desired state. Default off; the map's kernel-zeroed content
+        // IS the off state, so nothing is written unless enabling.
+        if fib_cache_enabled(&cfg.section.directives) {
+            ctrl.programmer_handle().set_cache_enabled_nowait(true);
+            info!("fib-cache enabled (destination cache in front of the FIB LPM)");
+        }
         state.route_controller = Some(ctrl);
         info!(
             ?forwarding,
             "RouteController started (NeighborResolver + FibProgrammer active)"
         );
     } else {
+        if fib_cache_enabled(&cfg.section.directives) {
+            warn!("fib-cache on has no effect in kernel-fib mode (no custom FIB to cache)");
+        }
         info!(
             ?forwarding,
             "RouteController not started (kernel-fib mode); Option F control plane idle"

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -31,7 +31,7 @@ use std::fmt::Write as _;
 /// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
 /// tail-call diagnostics from the Prometheus export; a separate
 /// hardcoded 37 hid `pass_ndp` from `packetframe status`).
-pub const COUNTER_NAMES: [&str; 42] = [
+pub const COUNTER_NAMES: [&str; 45] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -80,6 +80,11 @@ pub const COUNTER_NAMES: [&str; 42] = [
     // --- Phase T: tc-ingress datapath A/B attribution ---
     "rx_total_tc",
     "fwd_ok_tc",
+    // --- v0.2.8: FIB destination cache (default-off experiment) ---
+    // Mutually exclusive probe outcomes; hit rate = hit/(hit+miss+stale).
+    "fib_cache_hit",
+    "fib_cache_miss",
+    "fib_cache_stale",
 ];
 
 /// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
@@ -231,12 +236,15 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 42);
+        assert_eq!(COUNTER_NAMES.len(), 45);
         assert_eq!(COUNTER_NAMES.len(), COUNTER_COUNT);
         // The newest counters, as a canary that the tail of the list
         // stayed aligned with the `StatIdx` discriminants.
         assert_eq!(COUNTER_NAMES[40], "rx_total_tc");
         assert_eq!(COUNTER_NAMES[41], "fwd_ok_tc");
+        assert_eq!(COUNTER_NAMES[42], "fib_cache_hit");
+        assert_eq!(COUNTER_NAMES[43], "fib_cache_miss");
+        assert_eq!(COUNTER_NAMES[44], "fib_cache_stale");
     }
 
     #[test]

--- a/crates/modules/fast-path/src/pin.rs
+++ b/crates/modules/fast-path/src/pin.rs
@@ -22,7 +22,7 @@ use std::path::{Path, PathBuf};
 use crate::MODULE_NAME;
 
 /// Every §4.5 map that gets pinned. Order is not significant.
-pub const MAP_NAMES: [&str; 20] = [
+pub const MAP_NAMES: [&str; 23] = [
     "ALLOW_V4",
     "ALLOW_V6",
     "CFG",
@@ -54,6 +54,13 @@ pub const MAP_NAMES: [&str; 20] = [
     // --- v0.2.7: per-CPU scratch for bpf_fib_lookup (replaces the
     // stack-allocated struct that was triggering memset libcalls).
     "FIB_LOOKUP_SCRATCH",
+    // --- v0.2.8: FIB destination cache (default-off experiment).
+    // Same rationale as the FIB maps: present in the ELF regardless
+    // of whether `fib-cache` is on, pinned for uniform detach. The
+    // programmer opens FIB_CACHE_CFG from its pin.
+    "FIB_CACHE_V4",
+    "FIB_CACHE_V6",
+    "FIB_CACHE_CFG",
 ];
 
 /// The fast-path XDP program's pinned basename (attached per-iface).

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -23,10 +23,10 @@ use packetframe_common::{
 use tracing::{info, warn};
 
 use crate::linux_impl::{
-    discover_bridge_chains, feature_flags_from_config, fib_flags_from_forwarding_mode,
-    if_nametoindex, mss_clamp_global_value, read_vlan_config, set_cfg_flag, ActiveState, FpCfg,
-    MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128, FP_CFG_FLAG_VLAN_PRESENT,
-    FP_CFG_VERSION_V2,
+    discover_bridge_chains, feature_flags_from_config, fib_cache_enabled,
+    fib_flags_from_forwarding_mode, if_nametoindex, mss_clamp_global_value, read_vlan_config,
+    set_cfg_flag, ActiveState, FpCfg, MssClampValue, VlanResolve, FP_CFG_FLAG_HEAD_SHIFT_128,
+    FP_CFG_FLAG_VLAN_PRESENT, FP_CFG_VERSION_V2,
 };
 use crate::MODULE_NAME;
 
@@ -46,6 +46,7 @@ pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResul
     let mss_clamp = reconcile_mss_clamp(state, cfg)?;
     let vlan = reconcile_vlan_resolve(state, cfg)?;
     let devmap = reconcile_devmap(state)?;
+    reconcile_fib_cache(state, cfg);
 
     info!(
         v4_added = v4.added,
@@ -380,6 +381,27 @@ pub(crate) fn reconcile_vlan_resolve(
         !desired.is_empty(),
     )?;
     Ok(delta)
+}
+
+/// Forward the `fib-cache` directive to the FibProgrammer. The
+/// programmer owns FIB_CACHE_CFG (reconcile never touches the map —
+/// the writer domains stay disjoint) and treats same-value commands
+/// as no-ops, so sending unconditionally on every SIGHUP is cheap and
+/// converges. A toggle transition bumps the generation inside the
+/// programmer, so re-enabling can't resurrect entries cached under an
+/// earlier enable epoch. In kernel-fib mode there is no controller
+/// and the directive is inert (warned at attach).
+fn reconcile_fib_cache(state: &mut ActiveState, cfg: &ModuleConfig<'_>) {
+    let want = fib_cache_enabled(&cfg.section.directives);
+    if let Some(ctrl) = &state.route_controller {
+        ctrl.programmer_handle().set_cache_enabled_nowait(want);
+        info!(
+            enabled = want,
+            "fib-cache directive forwarded to FibProgrammer"
+        );
+    } else if want {
+        warn!("fib-cache on ignored: no RouteController (kernel-fib mode)");
+    }
 }
 
 /// Reconcile REDIRECT_DEVMAP against the current `/sys/class/net`

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -287,13 +287,14 @@ impl Harness {
     /// `generation`. In production the FibProgrammer is the sole
     /// writer; tests poke the map directly to simulate its behavior
     /// (enable, and later bump the generation to invalidate).
-    pub fn set_fib_cache(&mut self, enabled: u32, generation: u32) {
-        /// Layout mirror of `FibCacheCfg` in `bpf/src/maps.rs`.
+    pub fn set_fib_cache(&mut self, enabled: u32, generation: u64) {
+        /// Layout mirror of `FibCacheCfg` in `bpf/src/maps.rs` (16 B).
         #[repr(C)]
         #[derive(Copy, Clone)]
         struct FibCacheCfg {
             enabled: u32,
-            generation: u32,
+            _pad: u32,
+            generation: u64,
         }
         unsafe impl Pod for FibCacheCfg {}
 
@@ -306,6 +307,7 @@ impl Harness {
             0,
             FibCacheCfg {
                 enabled,
+                _pad: 0,
                 generation,
             },
             0,

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -55,7 +55,7 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V2: u32 = 1;
-pub const STATS_COUNT: u32 = 42;
+pub const STATS_COUNT: u32 = 45;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.
@@ -117,6 +117,9 @@ pub enum StatIdx {
     ErrRedirectFailed = 39,
     RxTotalTc = 40,
     FwdOkTc = 41,
+    FibCacheHit = 42,
+    FibCacheMiss = 43,
+    FibCacheStale = 44,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a
@@ -278,6 +281,36 @@ impl Harness {
             mss_clamp_global: 0,
             version: FP_CFG_VERSION_V2,
         });
+    }
+
+    /// Write the destination-cache control entry: `enabled` (0/1) +
+    /// `generation`. In production the FibProgrammer is the sole
+    /// writer; tests poke the map directly to simulate its behavior
+    /// (enable, and later bump the generation to invalidate).
+    pub fn set_fib_cache(&mut self, enabled: u32, generation: u32) {
+        /// Layout mirror of `FibCacheCfg` in `bpf/src/maps.rs`.
+        #[repr(C)]
+        #[derive(Copy, Clone)]
+        struct FibCacheCfg {
+            enabled: u32,
+            generation: u32,
+        }
+        unsafe impl Pod for FibCacheCfg {}
+
+        let map = self
+            .bpf
+            .map_mut("FIB_CACHE_CFG")
+            .expect("FIB_CACHE_CFG map");
+        let mut arr: Array<_, FibCacheCfg> = Array::try_from(map).expect("Array try_from");
+        arr.set(
+            0,
+            FibCacheCfg {
+                enabled,
+                generation,
+            },
+            0,
+        )
+        .expect("FIB_CACHE_CFG set");
     }
 
     /// Insert an IPv4 prefix into the BLOCK_V4 trie. Callers must also

--- a/crates/modules/fast-path/tests/fib_fixtures.rs
+++ b/crates/modules/fast-path/tests/fib_fixtures.rs
@@ -515,3 +515,240 @@ fn set_nexthop_seq_permanent_odd(h: &mut Harness, idx: u32) {
     entry.seq = 0xdead_beef; // odd (low bit 1)
     arr.set(idx, entry, 0).expect("NEXTHOPS set");
 }
+
+// ========== FIB destination cache (v0.2.8, default-off) ==================
+//
+// The cache stores the FibValue keyed on the full dst and stamped with
+// the FIB_CACHE_CFG generation. Everything downstream of the FibValue
+// (NEXTHOPS seqlock read, ECMP flow hash) runs identically on hits, so
+// the assertions below lean on output-byte equality between cold and
+// warm runs. In production the FibProgrammer is the map's sole writer;
+// these tests poke FIB_CACHE_CFG directly to simulate enable/bump.
+
+const NEXTHOP_MAC_B: [u8; 6] = [0xde, 0xad, 0xbe, 0xef, 0, 0x0b];
+
+fn cache_pkt(dst_last: u8) -> Vec<u8> {
+    Ipv4TcpBuilder {
+        src_ip: [10, 0, 0, 5],
+        dst_ip: [10, 0, 0, dst_last],
+        ..Default::default()
+    }
+    .build()
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_off_is_byte_identical_and_counts_nothing() {
+    // Default state: FIB_CACHE_CFG untouched (kernel-zeroed = off).
+    let mut h = prep_custom_fib_harness();
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+
+    let pkt = cache_pkt(42);
+    let (v1, out1) = h.run(&pkt);
+    let (v2, out2) = h.run(&pkt);
+    assert_eq!(v1, xdp_action::XDP_REDIRECT);
+    assert_eq!(v2, xdp_action::XDP_REDIRECT);
+    assert_eq!(out1, out2, "off = repeat runs byte-identical");
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 0);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 0);
+    assert_eq!(h.stat(StatIdx::FibCacheStale), 0);
+    assert_eq!(h.stat(StatIdx::CustomFibHit), 2);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_v4_hit_skips_lpm_with_identical_output() {
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+
+    let pkt = cache_pkt(42);
+    let (v1, out1) = h.run(&pkt); // cold: probe misses, LPM walks, slot refills
+    assert_eq!(v1, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 1);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 0);
+
+    let (v2, out2) = h.run(&pkt); // warm: probe hits, LPM skipped
+    assert_eq!(v2, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 1);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 1, "no second miss");
+    assert_eq!(out1, out2, "cached FibValue must resolve identically");
+    // A cache hit is still a FIB hit — route-decision counters keep
+    // their semantics.
+    assert_eq!(h.stat(StatIdx::CustomFibHit), 2);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_stale_generation_refills_with_new_route() {
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_nexthop_v4(2, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC_B);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+
+    let pkt = cache_pkt(42);
+    let _ = h.run(&pkt); // warm the slot under gen 1 → NH 1
+
+    // Route change: prefix now points at NH 2; the programmer would
+    // bump the generation right after the LPM write.
+    h.add_fib_v4_single("10.0.0.0/24", 2);
+    h.set_fib_cache(1, 2);
+
+    let (v3, out3) = h.run(&pkt);
+    assert_eq!(v3, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheStale), 1, "gen mismatch detected");
+    assert_eq!(
+        &out3[0..6],
+        &NEXTHOP_MAC_B,
+        "stale entry must NOT be used; fresh LPM resolves NH 2"
+    );
+
+    let (v4, out4) = h.run(&pkt);
+    assert_eq!(v4, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 1, "refilled under gen 2");
+    assert_eq!(&out4[0..6], &NEXTHOP_MAC_B);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_ecmp_flow_placement_preserved() {
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v4("10.0.0.0/8");
+    let dmac_a: [u8; 6] = [0xaa, 0, 0, 0, 0, 0x01];
+    let dmac_b: [u8; 6] = [0xbb, 0, 0, 0, 0, 0x02];
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, dmac_a);
+    h.add_nexthop_v4(2, LO_IFINDEX, EGRESS_MAC, dmac_b);
+    h.add_ecmp_group(0, 5, &[1, 2]);
+    h.add_fib_v4_ecmp("10.0.0.0/24", 0);
+
+    // Each flow (distinct sport) must land on the same leg cold and
+    // warm: the cache stores the FibValue (group ref), so the per-flow
+    // 5-tuple hash still runs on hits.
+    for sport in [1000u16, 1001, 1002, 1003, 1004, 1005, 1006, 1007] {
+        let pkt = Ipv4TcpBuilder {
+            src_ip: [10, 0, 0, 5],
+            dst_ip: [10, 0, 0, 42],
+            src_port: sport,
+            ..Default::default()
+        }
+        .build();
+        let (v_cold, out_cold) = h.run(&pkt);
+        let (v_warm, out_warm) = h.run(&pkt);
+        assert_eq!(v_cold, xdp_action::XDP_REDIRECT);
+        assert_eq!(v_warm, xdp_action::XDP_REDIRECT);
+        assert_eq!(
+            &out_cold[0..6],
+            &out_warm[0..6],
+            "flow sport={sport} must keep its ECMP leg across cache warm-up"
+        );
+    }
+    assert!(
+        h.stat(StatIdx::FibCacheHit) >= 8,
+        "second run of each flow (same dst) must hit"
+    );
+    assert_eq!(
+        h.stat(StatIdx::EcmpHashV4),
+        16,
+        "ECMP hash runs on every packet, cached or not"
+    );
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_nexthop_churn_needs_no_invalidation() {
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+
+    let pkt = cache_pkt(42);
+    let _ = h.run(&pkt); // warm
+
+    // Neighbor churn: same nexthop ID, new MAC. No generation bump —
+    // the cached FibValue is an index, and the per-packet seqlock read
+    // picks up the rewrite.
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC_B);
+    let (v, out) = h.run(&pkt);
+    assert_eq!(v, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 1, "still a cache hit");
+    assert_eq!(
+        &out[0..6],
+        &NEXTHOP_MAC_B,
+        "cache hit must carry the NEW nexthop MAC"
+    );
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_v6_hit_and_stale() {
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v6("2001:db8::/32");
+    h.add_nexthop_v6(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_nexthop_v6(2, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC_B);
+    h.add_fib_v6_single("2001:db8::/32", 1);
+
+    let pkt = Ipv6TcpBuilder::default().build();
+    let _ = h.run(&pkt);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 1);
+    let (v2, out2) = h.run(&pkt);
+    assert_eq!(v2, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 1);
+    assert_eq!(&out2[0..6], &NEXTHOP_MAC);
+
+    h.add_fib_v6_single("2001:db8::/32", 2);
+    h.set_fib_cache(1, 2);
+    let (v3, out3) = h.run(&pkt);
+    assert_eq!(v3, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheStale), 1);
+    assert_eq!(&out3[0..6], &NEXTHOP_MAC_B);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_zeroed_slot_never_false_hits() {
+    // Enable with an arbitrary live generation but never warm the
+    // slot: a kernel-zeroed entry is {dst:0, gen:0} and gen 0 is
+    // reserved, so the first packet must be a MISS, never a hit.
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 7);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+
+    let (v, _) = h.run(&cache_pkt(42));
+    assert_eq!(v, xdp_action::XDP_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 1);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 0);
+    assert_eq!(h.stat(StatIdx::FibCacheStale), 0);
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn fib_cache_hit_on_tc_datapath() {
+    // fib.rs is shared by both datapaths; prove the cache works under
+    // the tc classifiers too.
+    let mut h = prep_custom_fib_harness();
+    h.set_fib_cache(1, 1);
+    h.add_allow_v4("10.0.0.0/8");
+    h.add_nexthop_v4(1, LO_IFINDEX, EGRESS_MAC, NEXTHOP_MAC);
+    h.add_fib_v4_single("10.0.0.0/24", 1);
+    h.add_tc_redirect_target(LO_IFINDEX);
+
+    let pkt = cache_pkt(42);
+    let (v1, out1) = h.run_tc(&pkt);
+    assert_eq!(v1, common::tc_action::TC_ACT_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheMiss), 1);
+    let (v2, out2) = h.run_tc(&pkt);
+    assert_eq!(v2, common::tc_action::TC_ACT_REDIRECT);
+    assert_eq!(h.stat(StatIdx::FibCacheHit), 1);
+    assert_eq!(out1, out2);
+}

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -34,8 +34,8 @@ use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent};
 use packetframe_fast_path::aligned_bpf_copy;
 use packetframe_fast_path::fib::programmer::FibProgrammer;
 use packetframe_fast_path::fib::types::{
-    EcmpGroup, FibValue, NexthopEntry, FIB_KIND_ECMP, FIB_KIND_SINGLE, NH_FAMILY_V4, NH_FAMILY_V6,
-    NH_STATE_INCOMPLETE,
+    EcmpGroup, FibCacheCfg, FibValue, NexthopEntry, FIB_KIND_ECMP, FIB_KIND_SINGLE, NH_FAMILY_V4,
+    NH_FAMILY_V6, NH_STATE_INCOMPLETE,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -133,7 +133,13 @@ impl Drop for PinDirs {
 fn load_and_pin(pins: &PinDirs) -> Ebpf {
     let bytes = aligned_bpf_copy();
     let ebpf = Ebpf::load(&bytes).expect("Ebpf::load");
-    for name in ["NEXTHOPS", "FIB_V4", "FIB_V6", "ECMP_GROUPS"] {
+    for name in [
+        "NEXTHOPS",
+        "FIB_V4",
+        "FIB_V6",
+        "ECMP_GROUPS",
+        "FIB_CACHE_CFG",
+    ] {
         let path = pins.path(name);
         ebpf.map(name)
             .unwrap_or_else(|| panic!("{name} map missing from ELF"))
@@ -216,6 +222,51 @@ impl ProgrammerHarness {
             handle,
             task: Some(task),
         }
+    }
+
+    /// Variant wiring the FIB_CACHE_CFG handle into the programmer,
+    /// for the destination-cache generation tests. Kept separate so
+    /// the existing tests keep exercising the `new()` shortcut
+    /// (cache-less construction must stay supported for harnesses).
+    fn new_with_cache() -> Self {
+        let pins = PinDirs::setup();
+        let ebpf = load_and_pin(&pins);
+        let nexthops: Array<MapData, NexthopEntry> = open_array(&pins.path("NEXTHOPS"));
+        let fib_v4 = open_lpm_v4(&pins.path("FIB_V4"));
+        let fib_v6 = open_lpm_v6(&pins.path("FIB_V6"));
+        let ecmp_groups: Array<MapData, EcmpGroup> = open_array(&pins.path("ECMP_GROUPS"));
+        let cache_cfg: Array<MapData, FibCacheCfg> = open_array(&pins.path("FIB_CACHE_CFG"));
+        let shutdown = CancellationToken::new();
+        let (_events_tx, events_rx) = tokio::sync::mpsc::channel(16);
+        let (programmer, handle) = FibProgrammer::new_with_resolver(
+            nexthops,
+            fib_v4,
+            fib_v6,
+            ecmp_groups,
+            Some(cache_cfg),
+            events_rx,
+            shutdown.clone(),
+            None,
+        );
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let task = rt.spawn(programmer.run());
+        Self {
+            pins,
+            _ebpf: ebpf,
+            rt,
+            shutdown,
+            handle,
+            task: Some(task),
+        }
+    }
+
+    /// Read FIB_CACHE_CFG via a fresh handle.
+    fn read_cache_cfg(&self) -> FibCacheCfg {
+        let arr: Array<MapData, FibCacheCfg> = open_array(&self.pins.path("FIB_CACHE_CFG"));
+        arr.get(&0, 0).expect("FIB_CACHE_CFG get")
     }
 
     /// Block on an async call against the programmer from sync test code.
@@ -1300,4 +1351,142 @@ fn add_path_lp_none_treated_as_default_100() {
     );
     let group = h.read_ecmp_group(fib.idx);
     assert_eq!(group.nh_count, 2);
+}
+
+/// Destination-cache generation ownership: every real LPM mutation
+/// bumps FIB_CACHE_CFG.generation, no-op recomputes don't, enable /
+/// disable transitions bump and publish, and torn-down nexthop slots
+/// are grace-deferred (never tombstoned instantly) so a cached
+/// FibValue can't observe a freed-and-reused slot.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn fib_cache_generation_semantics() {
+    let h = ProgrammerHarness::new_with_cache();
+    let prefix = IpPrefix::V4 {
+        addr: [203, 0, 113, 0],
+        prefix_len: 24,
+    };
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 21));
+    let peer = PeerId(0x3333);
+    let add = RouteEvent::Add {
+        peer_id: peer,
+        prefix,
+        nexthops: vec![nh],
+        path_id: None,
+        local_pref: None,
+    };
+    // Awaited no-op used as an ordering barrier behind the
+    // fire-and-forget toggle command (the loop is single-threaded, so
+    // a replied command proves everything queued before it ran).
+    let barrier = RouteEvent::Del {
+        peer_id: PeerId(0x9999),
+        prefix: IpPrefix::V4 {
+            addr: [192, 0, 2, 0],
+            prefix_len: 24,
+        },
+        path_id: None,
+    };
+
+    // Before enable: map is kernel-zeroed (off).
+    let cfg0 = h.read_cache_cfg();
+    assert_eq!(cfg0.enabled, 0);
+    assert_eq!(cfg0.generation, 0);
+
+    // Enable: transition bumps (1 → 2) and publishes.
+    h.handle.set_cache_enabled_nowait(true);
+    h.run(async {
+        h.handle.apply_route_event(barrier.clone()).await.unwrap();
+    });
+    let cfg1 = h.read_cache_cfg();
+    assert_eq!(cfg1.enabled, 1);
+    assert_eq!(
+        cfg1.generation, 2,
+        "enable transition bumps past the initial 1"
+    );
+
+    // Real Add → write_fib_entry bumps.
+    h.run(async {
+        h.handle.apply_route_event(add.clone()).await.unwrap();
+    });
+    let cfg2 = h.read_cache_cfg();
+    assert_eq!(cfg2.generation, 3, "LPM insert bumps");
+
+    // Identical re-Add → no-change shortcut, no bump.
+    h.run(async {
+        h.handle.apply_route_event(add.clone()).await.unwrap();
+    });
+    assert_eq!(
+        h.read_cache_cfg().generation,
+        3,
+        "no-op recompute must not flush the cache"
+    );
+
+    // Capture the nexthop slot before withdrawal.
+    let nexthops: Array<MapData, NexthopEntry> = open_array(&h.pins.path("NEXTHOPS"));
+    let entry_before: NexthopEntry = nexthops.get(&0, 0).expect("NEXTHOPS[0]");
+    assert_ne!(
+        entry_before.state,
+        packetframe_fast_path::fib::types::NH_STATE_FAILED
+    );
+
+    // Del → delete_fib_entry bumps, and the slot is grace-deferred:
+    // immediately after the (awaited) Del it must NOT be tombstoned.
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer,
+                prefix,
+                path_id: None,
+            })
+            .await
+            .unwrap();
+    });
+    assert_eq!(h.read_cache_cfg().generation, 4, "LPM remove bumps");
+    let entry_now: NexthopEntry = nexthops.get(&0, 0).expect("NEXTHOPS[0]");
+    assert_ne!(
+        entry_now.state,
+        packetframe_fast_path::fib::types::NH_STATE_FAILED,
+        "reclaim must be grace-deferred, not immediate"
+    );
+    // After the 100 ms grace + a few 50 ms reclaim ticks, the slot is
+    // tombstoned.
+    h.run(async {
+        tokio::time::sleep(Duration::from_millis(350)).await;
+    });
+    let entry_later: NexthopEntry = nexthops.get(&0, 0).expect("NEXTHOPS[0]");
+    assert_eq!(
+        entry_later.state,
+        packetframe_fast_path::fib::types::NH_STATE_FAILED,
+        "grace elapsed → slot tombstoned"
+    );
+
+    // Disable: transition bumps and publishes enabled = 0.
+    h.handle.set_cache_enabled_nowait(false);
+    h.run(async {
+        h.handle.apply_route_event(barrier).await.unwrap();
+    });
+    let cfg_off = h.read_cache_cfg();
+    assert_eq!(cfg_off.enabled, 0);
+    assert_eq!(cfg_off.generation, 5, "disable transition bumps");
+
+    // Same-value command is a no-op.
+    h.handle.set_cache_enabled_nowait(false);
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: PeerId(0x9998),
+                prefix: IpPrefix::V4 {
+                    addr: [192, 0, 2, 0],
+                    prefix_len: 25,
+                },
+                path_id: None,
+            })
+            .await
+            .unwrap();
+    });
+    assert_eq!(
+        h.read_cache_cfg().generation,
+        5,
+        "same-value toggle is a no-op"
+    );
 }

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -491,7 +491,7 @@ What it caches, and why the design is safe:
   under sustained BGP churn it is effectively always cold — `fib_cache_stale`
   measures exactly that.
 - **No negative caching**: unroutable destinations are never cached.
-- Direct-mapped, fixed memory (~27 MB total across 18 CPUs), no eviction
+- Direct-mapped, fixed memory (~37 MB total across 18 CPUs), no eviction
   machinery: under adversarial destination spray it degrades to baseline cost
   plus two array probes — not the eviction thrash that killed the Linux route
   cache in kernel 3.6, which is why this ships as an experiment anyway.

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -472,3 +472,44 @@ What to watch after enabling (canary):
 - Attach/reconcile logs: one `bridge egress short-circuit installed` line per
   collapsed chain says discovery proved the shape; absence means the topology
   didn't qualify and nothing changed.
+
+## FIB destination cache (`fib-cache`, experiment)
+
+Live profiling showed the custom-FIB LPM walks are the dominant *BPF-side* cost
+(~1.2 µs/packet of `trie_lookup_elem` + `longest_prefix_match` on a full table —
+the walks miss cache on a 2M-entry trie). `fib-cache on` puts a direct-mapped
+per-CPU cache in front of `FIB_V4`/`FIB_V6`: repeat destinations become one array
+probe instead of an LPM walk.
+
+What it caches, and why the design is safe:
+
+- **The FIB decision (`FibValue`), never the resolved neighbor.** The per-packet
+  seqlock read and the ECMP 5-tuple hash run identically on hits, so neighbor
+  MAC/state churn needs no invalidation, and per-flow ECMP placement is preserved.
+- **Any route change invalidates the whole cache** via a generation counter the
+  FibProgrammer bumps on every LPM insert/remove. The cache refills at line rate;
+  under sustained BGP churn it is effectively always cold — `fib_cache_stale`
+  measures exactly that.
+- **No negative caching**: unroutable destinations are never cached.
+- Direct-mapped, fixed memory (~27 MB total across 18 CPUs), no eviction
+  machinery: under adversarial destination spray it degrades to baseline cost
+  plus two array probes — not the eviction thrash that killed the Linux route
+  cache in kernel 3.6, which is why this ships as an experiment anyway.
+
+This is an experiment with a kill criterion, not a recommendation. Canary on one
+box (`fib-cache on` + `packetframe reconfigure`, no restart), run ≥24 h across
+normal BGP churn, then compute:
+
+```text
+hit_rate = fib_cache_hit / (fib_cache_hit + fib_cache_miss + fib_cache_stale)
+```
+
+- **≥ 70%** and the LPM share of CPU visibly down → keep it on.
+- **30–70%** → marginal; keep only if the CPU delta justifies 27 MB.
+- **< 30%**, or `fib_cache_stale` > ~20% of probes sustained → your destination
+  diversity or route churn defeats this cache design; turn it off and leave it
+  off. The counters stay (append-only) as a record.
+
+`fib-cache off` + reconfigure disables it immediately (the BPF probe stops on the
+next packet); re-enabling never resurrects pre-disable entries (the generation
+advances on every toggle).


### PR DESCRIPTION
Phase-2 perf, PR 2 of 2. **Stacked on #78** (both touch `reconcile()` and the directive enum); after #78 squash-merges I'll `git rebase --onto origin/main perf/bridge-egress-resolve perf/fib-dest-cache` and retarget to `main`.

## What

A direct-mapped per-CPU destination cache in front of `FIB_V4`/`FIB_V6`. Live profiling put the LPM walks at ~1.2 µs/packet (5.9% of all CPU) on the reference EFG — a full BGP table makes every lookup a DRAM-bound trie walk, and the walks, not the program bodies (2.6%), are the dominant BPF-side cost. A repeat destination becomes one array probe.

**Ships default-off, with an explicit kill criterion.** Internet-edge dst diversity may simply defeat a dst-keyed cache — Linux removed its route cache in 3.6 for exactly this. The counters decide: canary ≥24 h, `hit/(hit+miss+stale)` ≥70% → keep; <30% or stale >20% sustained → off permanently, documented in the runbook.

## Design (each constraint load-bearing)

- **Caches the `FibValue` (kind+idx), never the resolved nexthop.** Seqlock read + ECMP 5-tuple hash run unchanged on hits → neighbor churn needs *no* invalidation, per-flow ECMP placement preserved bit-for-bit.
- **Key = full /32 // /128** (`FibValue` records no prefix length; nothing coarser is sound).
- **Direct-mapped `PerCpuArray`, not LRU**: no LRU map type is proven on the 5.15-ui verifier; LRU insert is an alloc-under-spinlock helper call per miss; under adversarial dst spray LRU thrashes eviction lists while direct-mapped degrades to baseline + two array probes. Entries all-u32, zero-padding, size-asserted, field-by-field stores (MutationCtx anti-memset discipline).
- **Global generation in a new `FIB_CACHE_CFG` map, sole writer = FibProgrammer.** Bumped in `write_fib_entry`/`delete_fib_entry` (the two choke points), not on no-op recomputes; toggle transitions bump so re-enable can't resurrect a prior epoch. **Generation 0 reserved** → kernel-zeroed slots can never false-hit, no init pass. Config/SIGHUP reach it via a fire-and-forget `SetCacheEnabled` command — reconcile never touches the map (programmer/reconcile writer domains stay disjoint).
- **`reclaim_immediate` deleted**: a cached FibValue extends the in-flight window in which a packet holds a nexthop index, so full teardowns now ride the standard 100 ms grace queue. Uniform lifecycle, strictly safer.
- **No negative caching** (a stale "no route" is a blackhole-shaped bug).
- Counters 42–44 (`fib_cache_hit/miss/stale`, append-only, all six sync points updated). Stale ≠ miss because the remedies are opposite: churn defeating the global generation vs working set outsizing the table.
- Memory: 65,536 v4 + 16,384 v6 slots ≈ 27 MB across 18 CPUs, allocated at load like the FIB tries.

## Verifier risk + gate

New code is `PerCpuArray`/`Array` only (the most-exercised map types in tree), ~35 instructions inlined at the two `fib.rs` lookup sites, ~8 bytes of new scalars, no new stack structs. The qemu 5.15 job is the gate; the fixtures run the grown programs on that kernel.

## Tests

- Fixtures (`fib_fixtures.rs`, both datapaths where relevant): off = byte-identical + zero cache counters; hit skips LPM with identical output bytes; stale generation refuses the entry and resolves the *new* route; ECMP flows keep their leg cold→warm and `ecmp_hash_v4` still bumps per packet; nexthop MAC churn propagates through hits; v6 twins; zeroed-slot never false-hits under a live generation; tc-datapath hit twin.
- Programmer integration (`fib_programmer_integration.rs`): generation bumps on Add and Del, no bump on identical re-Add (no-change shortcut), enable/disable transitions bump + publish, same-value toggle is a no-op, and withdrawn nexthop slots are grace-deferred (not tombstoned instantly) then tombstoned after the grace window.
- Config parse tests; metrics tail-canary test extended to 45.

## Rollout

`fib-cache on` + `packetframe reconfigure` on the shadow first (no restart, no traffic blip), then briefly on the primary across normal BGP churn. Full procedure + decision table in `docs/runbooks/generic-mode-performance.md` §"FIB destination cache".

🤖 Generated with [Claude Code](https://claude.com/claude-code)