### PR TITLE
fix(ci): re-enable DPDK's cnxk family — the generic build cannot drive our NIC

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -86,18 +86,48 @@ jobs:
         id: exists
         env:
           GH_TOKEN: ${{ github.token }}
+          BEFORE: ${{ github.event.before }}
         run: |
           set -euo pipefail
           tag='${{ steps.pin.outputs.tag }}'
           force='${{ inputs.force }}'
+
+          # The tag is derived from the PIN alone, but the artifact is
+          # a function of the pin AND this workflow's build config —
+          # which disabled-driver overrides made materially true. So a
+          # workflow change that alters what gets built would otherwise
+          # hit the existence check and skip, leaving the fleet on an
+          # artifact built from superseded config, under a tag implying
+          # otherwise. Detect it and rebuild.
+          #
+          # Cost note against this file's own cost-control rationale:
+          # the workflow path is already a trigger, so this only fires
+          # on a push that edited it — twice a year in practice. It
+          # cannot distinguish a comment edit from a driver-list
+          # change, and rebuilding needlessly is far cheaper than
+          # silently shipping a stale artifact.
+          wf_changed=false
+          if [ '${{ github.event_name }}' = 'push' ] && \
+             [ -n "$BEFORE" ] && \
+             [ "$BEFORE" != '0000000000000000000000000000000000000000' ]; then
+            if gh api "repos/${{ github.repository }}/compare/${BEFORE}...${{ github.sha }}" \
+                 --jq '.files[].filename' 2>/dev/null \
+                 | grep -qx '.github/workflows/vpp-build.yml'; then
+              wf_changed=true
+            fi
+          fi
+
           if [ "$force" = "true" ]; then
             echo "needs_build=true" >> "$GITHUB_OUTPUT"
             echo "force requested; rebuilding"
-          elif gh release view "$tag" --repo '${{ github.repository }}' >/dev/null 2>&1; then
+          elif ! gh release view "$tag" --repo '${{ github.repository }}' >/dev/null 2>&1; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+          elif [ "$wf_changed" = "true" ]; then
+            echo "needs_build=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$tag exists, but this push changed the build workflow — rebuilding and replacing it."
+          else
             echo "needs_build=false" >> "$GITHUB_OUTPUT"
             echo "::notice::$tag is already published; nothing to build. Re-run with force to rebuild."
-          else
-            echo "needs_build=true" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -262,9 +292,24 @@ jobs:
           libs=$(printf '%s' "$vars" | sed -n 2p)
 
           filter() {
-            # Drop every cnxk member (common/, net/, mempool/, crypto/
-            # for drivers; the bare `cnxk` lib) and nothing else.
-            printf '%s' "$1" | tr ',' '\n' | grep -v cnxk | grep -v '^$' | paste -sd, -
+            # Drop every member of the Octeon driver families and
+            # nothing else: cnxk (common/, net/, mempool/, crypto/, and
+            # the bare `cnxk` lib) plus octeontx2, the name the same
+            # silicon used before DPDK 22.11 renamed it.
+            #
+            # octeontx2 is a no-op on every version in the fallback
+            # ladder — checked, not assumed: v22.02 disables neither
+            # family (so its octeontx2 PMD is on by default), v23.06
+            # disables only cnxk, and 26.03 has no octeontx2 driver at
+            # all. It is here as insurance for a version that does,
+            # since removing an absent entry costs nothing.
+            #
+            # Deliberately NOT matched: compress/octeontx, event/octeontx
+            # and mempool/octeontx — those are OCTEON TX v1, different
+            # silicon, and upstream means them disabled. `octeontx2`
+            # cannot match `octeontx`.
+            printf '%s' "$1" | tr ',' '\n' \
+              | grep -v -e cnxk -e octeontx2 | grep -v '^$' | paste -sd, -
           }
           for pair in "DRIVERS:$drivers" "LIBS:$libs"; do
             name=${pair%%:*}; val=${pair#*:}
@@ -275,10 +320,10 @@ jobs:
               *,*) : ;;
               *) echo "::error::DPDK_${name}_DISABLED evaluated to '$val' — upstream layout changed?"; exit 1 ;;
             esac
-            echo "$name removing: $(printf '%s' "$val" | tr ',' '\n' | grep cnxk | paste -sd, - || echo none)"
+            echo "$name removing: $(printf '%s' "$val" | tr ',' '\n' | grep -e cnxk -e octeontx2 | paste -sd, - || echo none)"
           done
-          printf '%s' "$drivers" | grep -q cnxk \
-            || echo "::warning::upstream no longer disables cnxk; this override is a no-op"
+          printf '%s' "$drivers" | grep -q -e cnxk -e octeontx2 \
+            || echo "::warning::upstream disables no Octeon driver family at this ref; the override is a no-op (fine — it means the PMD ships enabled)"
 
           {
             echo "DPDK_DRIVERS_KEPT=$(filter "$drivers")"
@@ -607,11 +652,27 @@ jobs:
             "\`vpp-api-json.tar.gz\` is the API-definition bundle consumed by the vpp-offload binary-API codegen; it is published separately so codegen does not download the .debs." \
             "" \
             "Install order and operational guidance: \`docs/runbooks/vpp-offload-spike.md\`.")
+          title="VPP ${{ needs.resolve.outputs.ref }} (${{ needs.resolve.outputs.platform }}, bullseye/arm64)"
           # Flat asset names, matching SHA256SUMS — see the manifest
           # step's note on why that matters after a download.
-          gh release create "$tag" \
-            --repo '${{ github.repository }}' \
-            --title "VPP ${{ needs.resolve.outputs.ref }} (${{ needs.resolve.outputs.platform }}, bullseye/arm64)" \
-            --notes "$notes" \
-            debs/*.deb vpp-api-json.tar.gz manifest.json SHA256SUMS
+          #
+          # The tag can already exist: resolve rebuilds when the build
+          # workflow itself changed, since the artifact depends on this
+          # file's config and not on the pin alone. Update in place
+          # (`--clobber`) rather than delete-and-recreate, so there is
+          # no window where the release the runbook points operators at
+          # does not exist.
+          if gh release view "$tag" --repo '${{ github.repository }}' >/dev/null 2>&1; then
+            echo "::notice::$tag exists — replacing its assets"
+            gh release edit "$tag" --repo '${{ github.repository }}' \
+              --title "$title" --notes "$notes"
+            gh release upload "$tag" --repo '${{ github.repository }}' --clobber \
+              debs/*.deb vpp-api-json.tar.gz manifest.json SHA256SUMS
+          else
+            gh release create "$tag" \
+              --repo '${{ github.repository }}' \
+              --title "$title" \
+              --notes "$notes" \
+              debs/*.deb vpp-api-json.tar.gz manifest.json SHA256SUMS
+          fi
           echo "::notice::published $tag"

--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -217,18 +217,93 @@ jobs:
             exit 1
           fi
 
+      # VPP's DPDK recipe disables the ENTIRE cnxk family by default —
+      # `common/cnxk`, `net/cnxk`, `mempool/cnxk`, `crypto/cnxk` all
+      # appear in DPDK_DRIVERS_DISABLED, and `cnxk` in
+      # DPDK_LIBS_DISABLED. That is upstream's choice for a portable
+      # build, and it is why the first artifact carried no Octeon
+      # driver at all: not a packaging accident, and not something a
+      # different VPP version fixes, because the disable list is
+      # long-standing. VPP 26.06 also has no native `dev_octeon` — its
+      # vpp_drivers/ ships atlantic, iavf and ige only — so DPDK's cnxk
+      # PMD is the only way this VPP can reach an Octeon NIC.
+      #
+      # Re-enabling it is a BUILD-CONFIG override, not a patch: the
+      # source tree stays verbatim (the clone step still asserts a
+      # clean working tree), we only pass different make variables.
+      #
+      # Derived from the pinned tree rather than hardcoded, so the rest
+      # of upstream's disable list keeps whatever upstream decides it
+      # should be across version bumps; we subtract cnxk and nothing
+      # else. Enabled unconditionally rather than under the cn9k
+      # platform, because `platform` means CPU TUNING here — a generic
+      # armv8-a build still has to drive this fleet's NIC.
+      - name: Re-enable the cnxk driver family in DPDK
+        run: |
+          set -euo pipefail
+          cd /vpp/build/external
+          # Ask make for the EFFECTIVE lists rather than parsing the
+          # .mk. Parsing is wrong here in a way that is easy to miss:
+          # the base lists are `:=` continued over ~40 backslashed
+          # lines, and dpdk.mk then APPENDS to them conditionally
+          # (net/tap, net/failsafe, and the mlx family, depending on
+          # DPDK_*_PMD). A file-scraped base list would silently drop
+          # those and enable drivers upstream meant to stay off.
+          # Including the real Makefile evaluates all of it, including
+          # the package versions dpdk.mk requires to parse at all.
+          # printf, not a heredoc: make demands a literal TAB to start a
+          # recipe line, and a heredoc indented to match this YAML block
+          # would prepend spaces (while `<<-` strips tabs, including the
+          # one that matters). Single quotes keep `$(...)` for make.
+          printf 'include Makefile\n__pf_print:\n\t@echo "$(DPDK_DRIVERS_DISABLED)"\n\t@echo "$(DPDK_LIBS_DISABLED)"\n' \
+            > /tmp/pf-dpdk-vars.mk
+          vars=$(make -s -f /tmp/pf-dpdk-vars.mk __pf_print | tail -2)
+          drivers=$(printf '%s' "$vars" | sed -n 1p)
+          libs=$(printf '%s' "$vars" | sed -n 2p)
+
+          filter() {
+            # Drop every cnxk member (common/, net/, mempool/, crypto/
+            # for drivers; the bare `cnxk` lib) and nothing else.
+            printf '%s' "$1" | tr ',' '\n' | grep -v cnxk | grep -v '^$' | paste -sd, -
+          }
+          for pair in "DRIVERS:$drivers" "LIBS:$libs"; do
+            name=${pair%%:*}; val=${pair#*:}
+            # An empty or single-token result means the evaluation went
+            # wrong; overriding with it would enable every driver DPDK
+            # has. Stopping here is much cheaper than that build.
+            case "$val" in
+              *,*) : ;;
+              *) echo "::error::DPDK_${name}_DISABLED evaluated to '$val' — upstream layout changed?"; exit 1 ;;
+            esac
+            echo "$name removing: $(printf '%s' "$val" | tr ',' '\n' | grep cnxk | paste -sd, - || echo none)"
+          done
+          printf '%s' "$drivers" | grep -q cnxk \
+            || echo "::warning::upstream no longer disables cnxk; this override is a no-op"
+
+          {
+            echo "DPDK_DRIVERS_KEPT=$(filter "$drivers")"
+            echo "DPDK_LIBS_KEPT=$(filter "$libs")"
+          } >> "$GITHUB_ENV"
+
       - name: Build release
         run: |
           set -euo pipefail
           cd /vpp
+          # Command-line make variables override the makefile's own
+          # assignments (these are `=`/`:=`, not `?=`, so environment
+          # alone would lose) and propagate to the external sub-make.
+          args=(
+            "DPDK_DRIVERS_DISABLED=$DPDK_DRIVERS_KEPT"
+            "DPDK_LIBS_DISABLED=$DPDK_LIBS_KEPT"
+          )
           if [ '${{ needs.resolve.outputs.platform }}' = 'cn9k' ]; then
-            # Marvell-tuned variant: LSE atomics + tuned memcpy. Only
-            # meaningful once packet-rate-bound; produces a separately
-            # tagged artifact.
-            make build-release VPP_EXTRA_CMAKE_ARGS='-DVPP_LIBRARY_FLAGS=-mcpu=octeontx2'
-          else
-            make build-release
+            # Marvell-tuned variant: LSE atomics + tuned memcpy, plus
+            # DPDK's own cn9k platform tuning. Only meaningful once
+            # packet-rate-bound; produces a separately tagged artifact.
+            args+=(DPDK_MACHINE=cn9k VPP_EXTRA_CMAKE_ARGS='-DVPP_LIBRARY_FLAGS=-mcpu=octeontx2')
           fi
+          printf 'make arg: %s\n' "${args[@]}"
+          make build-release "${args[@]}"
 
       - name: Package .debs
         run: |


### PR DESCRIPTION
The driver inventory added in #94 settles what three rounds were guessing at, and **the answer is not a CI bug — the artifact genuinely could not reach our hardware.**

```
vpp_drivers/: atlantic_driver.so, iavf_driver.so, ige_driver.so
```

Two findings:

**VPP 26.06 has no native `dev_octeon` at all.** My previous commit inferred one from the `octeon-roc 26.05` external in the build log. That library is built as a *dependency* and does not imply a driver — I read a build artifact as evidence of a feature. Wrong, and the inventory says so plainly.

**VPP's own DPDK recipe disables the entire cnxk family**, visible in the meson line from the failed run:

```
-Ddisable_drivers=...,common/cnxk,...,crypto/cnxk,...,mempool/cnxk,...,net/cnxk,...
-Ddisable_libs=...,cnxk,...
```

So the smoke test was right to fail. Two corollaries worth recording:

- **The version fallback ladder does not address this.** The disable list is long-standing upstream, not a 26.06 regression — dropping to v23.06 or v22.02 would produce the same driverless artifact.
- **Gate 0a was unaffected**, because it used standalone DPDK testpmd built from tarball, not VPP's curated DPDK. That result still stands.

## The fix

A **build-config override, not a patch** — the clone step still asserts a clean working tree; we only pass different make variables. On the command line rather than the environment, because these are `:=` assignments, so a file assignment would beat an exported value.

**The lists come from `make` evaluating VPP's own Makefile, not from scraping `dpdk.mk`.** That distinction is load-bearing: the base lists are `:=` continued over ~40 backslashed lines, and `dpdk.mk` then *appends* conditionally (`net/tap`, `net/failsafe`, the mlx family, depending on `DPDK_*_PMD`). A scraped base list silently drops those and enables drivers upstream meant to stay off.

Verified locally against a sparse checkout of v26.06 before pushing: the evaluated list matches the failed run's meson line **byte for byte**, and the filter removes exactly the five cnxk members (`common/`, `crypto/`, `mempool/`, `net/`, and the bare `cnxk` lib) and nothing else. The step also hard-fails if evaluation returns something unparseable, since an empty override would enable every driver DPDK has.

## Why unconditional, not under `cn9k`

`platform` means **CPU tuning** in this workflow — a portable armv8-a build still has to drive this fleet's NIC, so gating the driver on the tuning variant would just make `generic` permanently useless to us.

Relatedly: `cn9k` now also sets `DPDK_MACHINE=cn9k`, which is what actually reaches DPDK's platform tuning. The existing `VPP_EXTRA_CMAKE_ARGS` only tuned VPP itself — so the cn9k variant was never doing what its documentation claimed.

Merging re-triggers the build.