### PR TITLE
fix(vpp-offload): render the post-pivot startup.conf, not the DPDK one

### DIFF
--- a/crates/modules/vpp-offload/src/startup_conf.rs
+++ b/crates/modules/vpp-offload/src/startup_conf.rs
@@ -87,10 +87,20 @@ pub fn check_hugepage_budget(
 }
 
 /// One VPP dataplane port: the VF's PCI address plus the worker count
-/// the operator promised for it. Slice 1 renders the promise as
-/// explicit config; the scheduler's round-robin default is not
-/// trusted (plan v5 "cores promises are honored by rendering explicit
-/// rx-placement").
+/// the operator promised for it.
+///
+/// Input to the **runtime attach step**, not to [`render`]. Before the
+/// v7 driver pivot this was config: a `dpdk { dev <pci> }` stanza. The
+/// native octeon driver takes device identity at runtime instead
+/// (`dev_attach` with the PCI address, then `dev_create_port_if` with
+/// the port number and `num_rx_queues`), which is the better shape
+/// anyway — detach and reattach need no config rewrite, and the
+/// supervisor can sequence attach inside its resync pipeline.
+///
+/// `cores` still means what it meant: the operator's promise, rendered
+/// explicitly rather than left to the scheduler's round-robin default
+/// (plan v5, "cores promises are honored by rendering explicit
+/// rx-placement"). It now lands as `num_rx_queues` at attach.
 #[derive(Debug, Clone)]
 pub struct PortSpec {
     pub pci_addr: String,
@@ -102,9 +112,25 @@ pub struct PortSpec {
 /// the explicit CPU list for VPP workers (the plan's core-map set B);
 /// `api_socket`/`stats_socket` live under packetframe's runtime dir so
 /// supervision and metrics know where to look without guessing.
+///
+/// **Devices are deliberately absent.** After the v7 driver pivot the
+/// dataplane is VPP's native octeon driver, and devices attach at
+/// RUNTIME (`dev_attach` → `dev_create_port_if` over the binary API)
+/// rather than from a config stanza. There is no `dpdk {}` block
+/// because the DPDK PMD path cannot allocate NPA buffers on this NIC
+/// at any version, and no `devices {}` block either — an empty one is
+/// a parse error, and a populated one would duplicate what the
+/// supervisor attaches. That makes [`PortSpec`] input to the attach
+/// step, not to this function.
+///
+/// Shape matches what actually came up on the shadow (runbook §2,
+/// round 3). It is deliberately not "improved" beyond that: the one
+/// tempting change — keeping `plugin default { disable }` and enabling
+/// plugins explicitly — is untested against the native driver's
+/// loading path, and deviating from a hardware-proven config on an
+/// untested theory is how bring-up rounds get spent.
 pub fn render(
     sizing: &Sizing,
-    ports: &[PortSpec],
     worker_cores: &[u16],
     main_core: u16,
     api_socket: &str,
@@ -141,18 +167,17 @@ pub fn render(
     ));
     let _ = hugepage_bytes; // recorded in the header comment path later; kept as input for stability
     out.push_str("buffers {\n  buffers-per-numa 65536\n  default data-size 2048\n}\n");
-    out.push_str("dpdk {\n");
-    for p in ports {
-        out.push_str(&format!(
-            "  dev {} {{\n    num-rx-queues {}\n  }}\n",
-            p.pci_addr, p.cores
-        ));
-    }
-    out.push_str("}\n");
-    // linux-cp deliberately ABSENT: it cannot pair kernel-owned PFs
-    // (plan v3 correction). Routes and neighbors arrive over the
-    // binary API from the RouteController's VppSink (slice 3).
-    out.push_str("plugins {\n  plugin default { disable }\n  plugin dpdk_plugin.so { enable }\n  plugin ping_plugin.so { enable }\n}\n");
+    // dpdk_plugin OFF. Round 2 on the shadow established that both the
+    // otx2 and cnxk PMDs hard-require NPA mempool ops that VPP's buffer
+    // manager does not provide, so the DPDK path cannot allocate
+    // buffers on this NIC at ANY version — leaving the plugin enabled
+    // would only load a driver that cannot work and can bind the VF
+    // out from under the native one.
+    //
+    // linux-cp also deliberately ABSENT: it cannot pair kernel-owned
+    // PFs (plan v3 correction). Routes and neighbors arrive over the
+    // binary API from the RouteController's VppSink.
+    out.push_str("plugins {\n  plugin dpdk_plugin.so { disable }\n}\n");
     out
 }
 
@@ -188,19 +213,8 @@ mod tests {
     #[test]
     fn render_is_deterministic_and_complete() {
         let sizing = derive_sizing(1_400_000).unwrap();
-        let ports = [
-            PortSpec {
-                pci_addr: "0002:07:00.1".into(),
-                cores: 1,
-            },
-            PortSpec {
-                pci_addr: "0002:08:00.1".into(),
-                cores: 2,
-            },
-        ];
         let conf = render(
             &sizing,
-            &ports,
             &[14, 15],
             13,
             "/run/packetframe/vpp/api.sock",
@@ -208,15 +222,12 @@ mod tests {
         );
         let again = render(
             &sizing,
-            &ports,
             &[14, 15],
             13,
             "/run/packetframe/vpp/api.sock",
             512 << 20,
         );
         assert_eq!(conf, again, "renderer must be pure");
-        assert!(conf.contains("dev 0002:07:00.1"));
-        assert!(conf.contains("num-rx-queues 2"));
         assert!(conf.contains("corelist-workers 14,15"));
         assert!(conf.contains("main-heap-page-size default-hugepage"));
         assert!(
@@ -231,6 +242,39 @@ mod tests {
             (rendered_mib << 20) >= sizing.main_heap_bytes,
             "rendered heap {rendered_mib} MiB must not be below the derived {} bytes",
             sizing.main_heap_bytes
+        );
+    }
+
+    /// The v7 driver pivot, asserted rather than described. Round 2 on
+    /// the shadow proved the DPDK PMD path cannot allocate NPA buffers
+    /// on this NIC at any version, so a rendered `dpdk {}` stanza — or
+    /// an enabled dpdk_plugin — is not a style question, it is a
+    /// dataplane that will not come up.
+    #[test]
+    fn no_dpdk_and_no_device_stanzas() {
+        let sizing = derive_sizing(1_000).unwrap();
+        let conf = render(&sizing, &[14], 13, "/run/packetframe/vpp/api.sock", 0);
+
+        assert!(
+            conf.contains("plugin dpdk_plugin.so { disable }"),
+            "dpdk_plugin must be disabled:\n{conf}"
+        );
+        assert!(
+            !conf.contains("dpdk {"),
+            "no dpdk stanza — the PMD cannot drive this NIC:\n{conf}"
+        );
+        // An empty `devices {}` is a VPP parse error, and a populated
+        // one would duplicate what the supervisor attaches at runtime
+        // over dev_attach/dev_create_port_if.
+        assert!(
+            !conf.contains("devices {"),
+            "devices attach at runtime, not from config:\n{conf}"
+        );
+        // No PCI address may appear anywhere: device identity now
+        // lives in the attach step, not the config file.
+        assert!(
+            !conf.contains("0002:"),
+            "no device identity in startup.conf:\n{conf}"
         );
     }
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -525,13 +525,14 @@ renderer's arithmetic, updated for the round-4 decision (v4-only,
 pre-decision v4+v6 figure was ~4.4 GiB ⇒ 10 pages; item 10's measured
 number supersedes both.)
 
-startup.conf: **hand-write it; do NOT use the slice-1 renderer for
-now.** The renderer (`packetframe-vpp-offload::startup_conf::render`)
-still emits a `dpdk { dev ... }` stanza with dpdk_plugin enabled —
-the PMD path that round 2 proved CANNOT allocate NPA buffers on this
-NIC. Its sizing *arithmetic* (heap/hugepage math) remains valid; its
-*output shape* is pre-pivot and its native-driver rework is tracked
-for slice 3/4. The canonical working shape, from round 3:
+startup.conf: **the renderer now emits the post-pivot shape** — it
+dropped the `dpdk { dev ... }` stanza, disables `dpdk_plugin.so`, and
+carries no device identity at all (devices attach at runtime; see §3).
+Its sizing arithmetic was always valid and is unchanged. The hand-
+written config below stays here as the reference the renderer is
+tested against, and as what to fall back to if you are bringing up a
+box without a packetframe build. The canonical working shape, from
+round 3:
 
 ```
 unix {


### PR DESCRIPTION
Closes the renderer half of the v7 driver pivot. Independent of #105/#106 — branches off `main`, touches only `startup_conf.rs` and the runbook.

## The bug

`startup_conf::render()` still emitted the pre-pivot shape:

```
dpdk {
  dev 0002:07:00.1 { num-rx-queues 1 }
}
plugins { plugin default { disable } plugin dpdk_plugin.so { enable } ... }
```

Round 2 on the shadow established that **both** the otx2 and cnxk PMDs hard-require NPA mempool ops that VPP's buffer manager does not provide. So this config doesn't describe a slower dataplane — it describes one that cannot allocate buffers and never comes up. Leaving the plugin enabled is actively worse than useless: it loads a driver that cannot work and can bind the VF away from the native one.

The runbook has been telling operators to hand-write the file and *not* use the renderer since the pivot. That instruction is now removed, because the renderer produces the right thing.

## What it renders now

Matches what actually came up on hardware (runbook §2, round 3): `dpdk_plugin.so { disable }`, no `dpdk {}`, and no `devices {}` either — an empty devices block is a VPP parse error, and a populated one would duplicate what the supervisor attaches.

## Device identity leaves startup.conf entirely

`render()` no longer takes ports. `PortSpec` becomes input to the runtime attach step — `dev_attach` with the PCI address, then `dev_create_port_if` with the port number and `num_rx_queues`, both already in #105's generated API surface.

That's the better shape independent of what forced it: detach/reattach need no config rewrite, and the supervisor can sequence attach inside its resync pipeline (which is exactly what `Action::AttachDevices` in #106 exists for).

## What I deliberately did not change

Keeping `plugin default { disable }` with explicit re-enables is tidier and I was tempted. It is also **untested against the native driver's loading path** — the octeon driver ships in `vpp_drivers/`, not `vpp_plugins/`, and I can't verify from here whether the default-disable reaches it. Deviating from a hardware-proven config on an untested theory is how bring-up rounds get spent, so the rendered shape is exactly the proven one.

## Test

Asserts the pivot rather than describing it: no `dpdk {` stanza, no `devices {` stanza, `dpdk_plugin.so { disable }` present, and **no PCI address anywhere in the output** — device identity living in the config file at all is the thing being removed.

Sizing arithmetic (heap/hugepage math, MiB round-up) is untouched and its tests still pass.

**Note:** `HEAP_BYTES_PER_ROUTE = 2_048` remains the slice-1 placeholder awaiting gate-0b item 10's measured `show memory main-heap`. Unrelated to this change, still owed.