### PR TITLE
feat(vpp-offload): supervision layer — state machine, pidfd, wedge detector (slice 4)

### DIFF
--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -28,6 +28,7 @@ pub mod fib_sync;
 pub mod resources;
 pub mod sink;
 pub mod startup_conf;
+pub mod supervisor;
 pub mod vpp_api;
 
 #[cfg(target_os = "linux")]

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -25,6 +25,7 @@
 //! - the eBPF fast-path on the PFs is the permanent failover tier.
 
 pub mod fib_sync;
+pub mod liveness;
 pub mod process;
 pub mod resources;
 pub mod sink;

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -25,6 +25,7 @@
 //! - the eBPF fast-path on the PFs is the permanent failover tier.
 
 pub mod fib_sync;
+pub mod process;
 pub mod resources;
 pub mod sink;
 pub mod startup_conf;

--- a/crates/modules/vpp-offload/src/liveness.rs
+++ b/crates/modules/vpp-offload/src/liveness.rs
@@ -1,0 +1,220 @@
+//! Wedge detection: is VPP's binary API still answering?
+//!
+//! A crash is easy — the pidfd fires (see [`crate::process`]). The
+//! nastier failure is a VPP that is *alive and not forwarding*: a
+//! worker stuck in a driver call, a deadlocked main thread, a barrier
+//! that never lifts. `ps` says healthy, the pidfd stays quiet, and
+//! traffic disappears. A wedged forwarder drops exactly as thoroughly
+//! as a dead one, which is why the supervisor treats [`Event::Wedged`]
+//! and `ProcessExited` the same way.
+//!
+//! [`Event::Wedged`]: crate::supervisor::Event::Wedged
+//!
+//! Like [`crate::supervisor`], this is pure logic with the clock passed
+//! in. Timing code that calls `Instant::now()` internally can only be
+//! tested by sleeping, which makes for slow tests that are flaky under
+//! CI load — and a detector whose whole job is timing deserves tests
+//! that pin exact boundaries instead of hoping the scheduler cooperates.
+
+use std::time::{Duration, Instant};
+
+/// How often we send an API ping.
+pub const PING_INTERVAL: Duration = Duration::from_millis(500);
+
+/// How long the API may stay silent in steady state before we call it
+/// wedged.
+///
+/// This trades two costs against each other. Too long and a blackhole
+/// persists; too short and ordinary jitter triggers a restart, which
+/// costs a real outage (the recovery budget is ≤ 90 s) to cure a
+/// problem that did not exist. 1.5 s tolerates two missed pings — a
+/// scheduling hiccup — while keeping worst-case detection inside the
+/// published 2 s. See [`worst_case_detection`].
+pub const PING_BUDGET: Duration = Duration::from_millis(1_500);
+
+/// The relaxed budget to use while a full FIB resync is in flight.
+///
+/// VPP answers the binary API on its **main** thread, which is the
+/// same thread executing our route batches. Under a full-table load
+/// (~1.05M routes) it is legitimately busy, and a ping can queue
+/// behind a batch without anything being wrong. Applying the steady
+/// budget there would make every large resync look like a wedge and
+/// restart-loop the box precisely when it is doing the most work.
+///
+/// This is deliberately far above the steady budget: during resync we
+/// are not yet forwarding through VPP, so a slow answer costs latency
+/// in coming back, not dropped traffic.
+pub const SYNC_PING_BUDGET: Duration = Duration::from_secs(10);
+
+/// Worst-case time from "VPP wedges" to "we notice", for a given
+/// silence budget.
+///
+/// The bad case is a wedge that starts immediately after a successful
+/// pong: the budget must elapse, and we only observe it on the next
+/// scheduled ping, so the interval adds on top.
+pub const fn worst_case_detection(budget: Duration) -> Duration {
+    budget.saturating_add(PING_INTERVAL)
+}
+
+/// Tracks API liveness from ping/pong timestamps.
+///
+/// Deliberately does NOT own the transport. The detector decides
+/// *when* to ask and *what the silence means*; the caller owns the
+/// socket and can pipeline the ping alongside real work.
+#[derive(Debug, Clone)]
+pub struct WedgeDetector {
+    /// Last time the API actually answered.
+    last_ok: Instant,
+    /// Last time we sent a ping — tracked separately so a ping that
+    /// never answers does not also suppress the next attempt.
+    last_attempt: Instant,
+}
+
+impl WedgeDetector {
+    /// Start the clock. Called when the API first answers, not when
+    /// the process spawns: VPP takes a while to open its socket, and
+    /// counting that startup as silence would declare a wedge before
+    /// it ever had a chance to reply.
+    pub fn started(now: Instant) -> Self {
+        Self {
+            last_ok: now,
+            last_attempt: now,
+        }
+    }
+
+    /// Time to send another ping?
+    pub fn ping_due(&self, now: Instant) -> bool {
+        now.duration_since(self.last_attempt) >= PING_INTERVAL
+    }
+
+    pub fn on_ping_sent(&mut self, now: Instant) {
+        self.last_attempt = now;
+    }
+
+    pub fn on_pong(&mut self, now: Instant) {
+        self.last_ok = now;
+        // A pong is also proof the attempt landed; without this a
+        // reply arriving faster than the interval would leave
+        // `last_attempt` stale and immediately re-arm `ping_due`.
+        if now > self.last_attempt {
+            self.last_attempt = now;
+        }
+    }
+
+    /// How long the API has been silent.
+    pub fn silent_for(&self, now: Instant) -> Duration {
+        now.duration_since(self.last_ok)
+    }
+
+    /// Has it been silent past `budget`? Pass [`PING_BUDGET`] in
+    /// steady state and [`SYNC_PING_BUDGET`] while resyncing.
+    pub fn is_wedged(&self, now: Instant, budget: Duration) -> bool {
+        self.silent_for(now) > budget
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(base: Instant, ms: u64) -> Instant {
+        base + Duration::from_millis(ms)
+    }
+
+    /// The published failover number is "blackhole-wedge ≤ 2 s". That
+    /// promise is the sum of two constants, so assert the sum here —
+    /// otherwise someone raises PING_BUDGET for a good local reason
+    /// and silently invalidates a number in the runbook.
+    #[test]
+    fn steady_state_detection_stays_inside_the_published_two_seconds() {
+        assert!(
+            worst_case_detection(PING_BUDGET) <= Duration::from_secs(2),
+            "worst case {:?} exceeds the published 2 s",
+            worst_case_detection(PING_BUDGET)
+        );
+    }
+
+    #[test]
+    fn a_healthy_api_is_never_wedged() {
+        let t0 = Instant::now();
+        let mut d = WedgeDetector::started(t0);
+        for ms in (0..5_000).step_by(400) {
+            d.on_pong(at(t0, ms));
+            assert!(!d.is_wedged(at(t0, ms), PING_BUDGET));
+        }
+    }
+
+    #[test]
+    fn silence_past_the_budget_is_a_wedge() {
+        let t0 = Instant::now();
+        let d = WedgeDetector::started(t0);
+        assert!(
+            !d.is_wedged(at(t0, 1_500), PING_BUDGET),
+            "exactly at budget"
+        );
+        assert!(d.is_wedged(at(t0, 1_501), PING_BUDGET));
+    }
+
+    /// The false-positive guard: two missed pings must NOT trip it.
+    /// A needless restart costs a real outage to cure nothing.
+    #[test]
+    fn two_missed_pings_are_tolerated() {
+        let t0 = Instant::now();
+        let d = WedgeDetector::started(t0);
+        // Pings at 500 and 1000 both go unanswered.
+        assert!(!d.is_wedged(at(t0, 500), PING_BUDGET));
+        assert!(!d.is_wedged(at(t0, 1_000), PING_BUDGET));
+    }
+
+    /// A slow resync must not read as a wedge — this is the one that
+    /// would restart-loop the box during a full-table load.
+    #[test]
+    fn a_busy_resync_is_not_a_wedge_under_the_sync_budget() {
+        let t0 = Instant::now();
+        let d = WedgeDetector::started(t0);
+        let five_s = at(t0, 5_000);
+        assert!(
+            d.is_wedged(five_s, PING_BUDGET),
+            "steady budget would call this wedged"
+        );
+        assert!(
+            !d.is_wedged(five_s, SYNC_PING_BUDGET),
+            "the sync budget must tolerate a busy main thread"
+        );
+    }
+
+    #[test]
+    fn pings_are_due_on_the_interval_not_continuously() {
+        let t0 = Instant::now();
+        let mut d = WedgeDetector::started(t0);
+        assert!(!d.ping_due(at(t0, 499)));
+        assert!(d.ping_due(at(t0, 500)));
+        d.on_ping_sent(at(t0, 500));
+        assert!(!d.ping_due(at(t0, 999)));
+        assert!(d.ping_due(at(t0, 1_000)));
+    }
+
+    /// An unanswered ping must not suppress the next attempt — if it
+    /// did, one dropped ping would stretch detection without bound.
+    #[test]
+    fn an_unanswered_ping_still_lets_the_next_one_fire() {
+        let t0 = Instant::now();
+        let mut d = WedgeDetector::started(t0);
+        d.on_ping_sent(at(t0, 500)); // never answered
+        assert!(d.ping_due(at(t0, 1_000)));
+        assert!(d.is_wedged(at(t0, 1_600), PING_BUDGET));
+    }
+
+    /// A pong arriving sooner than the interval must not immediately
+    /// re-arm the next ping; otherwise a fast VPP gets pinged in a
+    /// tight loop.
+    #[test]
+    fn a_fast_pong_does_not_rearm_the_ping_immediately() {
+        let t0 = Instant::now();
+        let mut d = WedgeDetector::started(t0);
+        d.on_ping_sent(at(t0, 500));
+        d.on_pong(at(t0, 510));
+        assert!(!d.ping_due(at(t0, 900)));
+        assert!(d.ping_due(at(t0, 1_010)));
+    }
+}

--- a/crates/modules/vpp-offload/src/liveness.rs
+++ b/crates/modules/vpp-offload/src/liveness.rs
@@ -32,19 +32,49 @@ pub const PING_INTERVAL: Duration = Duration::from_millis(500);
 /// published 2 s. See [`worst_case_detection`].
 pub const PING_BUDGET: Duration = Duration::from_millis(1_500);
 
-/// The relaxed budget to use while a full FIB resync is in flight.
+/// The relaxed budget for a resync on a dataplane that is **not**
+/// carrying traffic.
 ///
 /// VPP answers the binary API on its **main** thread, which is the
-/// same thread executing our route batches. Under a full-table load
-/// (~1.05M routes) it is legitimately busy, and a ping can queue
-/// behind a batch without anything being wrong. Applying the steady
-/// budget there would make every large resync look like a wedge and
-/// restart-loop the box precisely when it is doing the most work.
+/// same thread executing our route batches, so under load a ping can
+/// queue behind a batch without anything being wrong. Applying the
+/// steady budget to a first-attach resync would make every large load
+/// look like a wedge and restart-loop the box while it does the most
+/// work — and nothing is lost by waiting, because no traffic is
+/// steered yet.
 ///
-/// This is deliberately far above the steady budget: during resync we
-/// are not yet forwarding through VPP, so a slow answer costs latency
-/// in coming back, not dropped traffic.
+/// **This budget must never be used while steering is up.** Pick it
+/// with [`budget_for`], not by asking "am I resyncing". See that
+/// function for why the distinction is load-bearing.
 pub const SYNC_PING_BUDGET: Duration = Duration::from_secs(10);
+
+/// Choose the silence budget from what is actually at stake.
+///
+/// The decision is **"is traffic currently steered into VPP"**, not
+/// "am I resyncing". Those look interchangeable and are not: the
+/// adopted path (`AdoptedResyncing`) resyncs a VPP that never stopped
+/// forwarding, which is the entire point of adoption. Selecting the
+/// relaxed budget there would let a wedged, *steered* VPP blackhole
+/// traffic for up to `SYNC_PING_BUDGET + PING_INTERVAL` — 10.5 s
+/// against a published promise of 2 s.
+///
+/// So: whenever packets are on VPP, the published number governs, and
+/// the risk moves to the other side of the trade — a busy adopted
+/// resync is now more likely to trip a restart. That is the correct
+/// direction to be wrong in. A restart unsteers first and recovers
+/// within the 90 s budget; a silent 10 s blackhole just drops traffic.
+/// It is also less likely than it looks: the drainer holds at most
+/// [`crate::fib_sync::DEFAULT_WINDOW`] requests in flight, so a ping
+/// queues behind ~256 route ops, not behind the whole table.
+pub const fn budget_for(steered: bool, converging: bool) -> Duration {
+    if steered {
+        PING_BUDGET
+    } else if converging {
+        SYNC_PING_BUDGET
+    } else {
+        PING_BUDGET
+    }
+}
 
 /// Worst-case time from "VPP wedges" to "we notice", for a given
 /// silence budget.
@@ -106,8 +136,10 @@ impl WedgeDetector {
         now.duration_since(self.last_ok)
     }
 
-    /// Has it been silent past `budget`? Pass [`PING_BUDGET`] in
-    /// steady state and [`SYNC_PING_BUDGET`] while resyncing.
+    /// Has it been silent past `budget`? Get `budget` from
+    /// [`budget_for`] rather than picking a constant directly — the
+    /// choice depends on whether traffic is steered, and getting it
+    /// from "am I resyncing" is the bug [`budget_for`] documents.
     pub fn is_wedged(&self, now: Instant, budget: Duration) -> bool {
         self.silent_for(now) > budget
     }
@@ -164,6 +196,31 @@ mod tests {
         // Pings at 500 and 1000 both go unanswered.
         assert!(!d.is_wedged(at(t0, 500), PING_BUDGET));
         assert!(!d.is_wedged(at(t0, 1_000), PING_BUDGET));
+    }
+
+    /// The published ≤2 s must hold whenever packets are on VPP —
+    /// including the adopted path, which resyncs a VPP that never
+    /// stopped forwarding. Choosing the budget by "am I resyncing"
+    /// would let a wedged, steered VPP blackhole for 10.5 s.
+    #[test]
+    fn a_steered_resync_keeps_the_published_budget() {
+        assert_eq!(
+            budget_for(true, true),
+            PING_BUDGET,
+            "steered + converging (adoption) must not get the relaxed budget"
+        );
+        assert!(
+            worst_case_detection(budget_for(true, true)) <= Duration::from_secs(2),
+            "a steered dataplane must stay inside the published 2 s"
+        );
+    }
+
+    /// The relaxed budget is only for a dataplane carrying no traffic.
+    #[test]
+    fn only_an_unsteered_resync_gets_the_relaxed_budget() {
+        assert_eq!(budget_for(false, true), SYNC_PING_BUDGET);
+        assert_eq!(budget_for(false, false), PING_BUDGET);
+        assert_eq!(budget_for(true, false), PING_BUDGET);
     }
 
     /// A slow resync must not read as a wedge — this is the one that

--- a/crates/modules/vpp-offload/src/process.rs
+++ b/crates/modules/vpp-offload/src/process.rs
@@ -1,0 +1,457 @@
+//! Process handle for VPP: spawn, adopt, signal, exit-notify — all via
+//! pidfd (SPEC.md §4.8; phase-4 plan, slice 4).
+//!
+//! **Why pidfd and not SIGCHLD.** Adoption is a first-class case here:
+//! packetframe restarts while VPP keeps forwarding, and the surviving
+//! VPP is *not* our child — it was reparented to init the moment its
+//! original parent died. `SIGCHLD` and `waitpid()` are therefore
+//! structurally unavailable for exactly the process we most need to
+//! watch. A pidfd works the same for a child we just forked and for a
+//! stranger we adopted, which collapses two supervision paths into one.
+//!
+//! **Why a pidfd rather than the bare pid.** Signalling a pid races
+//! PID reuse: between deciding "pid 4242 is wedged" and `kill(4242)`,
+//! the real VPP can exit and the kernel can hand 4242 to something
+//! else — and we send it SIGKILL as root. A pidfd is bound to one
+//! process for its whole lifetime, so `pidfd_send_signal` cannot be
+//! misdelivered no matter how long the fd sits idle.
+//!
+//! The state file's `(vpp_pid, vpp_start_ticks)` pair (slice 2) is the
+//! bootstrap identity: it survives our own death, where an fd cannot.
+//! [`VppProcess::adopt`] turns that pair back into a pidfd and refuses
+//! if the pid now belongs to someone else.
+
+use std::io;
+use std::path::Path;
+use std::time::Duration;
+
+/// Field 22 of `/proc/<pid>/stat` — process start time in clock ticks
+/// since boot. Paired with the pid it is a stable process identity
+/// across a PID-space wrap.
+///
+/// Parsing this is fiddlier than it looks, which is why it is a free
+/// function with its own tests: `comm` (field 2) is the executable
+/// name in parentheses, and it may contain **both spaces and closing
+/// parens** — a binary called `vpp (test)` is legal and would break
+/// any `split_whitespace().nth(21)`. The only robust anchor is the
+/// LAST `)` in the line; every field after it is whitespace-free.
+///
+/// Returns `None` on any shape we do not recognise rather than
+/// guessing, because a wrong start-time makes adoption either falsely
+/// refuse (harmless) or falsely accept (SIGKILL to a stranger).
+pub fn parse_start_ticks(stat: &str) -> Option<u64> {
+    let close = stat.rfind(')')?;
+    // Fields after `comm` begin at field 3 (state), so field 22
+    // (starttime) sits at index 19 of this tail.
+    stat[close + 1..].split_whitespace().nth(19)?.parse().ok()
+}
+
+/// How a process handle was obtained. Adopted processes cannot be
+/// reaped (they are init's children, not ours), so their exit status
+/// is unavailable — the supervisor's `ProcessExited { status }` is an
+/// `Option` for exactly this reason.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Origin {
+    Spawned,
+    Adopted,
+}
+
+#[cfg(target_os = "linux")]
+mod imp {
+    use super::{parse_start_ticks, Origin};
+    use std::fs;
+    use std::io;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+    use std::path::Path;
+    use std::process::{Child, Command, Stdio};
+    use std::time::{Duration, Instant};
+
+    /// How long to wait for a process to die after SIGKILL before
+    /// declaring it stuck. Long enough that ordinary scheduling delay
+    /// never trips it, short enough that detach fails loudly instead
+    /// of hanging.
+    const SIGKILL_BUDGET: Duration = Duration::from_secs(2);
+
+    /// `pidfd_open(2)`. Present since 5.3; the fleet is 5.15.
+    fn pidfd_open(pid: i32) -> io::Result<OwnedFd> {
+        // SAFETY: pidfd_open takes (pid_t, unsigned int) and returns a
+        // new fd or -1. No pointers are involved.
+        let fd = unsafe { libc::syscall(libc::SYS_pidfd_open, pid, 0) };
+        if fd < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        // SAFETY: the syscall returned a fresh, owned fd.
+        Ok(unsafe { OwnedFd::from_raw_fd(fd as RawFd) })
+    }
+
+    /// `pidfd_send_signal(2)`. Present since 5.1.
+    fn pidfd_send_signal(fd: RawFd, sig: i32) -> io::Result<()> {
+        // SAFETY: passing a NULL siginfo asks the kernel to synthesise
+        // one, which is the documented equivalent of kill(2).
+        let r = unsafe {
+            libc::syscall(
+                libc::SYS_pidfd_send_signal,
+                fd,
+                sig,
+                std::ptr::null::<libc::siginfo_t>(),
+                0,
+            )
+        };
+        if r < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    fn read_start_ticks(pid: i32) -> io::Result<u64> {
+        let raw = fs::read_to_string(format!("/proc/{pid}/stat"))?;
+        parse_start_ticks(&raw).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("/proc/{pid}/stat: no parsable starttime field"),
+            )
+        })
+    }
+
+    /// A live VPP process we are supervising.
+    #[derive(Debug)]
+    pub struct VppProcess {
+        pid: i32,
+        start_ticks: u64,
+        pidfd: OwnedFd,
+        origin: Origin,
+        /// Present only when we forked it. Kept so the zombie is
+        /// reaped and the exit status recovered; an adopted process
+        /// has neither.
+        child: Option<Child>,
+    }
+
+    impl VppProcess {
+        /// Fork/exec VPP against a rendered startup.conf.
+        ///
+        /// The conf sets `nodaemon`, so this child *is* the dataplane
+        /// rather than a launcher that exits — without that, the pidfd
+        /// would signal "exited" immediately and the supervisor would
+        /// restart-loop a perfectly healthy VPP.
+        pub fn spawn(binary: &Path, conf: &Path) -> io::Result<Self> {
+            let child = Command::new(binary)
+                .arg("-c")
+                .arg(conf)
+                // VPP's own `log` stanza owns its output. Inheriting
+                // our stdout would interleave dataplane chatter into
+                // packetframe's structured log.
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()?;
+            let pid = child.id() as i32;
+
+            // Open the pidfd before anything else can reap the child.
+            // `child` is still owned here, so even if VPP died during
+            // exec it is a zombie, not gone, and pidfd_open succeeds.
+            let pidfd = pidfd_open(pid)?;
+            let start_ticks = read_start_ticks(pid)?;
+            Ok(Self {
+                pid,
+                start_ticks,
+                pidfd,
+                origin: Origin::Spawned,
+                child: Some(child),
+            })
+        }
+
+        /// Re-acquire a VPP that outlived us, from the state file's
+        /// `(pid, start_ticks)` pair.
+        ///
+        /// `Ok(None)` means "nothing of ours is running" — either the
+        /// pid is gone, or it now belongs to an unrelated process.
+        /// Both are ordinary fresh-attach outcomes, not errors.
+        ///
+        /// Order matters: **open the pidfd first, verify identity
+        /// second.** The pidfd pins one process for its lifetime, so
+        /// once it is open no later reuse can change what we hold; the
+        /// start-time check then rules out a reuse that happened
+        /// *before* the open. Verifying first and opening second would
+        /// leave exactly the window this is meant to close.
+        pub fn adopt(pid: i32, start_ticks: u64) -> io::Result<Option<Self>> {
+            let pidfd = match pidfd_open(pid) {
+                Ok(fd) => fd,
+                // No such process: the normal "VPP died while we were
+                // down" case.
+                Err(e) if e.raw_os_error() == Some(libc::ESRCH) => return Ok(None),
+                Err(e) => return Err(e),
+            };
+            match read_start_ticks(pid) {
+                Ok(actual) if actual == start_ticks => Ok(Some(Self {
+                    pid,
+                    start_ticks,
+                    pidfd,
+                    origin: Origin::Adopted,
+                    child: None,
+                })),
+                // Recycled pid, or it exited between the two calls.
+                // Refusing costs one restart; accepting would aim
+                // SIGKILL at a stranger.
+                Ok(_) => Ok(None),
+                Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+                Err(e) => Err(e),
+            }
+        }
+
+        pub fn pid(&self) -> i32 {
+            self.pid
+        }
+
+        pub fn start_ticks(&self) -> u64 {
+            self.start_ticks
+        }
+
+        pub fn origin(&self) -> Origin {
+            self.origin
+        }
+
+        /// The pidfd, for a caller that wants to park it in its own
+        /// epoll set alongside the API socket rather than call
+        /// [`Self::poll_exit`].
+        pub fn as_raw_fd(&self) -> RawFd {
+            self.pidfd.as_raw_fd()
+        }
+
+        /// Has it exited? `Ok(None)` = still running.
+        ///
+        /// A pidfd becomes readable exactly once, when the process
+        /// terminates, so this is level-triggered and safe to call
+        /// repeatedly.
+        pub fn poll_exit(&mut self, timeout: Duration) -> io::Result<Option<Option<i32>>> {
+            let mut pfd = libc::pollfd {
+                fd: self.pidfd.as_raw_fd(),
+                events: libc::POLLIN,
+                revents: 0,
+            };
+            let ms = timeout.as_millis().min(i32::MAX as u128) as libc::c_int;
+            // SAFETY: one initialised pollfd, count matches.
+            let r = unsafe { libc::poll(&mut pfd, 1, ms) };
+            if r < 0 {
+                let e = io::Error::last_os_error();
+                // A signal during the wait is not an exit.
+                if e.kind() == io::ErrorKind::Interrupted {
+                    return Ok(None);
+                }
+                return Err(e);
+            }
+            if r == 0 {
+                return Ok(None);
+            }
+            Ok(Some(self.reap()))
+        }
+
+        /// Collect the exit status if we can. Adopted processes return
+        /// `None`: init reaped them, and no status is recoverable.
+        fn reap(&mut self) -> Option<i32> {
+            let child = self.child.as_mut()?;
+            match child.wait() {
+                Ok(status) => status.code(),
+                Err(_) => None,
+            }
+        }
+
+        /// Send a signal, race-free.
+        ///
+        /// Signalling a dead-but-not-yet-noticed process is `ESRCH`,
+        /// which is success for every caller here: the goal is "not
+        /// running", and it is not running.
+        pub fn signal(&self, sig: i32) -> io::Result<()> {
+            match pidfd_send_signal(self.pidfd.as_raw_fd(), sig) {
+                Err(e) if e.raw_os_error() == Some(libc::ESRCH) => Ok(()),
+                other => other,
+            }
+        }
+
+        /// SIGTERM, wait up to `grace`, then SIGKILL and wait again.
+        ///
+        /// This is the teardown half of the `<1 s` detach contract, so
+        /// `grace` is a budget the caller sets rather than a constant
+        /// here — the module's own deadline covers N VFs plus this.
+        pub fn terminate(&mut self, grace: Duration) -> io::Result<Option<i32>> {
+            self.signal(libc::SIGTERM)?;
+            if let Some(status) = self.wait_until(grace)? {
+                return Ok(status);
+            }
+            self.signal(libc::SIGKILL)?;
+            // SIGKILL cannot be refused, but it also cannot interrupt an
+            // uninterruptible sleep: a process parked in a driver call
+            // stays alive until that call returns. That is not
+            // hypothetical here — VPP sits on VFIO and DMA, which is
+            // exactly where D-state waits come from. So bound this and
+            // report honestly; an unbounded loop would hang detach
+            // forever rather than miss its deadline out loud.
+            match self.wait_until(SIGKILL_BUDGET)? {
+                Some(status) => Ok(status),
+                None => Err(io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    format!(
+                        "pid {} still alive {:?} after SIGKILL (uninterruptible?); \
+                         VF/hugepage teardown must not proceed while it may still DMA",
+                        self.pid, SIGKILL_BUDGET
+                    ),
+                )),
+            }
+        }
+
+        /// Wait for exit within `budget`. `Ok(None)` = still running
+        /// when the budget ran out.
+        fn wait_until(&mut self, budget: Duration) -> io::Result<Option<Option<i32>>> {
+            let deadline = Instant::now() + budget;
+            loop {
+                let left = deadline.saturating_duration_since(Instant::now());
+                if let Some(status) = self.poll_exit(left)? {
+                    return Ok(Some(status));
+                }
+                if left.is_zero() {
+                    return Ok(None);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+mod imp {
+    //! Non-Linux stub per the platform-gate policy: the macOS dev loop
+    //! must compile and test, and every entry point fails loudly as
+    //! unsupported rather than pretending to supervise something.
+    //!
+    //! `ErrorKind::Unsupported` rather than a literal ENOSYS because
+    //! this crate scopes its `libc` dependency to Linux targets, and
+    //! pulling libc onto every platform for one constant is a worse
+    //! trade than using the portable spelling of the same idea.
+    use super::Origin;
+    use std::io;
+    use std::path::Path;
+    use std::time::Duration;
+
+    fn unsupported<T>() -> io::Result<T> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "VPP process supervision is Linux-only (pidfd)",
+        ))
+    }
+
+    #[derive(Debug)]
+    pub struct VppProcess {
+        _priv: (),
+    }
+
+    impl VppProcess {
+        pub fn spawn(_binary: &Path, _conf: &Path) -> io::Result<Self> {
+            unsupported()
+        }
+        pub fn adopt(_pid: i32, _start_ticks: u64) -> io::Result<Option<Self>> {
+            unsupported()
+        }
+        pub fn pid(&self) -> i32 {
+            0
+        }
+        pub fn start_ticks(&self) -> u64 {
+            0
+        }
+        pub fn origin(&self) -> Origin {
+            Origin::Spawned
+        }
+        pub fn as_raw_fd(&self) -> std::os::fd::RawFd {
+            -1
+        }
+        pub fn poll_exit(&mut self, _timeout: Duration) -> io::Result<Option<Option<i32>>> {
+            unsupported()
+        }
+        pub fn signal(&self, _sig: i32) -> io::Result<()> {
+            unsupported()
+        }
+        pub fn terminate(&mut self, _grace: Duration) -> io::Result<Option<i32>> {
+            unsupported()
+        }
+    }
+}
+
+pub use imp::VppProcess;
+
+/// Convenience for the supervisor's start path: adopt if the state
+/// file still describes a live VPP, otherwise spawn a fresh one.
+///
+/// Returns the handle and whether it was adopted, because the two
+/// drive different supervisor events — adoption must NOT unsteer, and
+/// that distinction is the difference between a seamless packetframe
+/// restart and a self-inflicted blackhole.
+pub fn adopt_or_spawn(
+    prior: Option<(i32, u64)>,
+    binary: &Path,
+    conf: &Path,
+) -> io::Result<(VppProcess, bool)> {
+    if let Some((pid, ticks)) = prior {
+        if let Some(p) = VppProcess::adopt(pid, ticks)? {
+            return Ok((p, true));
+        }
+    }
+    Ok((VppProcess::spawn(binary, conf)?, false))
+}
+
+/// Best-effort teardown used on paths that must not fail, such as
+/// detach unwinding: log-and-continue rather than propagate.
+pub fn terminate_quietly(p: &mut VppProcess, grace: Duration) {
+    if let Err(e) = p.terminate(grace) {
+        tracing::warn!(pid = p.pid(), error = %e, "VPP termination did not complete cleanly");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The ordinary shape.
+    #[test]
+    fn start_ticks_is_field_22() {
+        let stat = "4242 (vpp) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 987654 \
+                    123456789 456 18446744073709551615";
+        assert_eq!(parse_start_ticks(stat), Some(987_654));
+    }
+
+    /// `comm` with a space in it. A `split_whitespace().nth(21)` parse
+    /// reads one field short here and silently returns the wrong
+    /// number — which would make adoption compare a bogus identity.
+    #[test]
+    fn a_comm_containing_a_space_does_not_shift_the_fields() {
+        let stat = "4242 (vpp worker) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 \
+                    987654 123456789 456";
+        assert_eq!(parse_start_ticks(stat), Some(987_654));
+    }
+
+    /// `comm` containing its own parens: the anchor has to be the LAST
+    /// `)`, not the first.
+    #[test]
+    fn a_comm_containing_parens_anchors_on_the_last_one() {
+        let stat = "4242 (vpp (test)) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 \
+                    987654 123456789 456";
+        assert_eq!(parse_start_ticks(stat), Some(987_654));
+    }
+
+    /// Truncated or foreign input must not produce a number. A wrong
+    /// start-time that happens to parse is the one failure mode that
+    /// could aim SIGKILL at an unrelated process.
+    #[test]
+    fn unrecognisable_input_returns_none_rather_than_guessing() {
+        assert_eq!(parse_start_ticks(""), None);
+        assert_eq!(parse_start_ticks("4242 (vpp) S 1 2 3"), None);
+        assert_eq!(parse_start_ticks("no parens here at all"), None);
+        // Field 22 present but not a number.
+        let bad = "4242 (vpp) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 xxx 1 2";
+        assert_eq!(parse_start_ticks(bad), None);
+    }
+
+    /// Real kernels emit a trailing newline.
+    #[test]
+    fn a_trailing_newline_is_tolerated() {
+        let stat = "4242 (vpp) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 987654 \
+                    123456789 456\n";
+        assert_eq!(parse_start_ticks(stat), Some(987_654));
+    }
+}

--- a/crates/modules/vpp-offload/src/process.rs
+++ b/crates/modules/vpp-offload/src/process.rs
@@ -46,6 +46,31 @@ pub fn parse_start_ticks(stat: &str) -> Option<u64> {
     stat[close + 1..].split_whitespace().nth(19)?.parse().ok()
 }
 
+/// Identity of the running kernel, from
+/// `/proc/sys/kernel/random/boot_id`.
+///
+/// **Load-bearing for adoption, not diagnostics.** `start_ticks` is
+/// measured in clock ticks *since boot*, and the state file outlives a
+/// reboot (the default state dir is under `/var/lib`). After a reboot
+/// the tick counter restarts, so an unrelated process can legitimately
+/// land on the recorded pid at the recorded tick and satisfy a
+/// `(pid, start_ticks)` equality check. We would then hold a pidfd for
+/// a stranger and later send it SIGTERM and SIGKILL as root.
+///
+/// The boot id makes the pair meaningful again: it changes on every
+/// boot, so a state file from a previous boot can never match.
+pub fn boot_id() -> std::io::Result<String> {
+    let raw = std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?;
+    let id = raw.trim().to_string();
+    if id.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "/proc/sys/kernel/random/boot_id is empty",
+        ));
+    }
+    Ok(id)
+}
+
 /// How a process handle was obtained. Adopted processes cannot be
 /// reaped (they are init's children, not ours), so their exit status
 /// is unavailable — the supervisor's `ProcessExited { status }` is an
@@ -103,6 +128,27 @@ mod imp {
         Ok(())
     }
 
+    /// Kill and reap a child we spawned but could not take ownership
+    /// of, then return the original error with that noted.
+    ///
+    /// Signalling by pid rather than pidfd is safe *here specifically*:
+    /// we hold the unreaped `Child`, so the pid cannot have been
+    /// recycled yet — it is at worst our own zombie.
+    fn orphan_cleanup(mut child: Child, pid: i32, cause: io::Error) -> io::Error {
+        // SAFETY: kill(2) on a pid we own and have not reaped.
+        unsafe { libc::kill(pid, libc::SIGKILL) };
+        // Reap so it does not linger as a zombie holding the pid.
+        let reaped = child.wait().is_ok();
+        io::Error::new(
+            cause.kind(),
+            format!(
+                "spawned VPP (pid {pid}) but could not take ownership of it: {cause}; \
+                 the child was killed{} to avoid an untracked VPP holding the VF",
+                if reaped { " and reaped" } else { "" }
+            ),
+        )
+    }
+
     fn read_start_ticks(pid: i32) -> io::Result<u64> {
         let raw = fs::read_to_string(format!("/proc/{pid}/stat"))?;
         parse_start_ticks(&raw).ok_or_else(|| {
@@ -134,7 +180,7 @@ mod imp {
         /// would signal "exited" immediately and the supervisor would
         /// restart-loop a perfectly healthy VPP.
         pub fn spawn(binary: &Path, conf: &Path) -> io::Result<Self> {
-            let child = Command::new(binary)
+            let mut child = Command::new(binary)
                 .arg("-c")
                 .arg(conf)
                 // VPP's own `log` stanza owns its output. Inheriting
@@ -149,8 +195,22 @@ mod imp {
             // Open the pidfd before anything else can reap the child.
             // `child` is still owned here, so even if VPP died during
             // exec it is a zombie, not gone, and pidfd_open succeeds.
-            let pidfd = pidfd_open(pid)?;
-            let start_ticks = read_start_ticks(pid)?;
+            //
+            // Both of these can fail on a healthy, RUNNING child — an
+            // fd-limit hit on `pidfd_open`, a procfs read error on the
+            // stat. Propagating with `?` would drop `child` and leave
+            // that VPP alive and untracked: still holding the VF and
+            // the API socket, invisible to the pidfd we never got, and
+            // the `SpawnFailed` retry would then start a SECOND VPP on
+            // the same resources. Kill what we started before giving up.
+            let pidfd = match pidfd_open(pid) {
+                Ok(fd) => fd,
+                Err(e) => return Err(orphan_cleanup(child, pid, e)),
+            };
+            let start_ticks = match read_start_ticks(pid) {
+                Ok(t) => t,
+                Err(e) => return Err(orphan_cleanup(child, pid, e)),
+            };
             Ok(Self {
                 pid,
                 start_ticks,
@@ -161,11 +221,20 @@ mod imp {
         }
 
         /// Re-acquire a VPP that outlived us, from the state file's
-        /// `(pid, start_ticks)` pair.
+        /// `(pid, start_ticks, boot_id)` triple.
         ///
-        /// `Ok(None)` means "nothing of ours is running" — either the
-        /// pid is gone, or it now belongs to an unrelated process.
-        /// Both are ordinary fresh-attach outcomes, not errors.
+        /// `Ok(None)` means "nothing of ours is running" — the pid is
+        /// gone, it now belongs to an unrelated process, or the state
+        /// file is from a previous boot. All three are ordinary
+        /// fresh-attach outcomes, not errors.
+        ///
+        /// **`recorded_boot_id` is not optional in spirit.** Passing
+        /// `None` (an old state file that predates the field) refuses
+        /// adoption, because `start_ticks` counts from boot and the
+        /// state file outlives a reboot: without a boot id, a fresh
+        /// unrelated process can match the recorded pid at the recorded
+        /// tick, and we would SIGKILL it as root. One needless restart
+        /// is the correct price.
         ///
         /// Order matters: **open the pidfd first, verify identity
         /// second.** The pidfd pins one process for its lifetime, so
@@ -173,7 +242,24 @@ mod imp {
         /// start-time check then rules out a reuse that happened
         /// *before* the open. Verifying first and opening second would
         /// leave exactly the window this is meant to close.
-        pub fn adopt(pid: i32, start_ticks: u64) -> io::Result<Option<Self>> {
+        pub fn adopt(
+            pid: i32,
+            start_ticks: u64,
+            recorded_boot_id: Option<&str>,
+        ) -> io::Result<Option<Self>> {
+            // Cheapest and most decisive check, before we touch a pid
+            // that may not be ours at all.
+            match (recorded_boot_id, super::boot_id()) {
+                (Some(recorded), Ok(current)) if recorded == current => {}
+                // Different boot: the state file's pid/tick pair refers
+                // to a process that cannot still exist.
+                (Some(_), Ok(_)) => return Ok(None),
+                // No recorded boot id: cannot establish identity.
+                (None, _) => return Ok(None),
+                // Cannot read our own boot id — refuse rather than
+                // adopt on an unverifiable identity.
+                (_, Err(e)) => return Err(e),
+            }
             let pidfd = match pidfd_open(pid) {
                 Ok(fd) => fd,
                 // No such process: the normal "VPP died while we were
@@ -346,7 +432,11 @@ mod imp {
         pub fn spawn(_binary: &Path, _conf: &Path) -> io::Result<Self> {
             unsupported()
         }
-        pub fn adopt(_pid: i32, _start_ticks: u64) -> io::Result<Option<Self>> {
+        pub fn adopt(
+            _pid: i32,
+            _start_ticks: u64,
+            _recorded_boot_id: Option<&str>,
+        ) -> io::Result<Option<Self>> {
             unsupported()
         }
         pub fn pid(&self) -> i32 {
@@ -383,23 +473,57 @@ pub use imp::VppProcess;
 /// that distinction is the difference between a seamless packetframe
 /// restart and a self-inflicted blackhole.
 pub fn adopt_or_spawn(
-    prior: Option<(i32, u64)>,
+    prior: Option<(i32, u64, Option<String>)>,
     binary: &Path,
     conf: &Path,
 ) -> io::Result<(VppProcess, bool)> {
-    if let Some((pid, ticks)) = prior {
-        if let Some(p) = VppProcess::adopt(pid, ticks)? {
+    if let Some((pid, ticks, boot)) = prior {
+        if let Some(p) = VppProcess::adopt(pid, ticks, boot.as_deref())? {
             return Ok((p, true));
         }
     }
     Ok((VppProcess::spawn(binary, conf)?, false))
 }
 
-/// Best-effort teardown used on paths that must not fail, such as
-/// detach unwinding: log-and-continue rather than propagate.
-pub fn terminate_quietly(p: &mut VppProcess, grace: Duration) {
-    if let Err(e) = p.terminate(grace) {
-        tracing::warn!(pid = p.pid(), error = %e, "VPP termination did not complete cleanly");
+/// Whether the caller may release the resources VPP was using.
+///
+/// The distinction is the whole point of [`VppProcess::terminate`]'s
+/// bounded SIGKILL wait, so it must survive into the teardown path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub enum Disposition {
+    /// The process is gone. VF unbind, numvfs=0, and hugepage release
+    /// are safe.
+    SafeToRelease,
+    /// The process may still be alive and DMA-capable. Resources MUST
+    /// be leaked rather than released.
+    MustLeak,
+}
+
+/// Teardown for paths that cannot propagate an error, such as detach
+/// unwinding — but which still must not release resources under a live
+/// process.
+///
+/// Returns a [`Disposition`] instead of swallowing the outcome. An
+/// earlier version logged the failure and returned `()`, which handed
+/// the caller no way to distinguish "VPP is gone" from "VPP survived
+/// SIGKILL and may still be writing into the buffers you are about to
+/// hand back to the kernel". Unbinding a VF or dropping hugepages under
+/// a process that can still DMA into them is memory corruption with a
+/// warning line in the log as its only trace — leaking a VF is
+/// dramatically cheaper, and it is visible in `packetframe status`.
+pub fn terminate_or_leak(p: &mut VppProcess, grace: Duration) -> Disposition {
+    match p.terminate(grace) {
+        Ok(_) => Disposition::SafeToRelease,
+        Err(e) => {
+            tracing::error!(
+                pid = p.pid(),
+                error = %e,
+                "VPP did not die; LEAKING its VF and hugepages rather than \
+                 releasing resources a live process may still DMA into"
+            );
+            Disposition::MustLeak
+        }
     }
 }
 
@@ -445,6 +569,45 @@ mod tests {
         // Field 22 present but not a number.
         let bad = "4242 (vpp) S 1 4242 4242 0 -1 4194560 1234 0 0 0 10 20 0 0 20 0 8 0 xxx 1 2";
         assert_eq!(parse_start_ticks(bad), None);
+    }
+
+    /// Adoption across a reboot is the case that could aim SIGKILL at
+    /// a stranger: `start_ticks` counts from boot and resets, while the
+    /// state file under `/var/lib` does not. A state file with no
+    /// recorded boot id therefore cannot establish identity at all, and
+    /// must be refused rather than trusted.
+    #[test]
+    fn adoption_without_a_recorded_boot_id_is_refused() {
+        // Our own pid is certainly alive, so this isolates the boot-id
+        // check from every other reason adoption can decline.
+        let me = std::process::id() as i32;
+        let ticks = 12345;
+        match VppProcess::adopt(me, ticks, None) {
+            Ok(None) => {} // refused, as required
+            Ok(Some(_)) => panic!("adopted a process on an unverifiable identity"),
+            // Non-Linux stubs return Unsupported; that is also "did not
+            // adopt", which is the property under test.
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::Unsupported, "{e}"),
+        }
+    }
+
+    /// A boot id from a different boot must not match.
+    #[test]
+    fn adoption_from_a_previous_boot_is_refused() {
+        let me = std::process::id() as i32;
+        match VppProcess::adopt(me, 12345, Some("not-the-current-boot-id")) {
+            Ok(None) => {}
+            Ok(Some(_)) => panic!("adopted across a reboot"),
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::Unsupported, "{e}"),
+        }
+    }
+
+    /// `Disposition` is the signal that stops teardown from releasing
+    /// a VF under a process that may still DMA into it. It must be
+    /// impossible to ignore by accident.
+    #[test]
+    fn disposition_distinguishes_safe_from_must_leak() {
+        assert_ne!(Disposition::SafeToRelease, Disposition::MustLeak);
     }
 
     /// Real kernels emit a trailing newline.

--- a/crates/modules/vpp-offload/src/process.rs
+++ b/crates/modules/vpp-offload/src/process.rs
@@ -180,7 +180,7 @@ mod imp {
         /// would signal "exited" immediately and the supervisor would
         /// restart-loop a perfectly healthy VPP.
         pub fn spawn(binary: &Path, conf: &Path) -> io::Result<Self> {
-            let mut child = Command::new(binary)
+            let child = Command::new(binary)
                 .arg("-c")
                 .arg(conf)
                 // VPP's own `log` stanza owns its output. Inheriting

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -93,6 +93,22 @@ pub struct ResourceState {
     /// ticks since boot) for `vpp_pid`. Together the pair is a stable
     /// process identity across a PID-space wrap.
     pub vpp_start_ticks: Option<u64>,
+    /// `/proc/sys/kernel/random/boot_id` when `vpp_pid` was recorded.
+    ///
+    /// The third leg of the identity, and it is not optional in spirit.
+    /// `vpp_start_ticks` counts from BOOT, and this file lives under
+    /// `/var/lib`, so it survives a reboot that the tick counter does
+    /// not: after a restart an unrelated process can land on the
+    /// recorded pid at the recorded tick and satisfy a `(pid, ticks)`
+    /// check, at which point we would hold a pidfd for a stranger and
+    /// eventually SIGKILL it as root.
+    ///
+    /// `serde(default)` so a state file written before this field
+    /// existed still parses — [`crate::process::VppProcess::adopt`]
+    /// treats the resulting `None` as "identity unverifiable, refuse
+    /// adoption", which costs one restart and cannot mis-target.
+    #[serde(default)]
+    pub vpp_boot_id: Option<String>,
 }
 
 impl ResourceState {
@@ -105,6 +121,7 @@ impl ResourceState {
             steer_rules: Vec::new(),
             vpp_pid: None,
             vpp_start_ticks: None,
+            vpp_boot_id: None,
         }
     }
 

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -41,6 +41,33 @@ pub const MAX_BACKOFF: Duration = Duration::from_secs(30);
 /// one and the FIB is still warm in bird's mirror.
 pub const BASE_BACKOFF: Duration = Duration::from_millis(250);
 
+/// How long VPP may take to answer its binary API after spawn before
+/// we give up on it.
+///
+/// Without this, `Starting` is a **trap with no exit**. A VPP that
+/// lives but deadlocks before opening its API socket generates no
+/// event at all: `ApiUp` never arrives, the pidfd stays quiet because
+/// the process is alive, and the wedge detector cannot help because it
+/// only starts once the API has answered at least once. Forwarding
+/// would stay down until an operator noticed.
+///
+/// Generous, because startup genuinely takes time on this platform:
+/// VPP allocates and faults in a multi-GB main heap on 512 MiB
+/// hugepages, then probes and attaches the device. Being wrong in the
+/// slow direction costs a longer first attach; being wrong in the fast
+/// direction restart-loops a VPP that was about to come up.
+pub const API_STARTUP_BUDGET: Duration = Duration::from_secs(60);
+
+/// How long a resync + verify cycle may take before we treat it as
+/// hung.
+///
+/// Same failure shape as [`API_STARTUP_BUDGET`]: a resync that never
+/// finishes emits neither `SyncComplete` nor a failure, so `Syncing`
+/// would also be a trap. Sized above the ≤60 s convergence budget the
+/// full v4 table is measured against, with room for the verify pass —
+/// exceeding it means something is wrong, not merely slow.
+pub const CONVERGENCE_BUDGET: Duration = Duration::from_secs(120);
+
 /// Where the supervised VPP is in its lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum State {
@@ -74,16 +101,13 @@ impl State {
     pub fn has_process(self) -> bool {
         !matches!(self, State::Stopped | State::Backoff)
     }
-
-    /// Whether a resync or verify is in flight — the window in which a
-    /// restart must not be started (rule 4).
-    pub fn is_converging(self) -> bool {
-        matches!(
-            self,
-            State::Syncing | State::Verifying | State::AdoptedResyncing
-        )
-    }
 }
+// NOTE: there is deliberately no `State::is_converging()`. Deriving
+// "a resync is in flight" from the lifecycle state is what broke rule
+// 4: `fail()` moves the state to `Backoff`, which is not a converging
+// state, so the guard vanished exactly when VPP died mid-convergence.
+// Ask `Supervisor::is_converging()`, which tracks the real thing.
+// `State::is_steered()` is absent for the same reason.
 
 /// Something that happened to the supervised process or its FIB.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -121,6 +145,27 @@ pub enum Event {
     /// alive but not scheduling; treated as death because a wedged
     /// forwarder drops exactly as thoroughly as a dead one.
     Wedged,
+    /// The current phase outran its budget — [`API_STARTUP_BUDGET`] in
+    /// `Starting`, [`CONVERGENCE_BUDGET`] while converging.
+    ///
+    /// Exists because those phases are otherwise **exitless**: a VPP
+    /// that is alive but not answering, or a resync that never
+    /// finishes, produces no event whatsoever. The caller arms a
+    /// deadline from [`Supervisor::phase_budget`] and sends this when
+    /// it fires.
+    PhaseTimedOut,
+    /// Installing the MCAM rules failed. The dataplane is verified but
+    /// traffic is NOT diverted — the safe staging state, reported
+    /// rather than papered over.
+    SteerFailed,
+    /// An aborted resync or verify has actually finished unwinding.
+    ///
+    /// The supervisor cannot observe this itself: the work runs in the
+    /// caller's task, so only the caller knows when it has stopped
+    /// touching the transport. Until it arrives,
+    /// [`Supervisor::may_restart`] stays false so a restart cannot
+    /// stack a second load onto one VPP.
+    ConvergenceStopped,
     /// Backoff elapsed.
     BackoffElapsed,
     /// Operator asked for a clean stop.
@@ -146,6 +191,10 @@ pub enum Action {
     StartVerify,
     /// Install MCAM steering rules.
     Steer,
+    /// Stop an in-flight resync/verify. Paired with
+    /// `Event::ConvergenceStopped`, which reports when it has actually
+    /// wound down — the restart waits for that, not for this.
+    AbortConvergence,
     /// Arm the backoff timer.
     ArmBackoff(Duration),
     /// Release VF/hugepage resources; terminal.
@@ -174,6 +223,19 @@ pub struct Supervisor {
     /// remembered across the restart so `Ready` knows whether to
     /// re-steer automatically or wait for the operator's canary.
     was_steered: bool,
+    /// Whether a resync or verify task is still running.
+    ///
+    /// A field for the same reason `steered` is one: derived from the
+    /// lifecycle state it was wrong in exactly the case that matters.
+    /// `fail()` moves the state straight to `Backoff`, and `Backoff` is
+    /// not a converging state — so `may_restart()` said yes while the
+    /// resync task was still unwinding, and rule 4 ("no restart while a
+    /// resync is in flight") failed precisely when VPP died *during*
+    /// convergence, which is when it is most likely to.
+    ///
+    /// Only the caller knows when its task has truly stopped, so this
+    /// is cleared by `Event::ConvergenceStopped`, not by a state change.
+    converging: bool,
 }
 
 impl Default for Supervisor {
@@ -189,6 +251,7 @@ impl Supervisor {
             failures: 0,
             steered: false,
             was_steered: false,
+            converging: false,
         }
     }
 
@@ -244,8 +307,12 @@ impl Supervisor {
             // ignores both StartRequested and BackoffElapsed, so the
             // retry policy it has would never run.
             (Starting, SpawnFailed) => self.fail(),
+            // VPP is alive but never answered. Without this the state
+            // is exitless — see API_STARTUP_BUDGET.
+            (Starting, PhaseTimedOut) => self.fail(),
             (Starting, ApiUp) => {
                 self.state = Syncing;
+                self.converging = true;
                 // Devices first: the FIB paths we are about to install
                 // reference interface indices that do not exist until
                 // the device is attached and its port interface
@@ -257,6 +324,7 @@ impl Supervisor {
             (Stopped | Backoff | Starting, Adopted { steered }) => {
                 self.steered = steered;
                 self.was_steered = steered;
+                self.converging = true;
                 // An adopted VPP is presumed good until proven stale:
                 // mark dirty, resync, verify — but do NOT unsteer a
                 // correctly-forwarding dataplane to do it.
@@ -269,8 +337,12 @@ impl Supervisor {
                 self.state = Verifying;
                 vec![Action::StartVerify]
             }
+            // A resync or verify that never finishes is the same trap
+            // as a VPP that never answers.
+            (Syncing | AdoptedResyncing | Verifying, PhaseTimedOut) => self.fail(),
             (Verifying, VerifyPassed) => {
                 self.failures = 0;
+                self.converging = false;
                 // Steer if traffic was flowing before the disruption —
                 // or is still flowing, in the adopted case. A first
                 // attach waits for the operator's explicit canary;
@@ -283,12 +355,18 @@ impl Supervisor {
                 // provisioning and deploys, so rules we installed
                 // before a restart may simply be gone. Re-asserting
                 // them is the reconcile step, and it is cheap.
+                //
+                // The state does NOT become `Steered` here. Installing
+                // MCAM rules can fail, and claiming success before the
+                // action has run would report a steered dataplane whose
+                // rules were never installed — failures cleared, no
+                // retry, traffic quietly still on the fallback tier.
+                // `Event::Steered` is the acknowledgement, exactly as
+                // on the first-attach path.
+                self.state = Ready;
                 if self.steered || self.was_steered {
-                    self.state = State::Steered;
-                    self.steered = true;
                     vec![Action::Steer]
                 } else {
-                    self.state = Ready;
                     vec![]
                 }
             }
@@ -296,6 +374,7 @@ impl Supervisor {
                 // A FIB we cannot verify is not one to divert traffic
                 // into. Treat as a failure and cycle, rather than
                 // steering optimistically.
+                self.converging = false;
                 self.fail()
             }
             (Ready, Event::Steered) => {
@@ -313,12 +392,31 @@ impl Supervisor {
                 self.fail()
             }
 
+            // Steering could not be installed. We stay verified but
+            // UNSTEERED — the safe staging state, and one an operator
+            // can see. Deliberately not a `fail()`: the dataplane is
+            // fine, so killing and restarting VPP would trade a
+            // working-but-idle forwarder for an outage. `steered` is
+            // left untouched, because on the adopted path the previous
+            // rules may still be live and claiming otherwise would
+            // suppress the Unsteer we owe on teardown.
+            (Ready, SteerFailed) => vec![],
+
+            // --- convergence bookkeeping ---
+            (_, ConvergenceStopped) => {
+                self.converging = false;
+                vec![]
+            }
+
             // --- clean stop ---
             (_, StopRequested) => {
                 let mut actions = Vec::new();
                 if self.steered {
                     actions.push(Action::Unsteer);
                     self.steered = false;
+                }
+                if self.converging {
+                    actions.push(Action::AbortConvergence);
                 }
                 actions.push(Action::Kill);
                 actions.push(Action::ReleaseResources);
@@ -349,6 +447,13 @@ impl Supervisor {
             actions.push(Action::Unsteer);
             self.steered = false;
         }
+        // Tell the caller to wind down any resync/verify still running.
+        // `converging` stays true until it confirms with
+        // `ConvergenceStopped`, which is what holds the restart back —
+        // this action only asks.
+        if self.converging {
+            actions.push(Action::AbortConvergence);
+        }
         actions.push(Action::Kill);
         self.failures = self.failures.saturating_add(1);
         let delay = self.backoff();
@@ -357,14 +462,36 @@ impl Supervisor {
         actions
     }
 
+    /// Whether a resync or verify is still running.
+    pub fn is_converging(&self) -> bool {
+        self.converging
+    }
+
+    /// How long the current phase may take before the caller should
+    /// send `Event::PhaseTimedOut`. `None` = no deadline applies.
+    ///
+    /// The caller arms this rather than the supervisor, which owns no
+    /// clock — but the *budget* belongs here, next to the states it
+    /// bounds.
+    pub fn phase_budget(&self) -> Option<Duration> {
+        match self.state {
+            State::Starting => Some(API_STARTUP_BUDGET),
+            State::Syncing | State::AdoptedResyncing | State::Verifying => Some(CONVERGENCE_BUDGET),
+            _ => None,
+        }
+    }
+
     /// Whether a restart may be started right now (rule 4).
     ///
-    /// The caller checks this before acting on a `BackoffElapsed`: a
-    /// resync still draining means the previous attempt has not
-    /// finished failing, and starting another would stack two loads
+    /// Gated on the `converging` FIELD, not on the lifecycle state.
+    /// `fail()` sets the state to `Backoff`, which is not a converging
+    /// state, so a state-derived check returned true while the resync
+    /// task was still unwinding — the guard evaporated exactly when VPP
+    /// died mid-convergence. The caller checks this before acting on
+    /// `BackoffElapsed`; starting another attempt would stack two loads
     /// onto one VPP.
     pub fn may_restart(&self) -> bool {
-        !self.state.is_converging()
+        !self.converging
     }
 }
 
@@ -569,11 +696,111 @@ mod tests {
         s.on(Event::SyncComplete);
         assert_eq!(s.state(), State::Verifying);
         let actions = s.on(Event::VerifyPassed);
-        assert_eq!(s.state(), State::Steered);
         assert!(
             actions.contains(&Action::Steer),
             "re-assert rules after adoption so ours own them"
         );
+        // Pending, not done: the rules are not confirmed installed
+        // until the action reports back.
+        assert_eq!(s.state(), State::Ready);
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Steered);
+        assert!(s.is_steered());
+    }
+
+    /// `Starting` used to be a trap with no exit: a VPP that lives but
+    /// never opens its API emits nothing at all — no `ApiUp`, no pidfd
+    /// exit (it is alive), and no wedge event (the detector only starts
+    /// after the first answer). Forwarding stayed down until a human
+    /// noticed.
+    #[test]
+    fn a_vpp_that_never_answers_its_api_is_not_waited_on_forever() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        assert_eq!(s.state(), State::Starting);
+        assert_eq!(
+            s.phase_budget(),
+            Some(API_STARTUP_BUDGET),
+            "the caller needs a deadline to arm"
+        );
+
+        let actions = s.on(Event::PhaseTimedOut);
+        assert_eq!(s.state(), State::Backoff);
+        assert!(actions.contains(&Action::Kill));
+        assert!(actions.iter().any(|a| matches!(a, Action::ArmBackoff(_))));
+        assert!(s.may_restart(), "nothing was converging");
+        assert_eq!(s.on(Event::BackoffElapsed), vec![Action::Spawn]);
+    }
+
+    /// Same trap, one phase later: a resync that never finishes.
+    #[test]
+    fn a_hung_resync_times_out_instead_of_hanging_forever() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        assert_eq!(s.state(), State::Syncing);
+        assert_eq!(s.phase_budget(), Some(CONVERGENCE_BUDGET));
+
+        let actions = s.on(Event::PhaseTimedOut);
+        assert_eq!(s.state(), State::Backoff);
+        assert!(
+            actions.contains(&Action::AbortConvergence),
+            "the hung task must be told to stop: {actions:?}"
+        );
+    }
+
+    /// Rule 4 through the path that actually breaks it. `fail()` sets
+    /// the state to `Backoff`, which is not a converging *state* — so a
+    /// state-derived `may_restart()` said yes while the resync task was
+    /// still unwinding, and the guard evaporated exactly when VPP died
+    /// mid-convergence.
+    #[test]
+    fn a_death_during_convergence_blocks_restart_until_the_task_stops() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        assert!(s.is_converging());
+
+        let actions = s.on(Event::ProcessExited { status: None });
+        assert_eq!(s.state(), State::Backoff);
+        assert!(
+            actions.contains(&Action::AbortConvergence),
+            "must ask the resync to wind down: {actions:?}"
+        );
+        assert!(
+            !s.may_restart(),
+            "a restart here would stack two loads onto one VPP"
+        );
+
+        // The action only ASKS. Only the caller knows when its task has
+        // actually stopped touching the transport.
+        s.on(Event::ConvergenceStopped);
+        assert!(s.may_restart());
+    }
+
+    /// A steer that fails must not be reported as success. The
+    /// first-attach path always waited for an acknowledgement; the
+    /// automatic-restore path assumed it.
+    #[test]
+    fn a_failed_steer_leaves_us_verified_but_unsteered() {
+        let mut s = running_and_steered();
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyPassed);
+        assert!(actions.contains(&Action::Steer));
+        assert_eq!(s.state(), State::Ready);
+
+        // Rules could not be installed.
+        assert_eq!(s.on(Event::SteerFailed), vec![]);
+        assert_eq!(
+            s.state(),
+            State::Ready,
+            "verified but not steered — the safe staging state"
+        );
+        // And it must NOT be reported as a running steered dataplane.
+        assert_ne!(s.state(), State::Steered);
     }
 
     #[test]
@@ -596,11 +823,13 @@ mod tests {
         s.on(Event::ApiUp);
         s.on(Event::SyncComplete);
         let actions = s.on(Event::VerifyPassed);
-        assert_eq!(s.state(), State::Steered);
         assert!(
             actions.contains(&Action::Steer),
             "traffic was flowing before the crash, so restore it"
         );
+        assert_eq!(s.state(), State::Ready, "awaiting the steer ack");
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Steered);
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -65,11 +65,6 @@ pub enum State {
 }
 
 impl State {
-    /// Whether MCAM rules are currently diverting traffic.
-    pub fn is_steered(self) -> bool {
-        matches!(self, State::Steered | State::AdoptedResyncing)
-    }
-
     /// Whether a supervised process exists that could die or wedge.
     ///
     /// `Backoff` deliberately counts as NO process: the previous one
@@ -97,6 +92,11 @@ pub enum Event {
     StartRequested,
     /// A child was spawned successfully.
     Spawned,
+    /// fork/exec failed — the binary is missing, not yet installed, or
+    /// the mount is briefly unavailable. Distinct from
+    /// `ProcessExited` because no process ever existed, so no pidfd
+    /// will report anything and the retry has to be driven from here.
+    SpawnFailed,
     /// A pre-existing VPP was adopted from the state file. `steered`
     /// records whether its MCAM rules are still in place, which
     /// decides whether we may keep traffic flowing through it.
@@ -158,6 +158,18 @@ pub struct Supervisor {
     state: State,
     /// Consecutive failures since the last verified-healthy moment.
     failures: u32,
+    /// Whether MCAM rules are diverting traffic RIGHT NOW.
+    ///
+    /// A field rather than a property of [`State`], because the two are
+    /// genuinely orthogonal and adoption proves it: an adopted VPP is
+    /// steered while it is still syncing and verifying. Deriving this
+    /// from the lifecycle state meant `AdoptedResyncing → Verifying`
+    /// silently dropped it, so a verify failure — or a crash, wedge, or
+    /// stop during that window — killed VPP *without* removing the
+    /// steering rules first, leaving traffic diverted to a VF nothing
+    /// was servicing. That is precisely the blackhole the ≤50 ms
+    /// teardown rule exists to prevent.
+    steered: bool,
     /// Whether steering was up when the current trouble started —
     /// remembered across the restart so `Ready` knows whether to
     /// re-steer automatically or wait for the operator's canary.
@@ -175,12 +187,18 @@ impl Supervisor {
         Self {
             state: State::Stopped,
             failures: 0,
+            steered: false,
             was_steered: false,
         }
     }
 
     pub fn state(&self) -> State {
         self.state
+    }
+
+    /// Whether MCAM rules are currently diverting traffic to VPP.
+    pub fn is_steered(&self) -> bool {
+        self.steered
     }
 
     pub fn failures(&self) -> u32 {
@@ -220,6 +238,12 @@ impl Supervisor {
                 vec![Action::Spawn]
             }
             (Starting, Spawned) => vec![],
+            // fork/exec itself failed — no process exists, so no pidfd
+            // will ever report an exit. Without an explicit event the
+            // supervisor would sit in `Starting` forever: `Starting`
+            // ignores both StartRequested and BackoffElapsed, so the
+            // retry policy it has would never run.
+            (Starting, SpawnFailed) => self.fail(),
             (Starting, ApiUp) => {
                 self.state = Syncing;
                 // Devices first: the FIB paths we are about to install
@@ -231,6 +255,7 @@ impl Supervisor {
 
             // --- adoption (rule 3) ---
             (Stopped | Backoff | Starting, Adopted { steered }) => {
+                self.steered = steered;
                 self.was_steered = steered;
                 // An adopted VPP is presumed good until proven stale:
                 // mark dirty, resync, verify — but do NOT unsteer a
@@ -245,16 +270,25 @@ impl Supervisor {
                 vec![Action::StartVerify]
             }
             (Verifying, VerifyPassed) => {
-                self.state = Ready;
                 self.failures = 0;
-                // Re-steer automatically only if traffic was already
-                // flowing before the disruption. A first attach waits
-                // for the operator's explicit canary — that is the
-                // whole point of `steer on|off` being per port.
-                if self.was_steered {
+                // Steer if traffic was flowing before the disruption —
+                // or is still flowing, in the adopted case. A first
+                // attach waits for the operator's explicit canary;
+                // that is the whole point of `steer on|off` being per
+                // port.
+                //
+                // Steer is emitted even when we believe we are already
+                // steered. On this platform that is not redundant: the
+                // UniFi controller wipes custom classifier state on
+                // provisioning and deploys, so rules we installed
+                // before a restart may simply be gone. Re-asserting
+                // them is the reconcile step, and it is cheap.
+                if self.steered || self.was_steered {
                     self.state = State::Steered;
+                    self.steered = true;
                     vec![Action::Steer]
                 } else {
+                    self.state = Ready;
                     vec![]
                 }
             }
@@ -266,23 +300,25 @@ impl Supervisor {
             }
             (Ready, Event::Steered) => {
                 self.state = State::Steered;
+                self.steered = true;
                 self.was_steered = true;
                 vec![]
             }
 
             // --- death and wedging ---
             (s, ProcessExited { .. }) | (s, Wedged) if s.has_process() => {
-                if s.is_steered() {
+                if self.steered {
                     self.was_steered = true;
                 }
                 self.fail()
             }
 
             // --- clean stop ---
-            (s, StopRequested) => {
+            (_, StopRequested) => {
                 let mut actions = Vec::new();
-                if s.is_steered() {
+                if self.steered {
                     actions.push(Action::Unsteer);
+                    self.steered = false;
                 }
                 actions.push(Action::Kill);
                 actions.push(Action::ReleaseResources);
@@ -306,8 +342,12 @@ impl Supervisor {
     /// steered packet is going to a VF nothing is servicing.
     fn fail(&mut self) -> Vec<Action> {
         let mut actions = Vec::new();
-        if self.state.is_steered() {
+        // Unsteer FIRST and unconditionally on the current fact, not on
+        // the lifecycle state: until the MCAM rules are gone, every
+        // steered packet is going to a VF nothing is servicing.
+        if self.steered {
             actions.push(Action::Unsteer);
+            self.steered = false;
         }
         actions.push(Action::Kill);
         self.failures = self.failures.saturating_add(1);
@@ -422,8 +462,104 @@ mod tests {
             !actions.contains(&Action::Unsteer),
             "a correctly-forwarding VPP must keep forwarding"
         );
-        assert!(s.state().is_steered());
+        assert!(s.is_steered());
         assert_eq!(actions, vec![Action::AttachDevices, Action::StartResync]);
+    }
+
+    /// The window the `steered` field exists to protect. An adopted
+    /// VPP is steered while it syncs AND while it verifies; if
+    /// steered-ness is derived from the lifecycle state, the
+    /// `AdoptedResyncing → Verifying` step silently drops it and every
+    /// teardown from there kills VPP with traffic still pointed at it.
+    #[test]
+    fn a_steered_adoptee_that_fails_verification_is_unsteered_first() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        s.on(Event::SyncComplete);
+        assert_eq!(s.state(), State::Verifying);
+        assert!(s.is_steered(), "still forwarding while we verify");
+
+        let actions = s.on(Event::VerifyFailed);
+        assert_eq!(
+            actions.first(),
+            Some(&Action::Unsteer),
+            "steering must come down BEFORE the kill: {actions:?}"
+        );
+        assert!(actions.contains(&Action::Kill));
+        assert!(!s.is_steered());
+    }
+
+    /// Same window, reached by the other three exits.
+    #[test]
+    fn every_teardown_during_adopted_verification_unsteers_first() {
+        for event in [
+            Event::VerifyFailed,
+            Event::ProcessExited { status: None },
+            Event::Wedged,
+            Event::StopRequested,
+        ] {
+            let mut s = Supervisor::new();
+            s.on(Event::Adopted { steered: true });
+            s.on(Event::SyncComplete);
+            let actions = s.on(event.clone());
+            assert_eq!(
+                actions.first(),
+                Some(&Action::Unsteer),
+                "{event:?} tore down without unsteering: {actions:?}"
+            );
+            assert!(!s.is_steered(), "{event:?} left us believing we steer");
+        }
+    }
+
+    /// A spawn that never produced a process still has to retry. There
+    /// is no pidfd to report an exit, and `Starting` ignores both
+    /// StartRequested and BackoffElapsed, so without this the
+    /// supervisor sits in `Starting` forever with its retry policy
+    /// intact and unreachable.
+    #[test]
+    fn a_failed_spawn_backs_off_and_retries() {
+        let mut s = Supervisor::new();
+        assert_eq!(s.on(Event::StartRequested), vec![Action::Spawn]);
+        assert_eq!(s.state(), State::Starting);
+
+        let actions = s.on(Event::SpawnFailed);
+        assert_eq!(s.state(), State::Backoff);
+        assert!(
+            actions.iter().any(|a| matches!(a, Action::ArmBackoff(_))),
+            "a failed spawn must arm the retry: {actions:?}"
+        );
+        assert_eq!(s.failures(), 1);
+        assert!(s.may_restart());
+
+        // And the retry actually fires.
+        assert_eq!(s.on(Event::BackoffElapsed), vec![Action::Spawn]);
+        assert_eq!(s.state(), State::Starting);
+    }
+
+    /// Repeated spawn failures escalate rather than hammering.
+    #[test]
+    fn repeated_spawn_failures_escalate_the_backoff() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        let mut last = Duration::ZERO;
+        for _ in 0..5 {
+            s.on(Event::SpawnFailed);
+            let d = s.backoff();
+            assert!(d >= last, "backoff went backwards: {d:?} after {last:?}");
+            last = d;
+            s.on(Event::BackoffElapsed);
+        }
+        assert!(last <= MAX_BACKOFF);
+    }
+
+    /// A spawn failure while nothing was ever steered must not invent
+    /// an Unsteer for rules that do not exist.
+    #[test]
+    fn an_unsteered_failure_does_not_emit_unsteer() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        let actions = s.on(Event::SpawnFailed);
+        assert!(!actions.contains(&Action::Unsteer), "{actions:?}");
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -1,0 +1,575 @@
+//! Supervision state machine for the VPP child.
+//!
+//! Pure logic: no processes, no sockets, no clock reads. Everything
+//! arrives as an [`Event`] and leaves as an [`Action`], which is what
+//! makes the ordering rules below testable at all — the failure modes
+//! that matter (a crash while steered, an adoption of a healthy VPP, a
+//! restart racing a resync) are exactly the ones that are miserable to
+//! reproduce against a live process.
+//!
+//! Four ordering rules are encoded here, each from a specific way this
+//! can go wrong:
+//!
+//! 1. **Steering is never enabled before a verified resync.** MCAM
+//!    diverts by allowlist, not by what we managed to install, so
+//!    steering into an unverified FIB blackholes whatever is missing —
+//!    and the diverted packet cannot fall back to the eBPF tier
+//!    because the hardware already took it.
+//! 2. **On process death while steered, steering dies FIRST.** That is
+//!    the ≤50 ms number: until the MCAM rules are gone, every steered
+//!    packet is going to a VF nothing is servicing. Restart comes
+//!    after.
+//! 3. **Adoption does NOT unsteer.** A packetframe restart that finds
+//!    a healthy VPP still forwarding must resync and verify *while
+//!    traffic keeps flowing*; tearing steering down to rebuild it
+//!    would create precisely the outage adoption exists to avoid.
+//! 4. **No restart while a resync is in flight.** Backoff is measured
+//!    against the recovery budget, so a crash loop cannot become a
+//!    resync loop that never converges.
+
+use std::time::Duration;
+
+/// Ceiling on restart backoff.
+///
+/// Deliberately below the published 90 s recovery number: a backoff
+/// longer than the recovery budget would mean the *waiting* dominates
+/// the outage, and the operator-visible promise would be a function of
+/// this constant rather than of how long a resync actually takes.
+pub const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// First retry delay. Short because the common crash is a transient
+/// one and the FIB is still warm in bird's mirror.
+pub const BASE_BACKOFF: Duration = Duration::from_millis(250);
+
+/// Where the supervised VPP is in its lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    /// Nothing running; not trying to.
+    Stopped,
+    /// Waiting out a backoff before the next start attempt.
+    Backoff,
+    /// Process exists, API not yet answering.
+    Starting,
+    /// API answering; devices attached; FIB resync in flight.
+    Syncing,
+    /// Resync drained; readback verification in flight.
+    Verifying,
+    /// Verified. Steering may be enabled — and only from here.
+    Ready,
+    /// Traffic is being diverted to VPP.
+    Steered,
+    /// Adopted a running VPP that is still steered. Resync and verify
+    /// run WITHOUT tearing steering down (rule 3), so this is
+    /// deliberately distinct from `Syncing`.
+    AdoptedResyncing,
+}
+
+impl State {
+    /// Whether MCAM rules are currently diverting traffic.
+    pub fn is_steered(self) -> bool {
+        matches!(self, State::Steered | State::AdoptedResyncing)
+    }
+
+    /// Whether a supervised process exists that could die or wedge.
+    ///
+    /// `Backoff` deliberately counts as NO process: the previous one
+    /// is already dead and its failure already counted. Without this,
+    /// a ping timeout landing just after an exit is handled would
+    /// count a second failure and double the backoff for one crash.
+    pub fn has_process(self) -> bool {
+        !matches!(self, State::Stopped | State::Backoff)
+    }
+
+    /// Whether a resync or verify is in flight — the window in which a
+    /// restart must not be started (rule 4).
+    pub fn is_converging(self) -> bool {
+        matches!(
+            self,
+            State::Syncing | State::Verifying | State::AdoptedResyncing
+        )
+    }
+}
+
+/// Something that happened to the supervised process or its FIB.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Event {
+    /// Operator or module asked for VPP to be running.
+    StartRequested,
+    /// A child was spawned successfully.
+    Spawned,
+    /// A pre-existing VPP was adopted from the state file. `steered`
+    /// records whether its MCAM rules are still in place, which
+    /// decides whether we may keep traffic flowing through it.
+    Adopted {
+        steered: bool,
+    },
+    /// The binary API answered.
+    ApiUp,
+    /// The pending map drained to empty.
+    SyncComplete,
+    /// Readback verification finished.
+    VerifyPassed,
+    VerifyFailed,
+    /// Steering rules installed.
+    Steered,
+    /// The process exited — from pidfd, not SIGCHLD, because adoption
+    /// reparents the child and SIGCHLD would never arrive.
+    ProcessExited {
+        status: Option<i32>,
+    },
+    /// The API ping did not answer within its interval. The process is
+    /// alive but not scheduling; treated as death because a wedged
+    /// forwarder drops exactly as thoroughly as a dead one.
+    Wedged,
+    /// Backoff elapsed.
+    BackoffElapsed,
+    /// Operator asked for a clean stop.
+    StopRequested,
+}
+
+/// What the caller must do. Ordering within a single transition is
+/// significant and given as a `Vec`, because "unsteer then restart"
+/// and "restart then unsteer" differ by an outage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Action {
+    /// Remove MCAM rules. First in any teardown.
+    Unsteer,
+    /// Kill the process if it is still alive.
+    Kill,
+    /// Spawn a new VPP.
+    Spawn,
+    /// Attach devices and create interfaces over the API.
+    AttachDevices,
+    /// Begin a full FIB resync against the authoritative mirror.
+    StartResync,
+    /// Begin readback verification.
+    StartVerify,
+    /// Install MCAM steering rules.
+    Steer,
+    /// Arm the backoff timer.
+    ArmBackoff(Duration),
+    /// Release VF/hugepage resources; terminal.
+    ReleaseResources,
+}
+
+/// Supervision state plus the backoff schedule.
+#[derive(Debug, Clone)]
+pub struct Supervisor {
+    state: State,
+    /// Consecutive failures since the last verified-healthy moment.
+    failures: u32,
+    /// Whether steering was up when the current trouble started —
+    /// remembered across the restart so `Ready` knows whether to
+    /// re-steer automatically or wait for the operator's canary.
+    was_steered: bool,
+}
+
+impl Default for Supervisor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Supervisor {
+    pub fn new() -> Self {
+        Self {
+            state: State::Stopped,
+            failures: 0,
+            was_steered: false,
+        }
+    }
+
+    pub fn state(&self) -> State {
+        self.state
+    }
+
+    pub fn failures(&self) -> u32 {
+        self.failures
+    }
+
+    /// Backoff for the current failure count: exponential, capped.
+    ///
+    /// No jitter, deliberately — there is exactly one supervised
+    /// process per box and nothing to thunder against, and a
+    /// deterministic schedule is one fewer variable when reading a
+    /// crash loop out of logs.
+    pub fn backoff(&self) -> Duration {
+        if self.failures == 0 {
+            return BASE_BACKOFF;
+        }
+        let shift = (self.failures - 1).min(16);
+        BASE_BACKOFF
+            .checked_mul(1u32 << shift)
+            .unwrap_or(MAX_BACKOFF)
+            .min(MAX_BACKOFF)
+    }
+
+    /// Apply an event, returning the ordered actions to perform.
+    pub fn on(&mut self, event: Event) -> Vec<Action> {
+        use Event::*;
+        use State::*;
+
+        match (self.state, event) {
+            // --- starting up ---
+            (Stopped, StartRequested) => {
+                self.state = Starting;
+                vec![Action::Spawn]
+            }
+            (Backoff, BackoffElapsed) => {
+                self.state = Starting;
+                vec![Action::Spawn]
+            }
+            (Starting, Spawned) => vec![],
+            (Starting, ApiUp) => {
+                self.state = Syncing;
+                // Devices first: the FIB paths we are about to install
+                // reference interface indices that do not exist until
+                // the device is attached and its port interface
+                // created.
+                vec![Action::AttachDevices, Action::StartResync]
+            }
+
+            // --- adoption (rule 3) ---
+            (Stopped | Backoff | Starting, Adopted { steered }) => {
+                self.was_steered = steered;
+                // An adopted VPP is presumed good until proven stale:
+                // mark dirty, resync, verify — but do NOT unsteer a
+                // correctly-forwarding dataplane to do it.
+                self.state = if steered { AdoptedResyncing } else { Syncing };
+                vec![Action::AttachDevices, Action::StartResync]
+            }
+
+            // --- converging ---
+            (Syncing | AdoptedResyncing, SyncComplete) => {
+                self.state = Verifying;
+                vec![Action::StartVerify]
+            }
+            (Verifying, VerifyPassed) => {
+                self.state = Ready;
+                self.failures = 0;
+                // Re-steer automatically only if traffic was already
+                // flowing before the disruption. A first attach waits
+                // for the operator's explicit canary — that is the
+                // whole point of `steer on|off` being per port.
+                if self.was_steered {
+                    self.state = State::Steered;
+                    vec![Action::Steer]
+                } else {
+                    vec![]
+                }
+            }
+            (Verifying, VerifyFailed) => {
+                // A FIB we cannot verify is not one to divert traffic
+                // into. Treat as a failure and cycle, rather than
+                // steering optimistically.
+                self.fail()
+            }
+            (Ready, Event::Steered) => {
+                self.state = State::Steered;
+                self.was_steered = true;
+                vec![]
+            }
+
+            // --- death and wedging ---
+            (s, ProcessExited { .. }) | (s, Wedged) if s.has_process() => {
+                if s.is_steered() {
+                    self.was_steered = true;
+                }
+                self.fail()
+            }
+
+            // --- clean stop ---
+            (s, StopRequested) => {
+                let mut actions = Vec::new();
+                if s.is_steered() {
+                    actions.push(Action::Unsteer);
+                }
+                actions.push(Action::Kill);
+                actions.push(Action::ReleaseResources);
+                self.state = Stopped;
+                self.was_steered = false;
+                self.failures = 0;
+                actions
+            }
+
+            // Anything else is a no-op: events can race (a ping
+            // timeout arriving just after an exit), and treating a
+            // stale event as a state change is how a supervisor
+            // restarts something it already restarted.
+            _ => vec![],
+        }
+    }
+
+    /// Common teardown for death, wedging, and failed verification.
+    ///
+    /// Steering comes down FIRST (rule 2) — until it does, every
+    /// steered packet is going to a VF nothing is servicing.
+    fn fail(&mut self) -> Vec<Action> {
+        let mut actions = Vec::new();
+        if self.state.is_steered() {
+            actions.push(Action::Unsteer);
+        }
+        actions.push(Action::Kill);
+        self.failures = self.failures.saturating_add(1);
+        let delay = self.backoff();
+        self.state = State::Backoff;
+        actions.push(Action::ArmBackoff(delay));
+        actions
+    }
+
+    /// Whether a restart may be started right now (rule 4).
+    ///
+    /// The caller checks this before acting on a `BackoffElapsed`: a
+    /// resync still draining means the previous attempt has not
+    /// finished failing, and starting another would stack two loads
+    /// onto one VPP.
+    pub fn may_restart(&self) -> bool {
+        !self.state.is_converging()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn running_and_steered() -> Supervisor {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::Spawned);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        s.on(Event::VerifyPassed);
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Steered);
+        s
+    }
+
+    #[test]
+    fn first_attach_does_not_steer_itself() {
+        // Steering is the operator's canary lever; a fresh attach
+        // reaching Ready must WAIT rather than divert traffic on its
+        // own initiative.
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Ready);
+        assert!(
+            !actions.contains(&Action::Steer),
+            "a first attach must not steer without being asked"
+        );
+    }
+
+    #[test]
+    fn devices_are_attached_before_the_resync() {
+        // FIB paths reference interface indices that do not exist
+        // until the device is attached — installing first would defer
+        // every route.
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        let actions = s.on(Event::ApiUp);
+        assert_eq!(
+            actions,
+            vec![Action::AttachDevices, Action::StartResync],
+            "device attach must precede the resync"
+        );
+    }
+
+    #[test]
+    fn steering_is_never_reached_without_a_passing_verify() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert_eq!(s.state(), State::Verifying);
+        // A Steered event arriving out of order must not promote us.
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Verifying, "verify gates steering");
+    }
+
+    #[test]
+    fn a_crash_while_steered_unsteers_before_anything_else() {
+        // The 50 ms number: until MCAM is torn down, steered packets
+        // go to a VF nothing services.
+        let mut s = running_and_steered();
+        let actions = s.on(Event::ProcessExited { status: Some(139) });
+        assert_eq!(actions[0], Action::Unsteer, "unsteer must come first");
+        assert!(actions.contains(&Action::Kill));
+        assert!(matches!(actions.last(), Some(Action::ArmBackoff(_))));
+        assert_eq!(s.state(), State::Backoff);
+    }
+
+    #[test]
+    fn a_wedge_is_treated_exactly_like_a_death() {
+        // A process that is alive but not scheduling drops just as
+        // thoroughly as one that exited.
+        let mut s = running_and_steered();
+        let actions = s.on(Event::Wedged);
+        assert_eq!(actions[0], Action::Unsteer);
+        assert!(actions.contains(&Action::Kill));
+    }
+
+    #[test]
+    fn adoption_of_a_steered_vpp_does_not_unsteer_it() {
+        // Rule 3, and the reason AdoptedResyncing exists as its own
+        // state: tearing steering down to rebuild it would create the
+        // outage adoption exists to avoid.
+        let mut s = Supervisor::new();
+        let actions = s.on(Event::Adopted { steered: true });
+        assert_eq!(s.state(), State::AdoptedResyncing);
+        assert!(
+            !actions.contains(&Action::Unsteer),
+            "a correctly-forwarding VPP must keep forwarding"
+        );
+        assert!(s.state().is_steered());
+        assert_eq!(actions, vec![Action::AttachDevices, Action::StartResync]);
+    }
+
+    #[test]
+    fn adoption_resyncs_and_verifies_then_keeps_steering() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        s.on(Event::SyncComplete);
+        assert_eq!(s.state(), State::Verifying);
+        let actions = s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Steered);
+        assert!(
+            actions.contains(&Action::Steer),
+            "re-assert rules after adoption so ours own them"
+        );
+    }
+
+    #[test]
+    fn adoption_of_an_unsteered_vpp_waits_for_the_canary() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: false });
+        assert_eq!(s.state(), State::Syncing);
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Ready);
+        assert!(!actions.contains(&Action::Steer));
+    }
+
+    #[test]
+    fn a_restart_re_steers_only_if_traffic_was_flowing_before() {
+        let mut s = running_and_steered();
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::BackoffElapsed);
+        assert_eq!(s.state(), State::Starting);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Steered);
+        assert!(
+            actions.contains(&Action::Steer),
+            "traffic was flowing before the crash, so restore it"
+        );
+    }
+
+    #[test]
+    fn no_restart_while_a_resync_is_in_flight() {
+        // Rule 4: a crash loop must not become a resync loop.
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        assert_eq!(s.state(), State::Syncing);
+        assert!(!s.may_restart(), "a draining resync blocks a restart");
+        s.on(Event::SyncComplete);
+        assert!(!s.may_restart(), "so does an in-flight verify");
+        s.on(Event::VerifyPassed);
+        assert!(s.may_restart());
+    }
+
+    #[test]
+    fn a_failed_verify_cycles_rather_than_steering_optimistically() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyFailed);
+        assert_eq!(s.state(), State::Backoff);
+        assert!(actions.contains(&Action::Kill));
+        assert_eq!(s.failures(), 1);
+    }
+
+    #[test]
+    fn backoff_grows_then_caps_below_the_recovery_budget() {
+        let mut s = Supervisor::new();
+        assert_eq!(s.backoff(), BASE_BACKOFF);
+        let mut seen = Vec::new();
+        for _ in 0..12 {
+            s.on(Event::StartRequested);
+            s.on(Event::ProcessExited { status: None });
+            seen.push(s.backoff());
+            s.on(Event::BackoffElapsed);
+        }
+        assert!(
+            seen.windows(2).all(|w| w[1] >= w[0]),
+            "backoff must be monotonic: {seen:?}"
+        );
+        assert_eq!(*seen.last().unwrap(), MAX_BACKOFF);
+        assert!(
+            MAX_BACKOFF < Duration::from_secs(90),
+            "a backoff above the recovery budget would make the published \
+             number a function of this constant rather than of resync time"
+        );
+    }
+
+    #[test]
+    fn a_healthy_verify_clears_the_failure_count() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::ProcessExited { status: None });
+        assert!(s.failures() >= 1);
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        s.on(Event::VerifyPassed);
+        assert_eq!(s.failures(), 0, "a healthy cycle resets the schedule");
+        assert_eq!(s.backoff(), BASE_BACKOFF);
+    }
+
+    #[test]
+    fn a_stale_event_is_a_no_op_not_a_second_restart() {
+        // A ping timeout can land just after an exit was handled.
+        // Acting on both would restart something already restarting.
+        let mut s = running_and_steered();
+        s.on(Event::ProcessExited { status: None });
+        let failures = s.failures();
+        let actions = s.on(Event::Wedged);
+        assert!(actions.is_empty(), "the second event must do nothing");
+        assert_eq!(s.failures(), failures, "and must not count twice");
+    }
+
+    #[test]
+    fn stop_unsteers_then_kills_then_releases() {
+        let mut s = running_and_steered();
+        let actions = s.on(Event::StopRequested);
+        assert_eq!(
+            actions,
+            vec![Action::Unsteer, Action::Kill, Action::ReleaseResources],
+            "teardown order is steering, process, resources"
+        );
+        assert_eq!(s.state(), State::Stopped);
+    }
+
+    #[test]
+    fn stopping_an_unsteered_supervisor_skips_the_unsteer() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        let actions = s.on(Event::StopRequested);
+        assert!(!actions.contains(&Action::Unsteer));
+        assert_eq!(actions, vec![Action::Kill, Action::ReleaseResources]);
+    }
+
+    #[test]
+    fn events_while_stopped_do_nothing() {
+        let mut s = Supervisor::new();
+        assert!(s.on(Event::ProcessExited { status: None }).is_empty());
+        assert!(s.on(Event::Wedged).is_empty());
+        assert_eq!(s.state(), State::Stopped);
+        assert_eq!(s.failures(), 0);
+    }
+}


### PR DESCRIPTION
Slice 4's supervision layer, in three commits: the state machine, the pidfd process handle, and the wedge detector. Stacked on #105 — review that first; this branch contains its commits.

The split is deliberate. Supervision decisions are pure logic with the clock and the OS passed in, so the failure modes that matter — a crash while traffic is steered, adopting a healthy VPP across a packetframe restart, a restart racing an in-flight resync — are unit tests that run in microseconds instead of hardware drills nobody can reproduce on demand.

---

## 1. Supervision state machine

Events in, ordered actions out. Four ordering rules, each from a specific way this goes wrong:

**Steering is never enabled before a verified resync.** MCAM diverts by *allowlist*, not by what we managed to install, so steering into an unverified FIB blackholes whatever is missing — and the diverted packet can't fall back to the eBPF tier, because the hardware already took it. A first attach reaching `Ready` deliberately does **not** steer itself; that's the operator's canary lever.

**On death while steered, steering comes down FIRST.** That's the ≤50 ms number: until the MCAM rules are gone, every steered packet is going to a VF nothing is servicing. Actions come back as an ordered `Vec` precisely for this — "unsteer then restart" and "restart then unsteer" differ by an outage.

**Adoption does NOT unsteer.** A packetframe restart that finds a healthy VPP still forwarding resyncs and verifies *while traffic keeps flowing*. `AdoptedResyncing` is its own state so that invariant is structural rather than a comment someone deletes.

**No restart while a resync is in flight**, so a crash loop can't become a resync loop that never converges. Backoff caps at 30 s — below the published 90 s recovery number, because a longer cap would make the operator-visible promise a function of this constant rather than of how long a resync actually takes.

Two bugs the tests caught: a wedge has to be treated exactly like a death, and `Backoff` had to be excluded from the death handler — a ping timeout landing just after an exit was already handled counted a *second* failure and doubled the backoff for one crash.

## 2. pidfd process handle

**Why not SIGCHLD:** an adopted VPP was reparented to init when its original parent died, so `waitpid()` will never see it — and adoption is the case most worth getting right, since it's what makes a packetframe restart seamless instead of an outage. A pidfd behaves identically for a child we forked and a stranger we adopted.

**Why not a bare pid:** signalling a pid races reuse. Between "pid 4242 is wedged" and `kill(4242)`, the real VPP can exit and the kernel can hand 4242 to something else — which we then SIGKILL as root.

`adopt()` opens the pidfd **before** verifying the start-time cookie, not after. The fd pins one process for its lifetime, so once it's open no later reuse can change what we hold; checking first and opening second leaves open exactly the window the check exists to close. A mismatch refuses adoption — one extra restart beats signalling a stranger.

`terminate()` bounds its post-SIGKILL wait rather than looping until the process dies. SIGKILL can't be refused but can't interrupt an uninterruptible sleep either, and VPP sits on VFIO and DMA, which is where D-state waits come from. Timing out loudly lets detach report a stuck process; an unbounded loop would hang teardown forever — and teardown must not release VFs and hugepages under a process that may still be DMAing into them.

`parse_start_ticks()` is a tested free function because `/proc/<pid>/stat` is a trap: `comm` may contain spaces **and** parens, so the only safe anchor is the last `)`. A `split_whitespace().nth(21)` parse reads the wrong field for a binary named `vpp worker` and silently compares a bogus identity.

## 3. Wedge detector

The pidfd covers a crash. It doesn't cover a VPP that's alive and not forwarding — `ps` looks healthy, the pidfd stays quiet, traffic disappears.

**Two budgets**, because VPP answers the binary API on its **main** thread, the same thread executing our route batches. Under a full-table load a ping legitimately queues behind ~1.05M routes. A single budget would force a choice between never detecting a wedge and restart-looping the box during every large resync. Steady state gets 1.5 s; a resync in flight gets 10 s — affordable precisely because we aren't forwarding through VPP yet, so slowness there costs recovery latency rather than dropped packets.

The steady budget is derived from the published number, not taste: worst-case detection is `budget + interval`, and a test asserts that sum stays inside the runbook's "blackhole-wedge ≤ 2 s". Raising it for a good local reason now fails CI instead of quietly invalidating an operator-facing promise.

---

Also in this branch: a fix for a **genuinely flaky loopback test** from #105 (`handshake_then_install_a_batch`). It failed CI here at 9-of-10 with every client-side assertion passing. The fake VPP counted each reply *after* writing it, so the drain — which returns the instant it reads the last reply — could assert before the fake's own bookkeeping retired. Counting before the write makes the ordering causal. That commit is on the #105 branch, so it lands with slice 3.

30 tests across the three modules; `cargo fmt --check`, `clippy -D warnings`, and the 315-test workspace suite all green.

**Still owed in slice 4:** the executor that drives the action list against #105's transport, plus the VppSink health/status/metrics surface. The failover drills that actually *measure* the 50 ms / 2 s / 90 s numbers are slice 5 on hardware — nothing here claims them, it only makes them structurally possible.
