### PR TITLE
fix(ci): install upstream CMake — bullseye's 3.18 is below VPP 26.06's floor

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -175,6 +175,49 @@ jobs:
           # Redirecting guarantees a read returns instead of parking.
           UNATTENDED=y make install-dep < /dev/null
 
+      # VPP 26.06's CMakeLists.txt sets cmake_minimum_required(3.19);
+      # bullseye ships 3.18.4, so `make build-release` aborts at
+      # vpp-configure with "CMake 3.19 or higher is required". Note
+      # what this does and does not mean: VPP's Makefile really does
+      # have debian-11 handling and `install-dep` really does succeed —
+      # what has moved past bullseye is the TOOLCHAIN requirement, not
+      # dependency packaging. The two are easy to conflate.
+      #
+      # Upstream's own aarch64 binary, pinned with a checksum rather
+      # than pulled from bullseye-backports: cmake is a build-time tool
+      # that leaves no trace in the produced .debs (it cannot raise the
+      # glibc floor, which is the only reason we build on bullseye at
+      # all), and a pinned tarball does not depend on the lifecycle of a
+      # backports suite for a release nearing EOL. Deliberately a 3.31
+      # and not a 4.x: CMake 4 dropped compatibility with
+      # cmake_minimum_required < 3.5, which VPP's vendored externals
+      # still rely on.
+      - name: Install CMake (bullseye's 3.18 is below VPP's floor)
+        env:
+          CMAKE_VERSION: '3.31.9'
+          CMAKE_SHA256: '09b7127b09e3d3ed5fa894f4e59f6a01112f267da6acc4249e46dba97b14afcb'
+        run: |
+          set -euo pipefail
+          series="${CMAKE_VERSION%.*}"
+          tarball="cmake-${CMAKE_VERSION}-linux-aarch64.tar.gz"
+          curl -fsSL -o "/tmp/${tarball}" \
+            "https://cmake.org/files/v${series}/${tarball}"
+          echo "${CMAKE_SHA256}  /tmp/${tarball}" | sha256sum -c -
+          # --strip-components=1 into /usr/local keeps cmake's modules
+          # in the share/ path it resolves relative to the binary.
+          tar -xzf "/tmp/${tarball}" -C /usr/local --strip-components=1
+          hash -r
+          cmake --version
+          # /usr/local/bin precedes /usr/bin, but assert rather than
+          # assume: install-dep may have pulled bullseye's cmake, and
+          # silently building with 3.18 is the failure we just fixed.
+          have=$(cmake --version | head -1 | awk '{print $3}')
+          major=${have%%.*}; rest=${have#*.}; minor=${rest%%.*}
+          if [ "$major" -lt 3 ] || { [ "$major" -eq 3 ] && [ "$minor" -lt 19 ]; }; then
+            echo "::error::cmake $have is below VPP's 3.19 floor (which cmake: $(command -v cmake))"
+            exit 1
+          fi
+
       - name: Build release
         run: |
           set -euo pipefail

--- a/vpp/pin.toml
+++ b/vpp/pin.toml
@@ -38,6 +38,16 @@
 # inferred from fd.io's *package* matrix, which describes their CI,
 # not what the source can build. Checked, wrong, corrected.)
 #
+# That said, "install-dep succeeds" is NOT the same as "bullseye's
+# toolchain is new enough". 26.06 requires CMake >= 3.19 and bullseye
+# ships 3.18.4, so the workflow installs upstream CMake before
+# building. Expect that supplementing to be the shape of any future
+# obstacle on this line: dependency PACKAGING still targets debian-11,
+# but individual TOOL floors have moved past it. If the list of
+# supplements ever grows past a couple of pinned tools, that is the
+# signal to take the fallback ladder below rather than to keep
+# rebuilding bullseye's toolchain from tarballs.
+#
 # The one genuine risk with newness is the AF↔VF mailbox: this fleet
 # runs a 5.15 vendor kernel whose AF is SDK-era, and gate 0a's
 # handshake passed with DPDK 20.11's `octeontx2` PMD. A modern cnxk


### PR DESCRIPTION
With the debconf hang cleared, [run 30737198531](https://github.com/unredacted/packetframe/actions/runs/30737198531) got all the way to `vpp-configure` and died there:

```
CMake Error at CMakeLists.txt:14 (cmake_minimum_required):
  CMake 3.19 or higher is required.  You are running version 3.18.4
```

## This corrects a claim I made in `vpp/pin.toml`

"VPP's Makefile has explicit `debian-11` handling, so bullseye is a supported build host" is true as far as it goes — `install-dep` really does succeed, and it did here. But **dependency packaging targeting debian-11 is not the same as bullseye's toolchain being new enough**, and I conflated the two when arguing for pinning latest-stable. The pin comment now says so explicitly, and adds the escalation rule: if the list of tools needing supplementing grows past a couple, that's the signal to take the fallback ladder rather than keep rebuilding bullseye's toolchain from tarballs.

## Why upstream's tarball rather than bullseye-backports

CMake is a **build-time** tool — it leaves no trace in the produced `.debs` and cannot raise the glibc floor, which is the only reason we build on bullseye at all. So the usual "stay inside the distro" argument doesn't buy anything here, while a pinned tarball avoids depending on the lifecycle of a backports suite for a release nearing EOL.

Pinned to **3.31.9** with its published SHA-256, deliberately not 4.x: CMake 4 dropped compatibility with `cmake_minimum_required < 3.5`, which VPP's vendored externals still rely on.

Installed **after** `install-dep` so an apt-provided cmake can't shadow it, and the step asserts the resolved version clears 3.19 rather than trusting PATH order — silently configuring with 3.18 is exactly the failure being fixed.

## Expectation setting

This may not be the last one. Bullseye is old and 26.06 is current; other tool floors could sit above it too. The next run will tell us, and the fallback ladder in `pin.toml` (v25.10/v24.10 → v23.06 → v22.02) exists for the case where the supplementing gets out of hand.

Merging re-triggers the build, as before.