### PR TITLE
fix(ci): grep for the PMD's registered names — net_cn9k, not net_cnxk

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -112,7 +112,7 @@ jobs:
              [ "$BEFORE" != '0000000000000000000000000000000000000000' ]; then
             if gh api "repos/${{ github.repository }}/compare/${BEFORE}...${{ github.sha }}" \
                  --jq '.files[].filename' 2>/dev/null \
-                 | grep -qx '.github/workflows/vpp-build.yml'; then
+                 | grep -x '.github/workflows/vpp-build.yml' >/dev/null; then
               wf_changed=true
             fi
           fi
@@ -473,9 +473,18 @@ jobs:
             if [ -n "$matched" ]; then
               echo "Octeon drivers linked into $(basename "$plugin"): $matched"
               driver="${driver:+$driver,}$matched"
+              # Hard requirement, not a warning: the fleet is cn9670 =
+              # CN9K, so a plugin carrying only net_cn10k/net_cn20k
+              # cannot drive a single one of our NICs. "Has Octeon
+              # drivers" is not the gate; "has OUR Octeon driver" is —
+              # publishing the former as verified would be the exact
+              # lie this step exists to stop.
               case ",$matched," in
                 *,net_cn9k,*|*,net_octeontx2,*) : ;;
-                *) echo "::warning::plugin has Octeon drivers ($matched) but none for CN9K silicon — the fleet is cn9670" ;;
+                *)
+                  echo "::error::plugin has Octeon drivers ($matched) but none that drives CN9K silicon (need net_cn9k or net_octeontx2) — unusable on this fleet"
+                  exit 1
+                  ;;
               esac
             elif [ -n "$pmd_lib" ]; then
               echo "::error::an Octeon PMD was built ($pmd_lib) but none of its registered driver names ($OCTEON_PMD_NAMES) appear in dpdk_plugin.so — built but not linked, and nothing loads PMDs at runtime (dpdk.mk deletes the shared objects at install)."
@@ -641,11 +650,19 @@ jobs:
             echo "installed native Octeon driver: $native"
           elif [ -n "$pmd_so" ]; then
             echo "installed standalone PMD: $pmd_so"
-          elif [ -n "$plugin" ] && strings "$plugin" | grep -qE 'net_cn9k|net_cn10k|net_cn20k|net_octeontx2'; then
-            # REGISTERED driver names, not the library name: the cnxk
-            # PMD registers net_cn9k/net_cn10k/net_cn20k — the string
-            # `net_cnxk` exists in no working build (see the smoke
-            # test's needle note; this cost a CI round).
+          elif [ -n "$plugin" ] && strings "$plugin" | grep -E 'net_cn9k|net_octeontx2' >/dev/null; then
+            # REGISTERED driver names, not the library name (`net_cnxk`
+            # exists in no working build — see the smoke test's needle
+            # note), and only the names that can drive CN9K silicon:
+            # a plugin with just net_cn10k/net_cn20k is unusable on
+            # this fleet and must not verify.
+            #
+            # `grep -E ... >/dev/null`, NOT `grep -q`: under this
+            # step's pipefail, -q exits at the first match, the
+            # still-writing strings gets SIGPIPE (141), and the
+            # pipeline — and so this condition — goes false on a GOOD
+            # plugin. Without -q grep reads the stream to EOF, so the
+            # pipeline status is grep's own.
             echo "installed PMD linked into: $plugin"
           else
             echo "::error::the installed packages carry no Octeon driver (native or DPDK)"

--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -446,14 +446,21 @@ jobs:
           #
           # Consequence: a surviving librte_net_cnxk.a proves DPDK
           # BUILT the driver, but the artifact only works if that .a
-          # actually got whole-archived into dpdk_plugin.so. Those can
-          # diverge (a GROUP generated before the .a landed, or
-          # whole-archive failing to propagate through the script), so
-          # when both a static PMD and the plugin exist, the plugin
-          # must contain the driver's name string — a driver that was
-          # built but not linked is a dead artifact and must fail HERE,
-          # with the divergence named, not in verify-package with a
-          # generic "no PMD found".
+          # actually got whole-archived into dpdk_plugin.so — so when
+          # both exist, the plugin must contain the driver's REGISTERED
+          # names.
+          #
+          # And those names are NOT the library's name. This cost a
+          # full CI round: the cnxk PMD registers one driver per SoC
+          # generation — net_cn9k, net_cn10k, net_cn20k — and no
+          # string `net_cnxk` exists in any working build. A probe
+          # grepping for the library name reported a perfectly good
+          # plugin as driverless. The needle below is the set of
+          # REGISTERED names across the eras we can pin: cn9k/cn10k/
+          # cn20k (cnxk era) and net_octeontx2 (<= DPDK 21.11 era).
+          # The fleet is cn9670 = CN9K, so net_cn9k specifically is
+          # the load-bearing one.
+          OCTEON_PMD_NAMES='net_cn9k|net_cn10k|net_cn20k|net_octeontx2'
           native=$(find "$instroot" -name 'dev_octeon*.so*' -print -quit)
           pmd_lib=$(find "$instroot" \( -name 'librte_net_cnxk*' -o -name 'librte_net_octeontx2*' \) -print -quit)
           driver=''
@@ -461,31 +468,23 @@ jobs:
             echo "native Octeon driver: $native"
             driver=dev_octeon
           fi
-          if [ -n "$pmd_lib" ]; then
-            case "$pmd_lib" in
-              *cnxk*) pmdname=net_cnxk ;;
-              *) pmdname=net_octeontx2 ;;
-            esac
-            echo "DPDK Octeon PMD built: $pmd_lib ($pmdname)"
-            if [ -n "$plugin" ]; then
-              if strings "$plugin" | grep -q "$pmdname"; then
-                echo "$pmdname is linked into $(basename "$plugin")"
-                driver="${driver:+$driver,}$pmdname"
-              else
-                echo "::error::$pmdname was BUILT ($pmd_lib) but is NOT linked into dpdk_plugin.so — the libdpdk.a GROUP/whole-archive chain dropped it, and nothing loads PMDs at runtime (dpdk.mk deletes the shared objects at install). The shipped artifact cannot drive the NIC."
-                exit 1
-              fi
-            else
-              # No dpdk plugin at all: the .a alone is unreachable.
-              echo "::error::$pmdname built but dpdk_plugin.so is missing entirely"
+          if [ -n "$plugin" ]; then
+            matched=$(strings "$plugin" | grep -oE "$OCTEON_PMD_NAMES" | sort -u | paste -sd, - || true)
+            if [ -n "$matched" ]; then
+              echo "Octeon drivers linked into $(basename "$plugin"): $matched"
+              driver="${driver:+$driver,}$matched"
+              case ",$matched," in
+                *,net_cn9k,*|*,net_octeontx2,*) : ;;
+                *) echo "::warning::plugin has Octeon drivers ($matched) but none for CN9K silicon — the fleet is cn9670" ;;
+              esac
+            elif [ -n "$pmd_lib" ]; then
+              echo "::error::an Octeon PMD was built ($pmd_lib) but none of its registered driver names ($OCTEON_PMD_NAMES) appear in dpdk_plugin.so — built but not linked, and nothing loads PMDs at runtime (dpdk.mk deletes the shared objects at install)."
               exit 1
             fi
-          elif [ -n "$plugin" ]; then
-            linked=$(strings "$plugin" | grep -m1 -oE 'net_cnxk|net_octeontx2' || true)
-            if [ -n "$linked" ]; then
-              echo "PMD linked into $plugin: $linked"
-              driver="${driver:+$driver,}${linked}"
-            fi
+          elif [ -n "$pmd_lib" ]; then
+            # No dpdk plugin at all: the .a alone is unreachable.
+            echo "::error::$(basename "$pmd_lib") built but dpdk_plugin.so is missing entirely"
+            exit 1
           fi
           echo "octeon driver(s): ${driver:-NONE}"
           if [ -z "$driver" ]; then
@@ -642,7 +641,11 @@ jobs:
             echo "installed native Octeon driver: $native"
           elif [ -n "$pmd_so" ]; then
             echo "installed standalone PMD: $pmd_so"
-          elif [ -n "$plugin" ] && strings "$plugin" | grep -qE 'net_cnxk|net_octeontx2'; then
+          elif [ -n "$plugin" ] && strings "$plugin" | grep -qE 'net_cn9k|net_cn10k|net_cn20k|net_octeontx2'; then
+            # REGISTERED driver names, not the library name: the cnxk
+            # PMD registers net_cn9k/net_cn10k/net_cn20k — the string
+            # `net_cnxk` exists in no working build (see the smoke
+            # test's needle note; this cost a CI round).
             echo "installed PMD linked into: $plugin"
           else
             echo "::error::the installed packages carry no Octeon driver (native or DPDK)"

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -253,10 +253,22 @@ than re-derived:
 
 - **glibc symbol floor `GLIBC_2.17`** against UniFi OS's 2.31. This is
   the check that killed the fd.io jammy deb, applied to what we ship.
-- The Octeon PMD is present. Note it is a **standalone
-  `librte_net_cnxk*.so` under `dpdk/pmds-<abi>/`**, not linked into
-  `dpdk_plugin.so` — so `strings dpdk_plugin.so | grep net_cnxk` finds
-  nothing and means nothing. Look for the PMD object itself.
+- The Octeon PMD is present, **statically linked into
+  `dpdk_plugin.so`** (VPP whole-archives its DPDK and deletes the
+  shared driver objects at install — there is no standalone PMD `.so`
+  in this build; an earlier revision of this bullet claimed one). And
+  check for the **registered driver names, not the library name**: the
+  cnxk PMD registers one driver per SoC generation, so
+
+  ```sh
+  strings /usr/lib/*/vpp_plugins/dpdk_plugin.so | grep -E 'net_cn9k|net_cn10k|net_cn20k'
+  ```
+
+  is the probe that means something, while `grep net_cnxk` finds
+  nothing in any working build (that miss cost a CI round). The fleet
+  is cn9670 = CN9K: **`net_cn9k` is the one that matters**, and it is
+  also the name to expect in `show hardware-interfaces` driver output
+  during this spike.
 - The `.debs` install into a clean bullseye and the installed binary
   resolves its libraries (the `verify-package` job).
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -261,14 +261,17 @@ than re-derived:
   cnxk PMD registers one driver per SoC generation, so
 
   ```sh
-  strings /usr/lib/*/vpp_plugins/dpdk_plugin.so | grep -E 'net_cn9k|net_cn10k|net_cn20k'
+  strings /usr/lib/*/vpp_plugins/dpdk_plugin.so | grep -E 'net_cn9k|net_cn10k|net_cn20k|net_octeontx2'
   ```
 
   is the probe that means something, while `grep net_cnxk` finds
   nothing in any working build (that miss cost a CI round). The fleet
-  is cn9670 = CN9K: **`net_cn9k` is the one that matters**, and it is
-  also the name to expect in `show hardware-interfaces` driver output
-  during this spike.
+  is cn9670 = CN9K: **`net_cn9k` is the one that matters** on the
+  current pin, and it is also the name to expect in
+  `show hardware-interfaces` driver output during this spike.
+  `net_octeontx2` is the same silicon's name in the ≤ DPDK 21.11 era —
+  it is what a `v22.02` fallback artifact registers instead, so on a
+  fallback pin its presence (not net_cn9k's) is the pass condition.
 - The `.debs` install into a clean bullseye and the installed binary
   resolves its libraries (the `verify-package` job).
 


### PR DESCRIPTION
The tightened gate from #96 fired, and its diagnostic answered the standing contradiction in one line:

```
PMD names inside dpdk_plugin.so: ... net_bnxt net_cn10k net_cn20k net_cn9k net_cpfl ...
```

## The cnxk PMD has been linked in all along

It registers **one driver per SoC generation** — `net_cn9k`, `net_cn10k`, `net_cn20k`. The string `net_cnxk` is the *library's* name, and it exists in no working build — yet it's what every probe since the first round grepped for. The GROUP/whole-archive chain was never broken; the needle was wrong. **The artifact from the previous run was already good.**

(Good news inside the good news: the fleet is cn9670 = CN9K, and `net_cn9k` is present — the exact driver our silicon needs.)

## Changes

- Both jobs match the **registered** names, plus `net_octeontx2` for the ≤ DPDK 21.11 fallback era.
- `PMD_FAMILY` records the actual matched set, so the manifest and release notes say what's really in the plugin. A plugin carrying Octeon drivers but none for CN9K draws a warning naming the silicon.
- Built-but-not-linked still fails, with the same named error — that gate stays, it just uses a needle that can match now.
- The runbook bullet telling operators to look for a standalone `librte_net_cnxk*.so` (a shape `dpdk.mk` deletes at install) now gives the strings probe that means something, and names `net_cn9k` as what `show hardware-interfaces` should report at gate 0b.

## Verified before pushing

Three simulated worlds: per-gen names → pass, `PMD_FAMILY=net_cn10k,net_cn20k,net_cn9k`; CN10K-only plugin → pass with silicon warning; built-but-not-linked → named failure.

Merging re-triggers the build. If it goes green this time, it publishes — `verify-package` finally runs, and the libnl `Depends:` question gets its answer on the release page.