### PR TITLE
vpp: pin v22.02 — cn9670's die stepping is unknown to the entire cnxk era

### DIFF
--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -186,6 +186,40 @@ mailbox does not follow newer-is-better):
    mailbox does not follow newer-is-better — but that is a reason to
    TEST the newest, not to pre-emptively ship something old.
 
+### RESULT (2026-08-02, shadow): the v26.06 rung fails BEFORE the mailbox
+
+Tested on the shadow with the published artifact. Install, mask,
+sysctl-skip and bring-up all held; VPP ran; `-a 0002:07:00.1` reached
+EAL (the init.c "Unsupported PCI device" warning is **cosmetic** — it
+skips only the uio-bind step and does not blacklist; confirmed in
+source and by `show dpdk version` showing the `-a`). The probe then
+died at the ROC model check, before any AF contact:
+
+```
+CNXK: populate_model():224 Invalid RoC model (impl=0x43, part=0xb2, major=0x3, minor=0x0)
+CNXK: cn9k_nix_probe():810 Failed to initialize platform model, rc=-22
+```
+
+**The cn9670 reports MIDR variant 3 — a die stepping absent from
+`drivers/common/cnxk/roc_model.c` in every public DPDK** (the CN96xx
+table stops at variant 2), and unknown MIDR is a hard `-EINVAL` with
+no override (no env, no devargs, no default-to-nearest; verified in
+v26.03 source). Consequences:
+
+- **The mailbox question is STILL OPEN** — this failure is upstream
+  of it.
+- **The whole cnxk era is gated identically**: v25.10/v24.10/v23.06
+  would fail the same way. The ladder's middle rungs are skipped by
+  measurement, not caution.
+- **v22.02 (DPDK 21.11) is the active rung**: the octeontx2 driver
+  reads no MIDR at probe (verified in v21.11 source), and gate 0a's
+  DPDK 20.11 testpmd moved real packets on this exact silicon. 21.11
+  ships both PMD families; if its cnxk half hits the same gate, EAL
+  falls through to the next matching driver — the gate-free octeontx2.
+- **Road back to current VPP**: upstream the one-line MIDR entry to
+  DPDK / marvell-octeon-roc. No local patch — the pin stays in the
+  octeontx2 era until an upstream release carries the fix.
+
 ### Getting the build onto the shadow
 
 Derive the tag from the pin rather than typing a version — otherwise

--- a/vpp/pin.toml
+++ b/vpp/pin.toml
@@ -48,18 +48,37 @@
 # signal to take the fallback ladder below rather than to keep
 # rebuilding bullseye's toolchain from tarballs.
 #
-# The one genuine risk with newness is the AF↔VF mailbox: this fleet
-# runs a 5.15 vendor kernel whose AF is SDK-era, and gate 0a's
-# handshake passed with DPDK 20.11's `octeontx2` PMD. A modern cnxk
-# PMD may or may not agree with it — the mailbox does not follow
-# newer-is-better. That is a question for MEASUREMENT, not for
-# pre-emptive downgrading. Fallback ladder if gate 0b's handshake
-# fails, in order:
-#   v25.10 / v24.10  → newer cnxk, still recent
-#   v23.06           → last line before the cnxk-era churn
+# v26.06 was tried on the shadow (2026-08-02) and its cnxk PMD fails
+# BEFORE the mailbox — this is measured, not assumed:
+#
+#   CNXK: populate_model(): Invalid RoC model (impl=0x43, part=0xb2,
+#                                              major=0x3, minor=0x0)
+#   CNXK: cn9k_nix_probe(): Failed to initialize platform model, rc=-22
+#
+# The cn9670 reports MIDR variant 3 — a die stepping absent from
+# drivers/common/cnxk/roc_model.c in EVERY public DPDK (the CN96xx
+# table stops at variant 2), and unknown MIDR is a hard -EINVAL with
+# no override (checked in v26.03 source: no env, no devargs, no
+# default-to-nearest). That gates the ENTIRE cnxk era, so the middle
+# fallback rungs (v25.10 / v24.10 / v23.06) would fail identically
+# and are SKIPPED on purpose.
+#
+# The octeontx2 era has no such gate: DPDK 21.11's otx2 code reads no
+# MIDR at probe (verified in source), and gate 0a's DPDK 20.11
+# testpmd moved real packets on this exact silicon. Hence v22.02 —
+# DPDK 21.11, the last `octeontx2`-named era. Note 21.11 ships BOTH
+# PMD families; if its cnxk half hits the same model gate, EAL tries
+# the next matching driver, which is exactly the gate-free octeontx2.
+#
+# The AF↔VF mailbox question itself is therefore STILL OPEN — v26.06
+# never got far enough to ask it. The proper road back to current
+# VPP is upstreaming the one-line MIDR entry to DPDK/octeon-roc, not
+# carrying a local patch; until that lands and reaches a release,
+# this pin stays in the octeontx2 era.
+#   v25.10 / v24.10 / v23.06 → cnxk-era: same roc_model gate, skip
 #   v22.02           → DPDK 21.11, last `octeontx2`-named PMD, closest
 #                      to the DPDK 20.11 build that passed gate 0a
-ref = "v26.06"
+ref = "v22.02"
 
 # Optional strict pin. When non-empty the workflow verifies the ref
 # resolves to exactly this commit and fails otherwise, so a retagged


### PR DESCRIPTION
Gate 0b's first hardware round, measured on the shadow with the published v26.06 artifact.

## What held

Everything up to the probe: install (libnl `>=` satisfied, as predicted from the control file), the pre-mask, `VPP_INSTALL_SKIP_SYSCTL` (nr_hugepages untouched), VPP bring-up on lean hugepage sizing, and `-a 0002:07:00.1` reaching EAL — which also proves the `init.c` "Unsupported PCI device" warning is **cosmetic**: it skips only the uio-bind step and never blacklists.

## What failed, and where exactly

```
CNXK: populate_model():224 Invalid RoC model (impl=0x43, part=0xb2, major=0x3, minor=0x0)
CNXK: cn9k_nix_probe():810 Failed to initialize platform model, rc=-22
```

**Before any AF mailbox contact.** The cn9670 reports MIDR variant 3 — a die stepping absent from `drivers/common/cnxk/roc_model.c` in every public DPDK (the CN96xx table: A0=(0,0), B0=(0,1), C0=(2,0), C1=(2,1) — no variant 3), and unknown MIDR is a hard `-EINVAL` with **no override** — no env var, no devargs, no default-to-nearest. Verified in the v26.03 source, not inferred from the log.

## Consequences

- **The mailbox question is still open** — this failure sits upstream of it.
- **The whole cnxk era is gated identically.** v25.10/v24.10/v23.06 carry the same table; the ladder's middle rungs are skipped **by measurement, not caution**.
- **v22.02 (DPDK 21.11) is the active rung.** The octeontx2 driver reads no MIDR at probe (verified in v21.11 source), and gate 0a's DPDK 20.11 testpmd moved real packets on this exact silicon. 21.11 ships both PMD families — if its cnxk half trips the same gate, EAL falls through to the next matching driver, which is precisely the gate-free octeontx2.
- **Road back to current VPP:** upstream the one-line MIDR entry to DPDK / marvell-octeon-roc. No local patch — the pin stays in the octeontx2 era until an upstream release carries the fix.

The workflow needs no changes for this era: the cnxk re-enable no-ops (v22.02 disables neither family — with the logged warning we built for exactly this), `net_octeontx2` is in every detection needle, and the CN9K-silicon gate accepts it.

Merging triggers the v22.02 build → new tag `vpp-v22.02-generic-bullseye-arm64`. Then back to the shadow, where `show hardware-interfaces` finally gets to ask the actual mailbox question.