### PR TITLE
feat(vpp-offload): device attach + readback verify over the binary API

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -1,0 +1,257 @@
+//! Device attach over the binary API — the `AttachDevices` action.
+//!
+//! After the v7 driver pivot, device identity does not live in
+//! startup.conf: the native octeon driver is attached at runtime, so
+//! bringing a VF into VPP is API traffic. The sequence is the one
+//! proven on the shadow (runbook §3, round 3), expressed as three
+//! messages instead of three `vppctl` invocations:
+//!
+//! ```text
+//! dev_attach          pci/0002:07:00.1 driver octeon   → dev_index
+//! dev_create_port_if  dev_index, port 0, num_rx_queues → sw_if_index
+//! sw_interface_set_flags sw_if_index up
+//! ```
+//!
+//! **Why this runs before the resync, not after.** A FIB path is
+//! encoded with an `sw_if_index`, and those indices do not exist until
+//! `dev_create_port_if` returns them. Installing routes first would
+//! either defer every one of them or — worse, if anything defaulted —
+//! point them at index 0, which is `local0`: a route that looks
+//! installed and silently drops. The supervisor orders
+//! `AttachDevices` ahead of `StartResync` for exactly this reason.
+
+use crate::vpp_api::generated::{
+    DevAttach, DevAttachReply, DevCreatePortIf, DevCreatePortIfReply, SwInterfaceSetFlags,
+    SwInterfaceSetFlagsReply,
+};
+use crate::vpp_api::{Transport, TransportError};
+
+/// The driver name the native octeon path registers under.
+///
+/// Not `dev_octeon`, not a `net_*` PMD string — those are DPDK
+/// spellings and this is not the DPDK path. Established by measurement
+/// on the shadow: the driver ships as `vpp_drivers/octeon_driver.so`
+/// and registers as `octeon`.
+pub const OCTEON_DRIVER: &str = "octeon";
+
+/// `IF_STATUS_API_FLAG_ADMIN_UP` from interface_types.api.
+const ADMIN_UP: u32 = 1;
+
+/// What to attach: one member port's VF.
+#[derive(Debug, Clone)]
+pub struct PortAttach {
+    /// Kernel-side name of the PF this VF belongs to (`eth3`), used as
+    /// the key the nexthop mapping resolves against.
+    pub port: String,
+    /// VF PCI address, e.g. `0002:07:00.1`.
+    pub pci_addr: String,
+    /// Port number within the device. 0 on this NIC.
+    pub port_id: u16,
+    /// Receive queues, from the operator's `cores` promise.
+    pub num_rx_queues: u16,
+}
+
+/// A port VPP has accepted, with the index FIB paths must reference.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachedPort {
+    pub port: String,
+    pub dev_index: u32,
+    pub sw_if_index: u32,
+}
+
+#[derive(Debug)]
+pub enum AttachError {
+    Transport(TransportError),
+    /// VPP refused a step. `error_string` is VPP's own text, which is
+    /// far more useful than the retval alone (it names the driver or
+    /// device that failed).
+    Refused {
+        step: &'static str,
+        port: String,
+        retval: i32,
+        detail: String,
+    },
+    /// VPP returned success and an index of 0 for an interface.
+    ///
+    /// Treated as a hard failure rather than accepted: `sw_if_index` 0
+    /// is `local0`, VPP's own drop interface. A FIB path pointing there
+    /// forwards nothing while looking perfectly healthy, which is the
+    /// single worst outcome this module can produce.
+    LocalZero {
+        port: String,
+    },
+}
+
+impl std::fmt::Display for AttachError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AttachError::Transport(e) => write!(f, "{e}"),
+            AttachError::Refused {
+                step,
+                port,
+                retval,
+                detail,
+            } => {
+                write!(f, "{step} for {port} failed (retval {retval})")?;
+                if !detail.is_empty() {
+                    write!(f, ": {detail}")?;
+                }
+                Ok(())
+            }
+            AttachError::LocalZero { port } => write!(
+                f,
+                "VPP returned sw_if_index 0 (local0) for {port}; refusing to build FIB paths \
+                 that would silently drop"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for AttachError {}
+
+impl From<TransportError> for AttachError {
+    fn from(e: TransportError) -> Self {
+        AttachError::Transport(e)
+    }
+}
+
+/// Attach every port and bring it admin-up.
+///
+/// Sequential rather than pipelined, deliberately: each step consumes
+/// the index the previous one returned, and there are a handful of
+/// ports rather than a million routes — the latency this would save is
+/// irrelevant next to being able to name exactly which port failed.
+///
+/// Stops at the first failure. Ports already attached are returned in
+/// the error-free prefix only on success; on failure the caller tears
+/// the process down anyway (the supervisor routes an attach failure
+/// through `fail()`), so partial cleanup here would duplicate work
+/// that `Kill` does more reliably.
+pub fn attach_ports(
+    t: &mut Transport,
+    ports: &[PortAttach],
+) -> Result<Vec<AttachedPort>, AttachError> {
+    let mut out = Vec::with_capacity(ports.len());
+    for p in ports {
+        let dev_index = attach_device(t, p)?;
+        let sw_if_index = create_port_if(t, p, dev_index)?;
+        set_admin_up(t, p, sw_if_index)?;
+        out.push(AttachedPort {
+            port: p.port.clone(),
+            dev_index,
+            sw_if_index,
+        });
+    }
+    Ok(out)
+}
+
+fn attach_device(t: &mut Transport, p: &PortAttach) -> Result<u32, AttachError> {
+    // VPP's device id is scheme-qualified: `pci/<addr>`, not the bare
+    // address.
+    let reply = t.request::<DevAttach, DevAttachReply>(DevAttach {
+        context: 0,
+        device_id: format!("pci/{}", p.pci_addr),
+        driver_name: OCTEON_DRIVER.to_string(),
+        flags: 0,
+        args: String::new(),
+    })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "dev_attach",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: reply.error_string,
+        });
+    }
+    Ok(reply.dev_index)
+}
+
+fn create_port_if(t: &mut Transport, p: &PortAttach, dev_index: u32) -> Result<u32, AttachError> {
+    let reply = t.request::<DevCreatePortIf, DevCreatePortIfReply>(DevCreatePortIf {
+        context: 0,
+        dev_index,
+        // Empty asks VPP to name it, which yields the `octeonN/P` form
+        // the runbook and every operator command already use. Choosing
+        // our own name would make `show interface` output diverge from
+        // the documentation for no gain.
+        intf_name: String::new(),
+        num_rx_queues: p.num_rx_queues,
+        num_tx_queues: p.num_rx_queues,
+        // 0 = driver default. The gate-0b bring-up used defaults, and
+        // queue sizing is a tuning question to open only once we are
+        // packet-rate-bound with numbers to justify a change.
+        rx_queue_size: 0,
+        tx_queue_size: 0,
+        port_id: p.port_id,
+        flags: 0,
+        args: String::new(),
+    })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "dev_create_port_if",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: reply.error_string,
+        });
+    }
+    if reply.sw_if_index == 0 {
+        return Err(AttachError::LocalZero {
+            port: p.port.clone(),
+        });
+    }
+    Ok(reply.sw_if_index)
+}
+
+fn set_admin_up(t: &mut Transport, p: &PortAttach, sw_if_index: u32) -> Result<(), AttachError> {
+    let reply =
+        t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
+            context: 0,
+            sw_if_index,
+            flags: ADMIN_UP,
+        })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_flags",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_id_is_scheme_qualified() {
+        // `dev_attach` takes `pci/<addr>`; the bare address is rejected
+        // by VPP's device-id parser.
+        let p = PortAttach {
+            port: "eth3".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        };
+        assert_eq!(format!("pci/{}", p.pci_addr), "pci/0002:07:00.1");
+    }
+
+    #[test]
+    fn the_driver_name_is_the_native_one() {
+        // Guards against reintroducing a DPDK spelling: `net_cn9k`,
+        // `net_octeontx2` and `dev_octeon` are all wrong here, and two
+        // of them cost a bring-up round to establish.
+        assert_eq!(OCTEON_DRIVER, "octeon");
+    }
+
+    #[test]
+    fn local_zero_error_explains_the_danger() {
+        let e = AttachError::LocalZero {
+            port: "eth3".into(),
+        };
+        let msg = e.to_string();
+        assert!(msg.contains("local0"), "{msg}");
+        assert!(msg.contains("silently drop"), "{msg}");
+    }
+}

--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -21,8 +21,8 @@
 //! `AttachDevices` ahead of `StartResync` for exactly this reason.
 
 use crate::vpp_api::generated::{
-    DevAttach, DevAttachReply, DevCreatePortIf, DevCreatePortIfReply, SwInterfaceSetFlags,
-    SwInterfaceSetFlagsReply,
+    DevAttach, DevAttachReply, DevCreatePortIf, DevCreatePortIfReply, SwInterfaceDetails,
+    SwInterfaceDump, SwInterfaceSetFlags, SwInterfaceSetFlagsReply,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -35,7 +35,9 @@ use crate::vpp_api::{Transport, TransportError};
 pub const OCTEON_DRIVER: &str = "octeon";
 
 /// `IF_STATUS_API_FLAG_ADMIN_UP` from interface_types.api.
-const ADMIN_UP: u32 = 1;
+pub const IF_STATUS_ADMIN_UP: u32 = 1;
+/// `IF_STATUS_API_FLAG_LINK_UP` — carrier, not configuration.
+pub const IF_STATUS_LINK_UP: u32 = 2;
 
 /// What to attach: one member port's VF.
 #[derive(Debug, Clone)]
@@ -55,7 +57,10 @@ pub struct PortAttach {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AttachedPort {
     pub port: String,
-    pub dev_index: u32,
+    /// `Some` when we attached the device this pass; `None` when the
+    /// interface was reused from a previous one (the dump does not
+    /// report a device index, and nothing downstream needs it).
+    pub dev_index: Option<u32>,
     pub sw_if_index: u32,
 }
 
@@ -80,6 +85,16 @@ pub enum AttachError {
     LocalZero {
         port: String,
     },
+    /// The state file records an index VPP no longer has.
+    ///
+    /// Refused rather than silently re-attached: we cannot tell from
+    /// here whether a live FIB still references the old index, and
+    /// creating a second interface would leave routes pointing at
+    /// something nothing services. A clean restart is the safe answer.
+    StaleIndex {
+        port: String,
+        sw_if_index: u32,
+    },
 }
 
 impl std::fmt::Display for AttachError {
@@ -98,6 +113,12 @@ impl std::fmt::Display for AttachError {
                 }
                 Ok(())
             }
+            AttachError::StaleIndex { port, sw_if_index } => write!(
+                f,
+                "state file records sw_if_index {sw_if_index} for {port} but VPP no longer has \
+                 it; refusing to attach a duplicate while a live FIB may still reference the old \
+                 index"
+            ),
             AttachError::LocalZero { port } => write!(
                 f,
                 "VPP returned sw_if_index 0 (local0) for {port}; refusing to build FIB paths \
@@ -115,34 +136,132 @@ impl From<TransportError> for AttachError {
     }
 }
 
-/// Attach every port and bring it admin-up.
+/// Attach every port and bring it admin-up — **idempotently**.
 ///
 /// Sequential rather than pipelined, deliberately: each step consumes
 /// the index the previous one returned, and there are a handful of
 /// ports rather than a million routes — the latency this would save is
 /// irrelevant next to being able to name exactly which port failed.
 ///
-/// Stops at the first failure. Ports already attached are returned in
-/// the error-free prefix only on success; on failure the caller tears
-/// the process down anyway (the supervisor routes an attach failure
-/// through `fail()`), so partial cleanup here would duplicate work
-/// that `Kill` does more reliably.
+/// **A port VPP already has is reused, not re-attached.** The
+/// supervisor emits `AttachDevices` on the adopted path too, where the
+/// device and its interface already exist and the live FIB is already
+/// pointing at their indices. Blindly re-issuing `dev_attach` there
+/// would either be refused — and this module treats a refusal as fatal,
+/// so it would cycle a healthy, possibly *steered* VPP, creating
+/// exactly the outage adoption exists to avoid — or create a duplicate
+/// interface whose index nothing in the FIB references. So the first
+/// thing we do is ask VPP what it already has.
+///
+/// Stops at the first genuine failure. On failure the caller tears the
+/// process down anyway (the supervisor routes it through `fail()`), so
+/// partial cleanup here would duplicate what `Kill` does more reliably.
+/// `known` maps a port name to the `sw_if_index` a previous attach
+/// recorded — empty on a fresh attach, populated from the state file on
+/// the adopted path. It is the identity source **because the interface
+/// dump cannot be one**: the dump exposes `octeonN/P` and no PCI
+/// address, so on a box with several member ports `octeon0/0` and
+/// `octeon1/0` are indistinguishable by port id alone. Guessing there
+/// would map a port to the wrong VF, which is worse than not adopting.
 pub fn attach_ports(
     t: &mut Transport,
     ports: &[PortAttach],
+    known: &[(String, u32)],
 ) -> Result<Vec<AttachedPort>, AttachError> {
+    // One dump for the whole pass: it both confirms recorded indices
+    // still exist and is the only way to see link state.
+    let existing = interfaces(t)?;
     let mut out = Vec::with_capacity(ports.len());
     for p in ports {
+        let recorded = known
+            .iter()
+            .find(|(name, _)| *name == p.port)
+            .map(|(_, idx)| *idx);
+
+        if let Some(idx) = recorded {
+            if existing.iter().any(|i| i.sw_if_index == idx) {
+                // Reuse. `dev_index` is not recoverable from the dump,
+                // and nothing downstream needs it — FIB paths and link
+                // checks both key on `sw_if_index` — so it stays `None`
+                // rather than being invented.
+                //
+                // Admin-up is still asserted: controller deploys and
+                // udapi provisioning can flap interface state under us,
+                // and this is the reconcile point.
+                set_admin_up(t, p, idx)?;
+                out.push(AttachedPort {
+                    port: p.port.clone(),
+                    dev_index: None,
+                    sw_if_index: idx,
+                });
+                continue;
+            }
+            // Recorded but gone: the state file outlived the interface.
+            // Refuse rather than attach a second one, because we cannot
+            // tell whether the live FIB still references the old index.
+            return Err(AttachError::StaleIndex {
+                port: p.port.clone(),
+                sw_if_index: idx,
+            });
+        }
+
         let dev_index = attach_device(t, p)?;
         let sw_if_index = create_port_if(t, p, dev_index)?;
         set_admin_up(t, p, sw_if_index)?;
         out.push(AttachedPort {
             port: p.port.clone(),
-            dev_index,
+            dev_index: Some(dev_index),
             sw_if_index,
         });
     }
     Ok(out)
+}
+
+/// Every interface VPP currently has.
+///
+/// Returns [`TransportError`] rather than [`AttachError`] because a
+/// dump has no attach-specific failure modes — and because
+/// [`crate::verify`] needs it too, for link state.
+pub fn interfaces(t: &mut Transport) -> Result<Vec<Interface>, TransportError> {
+    let details: Vec<SwInterfaceDetails> = t.dump(SwInterfaceDump {
+        context: 0,
+        // ~0 = all interfaces; an empty name filter must be paired with
+        // `name_filter_valid = false` or VPP matches nothing.
+        sw_if_index: u32::MAX,
+        name_filter_valid: false,
+        name_filter: String::new(),
+    })?;
+    Ok(details
+        .into_iter()
+        .map(|d| Interface {
+            sw_if_index: d.sw_if_index,
+            name: d.interface_name,
+            flags: d.flags,
+        })
+        .collect())
+}
+
+/// One interface as VPP reports it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Interface {
+    pub sw_if_index: u32,
+    pub name: String,
+    pub flags: u32,
+}
+
+impl Interface {
+    pub fn admin_up(&self) -> bool {
+        self.flags & IF_STATUS_ADMIN_UP != 0
+    }
+
+    /// Whether the interface has carrier.
+    ///
+    /// Distinct from [`Self::admin_up`] and that distinction is the
+    /// whole point: an admin-up interface with no link keeps every FIB
+    /// path pointing at a valid index while forwarding nothing.
+    pub fn link_up(&self) -> bool {
+        self.flags & IF_STATUS_LINK_UP != 0
+    }
 }
 
 fn attach_device(t: &mut Transport, p: &PortAttach) -> Result<u32, AttachError> {
@@ -207,7 +326,7 @@ fn set_admin_up(t: &mut Transport, p: &PortAttach, sw_if_index: u32) -> Result<(
         t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
             context: 0,
             sw_if_index,
-            flags: ADMIN_UP,
+            flags: IF_STATUS_ADMIN_UP,
         })?;
     if reply.retval != 0 {
         return Err(AttachError::Refused {

--- a/crates/modules/vpp-offload/src/fib_sync.rs
+++ b/crates/modules/vpp-offload/src/fib_sync.rs
@@ -74,6 +74,15 @@ impl PortIndex {
     pub fn is_empty(&self) -> bool {
         self.idx.is_empty()
     }
+
+    /// Every interface index we own.
+    ///
+    /// Readback verification uses this to reject a FIB path pointing
+    /// anywhere else — most importantly index 0, `local0`, which
+    /// forwards nothing while looking installed.
+    pub fn indices(&self) -> std::collections::HashSet<u32> {
+        self.idx.values().copied().collect()
+    }
 }
 
 /// Wire form of an address, family tag and all.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -24,6 +24,7 @@
 //!   must mean pure stateless L3 transit;
 //! - the eBPF fast-path on the PFs is the permanent failover tier.
 
+pub mod attach;
 pub mod fib_sync;
 pub mod liveness;
 pub mod process;
@@ -31,6 +32,7 @@ pub mod resources;
 pub mod sink;
 pub mod startup_conf;
 pub mod supervisor;
+pub mod verify;
 pub mod vpp_api;
 
 #[cfg(target_os = "linux")]

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -62,6 +62,15 @@ pub enum Mismatch {
     ForeignPath { prefix: IpPrefix, sw_if_index: u32 },
 }
 
+/// An interface that cannot forward, whatever the FIB says.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeadInterface {
+    pub sw_if_index: u32,
+    pub name: String,
+    pub admin_up: bool,
+    pub link_up: bool,
+}
+
 /// Result of one verify pass.
 #[derive(Debug, Clone, Default)]
 pub struct VerifyOutcome {
@@ -77,32 +86,57 @@ pub struct VerifyOutcome {
     /// on it would convert a graceful degradation into a restart loop.
     /// Reported so it can alarm separately.
     pub withheld: u64,
+    /// Owned interfaces that are not both admin-up and link-up.
+    pub dead_interfaces: Vec<DeadInterface>,
 }
 
 impl VerifyOutcome {
-    /// Pass criteria: nothing sampled disagreed with the ledger, and
-    /// nothing is unresolvable.
+    /// Pass criteria: at least one route was actually probed, nothing
+    /// sampled disagreed with the ledger, nothing is unresolvable, and
+    /// every owned interface can forward.
+    ///
+    /// **`sampled == 0` fails.** An earlier version treated it as a
+    /// vacuous pass, and a test asserted that as intended — which was
+    /// wrong in the case that matters: a resync completing against an
+    /// unexpectedly empty mirror would verify clean, and the supervisor
+    /// would (re-)steer traffic into a VPP with an empty FIB. That is
+    /// the blackhole rule 1 exists to prevent, arrived at through the
+    /// gate meant to prevent it. A box with genuinely no routes should
+    /// not be steered either, so failing is right in both readings.
     ///
     /// `unresolvable > 0` fails because it means the nexthop-device
     /// mapping is wrong — a misconfiguration, not a capacity condition
     /// — and steering traffic into a FIB with known holes is how a
     /// deploy becomes an outage.
     pub fn passed(&self) -> bool {
-        self.mismatches.is_empty() && self.unresolvable == 0
+        self.sampled > 0
+            && self.mismatches.is_empty()
+            && self.unresolvable == 0
+            && self.dead_interfaces.is_empty()
     }
 
     /// One-line operator summary. Separates the two degraded counts,
     /// because "mapping is misconfigured" and "table outgrew the box"
     /// are different pages at 03:00.
     pub fn summary(&self) -> String {
-        format!(
+        let mut s = format!(
             "verify {}: {}/{} probes matched, unresolvable={}, withheld={}",
             if self.passed() { "PASS" } else { "FAIL" },
-            self.sampled - self.mismatches.len(),
+            self.sampled.saturating_sub(self.mismatches.len()),
             self.sampled,
             self.unresolvable,
             self.withheld
-        )
+        );
+        if self.sampled == 0 {
+            s.push_str(" (no installed routes to verify)");
+        }
+        for d in &self.dead_interfaces {
+            s.push_str(&format!(
+                ", {} (idx {}) admin_up={} link_up={}",
+                d.name, d.sw_if_index, d.admin_up, d.link_up
+            ));
+        }
+        s
     }
 }
 
@@ -170,6 +204,27 @@ pub fn verify(
         withheld: counts.withheld,
         ..Default::default()
     };
+
+    // Link state, before the probes. A VF that is admin-up with no
+    // carrier keeps every route on a valid, owned `sw_if_index`, so the
+    // per-route checks below cannot see it at all — every probe passes
+    // and we steer into an interface that forwards nothing. The runbook
+    // treats link-up as the bring-up pass for exactly this reason;
+    // `set_admin_up` only ever asserted the administrative flag.
+    for iface in crate::attach::interfaces(t)? {
+        if !owned.contains(&iface.sw_if_index) {
+            continue;
+        }
+        let (admin_up, link_up) = (iface.admin_up(), iface.link_up());
+        if !admin_up || !link_up {
+            out.dead_interfaces.push(DeadInterface {
+                sw_if_index: iface.sw_if_index,
+                name: iface.name,
+                admin_up,
+                link_up,
+            });
+        }
+    }
 
     for prefix in probes {
         let reply = t.request::<IpRouteLookup, IpRouteLookupReply>(IpRouteLookup {

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -1,0 +1,317 @@
+//! Readback verification — the `StartVerify` action.
+//!
+//! Health is not "the process answers". A VPP that is up, pingable and
+//! holding an empty or half-installed FIB will accept steered traffic
+//! and drop it, so steering is gated on this passing (rule 1). The
+//! mechanism is defined here, ahead of the incident that would
+//! otherwise define it.
+//!
+//! **Prefixes are re-sampled on every pass.** A fixed probe set is
+//! worse than useless: once those few routes install, it passes forever
+//! while the rest of the table rots. The caller varies `seed` per
+//! verify, so each pass looks at different routes and repeated passes
+//! cover the table stochastically.
+//!
+//! **What this checks, precisely.** For each sampled prefix the ledger
+//! believes is installed, VPP must return a route with at least one
+//! path, and every path must egress an interface we actually own. That
+//! last clause is the valuable one: `sw_if_index` 0 is `local0`, VPP's
+//! drop interface, so a path pointing there is a route that looks
+//! installed and forwards nothing — the exact silent blackhole the
+//! deferred-index logic in the drainer exists to prevent, checked here
+//! from the other side.
+//!
+//! **What it does NOT check**, so nobody reads more into a pass than
+//! it earns:
+//!
+//! - *Per-path nexthop correctness.* Confirming VPP's paths match
+//!   bird's intent would mean holding the expected nexthop set for
+//!   ~1.05M prefixes, which is the memory the ledger deliberately does
+//!   not spend. Path bytes are covered instead by the golden vectors
+//!   (encoding) and the drainer's per-route acknowledgement (delivery).
+//! - *Total route count.* The plan pairs sampling with VPP's own
+//!   `show ip fib summary`, which needs `cli_inband` — a message from
+//!   `vlib.api.json`, not among the vendored files. Until that is
+//!   vendored, a uniform shortfall is caught only stochastically by
+//!   sampling. Recorded as owed rather than quietly dropped.
+
+use packetframe_common::fib::IpPrefix;
+
+use crate::fib_sync::{to_prefix, PortIndex};
+use crate::sink::RouteLedger;
+use crate::vpp_api::generated::{IpRouteLookup, IpRouteLookupReply};
+use crate::vpp_api::{Transport, TransportError};
+
+/// How many prefixes a verify pass probes.
+///
+/// A round trip each, so this is a latency cost paid inside the
+/// recovery budget — 64 keeps a pass well under a second while giving
+/// a wide-enough net that a systemic miss is very unlikely to hide. It
+/// is a sample, not a proof, and the module docs say so.
+pub const DEFAULT_SAMPLE: usize = 64;
+
+/// Why a sampled prefix failed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Mismatch {
+    /// VPP has no route for a prefix the ledger says is installed.
+    Absent { prefix: IpPrefix, retval: i32 },
+    /// The route exists but carries no paths.
+    NoPaths { prefix: IpPrefix },
+    /// A path egresses an interface we do not own — `local0` (index 0)
+    /// or something attached behind our back.
+    ForeignPath { prefix: IpPrefix, sw_if_index: u32 },
+}
+
+/// Result of one verify pass.
+#[derive(Debug, Clone, Default)]
+pub struct VerifyOutcome {
+    pub sampled: usize,
+    pub mismatches: Vec<Mismatch>,
+    /// Routes the mapping could not resolve to a VPP-owned device.
+    /// Steady state on the reference fleet is exactly 0, which is what
+    /// makes it a usable gate rather than noise.
+    pub unresolvable: u64,
+    /// Routes held back by capacity. Degraded but *known*, and
+    /// deliberately NOT a verify failure: withholding is the designed
+    /// response to a table that outgrew its heap, and failing verify
+    /// on it would convert a graceful degradation into a restart loop.
+    /// Reported so it can alarm separately.
+    pub withheld: u64,
+}
+
+impl VerifyOutcome {
+    /// Pass criteria: nothing sampled disagreed with the ledger, and
+    /// nothing is unresolvable.
+    ///
+    /// `unresolvable > 0` fails because it means the nexthop-device
+    /// mapping is wrong — a misconfiguration, not a capacity condition
+    /// — and steering traffic into a FIB with known holes is how a
+    /// deploy becomes an outage.
+    pub fn passed(&self) -> bool {
+        self.mismatches.is_empty() && self.unresolvable == 0
+    }
+
+    /// One-line operator summary. Separates the two degraded counts,
+    /// because "mapping is misconfigured" and "table outgrew the box"
+    /// are different pages at 03:00.
+    pub fn summary(&self) -> String {
+        format!(
+            "verify {}: {}/{} probes matched, unresolvable={}, withheld={}",
+            if self.passed() { "PASS" } else { "FAIL" },
+            self.sampled - self.mismatches.len(),
+            self.sampled,
+            self.unresolvable,
+            self.withheld
+        )
+    }
+}
+
+/// Deterministic sampler.
+///
+/// Seeded rather than drawing from the OS so a failing verify can be
+/// replayed exactly — a probe set you cannot reproduce is a bug report
+/// nobody can act on. The caller supplies a fresh seed per pass, which
+/// is what makes the sampling vary.
+fn xorshift(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+/// Pick up to `n` distinct prefixes from `all`.
+///
+/// Partial Fisher-Yates over indices: distinct by construction, and
+/// O(n) rather than O(len), which matters when `all` is the whole
+/// installed table and `n` is 64.
+pub fn sample(all: &[IpPrefix], n: usize, seed: u64) -> Vec<IpPrefix> {
+    if all.is_empty() {
+        return Vec::new();
+    }
+    let take = n.min(all.len());
+    // Seed 0 is a fixed point for xorshift — it would return the same
+    // index forever and silently collapse the sample to one prefix.
+    let mut state = if seed == 0 {
+        0x9E37_79B9_7F4A_7C15
+    } else {
+        seed
+    };
+    let mut idx: Vec<usize> = (0..all.len()).collect();
+    for i in 0..take {
+        let j = i + (xorshift(&mut state) as usize) % (idx.len() - i);
+        idx.swap(i, j);
+    }
+    idx[..take].iter().map(|&i| all[i]).collect()
+}
+
+/// Probe a random sample of installed prefixes against VPP's FIB.
+///
+/// Errors only on transport failure; a route that disagrees is a
+/// [`Mismatch`] in the outcome, not an error, because the caller needs
+/// the whole picture to decide whether to steer rather than the first
+/// disagreement.
+pub fn verify(
+    t: &mut Transport,
+    ledger: &RouteLedger,
+    ports: &PortIndex,
+    sample_size: usize,
+    seed: u64,
+) -> Result<VerifyOutcome, TransportError> {
+    let counts = ledger.counts();
+    let installed = ledger.verifiable_prefixes();
+    let probes = sample(&installed, sample_size, seed);
+    let owned = ports.indices();
+
+    let mut out = VerifyOutcome {
+        sampled: probes.len(),
+        unresolvable: counts.unresolvable,
+        withheld: counts.withheld,
+        ..Default::default()
+    };
+
+    for prefix in probes {
+        let reply = t.request::<IpRouteLookup, IpRouteLookupReply>(IpRouteLookup {
+            context: 0,
+            table_id: 0,
+            // Exact-match: a covering less-specific route would
+            // otherwise answer for a prefix that is actually missing,
+            // which is precisely the hole we are looking for.
+            exact: 1,
+            prefix: to_prefix(prefix),
+        })?;
+        if reply.retval != 0 {
+            out.mismatches.push(Mismatch::Absent {
+                prefix,
+                retval: reply.retval,
+            });
+            continue;
+        }
+        if reply.route.paths.is_empty() {
+            out.mismatches.push(Mismatch::NoPaths { prefix });
+            continue;
+        }
+        for path in &reply.route.paths {
+            if !owned.contains(&path.sw_if_index) {
+                out.mismatches.push(Mismatch::ForeignPath {
+                    prefix,
+                    sw_if_index: path.sw_if_index,
+                });
+                break;
+            }
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4(a: u8, b: u8) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [10, a, b, 0],
+            prefix_len: 24,
+        }
+    }
+
+    fn table(n: usize) -> Vec<IpPrefix> {
+        (0..n)
+            .map(|i| v4((i / 256) as u8, (i % 256) as u8))
+            .collect()
+    }
+
+    #[test]
+    fn sampling_returns_distinct_prefixes() {
+        let all = table(500);
+        let got = sample(&all, 64, 12345);
+        assert_eq!(got.len(), 64);
+        let uniq: std::collections::HashSet<_> = got.iter().collect();
+        assert_eq!(uniq.len(), 64, "a probe set with duplicates wastes probes");
+    }
+
+    /// The whole point of seeding: consecutive passes must look at
+    /// different routes, or a fixed probe set passes forever while the
+    /// rest of the table rots.
+    #[test]
+    fn different_seeds_sample_differently() {
+        let all = table(500);
+        let a = sample(&all, 64, 1);
+        let b = sample(&all, 64, 2);
+        assert_ne!(a, b, "re-sampling must actually re-sample");
+    }
+
+    /// ...but a given seed must replay exactly, so a failing verify can
+    /// be reproduced.
+    #[test]
+    fn the_same_seed_replays_exactly() {
+        let all = table(500);
+        assert_eq!(sample(&all, 32, 99), sample(&all, 32, 99));
+    }
+
+    /// Seed 0 is a xorshift fixed point. Unguarded it would return one
+    /// index forever, collapsing a 64-probe verify to a single route
+    /// while still reporting 64 samples.
+    #[test]
+    fn seed_zero_does_not_collapse_the_sample() {
+        let all = table(500);
+        let got = sample(&all, 64, 0);
+        let uniq: std::collections::HashSet<_> = got.iter().collect();
+        assert_eq!(uniq.len(), 64);
+    }
+
+    #[test]
+    fn sampling_a_short_table_takes_everything_once() {
+        let all = table(10);
+        let got = sample(&all, 64, 7);
+        assert_eq!(got.len(), 10);
+        let uniq: std::collections::HashSet<_> = got.iter().collect();
+        assert_eq!(uniq.len(), 10);
+    }
+
+    #[test]
+    fn an_empty_table_samples_nothing() {
+        assert!(sample(&[], 64, 1).is_empty());
+    }
+
+    #[test]
+    fn unresolvable_fails_the_pass_but_withheld_does_not() {
+        let mut o = VerifyOutcome {
+            sampled: 64,
+            withheld: 5_000,
+            ..Default::default()
+        };
+        assert!(
+            o.passed(),
+            "withholding is the designed response to a full table, not a fault"
+        );
+        o.unresolvable = 1;
+        assert!(!o.passed(), "a mapping hole must block steering");
+    }
+
+    #[test]
+    fn a_mismatch_fails_the_pass() {
+        let o = VerifyOutcome {
+            sampled: 64,
+            mismatches: vec![Mismatch::NoPaths { prefix: v4(0, 1) }],
+            ..Default::default()
+        };
+        assert!(!o.passed());
+        assert!(o.summary().contains("FAIL"), "{}", o.summary());
+        assert!(o.summary().contains("63/64"), "{}", o.summary());
+    }
+
+    #[test]
+    fn the_summary_separates_the_two_degraded_counts() {
+        let o = VerifyOutcome {
+            sampled: 10,
+            unresolvable: 3,
+            withheld: 7,
+            ..Default::default()
+        };
+        let s = o.summary();
+        assert!(s.contains("unresolvable=3"), "{s}");
+        assert!(s.contains("withheld=7"), "{s}");
+    }
+}

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -33,6 +33,8 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "ip_neighbor_add_del_reply", crc: "0x1992deab", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_flags", crc: "0xf5aec1b8", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "sw_interface_set_flags_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "sw_interface_dump", crc: "0xaa610c27", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "sw_interface_details", crc: "0x6c221fc7", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "dev_attach", crc: "0x44b725fc", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "dev_attach_reply", crc: "0x6082b181", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "dev_detach", crc: "0xafae52d6", context_offset: 6, client_index_prefix: true },
@@ -84,10 +86,33 @@ pub const FIB_API_PATH_TYPE_CLASSIFY: u32 = 10;
 pub const IF_STATUS_API_FLAG_ADMIN_UP: u32 = 1;
 pub const IF_STATUS_API_FLAG_LINK_UP: u32 = 2;
 
+// enum if_type : u32
+pub const IF_API_TYPE_HARDWARE: u32 = 0;
+pub const IF_API_TYPE_SUB: u32 = 1;
+pub const IF_API_TYPE_P2P: u32 = 2;
+pub const IF_API_TYPE_PIPE: u32 = 3;
+
 // enum ip_neighbor_flags : u8
 pub const IP_API_NEIGHBOR_FLAG_NONE: u8 = 0;
 pub const IP_API_NEIGHBOR_FLAG_STATIC: u8 = 1;
 pub const IP_API_NEIGHBOR_FLAG_NO_FIB_ENTRY: u8 = 2;
+
+// enum link_duplex : u32
+pub const LINK_DUPLEX_API_UNKNOWN: u32 = 0;
+pub const LINK_DUPLEX_API_HALF: u32 = 1;
+pub const LINK_DUPLEX_API_FULL: u32 = 2;
+
+// enum sub_if_flags : u32
+pub const SUB_IF_API_FLAG_NO_TAGS: u32 = 1;
+pub const SUB_IF_API_FLAG_ONE_TAG: u32 = 2;
+pub const SUB_IF_API_FLAG_TWO_TAGS: u32 = 4;
+pub const SUB_IF_API_FLAG_DOT1AD: u32 = 8;
+pub const SUB_IF_API_FLAG_EXACT_MATCH: u32 = 16;
+pub const SUB_IF_API_FLAG_DEFAULT: u32 = 32;
+pub const SUB_IF_API_FLAG_OUTER_VLAN_ID_ANY: u32 = 64;
+pub const SUB_IF_API_FLAG_INNER_VLAN_ID_ANY: u32 = 128;
+pub const SUB_IF_API_FLAG_MASK_VNET: u32 = 254;
+pub const SUB_IF_API_FLAG_DOT1AH: u32 = 256;
 
 /// `address_union` — fixed 16-byte union overlay.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -942,6 +967,210 @@ impl Decode for SwInterfaceSetFlagsReply {
 impl Message for SwInterfaceSetFlagsReply {
     const NAME: &'static str = "sw_interface_set_flags_reply";
     const CRC: &'static str = "0xe8d4e804";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_dump` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceDump {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub name_filter_valid: bool,
+    pub name_filter: String,
+}
+
+impl Encode for SwInterfaceDump {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.push(if self.name_filter_valid { 1u8 } else { 0u8 });
+        buf.extend_from_slice(&(self.name_filter.len() as u32).to_be_bytes());
+        buf.extend_from_slice(self.name_filter.as_bytes());
+    }
+}
+
+impl Decode for SwInterfaceDump {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let name_filter_valid = d.bool()?;
+        let name_filter = d.string_var()?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            name_filter_valid,
+            name_filter,
+        })
+    }
+}
+
+impl Message for SwInterfaceDump {
+    const NAME: &'static str = "sw_interface_dump";
+    const CRC: &'static str = "0xaa610c27";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_details` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceDetails {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub sup_sw_if_index: u32,
+    pub l2_address: [u8; 6],
+    pub flags: u32,
+    pub r#type: u32,
+    pub link_duplex: u32,
+    pub link_speed: u32,
+    pub link_mtu: u16,
+    pub mtu: [u32; 4],
+    pub sub_id: u32,
+    pub sub_number_of_tags: u8,
+    pub sub_outer_vlan_id: u16,
+    pub sub_inner_vlan_id: u16,
+    pub sub_if_flags: u32,
+    pub vtr_op: u32,
+    pub vtr_push_dot1q: u32,
+    pub vtr_tag1: u32,
+    pub vtr_tag2: u32,
+    pub outer_tag: u16,
+    pub b_dmac: [u8; 6],
+    pub b_smac: [u8; 6],
+    pub b_vlanid: u16,
+    pub i_sid: u32,
+    pub interface_name: String,
+    pub interface_dev_type: String,
+    pub tag: String,
+}
+
+impl Encode for SwInterfaceDetails {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.extend_from_slice(&(self.sup_sw_if_index).to_be_bytes());
+        buf.extend_from_slice(&self.l2_address[..]);
+        buf.extend_from_slice(&(self.flags as u32).to_be_bytes());
+        buf.extend_from_slice(&(self.r#type as u32).to_be_bytes());
+        buf.extend_from_slice(&(self.link_duplex as u32).to_be_bytes());
+        buf.extend_from_slice(&(self.link_speed).to_be_bytes());
+        buf.extend_from_slice(&(self.link_mtu).to_be_bytes());
+        for it in self.mtu.iter() {
+        buf.extend_from_slice(&(*it).to_be_bytes());
+        }
+        buf.extend_from_slice(&(self.sub_id).to_be_bytes());
+        buf.extend_from_slice(&(self.sub_number_of_tags).to_be_bytes());
+        buf.extend_from_slice(&(self.sub_outer_vlan_id).to_be_bytes());
+        buf.extend_from_slice(&(self.sub_inner_vlan_id).to_be_bytes());
+        buf.extend_from_slice(&(self.sub_if_flags as u32).to_be_bytes());
+        buf.extend_from_slice(&(self.vtr_op).to_be_bytes());
+        buf.extend_from_slice(&(self.vtr_push_dot1q).to_be_bytes());
+        buf.extend_from_slice(&(self.vtr_tag1).to_be_bytes());
+        buf.extend_from_slice(&(self.vtr_tag2).to_be_bytes());
+        buf.extend_from_slice(&(self.outer_tag).to_be_bytes());
+        buf.extend_from_slice(&self.b_dmac[..]);
+        buf.extend_from_slice(&self.b_smac[..]);
+        buf.extend_from_slice(&(self.b_vlanid).to_be_bytes());
+        buf.extend_from_slice(&(self.i_sid).to_be_bytes());
+        {
+            let mut tmp = [0u8; 64];
+            let b = self.interface_name.as_bytes();
+            let k = b.len().min(64);
+            tmp[..k].copy_from_slice(&b[..k]);
+            buf.extend_from_slice(&tmp);
+        }
+        {
+            let mut tmp = [0u8; 64];
+            let b = self.interface_dev_type.as_bytes();
+            let k = b.len().min(64);
+            tmp[..k].copy_from_slice(&b[..k]);
+            buf.extend_from_slice(&tmp);
+        }
+        {
+            let mut tmp = [0u8; 64];
+            let b = self.tag.as_bytes();
+            let k = b.len().min(64);
+            tmp[..k].copy_from_slice(&b[..k]);
+            buf.extend_from_slice(&tmp);
+        }
+    }
+}
+
+impl Decode for SwInterfaceDetails {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let sup_sw_if_index = d.u32()?;
+        let l2_address = d.bytes::<6>()?;
+        let flags = d.u32()?;
+        let r#type = d.u32()?;
+        let link_duplex = d.u32()?;
+        let link_speed = d.u32()?;
+        let link_mtu = d.u16()?;
+        let mtu = {
+            let mut a = <[_; 4]>::default();
+            for slot in a.iter_mut() {
+                *slot = d.u32()?;
+            }
+            a
+        };
+        let sub_id = d.u32()?;
+        let sub_number_of_tags = d.u8()?;
+        let sub_outer_vlan_id = d.u16()?;
+        let sub_inner_vlan_id = d.u16()?;
+        let sub_if_flags = d.u32()?;
+        let vtr_op = d.u32()?;
+        let vtr_push_dot1q = d.u32()?;
+        let vtr_tag1 = d.u32()?;
+        let vtr_tag2 = d.u32()?;
+        let outer_tag = d.u16()?;
+        let b_dmac = d.bytes::<6>()?;
+        let b_smac = d.bytes::<6>()?;
+        let b_vlanid = d.u16()?;
+        let i_sid = d.u32()?;
+        let interface_name = d.string_fixed(64)?;
+        let interface_dev_type = d.string_fixed(64)?;
+        let tag = d.string_fixed(64)?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            sup_sw_if_index,
+            l2_address,
+            flags,
+            r#type,
+            link_duplex,
+            link_speed,
+            link_mtu,
+            mtu,
+            sub_id,
+            sub_number_of_tags,
+            sub_outer_vlan_id,
+            sub_inner_vlan_id,
+            sub_if_flags,
+            vtr_op,
+            vtr_push_dot1q,
+            vtr_tag1,
+            vtr_tag2,
+            outer_tag,
+            b_dmac,
+            b_smac,
+            b_vlanid,
+            i_sid,
+            interface_name,
+            interface_dev_type,
+            tag,
+        })
+    }
+}
+
+impl Message for SwInterfaceDetails {
+    const NAME: &'static str = "sw_interface_details";
+    const CRC: &'static str = "0x6c221fc7";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;
     fn set_context(&mut self, context: u32) { self.context = context; }

--- a/crates/modules/vpp-offload/src/vpp_api/transport.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/transport.rs
@@ -314,6 +314,43 @@ impl Transport {
         Ok(reply.vpe_pid)
     }
 
+    /// Run a DUMP request and collect every streamed item.
+    ///
+    /// VPP dumps have **no end-of-stream marker**. The idiom every
+    /// client uses is to trail the dump with a `control_ping`: replies
+    /// come back in order, so the ping's reply arriving means the dump
+    /// finished. That is why this cannot be expressed as
+    /// [`Self::request`] — one request, N replies, and the terminator is
+    /// a different message type.
+    ///
+    /// A message that is neither an item nor the terminator is a
+    /// desynchronised stream, not something to skip: silently ignoring
+    /// it would leave the next caller reading someone else's reply.
+    pub fn dump<Req, Item>(&mut self, req: Req) -> Result<Vec<Item>, TransportError>
+    where
+        Req: Message,
+        Item: Message + Decode,
+    {
+        let item_id = self.id_of::<Item>()?;
+        let end_id = self.id_of::<ControlPingReply>()?;
+        self.send(req)?;
+        self.send(ControlPing { context: 0 })?;
+
+        let mut out = Vec::new();
+        loop {
+            let payload = self.read_frame()?;
+            let id = peek_msg_id(&payload)?;
+            if id == end_id {
+                return Ok(out);
+            }
+            if id != item_id {
+                return Err(TransportError::UnknownReplyId(id));
+            }
+            let mut d = Decoder::new(&payload);
+            out.push(Item::decode(&mut d)?);
+        }
+    }
+
     pub fn client_index(&self) -> u32 {
         self.client_index
     }

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -1,0 +1,567 @@
+//! Device attach and readback verify against a fake VPP.
+//!
+//! The unit tests cover the decisions (which driver name, what fails a
+//! pass, how sampling behaves). These cover the part that only a socket
+//! can: that the three attach messages are sent in the order the
+//! hardware requires, that indices thread from one reply into the next,
+//! and that a verify pass turns real `ip_route_lookup` replies into the
+//! right verdict.
+//!
+//! The fake dispatches on message id, so a request sent out of order
+//! shows up as a wrong-message failure rather than passing by accident.
+
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread;
+use std::time::Duration;
+
+use packetframe_common::fib::IpPrefix;
+use packetframe_vpp_offload::attach::{attach_ports, AttachError, PortAttach};
+use packetframe_vpp_offload::fib_sync::{to_prefix, PortIndex};
+use packetframe_vpp_offload::sink::{Capacity, RouteLedger};
+use packetframe_vpp_offload::verify::{verify, Mismatch};
+use packetframe_vpp_offload::vpp_api::codec::{
+    parse_frame_header, peek_msg_id, write_frame_header, Encode, MSG_HEADER_LEN,
+    SOCKCLNT_CREATE_MSG_ID,
+};
+use packetframe_vpp_offload::vpp_api::generated::{
+    DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteLookupReply, MessageTableEntry,
+    SockclntCreateReply, SwInterfaceSetFlagsReply, MESSAGE_META,
+};
+use packetframe_vpp_offload::vpp_api::Transport;
+
+fn id_for(name: &str) -> u16 {
+    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
+}
+
+fn name_for(id: u16) -> &'static str {
+    MESSAGE_META[(id - 100) as usize].name
+}
+
+/// Start a reply payload for `name`.
+///
+/// **The header geometry is per-message, not uniform**, and this fake
+/// has to honour that or it tests nothing. `dev_create_port_if_reply`
+/// carries a `client_index` between the id and the context; its own
+/// sibling `dev_attach_reply` does not. Reading the layout out of
+/// `MESSAGE_META` rather than hardcoding `[id][context]` is what makes
+/// the fake speak the same wire the real VPP does — a hand-assumed
+/// prefix here would have quietly matched a hand-assumed prefix in the
+/// client and proved nothing.
+fn reply_head(name: &str) -> Vec<u8> {
+    let meta = MESSAGE_META
+        .iter()
+        .find(|m| m.name == name)
+        .expect("known reply");
+    let mut out = Vec::new();
+    out.extend_from_slice(&id_for(name).to_be_bytes());
+    if meta.client_index_prefix {
+        out.extend_from_slice(&7u32.to_be_bytes());
+    }
+    out
+}
+
+fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
+    let mut hdr = [0u8; MSG_HEADER_LEN];
+    s.read_exact(&mut hdr).ok()?;
+    let len = parse_frame_header(&hdr) as usize;
+    let mut payload = vec![0u8; len];
+    s.read_exact(&mut payload).ok()?;
+    Some(payload)
+}
+
+fn write_frame(s: &mut UnixStream, payload: &[u8]) {
+    let mut framed = Vec::new();
+    write_frame_header(&mut framed, payload.len());
+    framed.extend_from_slice(payload);
+    let _ = s.write_all(&framed);
+    let _ = s.flush();
+}
+
+/// Requests carry `[msg_id][client_index][context]`.
+fn request_context(payload: &[u8]) -> u32 {
+    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
+}
+
+mod tempdir {
+    use std::path::{Path, PathBuf};
+    pub struct TempDir(PathBuf);
+    impl TempDir {
+        pub fn new(tag: &str) -> std::io::Result<Self> {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "pf-av-{tag}-{}-{:?}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&p)?;
+            Ok(Self(p))
+        }
+        pub fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
+/// How the fake behaves for the attach sequence.
+#[derive(Clone, Copy, Default)]
+struct AttachBehaviour {
+    /// Fail `dev_attach` with this retval.
+    attach_retval: i32,
+    /// Fail `dev_create_port_if` with this retval.
+    create_retval: i32,
+    /// Hand back this sw_if_index (0 exercises the local0 guard).
+    sw_if_index: u32,
+    dev_index: u32,
+}
+
+/// How the fake answers `ip_route_lookup`.
+#[derive(Clone, Copy)]
+enum LookupBehaviour {
+    /// Route present, one path on this index.
+    Found { sw_if_index: u32 },
+    /// Route present, zero paths.
+    NoPaths,
+    /// Not in the FIB.
+    Missing,
+}
+
+struct Fake {
+    path: PathBuf,
+    _dir: tempdir::TempDir,
+    /// Message names in the order the fake received them.
+    seen: Receiver<String>,
+}
+
+impl Fake {
+    fn start(tag: &str, attach: AttachBehaviour, lookup: LookupBehaviour) -> Self {
+        let dir = tempdir::TempDir::new(tag).unwrap();
+        let path = dir.path().join("api.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let (tx, rx): (Sender<String>, Receiver<String>) = channel();
+
+        thread::spawn(move || {
+            let Ok((mut sock, _)) = listener.accept() else {
+                return;
+            };
+            // Handshake.
+            let Some(_) = read_frame(&mut sock) else {
+                return;
+            };
+            let mut reply = SockclntCreateReply {
+                context: 1,
+                response: 0,
+                index: 7,
+                count: MESSAGE_META.len() as u16,
+                message_table: Vec::new(),
+            };
+            for (i, m) in MESSAGE_META.iter().enumerate() {
+                reply.message_table.push(MessageTableEntry {
+                    index: 100 + i as u16,
+                    name: format!("{}_{}", m.name, m.crc.trim_start_matches("0x")),
+                });
+            }
+            let mut payload = Vec::new();
+            payload.extend_from_slice(&SOCKCLNT_CREATE_MSG_ID.to_be_bytes());
+            payload.extend_from_slice(&7u32.to_be_bytes());
+            reply.encode(&mut payload);
+            write_frame(&mut sock, &payload);
+
+            loop {
+                let Some(req) = read_frame(&mut sock) else {
+                    return;
+                };
+                let id = peek_msg_id(&req).expect("msg id");
+                let ctx = request_context(&req);
+                let which = name_for(id);
+                let _ = tx.send(which.to_string());
+
+                let mut out;
+                match which {
+                    "dev_attach" => {
+                        out = reply_head("dev_attach_reply");
+                        DevAttachReply {
+                            context: ctx,
+                            dev_index: attach.dev_index,
+                            retval: attach.attach_retval,
+                            error_string: if attach.attach_retval == 0 {
+                                String::new()
+                            } else {
+                                "no such driver".into()
+                            },
+                        }
+                        .encode(&mut out);
+                    }
+                    "dev_create_port_if" => {
+                        out = reply_head("dev_create_port_if_reply");
+                        DevCreatePortIfReply {
+                            context: ctx,
+                            sw_if_index: attach.sw_if_index,
+                            retval: attach.create_retval,
+                            error_string: String::new(),
+                        }
+                        .encode(&mut out);
+                    }
+                    "sw_interface_set_flags" => {
+                        out = reply_head("sw_interface_set_flags_reply");
+                        SwInterfaceSetFlagsReply {
+                            context: ctx,
+                            retval: 0,
+                        }
+                        .encode(&mut out);
+                    }
+                    "ip_route_lookup" => {
+                        out = reply_head("ip_route_lookup_reply");
+                        let (retval, paths) = match lookup {
+                            LookupBehaviour::Found { sw_if_index } => {
+                                (0, vec![path_on(sw_if_index)])
+                            }
+                            LookupBehaviour::NoPaths => (0, Vec::new()),
+                            LookupBehaviour::Missing => (-6, Vec::new()),
+                        };
+                        IpRouteLookupReply {
+                            context: ctx,
+                            retval,
+                            route: IpRoute {
+                                table_id: 0,
+                                stats_index: 0,
+                                prefix: to_prefix(v4(10, 0)),
+                                n_paths: paths.len() as u8,
+                                paths,
+                            },
+                        }
+                        .encode(&mut out);
+                    }
+                    other => panic!("fake got unexpected message {other}"),
+                }
+                write_frame(&mut sock, &out);
+            }
+        });
+
+        Self {
+            path,
+            _dir: dir,
+            seen: rx,
+        }
+    }
+
+    fn connect(&self) -> Transport {
+        Transport::connect(&self.path, Duration::from_secs(5)).unwrap()
+    }
+
+    /// Drain the observed message names.
+    fn observed(&self) -> Vec<String> {
+        let mut v = Vec::new();
+        while let Ok(n) = self.seen.try_recv() {
+            v.push(n);
+        }
+        v
+    }
+}
+
+fn path_on(sw_if_index: u32) -> FibPath {
+    FibPath {
+        sw_if_index,
+        table_id: 0,
+        rpf_id: 0,
+        weight: 1,
+        preference: 0,
+        r#type: 0,
+        flags: 0,
+        proto: 0,
+        nh: Default::default(),
+        n_labels: 0,
+        label_stack: Default::default(),
+    }
+}
+
+fn v4(a: u8, b: u8) -> IpPrefix {
+    IpPrefix::V4 {
+        addr: [10, a, b, 0],
+        prefix_len: 24,
+    }
+}
+
+fn ports() -> Vec<PortAttach> {
+    vec![PortAttach {
+        port: "eth3".into(),
+        pci_addr: "0002:07:00.1".into(),
+        port_id: 0,
+        num_rx_queues: 1,
+    }]
+}
+
+#[test]
+fn attach_sends_the_three_messages_in_order() {
+    let fake = Fake::start(
+        "ok",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let got = attach_ports(&mut t, &ports()).expect("attach");
+
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].port, "eth3");
+    assert_eq!(got[0].dev_index, 3);
+    assert_eq!(got[0].sw_if_index, 7);
+
+    // Order is not cosmetic: create_port_if consumes dev_attach's
+    // index, and set_flags consumes create_port_if's.
+    assert_eq!(
+        fake.observed(),
+        vec![
+            "dev_attach".to_string(),
+            "dev_create_port_if".to_string(),
+            "sw_interface_set_flags".to_string(),
+        ]
+    );
+}
+
+/// The guard that matters most in this module. `sw_if_index` 0 is
+/// `local0`; a FIB path pointing there looks installed and forwards
+/// nothing, so a "successful" attach returning 0 must be refused.
+#[test]
+fn an_sw_if_index_of_zero_is_refused_as_local0() {
+    let fake = Fake::start(
+        "local0",
+        AttachBehaviour {
+            dev_index: 1,
+            sw_if_index: 0,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let err = attach_ports(&mut t, &ports()).expect_err("must refuse index 0");
+    assert!(matches!(err, AttachError::LocalZero { .. }), "{err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("local0"), "{msg}");
+
+    // And it stops there: no interface is brought up on a bad index.
+    assert_eq!(
+        fake.observed(),
+        vec!["dev_attach".to_string(), "dev_create_port_if".to_string()]
+    );
+}
+
+#[test]
+fn a_refused_dev_attach_reports_vpps_own_text() {
+    let fake = Fake::start(
+        "refused",
+        AttachBehaviour {
+            attach_retval: -1,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let err = attach_ports(&mut t, &ports()).expect_err("must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("dev_attach"), "{msg}");
+    assert!(msg.contains("eth3"), "names the port: {msg}");
+    assert!(msg.contains("no such driver"), "keeps VPP's detail: {msg}");
+    // Nothing further is attempted.
+    assert_eq!(fake.observed(), vec!["dev_attach".to_string()]);
+}
+
+/// A `dev_attach` that succeeds followed by a `dev_create_port_if` that
+/// does not — the shape of "driver loaded, port would not come up",
+/// which is what a queue or NPA-pool failure looks like from here.
+#[test]
+fn a_refused_create_port_if_names_the_step_that_failed() {
+    let fake = Fake::start(
+        "createfail",
+        AttachBehaviour {
+            dev_index: 2,
+            create_retval: -11,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let err = attach_ports(&mut t, &ports()).expect_err("must fail");
+    let msg = err.to_string();
+    assert!(msg.contains("dev_create_port_if"), "{msg}");
+    assert!(msg.contains("-11"), "reports the retval: {msg}");
+    // The device attached; only the port interface failed. No admin-up.
+    assert_eq!(
+        fake.observed(),
+        vec!["dev_attach".to_string(), "dev_create_port_if".to_string()]
+    );
+}
+
+/// A ledger holding `n` installed prefixes, all resolvable.
+fn ledger_with(n: usize) -> (RouteLedger, PortIndex) {
+    let mut ledger = RouteLedger::new(Capacity::new(10_000));
+    for i in 0..n {
+        let p = v4((i / 256) as u8, (i % 256) as u8);
+        ledger.classify_resolved(p, 1);
+        ledger.commit_installed(p);
+    }
+    let mut ports = PortIndex::default();
+    ports.insert("eth3", None, 7);
+    (ledger, ports)
+}
+
+#[test]
+fn verify_passes_when_every_probe_finds_a_route_on_an_owned_interface() {
+    let fake = Fake::start(
+        "vok",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(200);
+
+    let out = verify(&mut t, &ledger, &ports, 16, 42).expect("verify");
+    assert_eq!(out.sampled, 16);
+    assert!(out.mismatches.is_empty(), "{:?}", out.mismatches);
+    assert!(out.passed(), "{}", out.summary());
+    assert_eq!(fake.observed().len(), 16, "one lookup per probe");
+}
+
+/// The silent-blackhole check, from the readback side: VPP happily
+/// returns a route whose path is local0.
+#[test]
+fn verify_fails_a_path_on_an_interface_we_do_not_own() {
+    let fake = Fake::start(
+        "vlocal0",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 0 },
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(50);
+
+    let out = verify(&mut t, &ledger, &ports, 8, 7).expect("verify");
+    assert!(!out.passed());
+    assert_eq!(out.mismatches.len(), 8);
+    assert!(
+        out.mismatches
+            .iter()
+            .all(|m| matches!(m, Mismatch::ForeignPath { sw_if_index: 0, .. })),
+        "{:?}",
+        out.mismatches
+    );
+}
+
+#[test]
+fn verify_fails_an_absent_route() {
+    let fake = Fake::start(
+        "vmissing",
+        AttachBehaviour::default(),
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(50);
+
+    let out = verify(&mut t, &ledger, &ports, 4, 3).expect("verify");
+    assert!(!out.passed());
+    assert!(
+        out.mismatches
+            .iter()
+            .all(|m| matches!(m, Mismatch::Absent { .. })),
+        "{:?}",
+        out.mismatches
+    );
+}
+
+#[test]
+fn verify_fails_a_route_with_no_paths() {
+    let fake = Fake::start(
+        "vnopaths",
+        AttachBehaviour::default(),
+        LookupBehaviour::NoPaths,
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(50);
+
+    let out = verify(&mut t, &ledger, &ports, 4, 3).expect("verify");
+    assert!(!out.passed());
+    assert!(
+        out.mismatches
+            .iter()
+            .all(|m| matches!(m, Mismatch::NoPaths { .. })),
+        "{:?}",
+        out.mismatches
+    );
+}
+
+/// An unresolvable route fails the pass even when every probe matches:
+/// the mapping is misconfigured, and steering into a FIB with known
+/// holes is how a deploy becomes an outage.
+#[test]
+fn verify_fails_on_unresolvable_even_with_clean_probes() {
+    let fake = Fake::start(
+        "vunres",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+    );
+    let mut t = fake.connect();
+    let (mut ledger, ports) = ledger_with(50);
+    // A route whose nexthops resolve nowhere.
+    ledger.classify_resolved(v4(99, 99), 0);
+
+    let out = verify(&mut t, &ledger, &ports, 8, 11).expect("verify");
+    assert!(out.mismatches.is_empty(), "probes were clean");
+    assert_eq!(out.unresolvable, 1);
+    assert!(!out.passed(), "{}", out.summary());
+}
+
+/// An empty ledger cannot be verified into a pass by sampling nothing —
+/// but it also must not report a mismatch it never observed. Zero
+/// probes with zero unresolvable is a vacuous pass, and the caller
+/// (first attach, before any resync) is the one that knows that.
+#[test]
+fn an_empty_table_probes_nothing() {
+    let fake = Fake::start(
+        "vempty",
+        AttachBehaviour::default(),
+        LookupBehaviour::Missing,
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(0);
+
+    let out = verify(&mut t, &ledger, &ports, 16, 5).expect("verify");
+    assert_eq!(out.sampled, 0);
+    assert!(
+        fake.observed().is_empty(),
+        "no socket traffic for no routes"
+    );
+    assert!(out.passed());
+}
+
+/// Sampling must actually vary between passes against a live socket,
+/// not just in the unit test — a fixed probe set would pass forever
+/// once those routes installed.
+#[test]
+fn consecutive_passes_probe_different_routes() {
+    let fake = Fake::start(
+        "vresample",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(500);
+
+    let a = verify(&mut t, &ledger, &ports, 32, 1).expect("verify");
+    let b = verify(&mut t, &ledger, &ports, 32, 2).expect("verify");
+    assert_eq!(a.sampled, 32);
+    assert_eq!(b.sampled, 32);
+    // 64 lookups total reached the socket across the two passes.
+    assert_eq!(fake.observed().len(), 64);
+}

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -27,8 +27,9 @@ use packetframe_vpp_offload::vpp_api::codec::{
     SOCKCLNT_CREATE_MSG_ID,
 };
 use packetframe_vpp_offload::vpp_api::generated::{
-    DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteLookupReply, MessageTableEntry,
-    SockclntCreateReply, SwInterfaceSetFlagsReply, MESSAGE_META,
+    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteLookupReply,
+    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
+    MESSAGE_META,
 };
 use packetframe_vpp_offload::vpp_api::Transport;
 
@@ -143,8 +144,21 @@ struct Fake {
     seen: Receiver<String>,
 }
 
+/// `(sw_if_index, name, flags)` the fake reports from
+/// `sw_interface_dump`. `flags` uses IF_STATUS_ADMIN_UP|LINK_UP.
+type Ifaces = Vec<(u32, String, u32)>;
+
 impl Fake {
     fn start(tag: &str, attach: AttachBehaviour, lookup: LookupBehaviour) -> Self {
+        Self::start_with(tag, attach, lookup, vec![(7, "octeon0/0".into(), 3)])
+    }
+
+    fn start_with(
+        tag: &str,
+        attach: AttachBehaviour,
+        lookup: LookupBehaviour,
+        ifaces: Ifaces,
+    ) -> Self {
         let dir = tempdir::TempDir::new(tag).unwrap();
         let path = dir.path().join("api.sock");
         let listener = UnixListener::bind(&path).unwrap();
@@ -242,6 +256,26 @@ impl Fake {
                         }
                         .encode(&mut out);
                     }
+                    // A DUMP: stream one details frame per interface and
+                    // send NO terminator — the trailing control_ping's
+                    // reply is what ends the stream, exactly as VPP does.
+                    "sw_interface_dump" => {
+                        for (idx, name, flags) in &ifaces {
+                            let mut d = reply_head("sw_interface_details");
+                            details(*idx, name, *flags, ctx).encode(&mut d);
+                            write_frame(&mut sock, &d);
+                        }
+                        continue;
+                    }
+                    "control_ping" => {
+                        out = reply_head("control_ping_reply");
+                        ControlPingReply {
+                            context: ctx,
+                            retval: 0,
+                            vpe_pid: 4242,
+                        }
+                        .encode(&mut out);
+                    }
                     other => panic!("fake got unexpected message {other}"),
                 }
                 write_frame(&mut sock, &out);
@@ -269,6 +303,38 @@ impl Fake {
     }
 }
 
+fn details(sw_if_index: u32, name: &str, flags: u32, context: u32) -> SwInterfaceDetails {
+    SwInterfaceDetails {
+        context,
+        sw_if_index,
+        sup_sw_if_index: sw_if_index,
+        l2_address: [0u8; 6],
+        flags,
+        r#type: 0,
+        link_duplex: 0,
+        link_speed: 2_500_000,
+        link_mtu: 9000,
+        mtu: [9000, 0, 0, 0],
+        sub_id: 0,
+        sub_number_of_tags: 0,
+        sub_outer_vlan_id: 0,
+        sub_inner_vlan_id: 0,
+        sub_if_flags: 0,
+        vtr_op: 0,
+        vtr_push_dot1q: 0,
+        vtr_tag1: 0,
+        vtr_tag2: 0,
+        outer_tag: 0,
+        b_dmac: [0u8; 6],
+        b_smac: [0u8; 6],
+        b_vlanid: 0,
+        i_sid: 0,
+        interface_name: name.to_string(),
+        interface_dev_type: "octeon".into(),
+        tag: String::new(),
+    }
+}
+
 fn path_on(sw_if_index: u32) -> FibPath {
     FibPath {
         sw_if_index,
@@ -283,6 +349,15 @@ fn path_on(sw_if_index: u32) -> FibPath {
         n_labels: 0,
         label_stack: Default::default(),
     }
+}
+
+/// Route lookups the fake saw. Verify also issues an interface dump
+/// (dump + trailing ping), so a raw message count is not a probe count.
+fn lookups(f: &Fake) -> usize {
+    f.observed()
+        .iter()
+        .filter(|n| *n == "ip_route_lookup")
+        .count()
 }
 
 fn v4(a: u8, b: u8) -> IpPrefix {
@@ -313,18 +388,22 @@ fn attach_sends_the_three_messages_in_order() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let got = attach_ports(&mut t, &ports()).expect("attach");
+    let got = attach_ports(&mut t, &ports(), &[]).expect("attach");
 
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].port, "eth3");
-    assert_eq!(got[0].dev_index, 3);
+    assert_eq!(got[0].dev_index, Some(3));
     assert_eq!(got[0].sw_if_index, 7);
 
-    // Order is not cosmetic: create_port_if consumes dev_attach's
-    // index, and set_flags consumes create_port_if's.
+    // A discovery dump comes first (so an adopted VPP is not
+    // re-attached), then the attach proper. Order within the attach is
+    // not cosmetic: create_port_if consumes dev_attach's index, and
+    // set_flags consumes create_port_if's.
     assert_eq!(
         fake.observed(),
         vec![
+            "sw_interface_dump".to_string(),
+            "control_ping".to_string(),
             "dev_attach".to_string(),
             "dev_create_port_if".to_string(),
             "sw_interface_set_flags".to_string(),
@@ -347,7 +426,7 @@ fn an_sw_if_index_of_zero_is_refused_as_local0() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports()).expect_err("must refuse index 0");
+    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must refuse index 0");
     assert!(matches!(err, AttachError::LocalZero { .. }), "{err:?}");
     let msg = err.to_string();
     assert!(msg.contains("local0"), "{msg}");
@@ -355,7 +434,12 @@ fn an_sw_if_index_of_zero_is_refused_as_local0() {
     // And it stops there: no interface is brought up on a bad index.
     assert_eq!(
         fake.observed(),
-        vec!["dev_attach".to_string(), "dev_create_port_if".to_string()]
+        vec![
+            "sw_interface_dump".to_string(),
+            "control_ping".to_string(),
+            "dev_attach".to_string(),
+            "dev_create_port_if".to_string()
+        ]
     );
 }
 
@@ -370,13 +454,20 @@ fn a_refused_dev_attach_reports_vpps_own_text() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports()).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_attach"), "{msg}");
     assert!(msg.contains("eth3"), "names the port: {msg}");
     assert!(msg.contains("no such driver"), "keeps VPP's detail: {msg}");
     // Nothing further is attempted.
-    assert_eq!(fake.observed(), vec!["dev_attach".to_string()]);
+    assert_eq!(
+        fake.observed(),
+        vec![
+            "sw_interface_dump".to_string(),
+            "control_ping".to_string(),
+            "dev_attach".to_string()
+        ]
+    );
 }
 
 /// A `dev_attach` that succeeds followed by a `dev_create_port_if` that
@@ -394,15 +485,80 @@ fn a_refused_create_port_if_names_the_step_that_failed() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports()).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_create_port_if"), "{msg}");
     assert!(msg.contains("-11"), "reports the retval: {msg}");
     // The device attached; only the port interface failed. No admin-up.
     assert_eq!(
         fake.observed(),
-        vec!["dev_attach".to_string(), "dev_create_port_if".to_string()]
+        vec![
+            "sw_interface_dump".to_string(),
+            "control_ping".to_string(),
+            "dev_attach".to_string(),
+            "dev_create_port_if".to_string()
+        ]
     );
+}
+
+/// Adoption: VPP already has the interface, and the live FIB is already
+/// pointing at its index. Re-issuing `dev_attach` there would either be
+/// refused — fatal in this module, so it would cycle a healthy and
+/// possibly steered VPP — or create a duplicate interface nothing
+/// references.
+#[test]
+fn a_recorded_interface_is_reused_not_re_attached() {
+    let fake = Fake::start_with(
+        "adopt",
+        AttachBehaviour::default(),
+        LookupBehaviour::Missing,
+        vec![(7, "octeon0/0".into(), 3)],
+    );
+    let mut t = fake.connect();
+    let known = vec![("eth3".to_string(), 7u32)];
+    let got = attach_ports(&mut t, &ports(), &known).expect("adopt");
+
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].sw_if_index, 7);
+    assert_eq!(got[0].dev_index, None, "not attached this pass");
+
+    let seen = fake.observed();
+    assert!(
+        !seen.contains(&"dev_attach".to_string()),
+        "must not re-attach a device VPP already has: {seen:?}"
+    );
+    assert!(
+        !seen.contains(&"dev_create_port_if".to_string()),
+        "must not create a duplicate interface: {seen:?}"
+    );
+    // Admin-up IS re-asserted: controller deploys can flap state, and
+    // this is the reconcile point.
+    assert!(
+        seen.contains(&"sw_interface_set_flags".to_string()),
+        "{seen:?}"
+    );
+}
+
+/// A recorded index VPP no longer has must be refused, not silently
+/// re-attached: we cannot tell whether a live FIB still references the
+/// old index, and a duplicate would leave routes pointing at nothing.
+#[test]
+fn a_stale_recorded_index_is_refused() {
+    let fake = Fake::start_with(
+        "stale",
+        AttachBehaviour::default(),
+        LookupBehaviour::Missing,
+        // VPP has local0 only — index 7 is gone.
+        vec![(0, "local0".into(), 3)],
+    );
+    let mut t = fake.connect();
+    let known = vec![("eth3".to_string(), 7u32)];
+    let err = attach_ports(&mut t, &ports(), &known).expect_err("must refuse");
+    assert!(matches!(err, AttachError::StaleIndex { .. }), "{err:?}");
+    let msg = err.to_string();
+    assert!(msg.contains("no longer has it"), "{msg}");
+    let seen = fake.observed();
+    assert!(!seen.contains(&"dev_attach".to_string()), "{seen:?}");
 }
 
 /// A ledger holding `n` installed prefixes, all resolvable.
@@ -432,7 +588,7 @@ fn verify_passes_when_every_probe_finds_a_route_on_an_owned_interface() {
     assert_eq!(out.sampled, 16);
     assert!(out.mismatches.is_empty(), "{:?}", out.mismatches);
     assert!(out.passed(), "{}", out.summary());
-    assert_eq!(fake.observed().len(), 16, "one lookup per probe");
+    assert_eq!(lookups(&fake), 16, "one lookup per probe");
 }
 
 /// The silent-blackhole check, from the readback side: VPP happily
@@ -522,12 +678,13 @@ fn verify_fails_on_unresolvable_even_with_clean_probes() {
     assert!(!out.passed(), "{}", out.summary());
 }
 
-/// An empty ledger cannot be verified into a pass by sampling nothing —
-/// but it also must not report a mismatch it never observed. Zero
-/// probes with zero unresolvable is a vacuous pass, and the caller
-/// (first attach, before any resync) is the one that knows that.
+/// An empty ledger must NOT pass. Sampling nothing proves nothing, and
+/// a resync completing against an unexpectedly empty mirror would
+/// otherwise verify clean — letting the supervisor steer traffic into a
+/// VPP with an empty FIB, which is the blackhole rule 1 exists to
+/// prevent, reached through the gate meant to prevent it.
 #[test]
-fn an_empty_table_probes_nothing() {
+fn an_empty_table_fails_rather_than_passing_vacuously() {
     let fake = Fake::start(
         "vempty",
         AttachBehaviour::default(),
@@ -539,10 +696,72 @@ fn an_empty_table_probes_nothing() {
     let out = verify(&mut t, &ledger, &ports, 16, 5).expect("verify");
     assert_eq!(out.sampled, 0);
     assert!(
-        fake.observed().is_empty(),
-        "no socket traffic for no routes"
+        out.mismatches.is_empty(),
+        "nothing was observed to mismatch"
     );
-    assert!(out.passed());
+    assert!(!out.passed(), "zero probes is not evidence of health");
+    assert!(
+        out.summary().contains("no installed routes"),
+        "{}",
+        out.summary()
+    );
+    // No routes were probed; only the interface dump touched the socket.
+    assert_eq!(lookups(&fake), 0);
+}
+
+/// The check the route probes structurally cannot make. A VF that is
+/// admin-up with no carrier keeps every route on a valid, owned
+/// `sw_if_index` — so every probe passes and we would steer into an
+/// interface that forwards nothing. `set_admin_up` only ever asserted
+/// the administrative flag; the runbook treats link-up as the bring-up
+/// pass for exactly this reason.
+#[test]
+fn verify_fails_when_an_owned_interface_has_no_carrier() {
+    let fake = Fake::start_with(
+        "nolink",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+        // admin up (1), link DOWN — no 2 bit.
+        vec![(7, "octeon0/0".into(), 1)],
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(50);
+
+    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    assert!(
+        out.mismatches.is_empty(),
+        "every route probe looks perfect: {:?}",
+        out.mismatches
+    );
+    assert_eq!(out.dead_interfaces.len(), 1);
+    assert_eq!(out.dead_interfaces[0].sw_if_index, 7);
+    assert!(out.dead_interfaces[0].admin_up);
+    assert!(!out.dead_interfaces[0].link_up);
+    assert!(!out.passed(), "{}", out.summary());
+    assert!(out.summary().contains("link_up=false"), "{}", out.summary());
+}
+
+/// An interface we do NOT own being down is not our problem and must
+/// not fail our verify — otherwise any unrelated down interface on the
+/// box blocks steering forever.
+#[test]
+fn verify_ignores_link_state_on_interfaces_we_do_not_own() {
+    let fake = Fake::start_with(
+        "otherdown",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+        vec![
+            (7, "octeon0/0".into(), 3), // ours, up
+            (9, "octeon1/0".into(), 1), // not ours, link down
+            (0, "local0".into(), 0),    // local0, entirely down
+        ],
+    );
+    let mut t = fake.connect();
+    let (ledger, ports) = ledger_with(50);
+
+    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    assert!(out.dead_interfaces.is_empty(), "{:?}", out.dead_interfaces);
+    assert!(out.passed(), "{}", out.summary());
 }
 
 /// Sampling must actually vary between passes against a live socket,
@@ -563,5 +782,5 @@ fn consecutive_passes_probe_different_routes() {
     assert_eq!(a.sampled, 32);
     assert_eq!(b.sampled, 32);
     // 64 lookups total reached the socket across the two passes.
-    assert_eq!(fake.observed().len(), 64);
+    assert_eq!(lookups(&fake), 64);
 }

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -43,6 +43,15 @@ const MESSAGES: &[&str] = &[
     // Interface state.
     "sw_interface_set_flags",
     "sw_interface_set_flags_reply",
+    // Interface discovery + link state. `sw_interface_dump` is a DUMP:
+    // it streams `sw_interface_details` and is terminated by trailing a
+    // `control_ping`. Two jobs neither of which is optional — adoption
+    // must find the interfaces a surviving VPP already has rather than
+    // re-attaching them, and verification must confirm the link is UP,
+    // since a VF that is admin-up with no carrier keeps every route on
+    // the right index while forwarding nothing.
+    "sw_interface_dump",
+    "sw_interface_details",
     // Native-driver device attach (v7 pivot).
     "dev_attach",
     "dev_attach_reply",


### PR DESCRIPTION
Two more of slice 4's actions — `AttachDevices` and `StartVerify`. Both are API traffic rather than config, which is a consequence of the v7 driver pivot. Branches off `main`; no stack.

## AttachDevices

The native octeon driver takes device identity at runtime, so bringing a VF into VPP is three messages:

```
dev_attach              pci/0002:07:00.1 driver octeon   → dev_index
dev_create_port_if      dev_index, port 0, num_rx_queues → sw_if_index
sw_interface_set_flags  sw_if_index up
```

Sequential rather than pipelined, deliberately: each step consumes the index the previous one returned, there are a handful of ports rather than a million routes, and being able to name exactly which port failed is worth far more than the latency saved.

**`sw_if_index` 0 is refused as a hard error, even when VPP reports success.** Index 0 is `local0`, VPP's drop interface — a FIB path pointing there looks installed and forwards nothing. That's the same silent blackhole the drainer's deferred-index branch exists to prevent, and the worst thing this module could hand downstream.

## StartVerify

Defined now rather than invented during an incident, since steering is gated on it (rule 1).

For a random sample of prefixes the ledger believes are installed, VPP must return a route with ≥1 path, and **every path must egress an interface we own** — that last clause is the valuable one, catching `local0` from the readback side.

Prefixes are **re-sampled every pass**: a fixed probe set passes forever once those few routes install, while the rest of the table rots. But the seed comes from the caller, so a failing verify replays exactly. Seed 0 is special-cased — it's a xorshift fixed point and would have collapsed a 64-probe pass to a single route while still reporting `sampled: 64`.

**`unresolvable > 0` fails the pass; `withheld` does not.** Those are genuinely different conditions. A mapping hole is a misconfiguration and steering into known holes is how a deploy becomes an outage. Withholding is the *designed* response to a table that outgrew its heap — failing verify on it would convert a graceful degradation into a restart loop. Reported separately, because they're different pages at 03:00.

### What a pass does NOT mean

Stated in the module docs so nobody reads more into it than it earns:

- **Not per-path nexthop correctness.** Confirming VPP's paths match bird's intent means holding expected nexthops for ~1.05M prefixes — exactly the memory the ledger deliberately doesn't spend. Encoding is covered by the golden vectors, delivery by the drainer's per-route acks.
- **Not a total route count.** The plan pairs sampling with `show ip fib summary`, which needs `cli_inband` — a message from `vlib.api.json`, not among the vendored `.api.json` files. Until that's vendored, a *uniform* shortfall is caught only stochastically. Recorded as owed rather than quietly dropped.

## On the test fake

It builds reply headers from `MESSAGE_META` instead of assuming `[id][context]`. Not tidiness — `dev_create_port_if_reply` carries a `client_index` and its sibling `dev_attach_reply` doesn't, so a hand-assumed prefix in the fake would have silently agreed with a hand-assumed prefix in the client and proved nothing. It cost the first run of these tests to rediscover, which is roughly the point.

## Verification

- 358 workspace tests (11 new integration against a fake VPP, 22 new unit)
- host clippy `-D warnings` clean; **all four Linux cross-targets linted locally** before pushing
- codegen regenerate-and-diff clean (no `generated.rs` change)

**Next in slice 4:** the executor loop that drives the whole `Action` list, plus the VppSink health/metrics surface. `Steer`/`Unsteer` remain slice 5.