### PR TITLE
feat(probe): flag per-packet IRQ coalescing + runbook section

### DIFF
--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -196,10 +196,11 @@ pub fn run_probes(bpffs_root: &Path) -> FeasibilityReport {
 /// (`required = false`); see `docs/runbooks/generic-mode-performance.md`
 /// for what to do with the answers.
 pub fn run_iface_probes(ifaces: &[String]) -> Vec<Capability> {
-    let mut caps = Vec::with_capacity(ifaces.len() * 2);
+    let mut caps = Vec::with_capacity(ifaces.len() * 3);
     for iface in ifaces {
         caps.push(probe_iface_gro(iface));
         caps.push(probe_iface_rps(iface));
+        caps.push(probe_iface_coalesce(iface));
     }
     caps
 }
@@ -802,6 +803,108 @@ fn rps_mask_is_zero(mask: &str) -> bool {
     mask.chars().all(|c| c == '0' || c == ',')
 }
 
+/// IRQ coalescing via `SIOCETHTOOL`/`ETHTOOL_GCOALESCE`. On a
+/// generic-XDP box every packet costs a full IRQ + NAPI wakeup when
+/// the coalescing timer is effectively off; the reference EFG shipped
+/// with `rx-usecs 1 rx-frames 10`, which produced ~1 IRQ per packet
+/// (~800k/s at ~800 kpps) and measured −10.5% softirq/packet when
+/// raised to 50/32. A timer at or below this threshold cannot
+/// aggregate at realistic per-queue packet gaps (tens of µs), so it
+/// is reported as a (non-required) failure with the fix inline.
+/// See `docs/runbooks/generic-mode-performance.md` §"IRQ coalescing".
+const COALESCE_PER_PACKET_USECS: u32 = 2;
+
+fn coalesce_is_per_packet(rx_usecs: u32) -> bool {
+    rx_usecs <= COALESCE_PER_PACKET_USECS
+}
+
+fn probe_iface_coalesce(iface: &str) -> Capability {
+    let name = format!("iface.{iface}.coalesce");
+    match iface_coalesce_state(iface) {
+        Ok((rx_usecs, rx_frames)) => {
+            if coalesce_is_per_packet(rx_usecs) {
+                Capability::fail(
+                    &name,
+                    format!(
+                        "rx-usecs {rx_usecs} / rx-frames {rx_frames}: effectively one IRQ per \
+                         packet at forwarding rates; \
+                         `ethtool -C {iface} rx-usecs 50 rx-frames 32 tx-usecs 50 tx-frames 32` \
+                         measured −10.5% softirq/packet on the reference EFG — settings do not \
+                         survive reboot, see generic-mode-performance runbook §IRQ coalescing \
+                         for persistence"
+                    ),
+                    false,
+                )
+            } else {
+                Capability::pass(
+                    &name,
+                    format!("rx-usecs {rx_usecs} / rx-frames {rx_frames}"),
+                    false,
+                )
+            }
+        }
+        Err(e) => Capability::unknown(&name, e, false),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn iface_coalesce_state(iface: &str) -> Result<(u32, u32), String> {
+    // uapi `struct ethtool_coalesce`: cmd + 22 u32 parameter fields.
+    // Only rx_coalesce_usecs and rx_max_coalesced_frames are read;
+    // the rest exist so the kernel writes into memory we own.
+    const ETHTOOL_GCOALESCE: u32 = 0x0000_000e;
+    // Width-neutral for the ioctl request cast; see iface_gro_state.
+    const SIOCETHTOOL: u32 = 0x8946;
+    #[repr(C)]
+    #[derive(Default)]
+    struct EthtoolCoalesce {
+        cmd: u32,
+        rx_coalesce_usecs: u32,
+        rx_max_coalesced_frames: u32,
+        rest: [u32; 20],
+    }
+
+    let name_bytes = iface.as_bytes();
+    let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+    if name_bytes.len() >= ifr.ifr_name.len() {
+        return Err(format!("interface name `{iface}` exceeds IFNAMSIZ"));
+    }
+    for (dst, src) in ifr.ifr_name.iter_mut().zip(name_bytes) {
+        *dst = *src as libc::c_char;
+    }
+
+    let mut value = EthtoolCoalesce {
+        cmd: ETHTOOL_GCOALESCE,
+        ..Default::default()
+    };
+    ifr.ifr_ifru.ifru_data = &mut value as *mut EthtoolCoalesce as *mut libc::c_char;
+
+    let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+    if sock < 0 {
+        return Err(format!(
+            "socket(AF_INET, SOCK_DGRAM) failed: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    #[allow(clippy::unnecessary_cast)]
+    let r = unsafe { libc::ioctl(sock, SIOCETHTOOL as _, &mut ifr) };
+    let ioctl_err = std::io::Error::last_os_error();
+    unsafe { libc::close(sock) };
+    if r != 0 {
+        // EOPNOTSUPP is a normal answer (virtual devices, some
+        // drivers); the caller renders it as Unknown, not Fail.
+        return Err(format!(
+            "SIOCETHTOOL/ETHTOOL_GCOALESCE on {iface} failed: {ioctl_err}"
+        ));
+    }
+    Ok((value.rx_coalesce_usecs, value.rx_max_coalesced_frames))
+}
+
+#[cfg(not(target_os = "linux"))]
+fn iface_coalesce_state(_iface: &str) -> Result<(u32, u32), String> {
+    Err("coalescing probe is Linux-only".to_string())
+}
+
 #[cfg(target_os = "linux")]
 fn iface_gro_state(iface: &str) -> Result<bool, String> {
     // ethtool_value { cmd, data } with ETHTOOL_GGRO. A read-only get;
@@ -861,6 +964,18 @@ fn iface_gro_state(_iface: &str) -> Result<bool, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn coalesce_per_packet_threshold() {
+        // The EFG shipped at rx-usecs=1 (flagged); the runbook fix is
+        // 50 (passes). 2 µs cannot aggregate at tens-of-µs per-queue
+        // packet gaps, so it is still per-packet in practice.
+        assert!(coalesce_is_per_packet(0));
+        assert!(coalesce_is_per_packet(1));
+        assert!(coalesce_is_per_packet(2));
+        assert!(!coalesce_is_per_packet(3));
+        assert!(!coalesce_is_per_packet(50));
+    }
 
     #[test]
     fn kconfig_flag_matching() {
@@ -987,15 +1102,17 @@ CONFIG_HZ=250
 
     #[test]
     fn iface_probes_shape() {
-        // Two caps per iface, names prefixed with the iface. On
-        // non-Linux both come back Unknown, which is fine — the shape
+        // Three caps per iface, names prefixed with the iface. On
+        // non-Linux all come back Unknown, which is fine — the shape
         // is what this asserts.
         let caps = run_iface_probes(&["eth0".to_string(), "eth1".to_string()]);
-        assert_eq!(caps.len(), 4);
+        assert_eq!(caps.len(), 6);
         assert_eq!(caps[0].name, "iface.eth0.gro");
         assert_eq!(caps[1].name, "iface.eth0.rps");
-        assert_eq!(caps[2].name, "iface.eth1.gro");
-        assert_eq!(caps[3].name, "iface.eth1.rps");
+        assert_eq!(caps[2].name, "iface.eth0.coalesce");
+        assert_eq!(caps[3].name, "iface.eth1.gro");
+        assert_eq!(caps[4].name, "iface.eth1.rps");
+        assert_eq!(caps[5].name, "iface.eth1.coalesce");
         assert!(caps.iter().all(|c| !c.required));
     }
 }

--- a/crates/common/src/probe/mod.rs
+++ b/crates/common/src/probe/mod.rs
@@ -813,16 +813,57 @@ fn rps_mask_is_zero(mask: &str) -> bool {
 /// is reported as a (non-required) failure with the fix inline.
 /// See `docs/runbooks/generic-mode-performance.md` §"IRQ coalescing".
 const COALESCE_PER_PACKET_USECS: u32 = 2;
+/// A frame threshold at or below this coalesces nothing meaningful:
+/// the IRQ fires every packet (1) or every other packet (2).
+const COALESCE_PER_PACKET_FRAMES: u32 = 2;
 
-fn coalesce_is_per_packet(rx_usecs: u32) -> bool {
-    rx_usecs <= COALESCE_PER_PACKET_USECS
+/// Does this configuration effectively interrupt per packet?
+///
+/// The uapi semantics are a DISJUNCTION — the NIC raises an IRQ when
+/// `(usecs > 0 && timer elapsed) || (frames > 0 && count reached)` —
+/// so judging on `rx_usecs` alone gets both edges wrong: `rx-usecs 0
+/// rx-frames 32` coalesces fine but would read as a failure, while
+/// `rx-usecs 50 rx-frames 1` interrupts on every packet and would
+/// read as a pass. A setting is per-packet only when EVERY armed
+/// trigger is tight; a disarmed (0) trigger can't fire at all and so
+/// never rescues the other one.
+fn coalesce_is_per_packet(rx_usecs: u32, rx_frames: u32) -> bool {
+    // Nothing armed at all: the NIC interrupts on every packet.
+    if rx_usecs == 0 && rx_frames == 0 {
+        return true;
+    }
+    // Whichever ARMED trigger fires first decides the interrupt rate,
+    // so any tight one makes the configuration per-packet and a loose
+    // one cannot rescue it. A disarmed (0) trigger never fires and is
+    // simply not considered.
+    //
+    // Calibration: the reference EFG shipped `rx-usecs 1 rx-frames 10`
+    // and measured ~800k IRQs/s at ~800 kpps — one per packet —
+    // because the 1 µs timer always beat the 10-frame count at ~24 µs
+    // per-queue packet gaps. That measurement is what the `||`
+    // encodes; an `&&` would have called that configuration healthy.
+    let timer_per_packet = rx_usecs > 0 && rx_usecs <= COALESCE_PER_PACKET_USECS;
+    let frames_per_packet = rx_frames > 0 && rx_frames <= COALESCE_PER_PACKET_FRAMES;
+    timer_per_packet || frames_per_packet
 }
 
 fn probe_iface_coalesce(iface: &str) -> Capability {
     let name = format!("iface.{iface}.coalesce");
     match iface_coalesce_state(iface) {
-        Ok((rx_usecs, rx_frames)) => {
-            if coalesce_is_per_packet(rx_usecs) {
+        Ok(st) if st.adaptive_rx => Capability::unknown(
+            &name,
+            format!(
+                "adaptive RX coalescing is enabled (resting rx-usecs {} / rx-frames {}): the \
+                 driver varies these by packet rate, so the resting values do not describe \
+                 behavior under forwarding load. Measure IRQs/sec directly \
+                 (/proc/interrupts) before concluding anything",
+                st.rx_usecs, st.rx_frames
+            ),
+            false,
+        ),
+        Ok(st) => {
+            let (rx_usecs, rx_frames) = (st.rx_usecs, st.rx_frames);
+            if coalesce_is_per_packet(rx_usecs, rx_frames) {
                 Capability::fail(
                     &name,
                     format!(
@@ -847,8 +888,16 @@ fn probe_iface_coalesce(iface: &str) -> Capability {
     }
 }
 
+/// The subset of `ethtool_coalesce` the verdict depends on.
+#[derive(Debug, Clone, Copy)]
+struct CoalesceState {
+    rx_usecs: u32,
+    rx_frames: u32,
+    adaptive_rx: bool,
+}
+
 #[cfg(target_os = "linux")]
-fn iface_coalesce_state(iface: &str) -> Result<(u32, u32), String> {
+fn iface_coalesce_state(iface: &str) -> Result<CoalesceState, String> {
     // uapi `struct ethtool_coalesce`: cmd + 22 u32 parameter fields.
     // Only rx_coalesce_usecs and rx_max_coalesced_frames are read;
     // the rest exist so the kernel writes into memory we own.
@@ -861,7 +910,18 @@ fn iface_coalesce_state(iface: &str) -> Result<(u32, u32), String> {
         cmd: u32,
         rx_coalesce_usecs: u32,
         rx_max_coalesced_frames: u32,
-        rest: [u32; 20],
+        rx_coalesce_usecs_irq: u32,
+        rx_max_coalesced_frames_irq: u32,
+        tx_coalesce_usecs: u32,
+        tx_max_coalesced_frames: u32,
+        tx_coalesce_usecs_irq: u32,
+        tx_max_coalesced_frames_irq: u32,
+        stats_block_coalesce_usecs: u32,
+        /// Non-zero means the driver varies the RX settings by packet
+        /// rate, so the resting values above do not describe behavior
+        /// under forwarding load (a resting 50 can become 1 at rate).
+        use_adaptive_rx_coalesce: u32,
+        rest: [u32; 13],
     }
 
     let name_bytes = iface.as_bytes();
@@ -897,11 +957,15 @@ fn iface_coalesce_state(iface: &str) -> Result<(u32, u32), String> {
             "SIOCETHTOOL/ETHTOOL_GCOALESCE on {iface} failed: {ioctl_err}"
         ));
     }
-    Ok((value.rx_coalesce_usecs, value.rx_max_coalesced_frames))
+    Ok(CoalesceState {
+        rx_usecs: value.rx_coalesce_usecs,
+        rx_frames: value.rx_max_coalesced_frames,
+        adaptive_rx: value.use_adaptive_rx_coalesce != 0,
+    })
 }
 
 #[cfg(not(target_os = "linux"))]
-fn iface_coalesce_state(_iface: &str) -> Result<(u32, u32), String> {
+fn iface_coalesce_state(_iface: &str) -> Result<CoalesceState, String> {
     Err("coalescing probe is Linux-only".to_string())
 }
 
@@ -967,14 +1031,35 @@ mod tests {
 
     #[test]
     fn coalesce_per_packet_threshold() {
-        // The EFG shipped at rx-usecs=1 (flagged); the runbook fix is
-        // 50 (passes). 2 µs cannot aggregate at tens-of-µs per-queue
-        // packet gaps, so it is still per-packet in practice.
-        assert!(coalesce_is_per_packet(0));
-        assert!(coalesce_is_per_packet(1));
-        assert!(coalesce_is_per_packet(2));
-        assert!(!coalesce_is_per_packet(3));
-        assert!(!coalesce_is_per_packet(50));
+        // The EFG shipped at rx-usecs 1 / rx-frames 10 (flagged); the
+        // runbook fix is 50/32 (passes).
+        assert!(coalesce_is_per_packet(1, 10));
+        assert!(!coalesce_is_per_packet(50, 32));
+
+        // Both triggers armed: whichever fires first wins, so a tight
+        // timer OR tight frame count is enough to be per-packet.
+        assert!(coalesce_is_per_packet(50, 1), "frames=1 fires every packet");
+        assert!(coalesce_is_per_packet(2, 64), "usecs=2 fires every packet");
+        assert!(!coalesce_is_per_packet(3, 3), "both just past the line");
+
+        // A disarmed (0) trigger cannot fire, so it must not rescue
+        // the other one — nor condemn it.
+        assert!(
+            !coalesce_is_per_packet(0, 32),
+            "frame-only threshold of 32 coalesces fine"
+        );
+        assert!(
+            coalesce_is_per_packet(0, 1),
+            "frame-only threshold of 1 is per-packet"
+        );
+        assert!(
+            !coalesce_is_per_packet(50, 0),
+            "timer-only threshold of 50us coalesces fine"
+        );
+        assert!(coalesce_is_per_packet(1, 0), "timer-only 1us is per-packet");
+
+        // Nothing armed at all: the NIC interrupts per packet.
+        assert!(coalesce_is_per_packet(0, 0));
     }
 
     #[test]

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -150,6 +150,72 @@ Two other things worth acting on before any datapath change:
   dominate: a forwarded packet does three (`ALLOW` src, `ALLOW` dst, `FIB`). Any
   further BPF optimization should target lookup *count*, not instruction count.
 
+### IRQ coalescing: the cheapest measured win on this fleet
+
+The EFG ships with `rx-usecs 1, rx-frames 10, adaptive off` — a 1 µs timer that
+can never aggregate at realistic per-queue packet gaps (~24 µs at 42 kpps/queue
+on 18 queues), so the box takes **~one interrupt per packet** (~800k eth IRQs/s
+measured at ~800 kpps). Each IRQ buys entry/exit, a NAPI schedule, and a softirq
+wakeup; the sum hides across hundreds of small perf symbols, which is why the
+profile table above never shows it as one fat line. `packetframe feasibility`
+flags this state (`iface.<name>.coalesce`).
+
+Measured on the reference EFG (2026-08-01, ~800 kpps live):
+
+| Config | softirq ns/pkt | hardirq ns/pkt | total | eth IRQs/s |
+|---|---|---|---|---|
+| stock (`rx-usecs 1 rx-frames 10`) | 11,306 | not captured | — | ~800k |
+| `rx-usecs 50 rx-frames 32` (rx+tx) | **10,121** | 1,052 | **11,173** | 557k |
+| + NAPI defer (`napi_defer_hard_irqs 2`, `gro_flush_timeout 50000`) | 10,711 | 1,557 | 12,268 | 142k (eth only) |
+
+The winning setting, applied to every attach interface:
+
+```sh
+for i in eth0 eth1 eth2 eth3 eth4 eth5; do ethtool -C $i rx-usecs 50 rx-frames 32 tx-usecs 50 tx-frames 32; done
+```
+
+−10.5% softirq/packet. The 557k residual is exactly timer-bound (20k/s ×
+~28 active queue pairs), so a larger `rx-usecs` buys further reduction
+linearly — at proportionally more worst-case latency; 50 µs is noise at
+internet-edge RTTs, and diminishing returns set in fast beyond it.
+
+**NAPI deferral is a measured LOSS on cn9670 — do not apply the standard
+high-pps recipe here.** `gro_flush_timeout` re-polls NAPI from an hrtimer, and
+hrtimers fire as arch-timer *hardirqs* that `/proc/interrupts`' eth lines never
+show: the eth IRQ count collapsed 4× while both softirq and hardirq time went
+**up** (total +9.8% vs coalescing alone). On this SoC a timer interrupt costs
+more than the NIC interrupt it replaces. Tried, rejected, keep both knobs at 0.
+
+**Persistence:** `ethtool -C` state dies on reboot and may not survive a udapi
+provision cycle (unverified). A oneshot unit keeps the fleet honest:
+
+```ini
+# /etc/systemd/system/packetframe-coalesce.service
+[Unit]
+Description=NIC IRQ coalescing for generic-XDP forwarding (generic-mode-performance runbook)
+After=network-pre.target
+Before=network.target packetframe.service
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'for i in eth0 eth1 eth2 eth3 eth4 eth5; do ethtool -C $i rx-usecs 50 rx-frames 32 tx-usecs 50 tx-frames 32 || true; done'
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```sh
+systemctl daemon-reload && systemctl enable --now packetframe-coalesce
+```
+
+After any provision event or firmware update, `packetframe feasibility` (or
+`ethtool -c eth0`) confirms the settings held.
+
+**Judge the win by ns/packet and pps-at-ceiling, never by `%soft`.** On a
+CPU-bound box with BBR senders, freed CPU converts to throughput within a few
+RTTs (measured 766k → 806 kpps across this change) and `%soft` barely moves —
+induced demand working as intended, not a failed optimization.
+
 **`perf` is not available on UniFi OS.** There is no `perf` package; Debian
 bullseye ships `linux-perf` built for its own 5.10 kernel while these boxes run a
 UniFi 5.15, so `/usr/bin/perf` fails looking for `perf_5.15`. `apt install

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -193,8 +193,17 @@ provision cycle (unverified). A oneshot unit keeps the fleet honest:
 # /etc/systemd/system/packetframe-coalesce.service
 [Unit]
 Description=NIC IRQ coalescing for generic-XDP forwarding (generic-mode-performance runbook)
-After=network-pre.target
-Before=network.target packetframe.service
+# Order AFTER the network is actually up, not merely after
+# network-pre.target: on a box whose network manager creates, renames,
+# or reconfigures these NICs during boot, both it and this unit can run
+# in the same window with no ordering between them — so `ethtool -C`
+# either hits an interface that does not exist yet or gets overwritten
+# a moment later, and the per-interface `|| true` leaves the oneshot
+# "successful" so nothing retries. packetframe.service already waits
+# for network-online.target; slot in just ahead of it.
+After=network-online.target
+Wants=network-online.target
+Before=packetframe.service
 
 [Service]
 Type=oneshot
@@ -208,8 +217,16 @@ WantedBy=multi-user.target
 systemctl daemon-reload && systemctl enable --now packetframe-coalesce
 ```
 
-After any provision event or firmware update, `packetframe feasibility` (or
-`ethtool -c eth0`) confirms the settings held.
+After any provision event or firmware update, confirm the settings held —
+**with the config**, since a bare `packetframe feasibility` probes no
+interfaces at all (no attach set → no `iface.<name>.coalesce` lines → a
+clean-looking report that checked nothing):
+
+```sh
+packetframe feasibility --config /etc/packetframe/packetframe.conf --human | grep coalesce
+```
+
+or straight from the NIC with `ethtool -c eth0`.
 
 **Judge the win by ns/packet and pps-at-ceiling, never by `%soft`.** On a
 CPU-bound box with BBR senders, freed CPU converts to throughput within a few


### PR DESCRIPTION
## Why

Tonight's biggest effort-to-payoff win: the EFG ships `rx-usecs 1 rx-frames 10`, taking ~one IRQ per packet (~800k/s at ~800 kpps). `ethtool -C ... rx-usecs 50 rx-frames 32` measured **−10.5% softirq/packet** live. Nothing catches a box in the bad state today — the cost never shows as a single perf symbol, and the setting silently reverts on reboot.

## What

- **New feasibility probe** `iface.<name>.coalesce` (ETHTOOL_GCOALESCE, same ioctl idiom as the GRO probe): `rx-usecs <= 2` → non-required Fail with the fix inline; unsupported drivers → Unknown. Non-Linux stub as usual.
- **Runbook §"IRQ coalescing"**: the measured config table — including **NAPI deferral as a tested loss on cn9670** (+9.8% total vs coalescing alone; `gro_flush_timeout` hrtimers fire as arch-timer hardirqs that cost more than the NIC IRQs they replace, invisible in /proc/interrupts eth lines) — the persistence oneshot unit, and the judge-by-ns/pkt-not-%soft guidance.

Numbers from the 2026-08-01 live session on the reference EFG (edge1-mci1-net).

Note: touches `generic-mode-performance.md` in a section PR #81 doesn't edit, but if #81 merges first I'll rebase to be safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)