### PR TITLE
docs(vpp-offload): install the CI artifact at gate 0b, don't build on the box

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -111,15 +111,14 @@ jobs:
       image: debian:bullseye
     timeout-minutes: 120
     # VPP's `make install-dep` runs its own apt-get, and UNATTENDED=y
-    # only adds `-y` — it does not set a debconf frontend. Some of the
-    # dependency closure (wireshark-common) has a debconf question, so
-    # apt falls back to the Readline frontend and asks it. Under CI
-    # stdin is /dev/null, so it reads EOF and takes the default rather
-    # than hanging, but that is luck rather than design: the same
-    # command run from an interactive shell — or backgrounded from one,
-    # where the read earns SIGTTIN and suspends the job outright —
-    # blocks. Set the frontend job-wide so no step depends on how it
-    # was invoked.
+    # only adds `-y` — it does not set a debconf frontend. Part of the
+    # dependency closure (wireshark-common) asks a debconf question, so
+    # apt falls back to the Readline frontend and prompts, and the job
+    # HANGS: a container job's stdin is an open pipe that never
+    # delivers EOF, so the read parks forever with no error and no
+    # output. Observed for 26 minutes before cancellation. (Set
+    # job-wide rather than per-step: the per-command form in
+    # `Container prerequisites` never reached VPP's nested apt-get.)
     env:
       DEBIAN_FRONTEND: noninteractive
     # Container jobs get `sh -e` as the default shell, and dash has no
@@ -364,38 +363,6 @@ jobs:
             /out/SHA256SUMS
           retention-days: 14
 
-      - name: Publish release
-        # A push-triggered run leaves `inputs.publish` empty, which
-        # coerces equal to `false` — so the PRIMARY automatic trigger
-        # would spend the whole build and publish nothing, leaving the
-        # hwtest bundle's release pointer dangling. Gate on the event.
-        if: github.event_name == 'push' || inputs.publish
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          apt-get install -y --no-install-recommends gh || {
-            curl -fsSL https://github.com/cli/cli/releases/download/v2.62.0/gh_2.62.0_linux_arm64.tar.gz \
-              | tar xz -C /tmp && install /tmp/gh_2.62.0_linux_arm64/bin/gh /usr/local/bin/gh
-          }
-          tag='${{ needs.resolve.outputs.tag }}'
-          notes=$(printf '%s\n' \
-            "Unmodified upstream VPP \`${{ needs.resolve.outputs.ref }}\` (\`$VPP_COMMIT\`), built for Debian 11 (bullseye) arm64 — the only combination UniFi OS can install." \
-            "" \
-            "Variant: \`${{ needs.resolve.outputs.platform }}\` · Octeon PMD: \`${PMD_FAMILY:-unknown}\` · No patches applied." \
-            "" \
-            "Verified in CI: glibc symbol floor ≤ 2.31, cnxk/octeontx2 PMD present in the bundled DPDK, no unresolved shared libraries." \
-            "" \
-            "\`vpp-api-json.tar.gz\` is the API-definition bundle consumed by the vpp-offload binary-API codegen; it is published separately so codegen does not download the .debs." \
-            "" \
-            "Install order and operational guidance: \`docs/runbooks/vpp-offload-spike.md\`.")
-          gh release create "$tag" \
-            --repo '${{ github.repository }}' \
-            --title "VPP ${{ needs.resolve.outputs.ref }} (${{ needs.resolve.outputs.platform }}, bullseye/arm64)" \
-            --notes "$notes" \
-            /out/debs/*.deb /out/vpp-api-json.tar.gz /out/manifest.json /out/SHA256SUMS
-          echo "::notice::published $tag"
-
   verify-package:
     name: Verify installed package (clean bullseye)
     needs: [resolve, build]
@@ -425,10 +392,20 @@ jobs:
       - name: Install the built packages
         run: |
           set -euo pipefail
-          ls -la /pkg
+          find /pkg -type f | sort
+          # The .debs sit under /pkg/debs/: upload-artifact roots the
+          # artifact at the least common ancestor of its path patterns
+          # (/out), so the debs/ component survives the round trip. A
+          # bare /pkg/*.deb glob matches nothing and, unexpanded, gets
+          # handed to apt as a literal filename. Locate them instead —
+          # this job had never actually run before, so the shape of the
+          # download was assumption, not observation.
+          mapfile -t debs < <(find /pkg -name '*.deb' | sort)
+          [ "${#debs[@]}" -gt 0 ] || { echo "::error::no .deb in the artifact"; exit 1; }
+          printf 'installing: %s\n' "${debs[@]}"
           # `apt-get install ./*.deb` (not `dpkg -i`) so unmet
           # dependencies fail loudly here rather than on a router.
-          DEBIAN_FRONTEND=noninteractive apt-get install -y /pkg/*.deb
+          DEBIAN_FRONTEND=noninteractive apt-get install -y "${debs[@]}"
           command -v vpp || { echo "::error::no vpp on PATH after install"; exit 1; }
 
       - name: Verify the INSTALLED binary
@@ -470,3 +447,59 @@ jobs:
             exit 1
           fi
           echo "installed package verified: loads, resolves, and carries the Octeon PMD"
+
+  # Publishing is a SEPARATE job gated on verify-package, not a final
+  # step of `build`. It used to be the latter, which meant the .debs
+  # were downloadable before anything had tried installing them: a
+  # package that failed verification was already on the release page,
+  # and the runbook told operators that a published artifact had been
+  # verified. Ordering, not wording, is what makes that true.
+  publish:
+    name: Publish release
+    needs: [resolve, build, verify-package]
+    # A push-triggered run leaves `inputs.publish` empty, which coerces
+    # equal to `false` — so the PRIMARY automatic trigger would spend
+    # the whole build and publish nothing, leaving the runbook's
+    # release pointer dangling. Gate on the event.
+    if: github.event_name == 'push' || inputs.publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: vpp-${{ needs.resolve.outputs.ref }}-${{ needs.resolve.outputs.platform }}-bullseye-arm64
+          path: /tmp/pkg
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          cd /tmp/pkg
+          find . -type f | sort
+          # Facts come from the manifest the build wrote, not from job
+          # env: this job runs on a different runner, and re-deriving
+          # them here would let the release notes disagree with the
+          # artifact they describe.
+          commit=$(jq -r '.vpp_commit' manifest.json)
+          pmd=$(jq -r '.octeon_pmd' manifest.json)
+          tag='${{ needs.resolve.outputs.tag }}'
+          notes=$(printf '%s\n' \
+            "Unmodified upstream VPP \`${{ needs.resolve.outputs.ref }}\` (\`$commit\`), built for Debian 11 (bullseye) arm64 — the only combination UniFi OS can install." \
+            "" \
+            "Variant: \`${{ needs.resolve.outputs.platform }}\` · Octeon PMD: \`$pmd\` · No patches applied." \
+            "" \
+            "Verified in CI before publication: glibc symbol floor ≤ 2.31, no unresolved shared libraries, Octeon PMD present, and the .debs install cleanly into a stock bullseye." \
+            "" \
+            "\`vpp-api-json.tar.gz\` is the API-definition bundle consumed by the vpp-offload binary-API codegen; it is published separately so codegen does not download the .debs." \
+            "" \
+            "Install order and operational guidance: \`docs/runbooks/vpp-offload-spike.md\`.")
+          # Flat asset names, matching SHA256SUMS — see the manifest
+          # step's note on why that matters after a download.
+          gh release create "$tag" \
+            --repo '${{ github.repository }}' \
+            --title "VPP ${{ needs.resolve.outputs.ref }} (${{ needs.resolve.outputs.platform }}, bullseye/arm64)" \
+            --notes "$notes" \
+            debs/*.deb vpp-api-json.tar.gz manifest.json SHA256SUMS
+          echo "::notice::published $tag"

--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -279,22 +279,55 @@ jobs:
           # build logs `symlink-drivers-solibs.sh lib dpdk/pmds-26.1`,
           # i.e. the standalone shape). Checking only the first is how
           # a perfectly good build got failed.
+          echo "--- driver inventory ---"
+          find "$root" \( -path '*vpp_drivers*' -o -path '*dpdk*' -o -name 'librte_net_*' \) \
+            -type f | sort
+          echo "--- end inventory ---"
+
+          # Three shapes count as "this build can drive our NIC", and
+          # the third is the one that broke the previous assumption:
+          #
+          #  1. VPP's NATIVE Octeon driver (dev_octeon, under
+          #     vpp_drivers/). VPP >= 24.02 has its own device
+          #     framework, and 26.06's build downloads and compiles
+          #     marvell-octeon-roc specifically to feed it — visible in
+          #     the log as "installing octeon-roc 26.05". This path
+          #     does not involve DPDK at all.
+          #  2. DPDK's cnxk/octeontx2 PMD as a standalone
+          #     librte_net_*.so.
+          #  3. The same PMD linked into dpdk_plugin.so.
+          #
+          # The previous revision accepted only 2 and 3 and failed a
+          # build that had 1 — a `strings dpdk_plugin.so | grep
+          # net_cnxk` that finds nothing is evidence about DPDK's
+          # driver set, not about whether VPP can reach the hardware.
+          # Which shape we get decides the startup.conf that gate 0b
+          # writes, so the manifest records it rather than flattening
+          # it to a boolean.
+          native=$(find "$root" -name 'dev_octeon*.so*' -print -quit)
           pmd_so=$(find "$root" \( -name 'librte_net_cnxk*' -o -name 'librte_net_octeontx2*' \) -print -quit)
           plugin=$(find "$root" -name 'dpdk_plugin.so' -print -quit)
-          pmd=''
+          driver=''
+          if [ -n "$native" ]; then
+            echo "native Octeon driver: $native"
+            driver=dev_octeon
+          fi
           if [ -n "$pmd_so" ]; then
-            echo "standalone PMD object: $pmd_so"
-            case "$pmd_so" in *cnxk*) pmd=net_cnxk ;; *) pmd=net_octeontx2 ;; esac
+            echo "standalone DPDK PMD: $pmd_so"
+            case "$pmd_so" in *cnxk*) driver="${driver:+$driver,}net_cnxk" ;;
+                              *) driver="${driver:+$driver,}net_octeontx2" ;; esac
           elif [ -n "$plugin" ]; then
-            echo "dpdk_plugin: $plugin"
-            pmd=$(strings "$plugin" | grep -m1 -oE 'net_cnxk|net_octeontx2' || true)
-          else
-            echo "::error::neither dpdk_plugin.so nor a standalone Octeon PMD found under $root"
+            linked=$(strings "$plugin" | grep -m1 -oE 'net_cnxk|net_octeontx2' || true)
+            [ -n "$linked" ] && echo "PMD linked into $plugin: $linked"
+            driver="${driver:+$driver,}${linked}"
+            driver="${driver%,}"
+          fi
+          echo "octeon driver(s): ${driver:-NONE}"
+          if [ -z "$driver" ]; then
+            echo "::error::this build has no way to drive the Octeon NIC — neither VPP's native dev_octeon nor a DPDK cnxk/octeontx2 PMD (see inventory above)"
             exit 1
           fi
-          echo "octeon PMD: ${pmd:-NONE}"
-          [ -n "$pmd" ] || { echo "::error::no cnxk/octeontx2 PMD in the bundled DPDK"; exit 1; }
-          echo "PMD_FAMILY=$pmd" >> "$GITHUB_ENV"
+          echo "PMD_FAMILY=$driver" >> "$GITHUB_ENV"
 
           # Unresolved-symbol smoke test. `vpp -h` needs its own libs on
           # the path; a clean exit or a usage message both prove linkage.
@@ -432,21 +465,25 @@ jobs:
           fi
 
           # The NIC driver must survive packaging, not merely exist in
-          # the build tree. Same two shapes as the build-tree smoke
-          # test: linked into dpdk_plugin.so, or a standalone
-          # librte_net_*.so under dpdk/pmds-<abi>/.
+          # the build tree. Same three shapes the build-tree smoke test
+          # accepts — VPP's native dev_octeon, a standalone DPDK PMD, or
+          # one linked into dpdk_plugin.so — because which one this VPP
+          # ships is a property of the release, not a constant.
+          native=$(find / -name 'dev_octeon*.so*' -not -path '/proc/*' -print -quit 2>/dev/null || true)
           pmd_so=$(find / \( -name 'librte_net_cnxk*' -o -name 'librte_net_octeontx2*' \) \
             -not -path '/proc/*' -print -quit 2>/dev/null || true)
           plugin=$(find / -name dpdk_plugin.so -not -path '/proc/*' -print -quit 2>/dev/null || true)
-          if [ -n "$pmd_so" ]; then
+          if [ -n "$native" ]; then
+            echo "installed native Octeon driver: $native"
+          elif [ -n "$pmd_so" ]; then
             echo "installed standalone PMD: $pmd_so"
           elif [ -n "$plugin" ] && strings "$plugin" | grep -qE 'net_cnxk|net_octeontx2'; then
             echo "installed PMD linked into: $plugin"
           else
-            echo "::error::no cnxk/octeontx2 PMD in the installed packages"
+            echo "::error::the installed packages carry no Octeon driver (native or DPDK)"
             exit 1
           fi
-          echo "installed package verified: loads, resolves, and carries the Octeon PMD"
+          echo "installed package verified: loads, resolves, and carries an Octeon driver"
 
   # Publishing is a SEPARATE job gated on verify-package, not a final
   # step of `build`. It used to be the latter, which meant the .debs

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -143,19 +143,42 @@ re-litigate it from a half-memory:
   members, and the binary's symbol floor is **GLIBC_2.34** against our
   2.31 (`objdump -T`). Older-on-newer works; newer-on-older does not.
 
-Hence: **source build, on-box/in-CI** (18 cores; deps largely present
-from the gate-0a testpmd build). This also opens the cn9k-tuned build
-as a same-pipeline variant rather than a separate decision.
+Hence we build it ourselves — **in CI, not on the box.**
+
+> **Do not build VPP on the router.** The obvious `make install-dep`
+> route is a dead end there and the failure is not obvious in advance:
+> UniFi ships a patched `libnl-3-200 3.4.0-8+ubnt`, while Debian's
+> `libnl-3-dev` depends on its runtime sibling at an *exact* version
+> (`= 3.4.0-1+b1`). apt cannot resolve that and stops. The apparent fix
+> — downgrading `libnl-3-200` — would swap a patched netlink library
+> out from under udapi and the rest of UniFi's stack, on a production
+> router, to satisfy a build dependency. Don't.
+>
+> Verified 2026-08-02 on the primary.
+
+`.github/workflows/vpp-build.yml` builds unmodified upstream VPP in a
+clean `debian:bullseye` container on a native arm64 runner, where none
+of that applies, and publishes `.debs` under their own release tag. It
+runs when `vpp/pin.toml` changes, or on demand. This also makes the
+cn9k-tuned build a same-pipeline variant rather than a separate
+decision.
 
 Version pins, mirroring the gate-0a two-era doctrine (the AF↔VF
 mailbox does not follow newer-is-better):
 
-1. **`v26.06`** — the latest upstream stable — first. Its Makefile has
-   explicit `debian-11` handling, so bullseye is a supported build
-   host; fd.io simply doesn't *publish* bullseye arm64 binaries, which
-   says nothing about buildability. Default to newest for the security
-   fixes and upstream support, and drop back only on a measured
-   failure.
+1. **`v26.06`** — the latest upstream stable — first, and it **builds
+   and packages cleanly** (verified in CI 2026-08-02). fd.io simply
+   doesn't *publish* bullseye arm64 binaries, which says nothing about
+   buildability. Default to newest for the security fixes and upstream
+   support, and drop back only on a measured failure.
+
+   One caveat learned the hard way: `make install-dep` succeeding is
+   *not* evidence that bullseye's toolchain is new enough. Dependency
+   packaging still targets debian-11, but individual tool floors have
+   moved past it — 26.06 needs CMake ≥ 3.19 against bullseye's 3.18.4,
+   which the workflow supplements with a pinned upstream CMake. If that
+   list of supplements ever grows past a couple of tools, take the
+   ladder below rather than keep rebuilding bullseye's toolchain.
 2. Fallback ladder, only if 26.06's PMD fails the mailbox handshake:
    `v25.10`/`v24.10` → `v23.06` → `v22.02` (DPDK 21.11, the last
    `octeontx2`-named era, closest to the DPDK 20.11 build that passed
@@ -163,20 +186,53 @@ mailbox does not follow newer-is-better):
    mailbox does not follow newer-is-better — but that is a reason to
    TEST the newest, not to pre-emptively ship something old.
 
+### Getting the build onto the shadow
+
 ```sh
-cd /root && git clone --depth 1 --branch v26.06 https://github.com/FDio/vpp && cd vpp && UNATTENDED=y make install-dep && make build-release
+# On a workstation with `gh` authenticated, then scp to the shadow —
+# or run on the box if it has network + gh.
+gh release download vpp-v26.06-generic-bullseye-arm64 \
+  --repo unredacted/packetframe --dir /tmp/vpp
 ```
 
-(~30–45 min. Binaries land in
-`build-root/install-vpp-native/vpp/bin/vpp` with plugins alongside —
-run in place for the spike; `make pkg-deb` later for fleet packaging.)
-Record the exact tag/commit — it becomes the pin for slice 3's API
-codegen (`build-root/install-vpp-native/vpp/share/vpp/api/**/*.api.json`).
-Check the bundled PMD family with `strings
-build-root/install-vpp-native/vpp/lib/vpp_plugins/dpdk_plugin.so |
-grep -m1 -iE 'net_cnxk|net_octeontx2'` — that names which mailbox era
-this VPP will present to the AF, and if it fails the handshake the
-next rung of the fallback ladder is the next build.
+**Read the dependency line before installing anything.** The libnl
+divergence above lives at install time too, in a milder form: runtime
+deps are normally `>=` constraints, which UniFi's *newer* `3.4.0-8+ubnt`
+satisfies — but an `=` pin would be the same wall moved later.
+
+```sh
+dpkg -I /tmp/vpp/vpp_*.deb | grep -i depends
+```
+
+Then install with `apt-get install ./*.deb` rather than `dpkg -i`, so
+an unmet dependency fails loudly instead of leaving a half-configured
+package:
+
+```sh
+cd /tmp/vpp && apt-get install -y ./*.deb && command -v vpp && vpp --version
+```
+
+### What CI already proved, so you needn't re-check
+
+The build job verifies these on every run; they are recorded here so a
+failure on the box is read as *new* rather than re-derived:
+
+- **glibc symbol floor `GLIBC_2.17`** against UniFi OS's 2.31. This is
+  the check that killed the fd.io jammy deb, applied to what we ship.
+- The Octeon PMD is present. Note it is a **standalone
+  `librte_net_cnxk*.so` under `dpdk/pmds-<abi>/`**, not linked into
+  `dpdk_plugin.so` — so `strings dpdk_plugin.so | grep net_cnxk` finds
+  nothing and means nothing. Look for the PMD object itself.
+- The `.debs` install into a clean bullseye and the installed binary
+  resolves its libraries (the `verify-package` job).
+
+The `.api.json` definitions publish as a separate small asset on the
+same release — that is slice 3's codegen input, and the exact
+tag/commit in the release manifest is the pin it generates against.
+
+**If the PMD fails the mailbox handshake**, the next rung of the
+fallback ladder is a `vpp/pin.toml` edit, not an on-box rebuild:
+changing `ref` re-runs the workflow and publishes a new tag.
 
 ## 2. Stage resources + startup.conf
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -188,34 +188,68 @@ mailbox does not follow newer-is-better):
 
 ### Getting the build onto the shadow
 
+Derive the tag from the pin rather than typing a version — otherwise
+working the fallback ladder below re-downloads the build that just
+failed, which looks exactly like the fallback not working:
+
 ```sh
-# On a workstation with `gh` authenticated, then scp to the shadow —
-# or run on the box if it has network + gh.
-gh release download vpp-v26.06-generic-bullseye-arm64 \
+# From a checkout of this repo (workstation with `gh` authenticated;
+# scp to the shadow afterwards, or run on the box if it has both).
+ref=$(grep -E '^\s*ref\s*=' vpp/pin.toml | head -1 | cut -d'"' -f2)
+plat=$(grep -E '^\s*platform\s*=' vpp/pin.toml | head -1 | cut -d'"' -f2)
+gh release download "vpp-${ref}-${plat:-generic}-bullseye-arm64" \
   --repo unredacted/packetframe --dir /tmp/vpp
 ```
 
-**Read the dependency line before installing anything.** The libnl
+**Read the dependency lines before installing anything.** The libnl
 divergence above lives at install time too, in a milder form: runtime
 deps are normally `>=` constraints, which UniFi's *newer* `3.4.0-8+ubnt`
-satisfies — but an `=` pin would be the same wall moved later.
+satisfies — but an `=` pin would be the same wall moved later. Check
+**every** package, not just the main one: `vpp-plugin-dpdk` and the
+`-dev` packages carry their own dependency sets, and the plugin package
+is the one that pulls DPDK's libraries.
 
 ```sh
-dpkg -I /tmp/vpp/vpp_*.deb | grep -i depends
+for d in /tmp/vpp/*.deb; do echo "== $d"; dpkg -I "$d" | grep -i '^ *depends'; done
 ```
 
-Then install with `apt-get install ./*.deb` rather than `dpkg -i`, so
-an unmet dependency fails loudly instead of leaving a half-configured
-package:
+Then install with `apt-get install` rather than `dpkg -i`, so an unmet
+dependency fails loudly instead of leaving a half-configured package:
 
 ```sh
 cd /tmp/vpp && apt-get install -y ./*.deb && command -v vpp && vpp --version
 ```
 
+### Stop the packaged service before the manual bring-up
+
+Installing VPP's `.deb` brings its systemd unit with it, and the
+packaged daemon may start on the stock `/etc/vpp/startup.conf`. That
+matters here because §3 starts VPP **by hand** on a spike config: two
+instances contend for the same hugepages, VF, and API socket, and the
+second one's failure looks like a config or mailbox problem rather than
+what it is. `pkill vpp` will not settle it either — systemd restarts
+the unit underneath you.
+
+```sh
+systemctl stop vpp.service 2>/dev/null || true
+systemctl mask vpp.service          # survives a package reconfigure
+```
+
+Unmask at cleanup (`systemctl unmask vpp.service`) if you intend to
+leave the box able to run the packaged daemon. For the spike, staying
+masked is the safer state — nothing should start VPP except you.
+
 ### What CI already proved, so you needn't re-check
 
-The build job verifies these on every run; they are recorded here so a
-failure on the box is read as *new* rather than re-derived:
+**Publication is gated on verification** — the `publish` job runs only
+after `verify-package` passes, so a release tag existing is itself the
+evidence that the checks below passed. (This was not always true:
+publishing used to be the last step of the build job, which put
+unverified `.debs` on the release page. If you are looking at an
+artifact published before 2026-08-02, check the run.)
+
+They are recorded here so a failure on the box is read as *new* rather
+than re-derived:
 
 - **glibc symbol floor `GLIBC_2.17`** against UniFi OS's 2.31. This is
   the check that killed the fd.io jammy deb, applied to what we ship.
@@ -291,3 +325,10 @@ section:
 `pkill vpp`; sweep `/dev/hugepages/rtemap_*`; VF and hugepage teardown
 per the gate-0a notes (or leave staged for the next session — the
 shadow is the integration environment).
+
+`vpp.service` stays **masked** from §1 unless you deliberately want the
+packaged daemon running. Leave it masked between sessions: an
+unattended VPP holding hugepages and the VF is exactly the state that
+makes the next bring-up fail confusingly. Only `systemctl unmask
+vpp.service` when handing the box back to normal use — and note that
+`pkill vpp` alone does not survive an unmasked unit's restart policy.


### PR DESCRIPTION
Section 1 of the spike runbook still told the operator to run `make install-dep && make build-release` **on the router**. That command cannot succeed there, and it's the first thing you'd do at gate 0b.

## Why it can't work, and why the obvious fix is worse

UniFi ships a patched `libnl-3-200 3.4.0-8+ubnt`; Debian's `libnl-3-dev` depends on its runtime sibling at an **exact** version (`= 3.4.0-1+b1`). apt has no resolution and stops.

The apparent fix — downgrading `libnl-3-200` — would swap a patched netlink library out from under udapi and the rest of UniFi's stack, **on a production router**, to satisfy a build dependency. Now an explicit do-not with the reasoning, so nobody rediscovers it mid-spike and then talks themselves into the downgrade.

## Replaced with the artifact path

Download the release tag, then **read the dependency line before installing anything** — the same libnl divergence could reappear at install time if any runtime dep is pinned with `=` rather than `>=`:

```sh
dpkg -I /tmp/vpp/vpp_*.deb | grep -i depends
```

…and install via `apt-get install ./*.deb` rather than `dpkg -i`, so an unmet dependency fails loudly instead of leaving a half-configured package.

## Recorded what CI already proves

So an on-box failure reads as *new* rather than getting re-derived from scratch:

- glibc symbol floor **`GLIBC_2.17`** against UniFi OS's 2.31
- the `.debs` install into a clean bullseye and resolve their libraries
- **the Octeon PMD is a standalone `librte_net_cnxk*.so` under `dpdk/pmds-<abi>/`**, not linked into `dpdk_plugin.so`

That last one matters: the runbook previously suggested `strings dpdk_plugin.so | grep net_cnxk`, which finds nothing and **means** nothing. The same assumption cost a CI round in #93 — no reason for it to cost an hour on the shadow too.

Also corrected the version-pin note in the same spirit as `vpp/pin.toml`: `install-dep` succeeding is not evidence that bullseye's toolchain is new enough. 26.06 needs CMake ≥ 3.19 against bullseye's 3.18.4.

Docs only. Does not touch the workflow, so merging does not re-trigger a build.