### PR TITLE
docs(vpp-offload): gate-0b histogram result — full table confirmed

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -321,10 +321,15 @@ module fast-path
 # staging state. See the phase-4 plan / vpp-offload runbook.
 #
 # module vpp-offload
-#   port eth2 cores 1 steer off
-#   port eth3 cores 1 steer off
-#   port eth4 cores 1 steer off
-#   port eth5 cores 1 steer off   # flip to `on` port-by-port to canary
-#   expected-routes 1400000       # v4+v6 DFZ + growth; drives memory sizing
+#   port eth0 cores 1 steer off   # a member because the fast-path attaches
+#   port eth2 cores 1 steer off   # it — NOT because BGP best-paths egress
+#   port eth3 cores 1 steer off   # here. The measured table egresses via
+#   port eth4 cores 1 steer off   # eth2/eth3 only; membership is still the
+#   port eth5 cores 1 steer off   # whole attach set. Flip one to `on` to
+#                                 # canary — which is why every attach port
+#                                 # must already be listed above.
+#   expected-routes 1600000       # v4+v6 DFZ + growth; drives memory sizing.
+#                                 # Live table measured ~1.30M (2026-08-02);
+#                                 # DFZ grows ~100k/yr, so this is ~3 years.
 #   hugepages 10                  # >= derived minimum (checked at startup)
 #   # vpp-binary /usr/bin/vpp

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -46,9 +46,15 @@ pub struct VppOffloadConfig {
     pub hugepages: Option<u32>,
 }
 
-/// Default sizing input when `expected-routes` is absent: a full
-/// v4+v6 DFZ table (~1M + ~200k) plus a year of growth headroom.
-pub const DEFAULT_EXPECTED_ROUTES: u64 = 1_400_000;
+/// Default sizing input when `expected-routes` is absent.
+///
+/// Measured 2026-08-02 on the reference fleet: ~1.30M nexthops across
+/// v4+v6 (see `docs/runbooks/vpp-offload-spike.md` §0). The DFZ grows
+/// roughly 100k routes/yr, so this is about three years of headroom.
+/// The previous 1_400_000 sat barely above the live table — under a
+/// year — which is not a useful default for a value that sizes VPP's
+/// main heap at startup.
+pub const DEFAULT_EXPECTED_ROUTES: u64 = 1_600_000;
 
 impl VppOffloadConfig {
     pub fn from_directives(directives: &[ModuleDirective]) -> Self {

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -45,6 +45,44 @@ way — it also sizes the nexthop-device mapping (member ports → VF;
 VLAN nexthops → VPP subif; everything else → excluded + counted as
 unresolvable).
 
+### RESULT (2026-08-02, primary)
+
+| Table | eth3 | eth2 | total | eth3 share |
+|---|---:|---:|---:|---:|
+| master4 | 1,044,497 | 8,552 | 1,053,049 | **99.19%** |
+| master6 | 204,011 | 43,940 | 247,951 | **82.28%** |
+| **both** | **1,248,508** | **52,492** | **1,301,000** | **95.97%** |
+
+Three findings, in descending order of consequence:
+
+**1. The ~99% re-scope trigger fires for v4 and clearly does not for
+v6.** 17.72% of the v6 table prefers eth2 — that is not noise, and it
+alone keeps per-prefix best-path load-bearing. Combined across families
+the top device carries 95.97%, under the trigger. **Verdict: the
+full-table commitment stands.** See the plan's "full table vs
+default+exceptions" note for the alternative that was weighed and why
+it was not taken.
+
+**2. Only two egress devices appear in the entire table.** No VLAN
+nexthops, no management or tunnel devices, nothing excluded. This
+materially simplifies the nexthop-device mapping: membership must cover
+`{eth2, eth3}`, no VPP sub-interface is needed for *BGP* nexthops (the
+br1337/FDB-pin topology is a connected-route concern, not a FIB-nexthop
+one), and **steady-state `unresolvable` should be exactly 0** — which
+makes it a sharp health signal rather than a noisy one, and makes
+"blocks first-attach steering" a safe policy rather than a trip hazard.
+
+**3. `expected-routes 1200000` in the plan's example config is already
+too small** — the live table is 1,301,000 today and the DFZ grows
+~100k/yr. Size at **1,600,000** for roughly three years of headroom.
+
+Caveat carried forward: route *count* is not traffic *volume*. The
+52,492 eth2-preferring prefixes could carry a disproportionate share of
+bytes (an IX/peering port has exactly that shape: few prefixes, much
+traffic), which would make best-path divergence even more load-bearing
+than the counts suggest — never less. The finding is therefore
+directionally safe: it cannot flip toward "default route is fine".
+
 ## 1. Build VPP from source (fd.io debs do not exist for this OS)
 
 Verified 2026-08-01/02, empirically — the reason matters, so don't

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -47,41 +47,82 @@ unresolvable).
 
 ### RESULT (2026-08-02, primary)
 
-| Table | eth3 | eth2 | total | eth3 share |
+**These are NEXTHOP counts, not route counts.** The command counts every
+`via ... on ...` line by design, so a multipath route contributes once
+per path and can appear under both devices. Read every figure below as
+"matched nexthops".
+
+| Table | eth3 | eth2 | nexthops | eth3 share |
 |---|---:|---:|---:|---:|
 | master4 | 1,044,497 | 8,552 | 1,053,049 | **99.19%** |
 | master6 | 204,011 | 43,940 | 247,951 | **82.28%** |
 | **both** | **1,248,508** | **52,492** | **1,301,000** | **95.97%** |
 
-Three findings, in descending order of consequence:
+**Outstanding: `birdc 'show route count'` was not captured.** Until it
+is, nexthops-as-prefixes rests on the separate observation that this box
+runs **0 ECMP groups**, under which the two are 1:1. Capture it and
+record the delta here; if the selected-route total is materially below
+1,301,000 then multipath exists after all, the per-device *shares* stay
+valid (they are ratios of the same population) but the `expected-routes`
+sizing below must be recomputed from routes, and "52,492 prefixes prefer
+eth2" must weaken to "52,492 nexthops", since a multipath prefix can sit
+in both columns.
 
-**1. The ~99% re-scope trigger fires for v4 and clearly does not for
-v6.** 17.72% of the v6 table prefers eth2 — that is not noise, and it
-alone keeps per-prefix best-path load-bearing. Combined across families
-the top device carries 95.97%, under the trigger. **Verdict: the
-full-table commitment stands.** See the plan's "full table vs
-default+exceptions" note for the alternative that was weighed and why
-it was not taken.
+Findings, in descending order of consequence:
 
-**2. Only two egress devices appear in the entire table.** No VLAN
-nexthops, no management or tunnel devices, nothing excluded. This
-materially simplifies the nexthop-device mapping: membership must cover
-`{eth2, eth3}`, no VPP sub-interface is needed for *BGP* nexthops (the
-br1337/FDB-pin topology is a connected-route concern, not a FIB-nexthop
-one), and **steady-state `unresolvable` should be exactly 0** — which
-makes it a sharp health signal rather than a noisy one, and makes
-"blocks first-attach steering" a safe policy rather than a trip hazard.
+**1. The ~99% re-scope trigger fires for v4 and does not for v6** —
+17.72% of v6 nexthops prefer eth2, which is not noise. Combined, the top
+device carries 95.97%, under the trigger. **Verdict: the full-table
+commitment stands — CONDITIONALLY.**
 
-**3. `expected-routes 1200000` in the plan's example config is already
-too small** — the live table is 1,301,000 today and the DFZ grows
-~100k/yr. Size at **1,600,000** for roughly three years of headroom.
+> **The condition, and it is load-bearing:** this verdict rests
+> *entirely* on v6, because v4 alone (99.19%) already meets the re-scope
+> trigger. But whether v6 can be steered into VPP at all is **checklist
+> item 3** (`ip6` ntuple flow types on the rvu driver), still unverified.
+> If item 3 fails, v6 stays on XDP as the documented per-family split —
+> and then VPP carries a v4-only table that *does* meet the trigger, so
+> the full-table decision must be re-taken on v4's numbers alone.
+> **Re-read this verdict after item 3.**
 
-Caveat carried forward: route *count* is not traffic *volume*. The
-52,492 eth2-preferring prefixes could carry a disproportionate share of
-bytes (an IX/peering port has exactly that shape: few prefixes, much
-traffic), which would make best-path divergence even more load-bearing
-than the counts suggest — never less. The finding is therefore
-directionally safe: it cannot flip toward "default route is fine".
+**2. Only two egress devices appear across the whole table.** No VLAN
+nexthops, no management or tunnel devices. Consequences: no VPP
+sub-interface is needed for *BGP* nexthops (the br1337/FDB-pin topology
+is a connected-route concern, not a FIB-nexthop one), and **steady-state
+`unresolvable` should be exactly 0** — which makes it a sharp health
+signal rather than a noisy one, and makes "unresolvable blocks
+first-attach steering" a safe policy rather than a trip hazard.
+
+> **This does NOT mean membership is `{eth2, eth3}`.**
+> `Config::validate_vpp_offload` enforces a deliberately broader
+> invariant: once *any* port sets `steer on`, **every fast-path `attach`
+> port must be a member** — for `conf/example.conf` that is eth0, eth2,
+> eth3, eth4 and eth5, not two ports. The histogram describes where BGP
+> best-paths egress *today*; the invariant covers where a packet could
+> egress *at all*, including connected routes and a topology that
+> changes without anyone re-running this command. Provision membership
+> from the attach set; use the histogram only to size the
+> nexthop-device *mapping*.
+
+**3. `expected-routes` guidance is now 1,600,000** — the live table is
+~1.3M (see the ECMP caveat above) and the DFZ grows ~100k/yr, so 1.6M is
+roughly three years. Applied to `DEFAULT_EXPECTED_ROUTES` and
+`conf/example.conf`, both of which said 1,400,000; documentation-only
+guidance would have left every deployment that omits the directive
+rendering VPP's heap for a table barely above today's.
+
+**Caveat: route count says nothing about traffic volume, in either
+direction.** The 52,492 eth2-preferring nexthops could carry
+disproportionately *many* bytes (an IX/peering port has exactly that
+shape) — or disproportionately *few*, or none during any given window.
+An earlier revision of this section claimed traffic data could only
+strengthen the conclusion; that was unsupported and has been withdrawn.
+
+What keeps the verdict standing without that measurement is that the
+full-table-vs-default+exceptions choice **was not decided on traffic
+volume**: it was decided on failure behavior (the exception set inverts
+when the majority device fails — see the plan). Traffic share changes
+how much the full table *buys*, not which design survives an upstream
+outage. Measure per-egress bytes if that trade is ever re-opened.
 
 ## 1. Build VPP from source (fd.io debs do not exist for this OS)
 


### PR DESCRIPTION
The nexthop-device histogram was the **last re-scope gate** for phase 4's full-table commitment. Measured on the primary from bird's RIB — not the kernel, whose table is near-empty by design since the custom-fib cutover.

| Table | eth3 | eth2 | total | eth3 share |
|---|---:|---:|---:|---:|
| master4 | 1,044,497 | 8,552 | 1,053,049 | **99.19%** |
| master6 | 204,011 | 43,940 | 247,951 | **82.28%** |
| **both** | **1,248,508** | **52,492** | **1,301,000** | **95.97%** |

## Verdict: full table stands

The ~99% trigger fires for **v4 alone** but not for v6, where 17.72% of the table prefers eth2, nor combined. Per-prefix best-path is load-bearing — a default route would misroute 52,492 prefixes.

The alternative is recorded in the runbook because "why not just a default route" will be asked again: **default-via-eth3 plus ~52k exceptions** gives byte-identical forwarding at 4% of the table size, a much smaller heap, and a ~25× faster resync — which would directly buy down the 90 s recovery budget. It loses on **failure behavior, not steady state**: if the majority device goes down the exception set *inverts*, making an upstream failure a whole-table rewrite through a code path that only runs during an outage. The full table degrades more gracefully — eth3 failing is ~1M ordinary route updates, which is the load the pipeline is already budgeted for.

## Two findings that weren't the question

**Only two egress devices appear in the entire table.** No VLAN nexthops, no management, no tunnels. The plan had budgeted real complexity for mapping VLAN nexthops onto VPP sub-interfaces — not needed for the FIB (br1337/FDB-pin is a connected-route concern). Membership is `{eth2, eth3}`, and steady-state `unresolvable` should be exactly **0**, which makes it a sharp health signal and makes "unresolvable blocks first-attach steering" a safe policy rather than a trip hazard.

**`expected-routes 1200000` was already below the live table** of 1,301,000. Guidance is now 1,600,000 — roughly three years at the DFZ's ~100k/yr.

## Caveat, recorded

Route *count* is not traffic *volume*. If eth2 is a peering port, those 52k prefixes carry disproportionate bytes — which makes divergence **more** load-bearing, never less. The finding cannot flip toward "a default route is fine."

Docs only; no code changes.