### PR TITLE
fix(ci): stop the VPP build hanging on a debconf prompt

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -110,6 +110,18 @@ jobs:
     container:
       image: debian:bullseye
     timeout-minutes: 120
+    # VPP's `make install-dep` runs its own apt-get, and UNATTENDED=y
+    # only adds `-y` — it does not set a debconf frontend. Some of the
+    # dependency closure (wireshark-common) has a debconf question, so
+    # apt falls back to the Readline frontend and asks it. Under CI
+    # stdin is /dev/null, so it reads EOF and takes the default rather
+    # than hanging, but that is luck rather than design: the same
+    # command run from an interactive shell — or backgrounded from one,
+    # where the read earns SIGTTIN and suspends the job outright —
+    # blocks. Set the frontend job-wide so no step depends on how it
+    # was invoked.
+    env:
+      DEBIAN_FRONTEND: noninteractive
     # Container jobs get `sh -e` as the default shell, and dash has no
     # `set -o pipefail` — the first build attempt died on line 1 of the
     # first step. Everything below is bash; the bootstrap step opts
@@ -154,7 +166,14 @@ jobs:
         run: |
           set -euo pipefail
           cd /vpp
-          UNATTENDED=y make install-dep
+          # `< /dev/null` belt-and-braces alongside the job-level
+          # DEBIAN_FRONTEND: a container job's stdin is an open pipe
+          # that never delivers EOF, so any package whose maintainer
+          # script reads stdin blocks forever rather than failing. The
+          # first attempt at this build hung here for 26 minutes on
+          # wireshark-common's dumpcap question before being cancelled.
+          # Redirecting guarantees a read returns instead of parking.
+          UNATTENDED=y make install-dep < /dev/null
 
       - name: Build release
         run: |


### PR DESCRIPTION
The first `v26.06` build ([run 30735186305](https://github.com/unredacted/packetframe/actions/runs/30735186305)) sat in `install-dep` for **26 minutes** with no output and had to be cancelled.

## Cause

VPP's `make install-dep` runs its own `apt-get`, and `UNATTENDED=y` only adds `-y` — it sets no debconf frontend. `wireshark-common` is in the dependency closure and asks a debconf question about dumpcap privileges, so apt falls back to the Readline frontend and prompts.

I initially assumed CI would shrug this off because stdin would be `/dev/null` and the read would hit EOF. The hang disproved it: a **container job's stdin is an open pipe that never delivers EOF**, so the read parks indefinitely. No error, no further output — which is exactly why it read as a slow build rather than a stuck one.

## Fix

Two independent guards, since either alone would have prevented this and the failure mode is expensive to diagnose:

- **`DEBIAN_FRONTEND=noninteractive` at job level**, not per-step. The existing per-command form in *Container prerequisites* never reached VPP's own `apt-get`. The Makefile uses `sudo -E`, so a job-level value propagates.
- **`< /dev/null` on `install-dep`**, so any maintainer script that reads stdin regardless of frontend gets EOF rather than blocking.

The chosen default is also the one we want: dumpcap stays unprivileged.

## Note on merging

This file is itself a build trigger, so merging re-runs the build — which is the intent here, since the cancelled run published nothing. No manual dispatch needed.

Off-CI relevance: run backgrounded from an interactive shell, the same read earns `SIGTTIN` and suspends the job outright. That's what would have happened to the on-box build had it got past UniFi's held `libnl` packages.