### PR TITLE
feat(fast-path): err_parse_tc — per-hook parse-error attribution

### DIFF
--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -203,12 +203,21 @@ pub enum StatIdx {
     /// the global-generation invalidation; sustained Miss means the
     /// working set outsizes the table (or collisions dominate).
     FibCacheStale = 44,
+    // --- v0.2.9: per-hook parse-error attribution. Append-only. -----
+    /// `tc_fast_path` parse failure (bumped IN ADDITION to `ErrParse`,
+    /// which both datapaths share) — the `RxTotalTc`/`FwdOkTc` pattern
+    /// applied to the error path. Exists because the 2026-08-01
+    /// full-scale tc test showed `err_parse` running ~0.18% of tc-path
+    /// traffic vs ~zero under XDP, and the shared counter made the
+    /// excess unattributable without flipping datapaths. During any
+    /// mixed rollout, `err_parse - err_parse_tc` is the XDP share.
+    ErrParseTc = 45,
 }
 
 /// Total counter count. Sizes the `[u64; N]` value of the single-entry
 /// `STATS` per-CPU map. New counters bump this; dashboards keying on
 /// indices keep working.
-pub const STATS_COUNT: u32 = 45;
+pub const STATS_COUNT: u32 = 46;
 
 /// `STATS_COUNT` as usize, for the array-of-counters value type.
 pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;

--- a/crates/modules/fast-path/bpf/src/tc.rs
+++ b/crates/modules/fast-path/bpf/src/tc.rs
@@ -96,6 +96,7 @@ pub fn tc_fast_path(ctx: TcContext) -> i32 {
         Ok(verdict) => verdict,
         Err(()) => {
             bump(stats, StatIdx::ErrParse);
+            bump(stats, StatIdx::ErrParseTc);
             TC_ACT_OK as i32
         }
     }

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -31,7 +31,7 @@ use std::fmt::Write as _;
 /// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
 /// tail-call diagnostics from the Prometheus export; a separate
 /// hardcoded 37 hid `pass_ndp` from `packetframe status`).
-pub const COUNTER_NAMES: [&str; 45] = [
+pub const COUNTER_NAMES: [&str; 46] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -85,6 +85,8 @@ pub const COUNTER_NAMES: [&str; 45] = [
     "fib_cache_hit",
     "fib_cache_miss",
     "fib_cache_stale",
+    // --- v0.2.9: per-hook parse-error attribution ---
+    "err_parse_tc",
 ];
 
 /// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
@@ -236,7 +238,7 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 45);
+        assert_eq!(COUNTER_NAMES.len(), 46);
         assert_eq!(COUNTER_NAMES.len(), COUNTER_COUNT);
         // The newest counters, as a canary that the tail of the list
         // stayed aligned with the `StatIdx` discriminants.
@@ -245,6 +247,7 @@ mod tests {
         assert_eq!(COUNTER_NAMES[42], "fib_cache_hit");
         assert_eq!(COUNTER_NAMES[43], "fib_cache_miss");
         assert_eq!(COUNTER_NAMES[44], "fib_cache_stale");
+        assert_eq!(COUNTER_NAMES[45], "err_parse_tc");
     }
 
     #[test]

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -55,7 +55,7 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V2: u32 = 1;
-pub const STATS_COUNT: u32 = 45;
+pub const STATS_COUNT: u32 = 46;
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.
@@ -120,6 +120,7 @@ pub enum StatIdx {
     FibCacheHit = 42,
     FibCacheMiss = 43,
     FibCacheStale = 44,
+    ErrParseTc = 45,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a

--- a/crates/modules/fast-path/tests/tc_fixtures.rs
+++ b/crates/modules/fast-path/tests/tc_fixtures.rs
@@ -17,7 +17,7 @@
 mod common;
 
 use common::{
-    tc_action, FpCfg, Harness, Ipv4TcpBuilder, StatIdx, FP_CFG_FLAG_BLOCK_PRESENT,
+    tc_action, xdp_action, FpCfg, Harness, Ipv4TcpBuilder, StatIdx, FP_CFG_FLAG_BLOCK_PRESENT,
     FP_CFG_FLAG_CUSTOM_FIB, FP_CFG_FLAG_IPV4, FP_CFG_FLAG_IPV6, FP_CFG_FLAG_MSS_CLAMP_PRESENT,
     FP_CFG_VERSION_V2,
 };
@@ -171,4 +171,34 @@ fn tc_mss_clamp_parity_with_xdp() {
     // eth(14) + ipv4(20) + tcp fixed(20) + option kind/len(2).
     let mss_off = 14 + 20 + 20 + 2;
     assert_eq!(&out[mss_off..mss_off + 2], &1300u16.to_be_bytes());
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_parse_error_bumps_both_shared_and_tc_counter() {
+    let mut h = Harness::new();
+    h.set_custom_fib(true, false);
+    // 10 bytes: shorter than an Ethernet header, so both datapaths'
+    // very first bounds check fails and the packet passes pristine.
+    let runt = vec![0u8; 10];
+
+    let parse_before = h.stat(StatIdx::ErrParse);
+    let parse_tc_before = h.stat(StatIdx::ErrParseTc);
+
+    let (verdict, out) = h.run_tc(&runt);
+    assert_eq!(verdict, tc_action::TC_ACT_OK);
+    assert_eq!(out, runt, "parse failure must leave the packet pristine");
+    assert_eq!(h.stat(StatIdx::ErrParse), parse_before + 1);
+    assert_eq!(
+        h.stat(StatIdx::ErrParseTc),
+        parse_tc_before + 1,
+        "tc parse failure must be attributable per-hook"
+    );
+
+    // The same runt through the XDP hook bumps only the shared
+    // counter: `err_parse - err_parse_tc` must stay the XDP share.
+    let (verdict, _) = h.run(&runt);
+    assert_eq!(verdict, xdp_action::XDP_PASS);
+    assert_eq!(h.stat(StatIdx::ErrParse), parse_before + 2);
+    assert_eq!(h.stat(StatIdx::ErrParseTc), parse_tc_before + 1);
 }

--- a/crates/modules/fast-path/tests/tc_fixtures.rs
+++ b/crates/modules/fast-path/tests/tc_fixtures.rs
@@ -178,9 +178,18 @@ fn tc_mss_clamp_parity_with_xdp() {
 fn tc_parse_error_bumps_both_shared_and_tc_counter() {
     let mut h = Harness::new();
     h.set_custom_fib(true, false);
-    // 10 bytes: shorter than an Ethernet header, so both datapaths'
-    // very first bounds check fails and the packet passes pristine.
-    let runt = vec![0u8; 10];
+    // A frame the KERNEL accepts but the PARSER rejects. Sub-14-byte
+    // buffers can't be used here: `bpf_prog_test_run` fails the whole
+    // syscall with EINVAL when `size < ETH_HLEN`, so the program never
+    // runs and the test panics in the harness rather than exercising
+    // the parse-error path. Instead: a complete 14-byte Ethernet
+    // header declaring IPv4, with the IP header truncated to 6 bytes.
+    // Both datapaths clear the `EthHdr::LEN` check, then fail
+    // `start + ip_offset + Ipv4Hdr::LEN > end` — the parse error we
+    // actually want to attribute.
+    let mut runt = vec![0u8; 20];
+    runt[12] = 0x08; // ethertype 0x0800 (IPv4)
+    runt[13] = 0x00;
 
     let parse_before = h.stat(StatIdx::ErrParse);
     let parse_tc_before = h.stat(StatIdx::ErrParseTc);


### PR DESCRIPTION
## Why

The full-scale tc test (see the tc-datapath runbook's measured verdict, PR #81) showed `err_parse` at ~0.18% of tc-path traffic vs ~zero under XDP — fail-safe (those packets take the kernel slow path) but unattributable: the shared counter can't say which hook fails to parse without flipping datapaths on a production box.

## What

The established `rx_total_tc`/`fwd_ok_tc` attribution pattern, applied to the error path:

- `StatIdx::ErrParseTc = 45` (append-only; `STATS_COUNT` 45 → 46)
- `tc_fast_path` bumps it alongside the shared `ErrParse` — `err_parse - err_parse_tc` is always the XDP share
- Six sync points updated (StatIdx, STATS_COUNT, COUNTER_NAMES + length, metrics canary test, harness mirror)
- New fixture: a runt frame through both hooks — tc bumps both counters, XDP bumps only the shared one

Diagnosing the actual tc parse failure (suspects: VLAN skb-metadata path on bridge-member ports, GRO nonlinear head geometry) is follow-up work; this PR makes that investigation possible with counters instead of datapath flips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)