### PR TITLE
fix(ci): use upstream's VPP_INSTALL_SKIP_SYSCTL — in CI and, urgently, on the fleet

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -611,7 +611,21 @@ jobs:
           printf 'installing: %s\n' "${debs[@]}"
           # `apt-get install ./*.deb` (not `dpkg -i`) so unmet
           # dependencies fail loudly here rather than on a router.
-          DEBIAN_FRONTEND=noninteractive apt-get install -y "${debs[@]}"
+          #
+          # VPP_INSTALL_SKIP_SYSCTL is upstream's own knob (read the
+          # postinst: "Allow for a nerd knob to skip this, e.g. during
+          # the container installs"). Without it, vpp.postinst runs
+          # `sysctl --system`: in this container that dies on a missing
+          # sysctl binary — and installing procps would only trade that
+          # for an EPERM on the container's read-only /proc/sys/vm. The
+          # knob is ALSO mandatory on the fleet, for a harsher reason:
+          # the deb ships vm.nr_hugepages=1024 written for 2MB pages,
+          # and on the routers' 64K-page kernel (512MB default
+          # hugepages) applying it requests 512 GiB of hugepages on a
+          # 64 GB box, at install time. See the spike runbook's install
+          # section.
+          DEBIAN_FRONTEND=noninteractive VPP_INSTALL_SKIP_SYSCTL=1 \
+            apt-get install -y "${debs[@]}"
           command -v vpp || { echo "::error::no vpp on PATH after install"; exit 1; }
 
       - name: Verify the INSTALLED binary

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -235,13 +235,22 @@ is therefore too late — the daemon has already run once by then. Mask
 **first**; the postinst's own unmask only touches masks the packaging
 helper itself created, so an operator mask survives install.
 
-The full sequence:
+The full sequence — stop, then mask, then install, and the install is
+gated on the mask having succeeded (`&&`), because installing past a
+failed mask is exactly the daemon-starts-during-install trap:
 
 ```sh
-systemctl mask vpp.service          # BEFORE install — postinst starts the unit
-cd /tmp/vpp && VPP_INSTALL_SKIP_SYSCTL=1 apt-get install -y ./*.deb \
+# Stop tolerates a unit that does not exist yet (first install);
+# mask does not get that tolerance — if IT fails, do not install.
+# Mask alone is not enough on a rerun: it only blocks future
+# activations, and an already-running daemon keeps holding the
+# hugepages, VF, and API socket right through the install.
+systemctl stop vpp.service 2>/dev/null || true
+systemctl mask vpp.service \
+  && cd /tmp/vpp && VPP_INSTALL_SKIP_SYSCTL=1 apt-get install -y ./*.deb \
   && command -v vpp && vpp --version
 cat /proc/sys/vm/nr_hugepages        # belt-and-braces: must be UNCHANGED
+pgrep -a vpp || echo "no vpp running — correct"
 ```
 
 (`apt-get install`, not `dpkg -i`, so an unmet dependency fails loudly

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -201,43 +201,57 @@ gh release download "vpp-${ref}-${plat:-generic}-bullseye-arm64" \
   --repo unredacted/packetframe --dir /tmp/vpp
 ```
 
-**Read the dependency lines before installing anything.** The libnl
-divergence above lives at install time too, in a milder form: runtime
-deps are normally `>=` constraints, which UniFi's *newer* `3.4.0-8+ubnt`
-satisfies — but an `=` pin would be the same wall moved later. Check
-**every** package, not just the main one: `vpp-plugin-dpdk` and the
-`-dev` packages carry their own dependency sets, and the plugin package
-is the one that pulls DPDK's libraries.
+**The install-time libnl question is ANSWERED (2026-08-02, read from
+the built deb's control):** `vpp` depends on `libnl-3-200 (>= 3.2.7)`
+and `libnl-route-3-200 (>= 3.2.26)` — `>=` constraints, which UniFi's
+*newer* `3.4.0-8+ubnt` satisfies. The wall that kills the on-box
+*build* (libnl-3-dev's exact-version pin) does not exist at install
+time. The check below stays for future pins — an `=` could appear in
+any new version. Check **every** package, not just the main one:
 
 ```sh
 for d in /tmp/vpp/*.deb; do echo "== $d"; dpkg -I "$d" | grep -i '^ *depends'; done
 ```
 
-Then install with `apt-get install` rather than `dpkg -i`, so an unmet
-dependency fails loudly instead of leaving a half-configured package:
+### Two traps in vpp.postinst — handle BOTH before installing
+
+Read from the shipped postinst, not guessed:
+
+**1. It applies `sysctl --system`, and the deb ships
+`vm.nr_hugepages=1024` written for 2 MB pages.** On this fleet's
+64K-page kernel the default hugepage size is **512 MB**, so letting it
+run asks the kernel for **512 GiB of hugepages on a 64 GB router, at
+install time** — the kernel grabs what it can, which is a
+memory-eating event on a production box. Upstream ships its own
+escape hatch (`VPP_INSTALL_SKIP_SYSCTL`, quoted in the postinst as a
+"nerd knob... e.g. during the container installs"); on this fleet it
+is **mandatory, always**. Hugepages are managed deliberately — by the
+vpp-offload module in production, by hand in this spike — never by a
+package hook.
+
+**2. It STARTS `vpp.service` during install** (`deb-systemd-invoke
+start`) on the stock `/etc/vpp/startup.conf`. Masking *after* install
+is therefore too late — the daemon has already run once by then. Mask
+**first**; the postinst's own unmask only touches masks the packaging
+helper itself created, so an operator mask survives install.
+
+The full sequence:
 
 ```sh
-cd /tmp/vpp && apt-get install -y ./*.deb && command -v vpp && vpp --version
+systemctl mask vpp.service          # BEFORE install — postinst starts the unit
+cd /tmp/vpp && VPP_INSTALL_SKIP_SYSCTL=1 apt-get install -y ./*.deb \
+  && command -v vpp && vpp --version
+cat /proc/sys/vm/nr_hugepages        # belt-and-braces: must be UNCHANGED
 ```
 
-### Stop the packaged service before the manual bring-up
+(`apt-get install`, not `dpkg -i`, so an unmet dependency fails loudly
+instead of leaving a half-configured package.)
 
-Installing VPP's `.deb` brings its systemd unit with it, and the
-packaged daemon may start on the stock `/etc/vpp/startup.conf`. That
-matters here because §3 starts VPP **by hand** on a spike config: two
-instances contend for the same hugepages, VF, and API socket, and the
-second one's failure looks like a config or mailbox problem rather than
-what it is. `pkill vpp` will not settle it either — systemd restarts
-the unit underneath you.
-
-```sh
-systemctl stop vpp.service 2>/dev/null || true
-systemctl mask vpp.service          # survives a package reconfigure
-```
-
-Unmask at cleanup (`systemctl unmask vpp.service`) if you intend to
-leave the box able to run the packaged daemon. For the spike, staying
-masked is the safer state — nothing should start VPP except you.
+Unmask at cleanup (`systemctl unmask vpp.service`) only if you intend
+to leave the box able to run the packaged daemon. For the spike,
+staying masked is the safer state — nothing should start VPP except
+you, and §3 starting a second instance against a stock-config daemon
+reads as a config or mailbox failure rather than what it is.
 
 ### What CI already proved, so you needn't re-check
 


### PR DESCRIPTION
`verify-package` executed for the first time, and the build side held all the way: smoke test green, `net_cn9k` linked, glibc floor 2.17, packaging clean, publish correctly skipped. The install died configuring `vpp` itself:

```
Setting up vpp (26.06-release) ...
/var/lib/dpkg/info/vpp.postinst: 7: sysctl: not found
```

Instead of patching the symptom, I pulled the deb apart and read the postinst and control file. Three findings, each worth more than the fix.

## 1. Upstream anticipated this exact failure

The sysctl call sits behind a knob:

```sh
# Allow for a nerd knob to skip this, e.g. during the container installs
if [ -z "${VPP_INSTALL_SKIP_SYSCTL}" ]
```

CI now sets `VPP_INSTALL_SKIP_SYSCTL=1`. (Installing `procps` instead would only trade "not found" for an EPERM on the container's read-only `/proc/sys/vm` — same failed postinst, different message.)

## 2. The same knob is mandatory on the routers — this is the important one

The postinst runs `sysctl --system`, and the deb ships:

```
# Number of 2MB hugepages desired
vm.nr_hugepages=1024
```

Written for 2 MB pages. The fleet's 64K-page kernel has a **512 MB** default hugepage size, so an unguarded `apt-get install` requests **512 GiB of hugepages on a 64 GB router** — the kernel grabs what it can, at install time, on whatever box the operator happens to be standing on. The runbook's install sequence now sets the knob unconditionally and checks `/proc/sys/vm/nr_hugepages` is untouched afterwards. Hugepages are managed deliberately — by the vpp-offload module in production, by hand in the spike — never by a package hook.

## 3. The runbook's mask ordering was too late

The postinst **starts `vpp.service` during install** (`deb-systemd-invoke start`), so "stop and mask after installing" meant the stock-config daemon had already run once. Mask now comes **before** install — and the postinst's own unmask only touches masks the packaging helper itself created, so an operator mask survives.

## Bonus: the libnl question is answered

From the built deb's control file:

```
Depends: ... libnl-3-200 (>= 3.2.7), libnl-route-3-200 (>= 3.2.26), ...
```

`>=`, not `=`. UniFi's patched `3.4.0-8+ubnt` satisfies it. The libnl wall exists only at **build** time — **this artifact installs on the fleet.** Recorded in the runbook; the per-package `dpkg -I` check stays for future pins.

Merging re-triggers the build. If `verify-package` passes, it publishes — and gate 0b is fully unblocked.