### PR TITLE
vpp: the mailbox works — pivot to the native octeon driver (v26.06 + octeon9)

### DIFF
--- a/.github/workflows/vpp-build.yml
+++ b/.github/workflows/vpp-build.yml
@@ -374,12 +374,30 @@ jobs:
             "DPDK_DRIVERS_DISABLED=$DPDK_DRIVERS_KEPT"
             "DPDK_LIBS_DISABLED=$DPDK_LIBS_KEPT"
           )
-          if [ '${{ needs.resolve.outputs.platform }}' = 'cn9k' ]; then
-            # Marvell-tuned variant: LSE atomics + tuned memcpy, plus
-            # DPDK's own cn9k platform tuning. Only meaningful once
-            # packet-rate-bound; produces a separately tagged artifact.
-            args+=(DPDK_MACHINE=cn9k VPP_EXTRA_CMAKE_ARGS='-DVPP_LIBRARY_FLAGS=-mcpu=octeontx2')
-          fi
+          case '${{ needs.resolve.outputs.platform }}' in
+            octeon9)
+              # VPP's first-class Marvell platform (src/cmake/platform/
+              # octeon9.cmake: armv8.2-a+crc+crypto, 128B cache lines —
+              # correct for CN96xx, still runs on Neoverse CI runners).
+              # This is the ONLY build shape that produces the NATIVE
+              # octeon driver (src/drivers/octeon is gated on
+              # VPP_PLATFORM_NAME octeon9|octeon10), which is in turn
+              # the only mainline path onto this NIC: the DPDK PMDs
+              # inside VPP hard-require NPA mempool ops that VPP's
+              # buffer manager does not provide (measured on the
+              # shadow, 2026-08-02; no bypass exists in otx2 or cnxk).
+              # The native driver links octeon-roc, whose model table —
+              # unlike DPDK's stale copy — knows the cn9670's CN96xx D0
+              # stepping.
+              args+=(VPP_EXTRA_CMAKE_ARGS='-DVPP_PLATFORM=octeon9')
+              ;;
+            cn9k)
+              # Legacy DPDK-era tuning, for octeontx2-era pins
+              # (e.g. v22.02): LSE atomics + tuned memcpy + DPDK's own
+              # cn9k platform tuning.
+              args+=(DPDK_MACHINE=cn9k VPP_EXTRA_CMAKE_ARGS='-DVPP_LIBRARY_FLAGS=-mcpu=octeontx2')
+              ;;
+          esac
           printf 'make arg: %s\n' "${args[@]}"
           make build-release "${args[@]}"
 
@@ -442,7 +460,7 @@ jobs:
           find "$instroot" \( -path '*vpp_drivers*' -o -path '*vpp_plugins*' \
             -o -path '*dpdk/pmds*' -o -name 'librte_net_*' \) -type f | sort
           echo "--- octeon artifacts anywhere under the install trees ---"
-          find "$instroot" \( -name '*cnxk*' -o -name '*octeontx2*' -o -name 'dev_octeon*' \) \
+          find "$instroot" \( -name '*cnxk*' -o -name '*octeontx2*' -o -name 'dev_octeon*' -o -name 'octeon_driver*' \) \
             | sort | head -40
           echo "--- end inventory ---"
 
@@ -494,7 +512,12 @@ jobs:
           # The fleet is cn9670 = CN9K, so net_cn9k specifically is
           # the load-bearing one.
           OCTEON_PMD_NAMES='net_cn9k|net_cn10k|net_cn20k|net_octeontx2'
-          native=$(find "$instroot" -name 'dev_octeon*.so*' -print -quit)
+          # The native driver installs as vpp_drivers/octeon_driver.so —
+          # verified from src/drivers CMake (`add_vpp_driver(octeon)`,
+          # same pattern as atlantic_driver.so), NOT as dev_octeon*.
+          # The old needle predated reading the tree; keep both names
+          # in case upstream renames back.
+          native=$(find "$instroot" \( -name 'octeon_driver.so*' -o -name 'dev_octeon*.so*' \) -print -quit)
           pmd_lib=$(find "$instroot" \( -name 'librte_net_cnxk*' -o -name 'librte_net_octeontx2*' \) -print -quit)
           driver=''
           if [ -n "$native" ]; then
@@ -689,7 +712,7 @@ jobs:
           # accepts — VPP's native dev_octeon, a standalone DPDK PMD, or
           # one linked into dpdk_plugin.so — because which one this VPP
           # ships is a property of the release, not a constant.
-          native=$(find / -name 'dev_octeon*.so*' -not -path '/proc/*' -print -quit 2>/dev/null || true)
+          native=$(find / \( -name 'octeon_driver.so*' -o -name 'dev_octeon*.so*' \) -not -path '/proc/*' -print -quit 2>/dev/null || true)
           pmd_so=$(find / \( -name 'librte_net_cnxk*' -o -name 'librte_net_octeontx2*' \) \
             -not -path '/proc/*' -print -quit 2>/dev/null || true)
           plugin=$(find / -name dpdk_plugin.so -not -path '/proc/*' -print -quit 2>/dev/null || true)

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -220,6 +220,71 @@ v26.03 source). Consequences:
   DPDK / marvell-octeon-roc. No local patch — the pin stays in the
   octeontx2 era until an upstream release carries the fix.
 
+### RESULT (2026-08-02, shadow, round 2): **THE MAILBOX WORKS** — and the road is the native driver
+
+The v22.02 rung answered gate 0b's central question:
+
+```
+EAL: Probe PCI driver: net_octeontx2 (177d:a064) device: 0002:07:00.1 (socket 0)
+```
+
+Interface `Ethernet7/0/1` created, MAC assigned, full rx/tx capability
+tables enumerated — all of it AF-mailbox conversation, all of it
+working through the SDK-era AF. **The phase's architecture-killing
+risk is dead**, proven twice (testpmd 20.11 at gate 0a; otx2 21.11
+inside VPP here).
+
+It then failed one layer up, and this failure re-routes the phase:
+
+```
+PMD: otx2_nix_rx_queue_setup():600 mempool ops should be of octeontx2_npa type
+rte_eth_rx_queue_setup[port:0, errno:-22]
+```
+
+Both otx2 (21.11) and cnxk (26.03) **hard-require NPA mempool ops**
+for packet buffers — no bypass, no devarg (verified in both sources) —
+and mainline VPP's buffer manager only provides its own "vpp" mempool
+ops. **The DPDK-PMD-inside-VPP path is therefore dead on this NIC at
+every version.** Not the hardware, not the kernel, not the era: a
+VPP↔PMD buffer-integration wall (Marvell's out-of-tree VPP fork exists
+precisely to bridge it; we don't ship forks).
+
+**The mainline road: VPP's native octeon driver**, and every link is
+source-verified:
+
+- `src/drivers/octeon` builds only under `VPP_PLATFORM=octeon9|octeon10`
+  — which is why the generic artifact never contained it.
+- It links marvell-octeon-roc, and **octeon-roc v26.05's model table
+  HAS the cn9670's stepping**: MIDR (0x43, 0xB2, 3, 0) = **CN96xx D0**.
+  DPDK's copy of the same table is simply stale — that's the whole
+  cnxk-era failure, now explained end to end.
+- CN9K support is first-class (`roc_model_is_cn9k()` paths,
+  `PLATFORM_OCTEON9` defines).
+
+Pin is now `v26.06` + `platform = "octeon9"`. Two consequences for
+this runbook:
+
+1. The artifact tag becomes `vpp-v26.06-octeon9-bullseye-arm64`, and
+   the driver ships as `vpp_drivers/octeon_driver.so` — probe with
+   that name, not `net_*` strings and not `dev_octeon`.
+2. **The startup.conf changes shape**: the native driver is configured
+   through VPP's vnet/dev `devices {}` stanza, not `dpdk {}`. Replace
+   the `dpdk { dev 0002:07:00.1 }` block with:
+
+   ```
+   devices {
+     dev pci/0002:07:00.1 {
+       driver octeon
+     }
+   }
+   ```
+
+   (Exact grammar to be confirmed against the built artifact's
+   `vppctl show dev` on first bring-up; unix/socksvr/memory/cpu
+   sections carry over unchanged.)
+
+The v22.02 tag stays published as the mailbox-proof artifact.
+
 ### Getting the build onto the shadow
 
 Derive the tag from the pin rather than typing a version — otherwise

--- a/vpp/pin.toml
+++ b/vpp/pin.toml
@@ -70,15 +70,45 @@
 # PMD families; if its cnxk half hits the same model gate, EAL tries
 # the next matching driver, which is exactly the gate-free octeontx2.
 #
-# The AF↔VF mailbox question itself is therefore STILL OPEN — v26.06
-# never got far enough to ask it. The proper road back to current
-# VPP is upstreaming the one-line MIDR entry to DPDK/octeon-roc, not
-# carrying a local patch; until that lands and reaches a release,
-# this pin stays in the octeontx2 era.
-#   v25.10 / v24.10 / v23.06 → cnxk-era: same roc_model gate, skip
-#   v22.02           → DPDK 21.11, last `octeontx2`-named PMD, closest
-#                      to the DPDK 20.11 build that passed gate 0a
-ref = "v22.02"
+# v22.02 was then tried on the shadow (2026-08-02) and settled the
+# big question: **the AF↔VF mailbox WORKS.** DPDK 21.11's otx2 PMD
+# probed the VF through the SDK-era AF — interface created, MAC
+# assigned, full capability tables read. It then failed one layer up:
+#
+#   PMD: otx2_nix_rx_queue_setup(): mempool ops should be of
+#        octeontx2_npa type   (rte_eth_rx_queue_setup -> -22)
+#
+# Both otx2 and cnxk hard-require NPA mempool ops for packet buffers
+# (checked in 21.11 and 26.03 source — no bypass, no devarg), and
+# mainline VPP's buffer manager only provides its own "vpp" mempool
+# ops. So DPDK-PMD-inside-VPP is a dead end on this NIC at EVERY
+# version — the wall is VPP<->PMD buffer integration, not the
+# hardware, the kernel, or the era.
+#
+# The mainline path that remains is VPP's NATIVE octeon driver
+# (src/drivers/octeon), and every piece checks out in source:
+#   - it is gated on VPP_PLATFORM octeon9|octeon10 — which is why the
+#     generic build never contained it;
+#   - it links marvell-octeon-roc, and octeon-roc v26.05's model
+#     table (unlike DPDK's stale copy) HAS the cn9670's stepping:
+#     MIDR (0x43, 0xB2, major=3, minor=0) = **CN96xx D0**;
+#   - CN9K support is first-class (roc_model_is_cn9k() paths,
+#     PLATFORM_OCTEON9 defines).
+# Hence: ref back to latest stable, platform=octeon9. The native
+# driver is configured through VPP's vnet/dev `devices {}` startup
+# stanza, NOT `dpdk {}` — the spike runbook carries the shape.
+#
+# Kept for the record (all measured on the shadow, 2026-08-02):
+#   - v26.06 generic: cnxk PMD fails PRE-mailbox — DPDK's
+#     drivers/common/cnxk/roc_model.c stops at CN96xx variant 2 and
+#     hard-fails unknown MIDR with no override. Task #22 upstreams
+#     the D0 entry to DPDK (sync from octeon-roc); a courtesy fix
+#     now, not our critical path.
+#   - v25.10 / v24.10 / v23.06: same stale table, same failure, skip.
+#   - v22.02 generic: mailbox PASSES, rx queue setup fails on NPA
+#     mempool ops (above). Published tag stays as the mailbox-proof
+#     artifact.
+ref = "v26.06"
 
 # Optional strict pin. When non-empty the workflow verifies the ref
 # resolves to exactly this commit and fails otherwise, so a retagged
@@ -86,9 +116,14 @@ ref = "v22.02"
 # published manifest either way.
 commit = ""
 
-# Build variant. "generic" = baseline armv8-a, portable across any
-# arm64 EFG-class box. "cn9k" = Marvell-tuned (LSE atomics, tuned
-# memcpy) — a few percent on atomics/copy-heavy paths, only worth
-# measuring once we are packet-rate-bound. Changing this produces a
-# separately-tagged artifact; both can coexist.
-platform = "generic"
+# Build variant. Changing this produces a separately-tagged artifact;
+# variants coexist on the release page.
+#   "octeon9" = VPP_PLATFORM=octeon9: the ONLY shape that builds the
+#               native octeon driver (armv8.2-a+crc+crypto, 128B cache
+#               lines — correct for CN96xx). Required for this fleet;
+#               see above for why the DPDK PMD path cannot work.
+#   "generic" = baseline armv8-a, no octeon driver. Useful only for
+#               non-datapath testing of VPP itself.
+#   "cn9k"    = legacy DPDK-era tuning (octeontx2-era pins like
+#               v22.02): DPDK_MACHINE=cn9k + -mcpu=octeontx2.
+platform = "octeon9"


### PR DESCRIPTION
Gate 0b round 2, on the shadow with the v22.02 artifact. Two findings, one huge, one re-routing.

## The mailbox works

```
EAL: Probe PCI driver: net_octeontx2 (177d:a064) device: 0002:07:00.1 (socket 0)
```

Interface `Ethernet7/0/1` created, MAC assigned, full capability tables enumerated — all of it AF-mailbox conversation through the SDK-era AF. **The phase's one architecture-killing risk is dead**, proven in two independent stacks (testpmd 20.11 at gate 0a; otx2 21.11 inside VPP now).

## The wall that re-routes the phase

```
PMD: otx2_nix_rx_queue_setup():600 mempool ops should be of octeontx2_npa type
```

Both otx2 (21.11) and cnxk (26.03) **hard-require NPA mempool ops** for packet buffers — no bypass, no devarg, verified in both sources — and mainline VPP's buffer manager only provides its own `vpp` ops. **DPDK-PMD-inside-VPP is dead on this NIC at every version.** Marvell's out-of-tree VPP fork exists precisely to bridge this; we don't ship forks.

## The mainline road: VPP's native octeon driver

Every link source-verified:

- `src/drivers/octeon` builds **only** under `VPP_PLATFORM=octeon9|octeon10` — which is why the generic artifact never contained it
- It links **marvell-octeon-roc**, whose v26.05 model table — unlike DPDK's stale copy — **has the cn9670's stepping: MIDR (0x43, 0xB2, 3, 0) = CN96xx D0**
- CN9K support is first-class (`roc_model_is_cn9k()` paths, `PLATFORM_OCTEON9` defines)

The entire cnxk-era failure is now explained end to end: one library kept its silicon table current, the other didn't. (Task #22 — upstreaming the D0 entry to DPDK — remains as a courtesy fix, no longer critical path.)

## Changes

- **Pin: back to `v26.06`, `platform = "octeon9"`** → new tag `vpp-v26.06-octeon9-bullseye-arm64`
- Build step maps `octeon9` → `-DVPP_PLATFORM=octeon9` (armv8.2-a+crc+crypto, 128 B cache lines — correct for CN96xx, still runs on the Neoverse CI runner); `cn9k` stays as legacy DPDK-era tuning
- Driver needles accept `octeon_driver.so` — the name `add_vpp_driver()` actually produces (verified against the tree; the net_cnxk lesson, paid once, not twice)
- Runbook records both shadow rounds and the startup.conf shape change: the native driver configures via the vnet/dev `devices {}` stanza, not `dpdk {}`

The v22.02 tag stays published as the mailbox-proof artifact. Merging triggers the octeon9 build.