### PR TITLE
feat(vpp-offload): action executor, built invariants-first

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -39,6 +39,21 @@ pub const IF_STATUS_ADMIN_UP: u32 = 1;
 /// `IF_STATUS_API_FLAG_LINK_UP` — carrier, not configuration.
 pub const IF_STATUS_LINK_UP: u32 = 2;
 
+/// Whether the VPP on the other end of the socket is one we just
+/// started or one that was already running.
+///
+/// Explicit rather than inferred from `known` being empty, because the
+/// two genuinely differ: a fresh VPP has no interfaces, so attaching is
+/// always right; an adopted one may already have them, so attaching
+/// without knowing the index is a duplicate waiting to happen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AttachMode {
+    /// We spawned this process; it has no interfaces yet.
+    Fresh,
+    /// This process outlived us and may already own its interfaces.
+    Adopted,
+}
+
 /// What to attach: one member port's VF.
 #[derive(Debug, Clone)]
 pub struct PortAttach {
@@ -95,6 +110,17 @@ pub enum AttachError {
         port: String,
         sw_if_index: u32,
     },
+    /// We adopted a live VPP but have no recorded index for this port.
+    ///
+    /// Reachable without any schema mishap: process identity is
+    /// persisted at spawn and the interface index only after attach, so
+    /// a crash between those writes leaves a valid adoptable process
+    /// and no index. Attaching would duplicate an interface the running
+    /// VPP may already have, and the dump cannot disambiguate ports, so
+    /// a clean restart is the only safe answer.
+    UnknownIndexOnAdopt {
+        port: String,
+    },
 }
 
 impl std::fmt::Display for AttachError {
@@ -118,6 +144,11 @@ impl std::fmt::Display for AttachError {
                 "state file records sw_if_index {sw_if_index} for {port} but VPP no longer has \
                  it; refusing to attach a duplicate while a live FIB may still reference the old \
                  index"
+            ),
+            AttachError::UnknownIndexOnAdopt { port } => write!(
+                f,
+                "adopted a running VPP but no sw_if_index is recorded for {port}; refusing to \
+                 attach a possibly-duplicate interface — restart cleanly instead"
             ),
             AttachError::LocalZero { port } => write!(
                 f,
@@ -163,10 +194,21 @@ impl From<TransportError> for AttachError {
 /// address, so on a box with several member ports `octeon0/0` and
 /// `octeon1/0` are indistinguishable by port id alone. Guessing there
 /// would map a port to the wrong VF, which is worse than not adopting.
+///
+/// `mode` says whether the process on the other end of this socket was
+/// adopted or freshly spawned, and it is **not** derivable from `known`
+/// being empty. There is a real window in which we adopted a live VPP
+/// and yet have no recorded index: the state file records process
+/// identity at spawn and the interface index only after attach, so a
+/// crash between those two writes — after `dev_create_port_if` already
+/// succeeded — leaves exactly that combination. Blind-attaching there is
+/// the duplicate-interface case this function exists to avoid, so
+/// [`AttachMode::Adopted`] with a missing index refuses instead.
 pub fn attach_ports(
     t: &mut Transport,
     ports: &[PortAttach],
     known: &[(String, u32)],
+    mode: AttachMode,
 ) -> Result<Vec<AttachedPort>, AttachError> {
     // One dump for the whole pass: it both confirms recorded indices
     // still exist and is the only way to see link state.
@@ -177,6 +219,17 @@ pub fn attach_ports(
             .iter()
             .find(|(name, _)| *name == p.port)
             .map(|(_, idx)| *idx);
+
+        if recorded.is_none() && mode == AttachMode::Adopted {
+            // We are talking to a VPP that was already running, and we
+            // do not know what index it gave this port. It may already
+            // have the interface; attaching would duplicate it, and
+            // guessing from the dump is ruled out above. Refuse and let
+            // the supervisor restart cleanly instead.
+            return Err(AttachError::UnknownIndexOnAdopt {
+                port: p.port.clone(),
+            });
+        }
 
         if let Some(idx) = recorded {
             if existing.iter().any(|i| i.sw_if_index == idx) {

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -114,16 +114,21 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
 
     for action in actions {
         match action {
-            Action::Unsteer => match fx.unsteer() {
-                Ok(()) => {}
+            Action::Unsteer => out.events.push(match fx.unsteer() {
+                // Acknowledged, so the supervisor may believe steering
+                // is down. Reporting this rather than letting `fail()`
+                // assume it is what stops a later teardown from
+                // releasing a VF that MCAM is still pointing at.
+                Ok(()) => Event::Unsteered,
                 Err(e) => {
                     // Traffic is still being diverted to a dataplane we
                     // are about to stop supervising. Loud, and it
                     // forfeits the right to release the VF.
                     out.failures.push((*action, e));
                     teardown_clean = false;
+                    Event::UnsteerFailed
                 }
-            },
+            }),
             Action::Kill => {
                 if fx.kill() == Disposition::MustLeak {
                     out.failures.push((
@@ -131,6 +136,10 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                         "process survived termination; resources must not be released".into(),
                     ));
                     teardown_clean = false;
+                    // Not just a leaked VF: the restart must not spawn a
+                    // second VPP while this one can still own the API
+                    // socket and DMA through the VF.
+                    out.events.push(Event::TerminationFailed);
                 }
             }
             Action::Spawn => out.events.push(match fx.spawn() {
@@ -678,6 +687,99 @@ mod tests {
         );
         step(&mut sup, &mut r, Event::ConvergenceStopped);
         assert!(sup.may_restart());
+    }
+
+    /// The cross-batch hole. A failed `Unsteer` used to be forgotten
+    /// when `execute` returned, *and* the supervisor cleared `steered`
+    /// optimistically — so a later `StopRequested` emitted no `Unsteer`
+    /// at all and its fresh, clean batch released a VF that MCAM was
+    /// still pointing traffic at.
+    #[test]
+    fn a_failed_unsteer_still_withholds_the_vf_in_a_later_batch() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder {
+            fail_unsteer: true,
+            ..Default::default()
+        };
+        bring_up_steered(&mut sup, &mut r);
+
+        // Crash while steered. The unsteer fails.
+        step(&mut sup, &mut r, Event::ProcessExited { status: None });
+        assert!(
+            sup.is_steered(),
+            "a failed unsteer must NOT be recorded as unsteered"
+        );
+
+        // Now a clean stop, in a brand-new batch.
+        r.calls.clear();
+        let actions = sup.on(Event::StopRequested);
+        assert!(
+            actions.contains(&Action::Unsteer),
+            "the retry must be attempted because we still believe we steer: {actions:?}"
+        );
+        let out = execute(&actions, &mut r);
+        assert!(
+            !r.calls.contains(&"release"),
+            "the VF is still receiving diverted traffic: {:?}",
+            r.calls
+        );
+        assert!(out.resources_leaked);
+    }
+
+    /// The same path when the unsteer eventually succeeds: the VF is
+    /// then genuinely ours to release.
+    #[test]
+    fn an_unsteer_that_succeeds_on_retry_permits_release() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder {
+            fail_unsteer: true,
+            ..Default::default()
+        };
+        bring_up_steered(&mut sup, &mut r);
+        step(&mut sup, &mut r, Event::ProcessExited { status: None });
+        assert!(sup.is_steered());
+
+        r.fail_unsteer = false;
+        r.calls.clear();
+        let actions = sup.on(Event::StopRequested);
+        let out = execute(&actions, &mut r);
+        assert_eq!(r.calls, vec!["unsteer", "kill", "release"]);
+        assert!(out.ok());
+        // Feeding the ack back settles the belief.
+        for e in out.events {
+            sup.on(e);
+        }
+        assert!(!sup.is_steered());
+    }
+
+    /// A process that survived termination must not be joined by a
+    /// second one. `ArmBackoff` alone would let `BackoffElapsed` spawn
+    /// another VPP onto the same API socket and VF.
+    #[test]
+    fn a_process_that_survives_kill_blocks_the_restart() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder {
+            kill_disposition: Some(Disposition::MustLeak),
+            ..Default::default()
+        };
+        step(&mut sup, &mut r, Event::StartRequested);
+        step(&mut sup, &mut r, Event::Wedged);
+
+        assert_eq!(sup.state(), State::Backoff);
+        assert!(sup.is_undead(), "the old process may still be alive");
+        assert!(
+            !sup.may_restart(),
+            "a second VPP on the same VF is worse than staying down"
+        );
+
+        // The pidfd eventually reports the exit; only then may we retry.
+        sup.on(Event::ProcessExited { status: None });
+        assert!(!sup.is_undead());
+        assert!(sup.may_restart());
+        r.calls.clear();
+        r.kill_disposition = None;
+        step(&mut sup, &mut r, Event::BackoffElapsed);
+        assert_eq!(r.calls, vec!["spawn"]);
     }
 
     /// A clean stop releases resources; a stop whose teardown fails does

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -1,0 +1,710 @@
+//! Turns the supervisor's [`Action`] list into real effects.
+//!
+//! The supervisor decides *what* must happen and in *what order*; this
+//! carries it out and reports back what actually happened. Keeping the
+//! two apart is what lets the decisions be tested without a process and
+//! the execution be tested without a decision.
+//!
+//! **This module is where the ordering rules stop being advisory.** The
+//! supervisor returns a `Vec<Action>` whose order encodes an outage —
+//! "unsteer then kill" and "kill then unsteer" differ by however long
+//! MCAM keeps pointing traffic at a dead VF. An interpreter that
+//! reordered, skipped, or continued blindly past a failure would
+//! silently undo every guarantee upstream of it, and nothing in the
+//! supervisor's own tests could notice.
+//!
+//! So the effects are a trait, and the rules below are tested against a
+//! recording fake rather than trusted to review:
+//!
+//! 1. Actions run in the order given, with none skipped.
+//! 2. `ReleaseResources` is withheld unless teardown actually
+//!    succeeded — see [`Outcome::resources_leaked`].
+//! 3. Every action that can fail produces either a follow-up event the
+//!    supervisor understands, or a recorded failure. Silence is never
+//!    an outcome.
+
+use std::time::Duration;
+
+use crate::process::Disposition;
+use crate::supervisor::{Action, Event};
+
+/// Everything the executor does to the world outside itself.
+///
+/// A trait so the ordering and failure-handling rules can be tested
+/// against a recorder. The real implementation lands with the tick loop;
+/// `Steer`/`Unsteer` stay unimplemented until slice 5 builds MCAM, and
+/// deliberately **fail loudly** there rather than returning `Ok(())` —
+/// a no-op steer that reports success would let the supervisor believe
+/// traffic is diverted when nothing is, which is worse than not having
+/// the feature.
+pub trait Effects {
+    fn spawn(&mut self) -> Result<(), String>;
+
+    /// Remove MCAM steering rules. First in any teardown.
+    fn unsteer(&mut self) -> Result<(), String>;
+
+    /// Install MCAM steering rules.
+    fn steer(&mut self) -> Result<(), String>;
+
+    /// Stop the process. Returns whether its resources may be released
+    /// — see [`Disposition`].
+    fn kill(&mut self) -> Disposition;
+
+    fn attach_devices(&mut self) -> Result<(), String>;
+
+    /// Begin (not complete) a FIB resync. The drain proceeds across
+    /// ticks so the API ping and pidfd stay serviced; `SyncComplete`
+    /// comes from the loop, not from here.
+    fn start_resync(&mut self) -> Result<(), String>;
+
+    fn start_verify(&mut self) -> Result<(), String>;
+
+    /// Stop an in-flight resync/verify. Confirmation arrives later as
+    /// `Event::ConvergenceStopped`, so this cannot fail meaningfully.
+    fn abort_convergence(&mut self);
+
+    fn arm_backoff(&mut self, delay: Duration);
+
+    /// Release VF/hugepage resources. Only ever called when teardown
+    /// succeeded; see rule 2.
+    fn release_resources(&mut self) -> Result<(), String>;
+}
+
+/// What executing a batch of actions produced.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    /// Events to feed back into the supervisor, in order.
+    pub events: Vec<Event>,
+    /// Actions that failed, with the reason, for status and logs.
+    pub failures: Vec<(Action, String)>,
+    /// Resources were NOT released because teardown did not fully
+    /// succeed.
+    ///
+    /// The alternative to leaking is unbinding a VF or handing back
+    /// hugepages while a process may still be DMAing into them, or
+    /// while MCAM is still steering traffic at that VF. Both are memory
+    /// corruption or a hard blackhole; a leaked VF is a line in
+    /// `packetframe status` and a reboot's worth of inconvenience.
+    pub resources_leaked: bool,
+}
+
+impl Outcome {
+    pub fn ok(&self) -> bool {
+        self.failures.is_empty() && !self.resources_leaked
+    }
+}
+
+/// Execute `actions` in order, in full.
+///
+/// Failures are recorded and execution continues, with one exception
+/// that is the whole point of rule 2: a failed `Unsteer`, or a `Kill`
+/// that reports [`Disposition::MustLeak`], suppresses any later
+/// `ReleaseResources`.
+///
+/// Why continue at all after a failure? Because the remaining actions
+/// are usually the ones that contain the damage. If `Unsteer` fails,
+/// abandoning the batch leaves a wedged VPP running *and* traffic
+/// pointed at it; carrying on at least stops the process. What must not
+/// happen is handing the resources back, and that is what gets
+/// suppressed.
+pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
+    let mut out = Outcome::default();
+    // Set by anything that makes releasing resources unsafe.
+    let mut teardown_clean = true;
+
+    for action in actions {
+        match action {
+            Action::Unsteer => match fx.unsteer() {
+                Ok(()) => {}
+                Err(e) => {
+                    // Traffic is still being diverted to a dataplane we
+                    // are about to stop supervising. Loud, and it
+                    // forfeits the right to release the VF.
+                    out.failures.push((*action, e));
+                    teardown_clean = false;
+                }
+            },
+            Action::Kill => {
+                if fx.kill() == Disposition::MustLeak {
+                    out.failures.push((
+                        *action,
+                        "process survived termination; resources must not be released".into(),
+                    ));
+                    teardown_clean = false;
+                }
+            }
+            Action::Spawn => out.events.push(match fx.spawn() {
+                Ok(()) => Event::Spawned,
+                Err(e) => {
+                    out.failures.push((*action, e));
+                    // No process exists, so no pidfd will ever report
+                    // an exit — the retry has to be driven from here.
+                    Event::SpawnFailed
+                }
+            }),
+            Action::AttachDevices => {
+                if let Err(e) = fx.attach_devices() {
+                    out.failures.push((*action, e));
+                    out.events.push(Event::ConvergenceFailed);
+                }
+            }
+            Action::StartResync => {
+                if let Err(e) = fx.start_resync() {
+                    out.failures.push((*action, e));
+                    out.events.push(Event::ConvergenceFailed);
+                }
+            }
+            Action::StartVerify => {
+                if let Err(e) = fx.start_verify() {
+                    out.failures.push((*action, e));
+                    out.events.push(Event::ConvergenceFailed);
+                }
+            }
+            Action::Steer => out.events.push(match fx.steer() {
+                Ok(()) => Event::Steered,
+                Err(e) => {
+                    out.failures.push((*action, e));
+                    // Verified but not steered: reported, not papered
+                    // over, and NOT a process restart — the dataplane
+                    // is fine.
+                    Event::SteerFailed
+                }
+            }),
+            Action::AbortConvergence => fx.abort_convergence(),
+            Action::ArmBackoff(d) => fx.arm_backoff(*d),
+            Action::ReleaseResources => {
+                if !teardown_clean {
+                    out.resources_leaked = true;
+                    continue;
+                }
+                if let Err(e) = fx.release_resources() {
+                    out.failures.push((*action, e));
+                }
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Records calls in order and fails whichever ones it is told to.
+    #[derive(Default)]
+    struct Recorder {
+        calls: Vec<&'static str>,
+        fail_unsteer: bool,
+        fail_steer: bool,
+        fail_spawn: bool,
+        fail_attach: bool,
+        fail_resync: bool,
+        fail_verify: bool,
+        fail_release: bool,
+        kill_disposition: Option<Disposition>,
+    }
+
+    impl Effects for Recorder {
+        fn spawn(&mut self) -> Result<(), String> {
+            self.calls.push("spawn");
+            err_if(self.fail_spawn, "no such binary")
+        }
+        fn unsteer(&mut self) -> Result<(), String> {
+            self.calls.push("unsteer");
+            err_if(self.fail_unsteer, "ioctl refused")
+        }
+        fn steer(&mut self) -> Result<(), String> {
+            self.calls.push("steer");
+            err_if(self.fail_steer, "no free MCAM loc")
+        }
+        fn kill(&mut self) -> Disposition {
+            self.calls.push("kill");
+            self.kill_disposition.unwrap_or(Disposition::SafeToRelease)
+        }
+        fn attach_devices(&mut self) -> Result<(), String> {
+            self.calls.push("attach");
+            err_if(self.fail_attach, "dev_attach refused")
+        }
+        fn start_resync(&mut self) -> Result<(), String> {
+            self.calls.push("resync");
+            err_if(self.fail_resync, "socket closed")
+        }
+        fn start_verify(&mut self) -> Result<(), String> {
+            self.calls.push("verify");
+            err_if(self.fail_verify, "socket closed")
+        }
+        fn abort_convergence(&mut self) {
+            self.calls.push("abort");
+        }
+        fn arm_backoff(&mut self, _d: Duration) {
+            self.calls.push("backoff");
+        }
+        fn release_resources(&mut self) -> Result<(), String> {
+            self.calls.push("release");
+            err_if(self.fail_release, "numvfs write failed")
+        }
+    }
+
+    fn err_if(cond: bool, msg: &str) -> Result<(), String> {
+        if cond {
+            Err(msg.to_string())
+        } else {
+            Ok(())
+        }
+    }
+
+    // ---- Invariant 1: order is preserved, nothing is skipped ----
+
+    /// The teardown order IS the ≤50 ms number. Reordering these two is
+    /// not a style question; it is how long MCAM keeps pointing traffic
+    /// at a VF nothing is servicing.
+    #[test]
+    fn teardown_unsteers_before_it_kills() {
+        let mut r = Recorder::default();
+        let out = execute(
+            &[
+                Action::Unsteer,
+                Action::Kill,
+                Action::ArmBackoff(Duration::from_millis(250)),
+            ],
+            &mut r,
+        );
+        assert_eq!(r.calls, vec!["unsteer", "kill", "backoff"]);
+        assert!(out.ok());
+    }
+
+    /// Devices before routes: a FIB path references an `sw_if_index`
+    /// that does not exist until the device is attached.
+    #[test]
+    fn convergence_attaches_before_it_resyncs() {
+        let mut r = Recorder::default();
+        execute(&[Action::AttachDevices, Action::StartResync], &mut r);
+        assert_eq!(r.calls, vec!["attach", "resync"]);
+    }
+
+    #[test]
+    fn every_action_is_executed_exactly_once() {
+        let mut r = Recorder::default();
+        execute(
+            &[
+                Action::Unsteer,
+                Action::AbortConvergence,
+                Action::Kill,
+                Action::ArmBackoff(Duration::from_secs(1)),
+            ],
+            &mut r,
+        );
+        assert_eq!(r.calls, vec!["unsteer", "abort", "kill", "backoff"]);
+    }
+
+    // ---- Invariant 2: resources are never released under a live
+    // process or live steering ----
+
+    /// The invariant this module exists to hold. A process that
+    /// survived SIGKILL may still be DMAing into the buffers we are
+    /// about to hand back to the kernel.
+    #[test]
+    fn a_process_that_survives_kill_blocks_resource_release() {
+        let mut r = Recorder {
+            kill_disposition: Some(Disposition::MustLeak),
+            ..Default::default()
+        };
+        let out = execute(&[Action::Kill, Action::ReleaseResources], &mut r);
+
+        assert_eq!(r.calls, vec!["kill"], "release must not be attempted");
+        assert!(out.resources_leaked);
+        assert!(!out.ok());
+    }
+
+    /// Same invariant from the other direction: if steering is still up,
+    /// the VF is still receiving diverted traffic, so it is not ours to
+    /// give back.
+    #[test]
+    fn a_failed_unsteer_blocks_resource_release() {
+        let mut r = Recorder {
+            fail_unsteer: true,
+            ..Default::default()
+        };
+        let out = execute(
+            &[Action::Unsteer, Action::Kill, Action::ReleaseResources],
+            &mut r,
+        );
+
+        assert_eq!(
+            r.calls,
+            vec!["unsteer", "kill"],
+            "the kill still happens — abandoning the batch would leave a \
+             wedged VPP running AND traffic pointed at it"
+        );
+        assert!(out.resources_leaked);
+        assert!(out.failures.iter().any(|(a, _)| *a == Action::Unsteer));
+    }
+
+    /// A clean teardown does release.
+    #[test]
+    fn a_clean_teardown_releases_resources() {
+        let mut r = Recorder::default();
+        let out = execute(
+            &[Action::Unsteer, Action::Kill, Action::ReleaseResources],
+            &mut r,
+        );
+        assert_eq!(r.calls, vec!["unsteer", "kill", "release"]);
+        assert!(!out.resources_leaked);
+        assert!(out.ok());
+    }
+
+    /// A release that fails on its own is a failure but not a leak: we
+    /// had the right to release, the write just did not land.
+    #[test]
+    fn a_failed_release_is_reported_without_claiming_a_leak() {
+        let mut r = Recorder {
+            fail_release: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::Kill, Action::ReleaseResources], &mut r);
+        assert!(!out.resources_leaked);
+        assert!(out
+            .failures
+            .iter()
+            .any(|(a, _)| *a == Action::ReleaseResources));
+    }
+
+    // ---- Invariant 3: no action fails silently ----
+
+    #[test]
+    fn a_failed_spawn_reports_an_event_the_supervisor_understands() {
+        let mut r = Recorder {
+            fail_spawn: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::Spawn], &mut r);
+        assert_eq!(out.events, vec![Event::SpawnFailed]);
+        assert!(out.failures.iter().any(|(a, _)| *a == Action::Spawn));
+    }
+
+    #[test]
+    fn a_successful_spawn_reports_spawned() {
+        let mut r = Recorder::default();
+        let out = execute(&[Action::Spawn], &mut r);
+        assert_eq!(out.events, vec![Event::Spawned]);
+        assert!(out.ok());
+    }
+
+    /// Steering that could not be installed must say so, not report
+    /// success — the supervisor gates `Steered` on this acknowledgement
+    /// precisely so a failed MCAM install cannot look like a steered
+    /// dataplane.
+    #[test]
+    fn a_failed_steer_reports_steer_failed_not_steered() {
+        let mut r = Recorder {
+            fail_steer: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::Steer], &mut r);
+        assert_eq!(out.events, vec![Event::SteerFailed]);
+        assert!(!out.events.contains(&Event::Steered));
+    }
+
+    #[test]
+    fn a_successful_steer_reports_steered() {
+        let mut r = Recorder::default();
+        let out = execute(&[Action::Steer], &mut r);
+        assert_eq!(out.events, vec![Event::Steered]);
+    }
+
+    /// A deterministic pipeline failure must not be left for the phase
+    /// timeout to notice two minutes later.
+    #[test]
+    fn a_failed_attach_reports_convergence_failed_immediately() {
+        let mut r = Recorder {
+            fail_attach: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::AttachDevices, Action::StartResync], &mut r);
+        assert!(out.events.contains(&Event::ConvergenceFailed));
+        // The batch still completes; the supervisor decides what the
+        // events mean, not this loop.
+        assert_eq!(r.calls, vec!["attach", "resync"]);
+    }
+
+    #[test]
+    fn a_failed_resync_reports_convergence_failed() {
+        let mut r = Recorder {
+            fail_resync: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::StartResync], &mut r);
+        assert_eq!(out.events, vec![Event::ConvergenceFailed]);
+    }
+
+    #[test]
+    fn a_failed_verify_start_reports_convergence_failed() {
+        let mut r = Recorder {
+            fail_verify: true,
+            ..Default::default()
+        };
+        let out = execute(&[Action::StartVerify], &mut r);
+        assert_eq!(out.events, vec![Event::ConvergenceFailed]);
+    }
+
+    /// Actions with nothing to report stay silent, so the supervisor is
+    /// not fed events that did not happen.
+    #[test]
+    fn actions_with_no_outcome_emit_no_events() {
+        let mut r = Recorder::default();
+        let out = execute(
+            &[
+                Action::AbortConvergence,
+                Action::ArmBackoff(Duration::from_secs(1)),
+                Action::AttachDevices,
+                Action::StartResync,
+                Action::StartVerify,
+                Action::Kill,
+            ],
+            &mut r,
+        );
+        assert!(out.events.is_empty(), "{:?}", out.events);
+        assert!(out.ok());
+    }
+
+    #[test]
+    fn an_empty_batch_does_nothing() {
+        let mut r = Recorder::default();
+        let out = execute(&[], &mut r);
+        assert!(r.calls.is_empty());
+        assert_eq!(out, Outcome::default());
+    }
+
+    // ---- The two halves composed ----
+    //
+    // Each half is tested in isolation above and in supervisor.rs. What
+    // neither can catch alone is a mistake in the seam: an event the
+    // executor produces that the supervisor mishandles, or a batch whose
+    // follow-up events drive the wrong next batch. These drive both
+    // together, feeding executor output back in as supervisor input.
+
+    use crate::supervisor::{State, Supervisor};
+
+    /// Apply one event, execute what it asks for, and feed the resulting
+    /// events back until the system settles.
+    fn step(sup: &mut Supervisor, r: &mut Recorder, event: Event) {
+        let mut pending = vec![event];
+        // Bounded: a seam that will not settle is itself the bug, and an
+        // unbounded loop would hang the suite instead of reporting it.
+        for _ in 0..16 {
+            if pending.is_empty() {
+                return;
+            }
+            let mut next = Vec::new();
+            for e in pending.drain(..) {
+                let actions = sup.on(e);
+                next.extend(execute(&actions, r).events);
+            }
+            pending = next;
+        }
+        panic!("the supervisor/executor seam did not settle");
+    }
+
+    fn bring_up_steered(sup: &mut Supervisor, r: &mut Recorder) {
+        step(sup, r, Event::StartRequested);
+        step(sup, r, Event::ApiUp);
+        step(sup, r, Event::SyncComplete);
+        step(sup, r, Event::VerifyPassed);
+        // First attach does not steer itself — that is the operator's
+        // canary lever. Do it explicitly.
+        step(sup, r, Event::Steered);
+        assert_eq!(sup.state(), State::Steered);
+        assert!(sup.is_steered());
+    }
+
+    #[test]
+    fn a_crash_while_steered_unsteers_first_then_restarts() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+        bring_up_steered(&mut sup, &mut r);
+        r.calls.clear();
+
+        step(&mut sup, &mut r, Event::ProcessExited { status: None });
+
+        assert_eq!(
+            r.calls.first(),
+            Some(&"unsteer"),
+            "steering must come down before anything else: {:?}",
+            r.calls
+        );
+        assert!(r.calls.contains(&"kill"));
+        assert!(r.calls.contains(&"backoff"));
+        assert!(!sup.is_steered());
+        assert_eq!(sup.state(), State::Backoff);
+        // Crucially: no resource release on a crash we intend to recover
+        // from.
+        assert!(!r.calls.contains(&"release"), "{:?}", r.calls);
+    }
+
+    /// The full recovery, end to end: crash while steered → restart →
+    /// resync → verify → steering restored, and in that order.
+    #[test]
+    fn recovery_restores_steering_only_after_a_verified_resync() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+        bring_up_steered(&mut sup, &mut r);
+
+        step(&mut sup, &mut r, Event::ProcessExited { status: None });
+        r.calls.clear();
+
+        step(&mut sup, &mut r, Event::BackoffElapsed);
+        step(&mut sup, &mut r, Event::ApiUp);
+        step(&mut sup, &mut r, Event::SyncComplete);
+        step(&mut sup, &mut r, Event::VerifyPassed);
+
+        // The order of the recovery is the invariant: attach, then
+        // routes, then verify, and only then traffic.
+        let pos = |name: &str| r.calls.iter().position(|c| *c == name);
+        let (attach, resync, verify, steer) = (
+            pos("attach").expect("attached"),
+            pos("resync").expect("resynced"),
+            pos("verify").expect("verified"),
+            pos("steer").expect("steered"),
+        );
+        assert!(attach < resync, "devices before routes: {:?}", r.calls);
+        assert!(resync < verify, "routes before verification: {:?}", r.calls);
+        assert!(
+            verify < steer,
+            "traffic must not be diverted before the FIB is verified: {:?}",
+            r.calls
+        );
+        assert_eq!(sup.state(), State::Steered);
+        assert!(sup.is_steered());
+    }
+
+    /// Adoption composed: a surviving steered VPP is resynced and
+    /// verified with traffic still flowing, and `unsteer` is never
+    /// called.
+    #[test]
+    fn adoption_never_unsteers_a_forwarding_dataplane() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+
+        step(&mut sup, &mut r, Event::Adopted { steered: true });
+        step(&mut sup, &mut r, Event::SyncComplete);
+        step(&mut sup, &mut r, Event::VerifyPassed);
+
+        assert!(
+            !r.calls.contains(&"unsteer"),
+            "tearing steering down to rebuild it is the outage adoption avoids: {:?}",
+            r.calls
+        );
+        assert!(!r.calls.contains(&"spawn"), "{:?}", r.calls);
+        assert_eq!(sup.state(), State::Steered);
+    }
+
+    /// A failed steer during recovery must leave the system verified but
+    /// NOT steered, and must not restart the process — the dataplane is
+    /// healthy, so cycling it would trade an idle forwarder for an
+    /// outage.
+    #[test]
+    fn a_failed_steer_during_recovery_does_not_cycle_the_process() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+        bring_up_steered(&mut sup, &mut r);
+        step(&mut sup, &mut r, Event::ProcessExited { status: None });
+        step(&mut sup, &mut r, Event::BackoffElapsed);
+        step(&mut sup, &mut r, Event::ApiUp);
+        step(&mut sup, &mut r, Event::SyncComplete);
+
+        r.fail_steer = true;
+        r.calls.clear();
+        step(&mut sup, &mut r, Event::VerifyPassed);
+
+        assert!(
+            r.calls.contains(&"steer"),
+            "it was attempted: {:?}",
+            r.calls
+        );
+        assert_eq!(sup.state(), State::Ready, "verified but not steered");
+        assert!(!sup.is_steered());
+        assert!(
+            !r.calls.contains(&"kill"),
+            "a healthy dataplane must not be cycled for a steering failure: {:?}",
+            r.calls
+        );
+    }
+
+    /// A spawn that fails must land in backoff and retry, not stall —
+    /// this is the seam that made `SpawnFailed` necessary.
+    #[test]
+    fn a_failed_spawn_reaches_backoff_through_the_seam() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder {
+            fail_spawn: true,
+            ..Default::default()
+        };
+
+        step(&mut sup, &mut r, Event::StartRequested);
+        assert_eq!(sup.state(), State::Backoff, "{:?}", r.calls);
+        assert!(r.calls.contains(&"backoff"));
+        assert!(sup.may_restart());
+
+        // And the retry actually runs.
+        r.fail_spawn = false;
+        r.calls.clear();
+        step(&mut sup, &mut r, Event::BackoffElapsed);
+        assert_eq!(r.calls, vec!["spawn"]);
+        assert_eq!(sup.state(), State::Starting);
+    }
+
+    /// A deterministic attach failure reaches backoff immediately rather
+    /// than waiting out the convergence budget.
+    #[test]
+    fn a_failed_attach_reaches_backoff_without_waiting_for_the_timeout() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder {
+            fail_attach: true,
+            ..Default::default()
+        };
+
+        step(&mut sup, &mut r, Event::StartRequested);
+        step(&mut sup, &mut r, Event::ApiUp);
+
+        assert_eq!(sup.state(), State::Backoff, "{:?}", r.calls);
+        assert!(
+            r.calls.contains(&"abort"),
+            "the half-started convergence must be told to stop: {:?}",
+            r.calls
+        );
+        assert!(
+            !sup.may_restart(),
+            "and the restart waits for it to confirm"
+        );
+        step(&mut sup, &mut r, Event::ConvergenceStopped);
+        assert!(sup.may_restart());
+    }
+
+    /// A clean stop releases resources; a stop whose teardown fails does
+    /// not. This is the invariant-2 path through the seam.
+    #[test]
+    fn a_clean_stop_releases_but_a_failed_teardown_leaks() {
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+        bring_up_steered(&mut sup, &mut r);
+        r.calls.clear();
+
+        let actions = sup.on(Event::StopRequested);
+        let out = execute(&actions, &mut r);
+        assert_eq!(r.calls, vec!["unsteer", "kill", "release"]);
+        assert!(out.ok());
+        assert_eq!(sup.state(), State::Stopped);
+
+        // Same stop, but the process will not die.
+        let mut sup = Supervisor::new();
+        let mut r = Recorder::default();
+        bring_up_steered(&mut sup, &mut r);
+        r.calls.clear();
+        r.kill_disposition = Some(Disposition::MustLeak);
+
+        let actions = sup.on(Event::StopRequested);
+        let out = execute(&actions, &mut r);
+        assert!(!r.calls.contains(&"release"), "{:?}", r.calls);
+        assert!(out.resources_leaked);
+    }
+}

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -25,6 +25,7 @@
 //! - the eBPF fast-path on the PFs is the permanent failover tier.
 
 pub mod attach;
+pub mod executor;
 pub mod fib_sync;
 pub mod liveness;
 pub mod process;

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -60,6 +60,22 @@ pub struct PortState {
     /// Worker cores promised for this port (config echo, used by the
     /// startup.conf renderer on adopt without re-parsing config).
     pub cores: u16,
+    /// The `sw_if_index` VPP assigned this port's interface.
+    ///
+    /// **Adoption depends on this being persisted.**
+    /// [`crate::attach::attach_ports`] reuses a recorded index rather
+    /// than re-issuing `dev_attach` against a surviving VPP — which
+    /// would either be refused (fatal, cycling a healthy and possibly
+    /// steered dataplane) or create a duplicate interface the live FIB
+    /// does not reference. Without this field that mapping cannot be
+    /// reconstructed after a packetframe restart, so the adoption path
+    /// would always take the blind-attach branch it exists to avoid.
+    ///
+    /// `None` = not yet attached, or state written before this field
+    /// existed. Both make adoption fall back to a fresh attach, which
+    /// is correct: the index is unknown, so nothing may be reused.
+    #[serde(default)]
+    pub sw_if_index: Option<u32>,
 }
 
 /// Everything attach acquired, in acquisition order. Release walks it
@@ -513,6 +529,7 @@ mod tests {
             iface: "eth4".into(),
             vf_pci: "0002:07:00.1".into(),
             cores: 1,
+            sw_if_index: Some(7),
         });
         st.steer_rules.push(("eth4".into(), vec![1, 2, 3]));
         st.save(&dir).unwrap();
@@ -646,6 +663,7 @@ mod tests {
             iface: "eth4".into(),
             vf_pci: "0002:07:00.1".into(),
             cores: 1,
+            sw_if_index: None,
         };
 
         // No VF at all → provision-cleared message.

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -45,7 +45,18 @@ use serde::{Deserialize, Serialize};
 /// State-file schema version. Bump on layout change; adopt refuses a
 /// version it doesn't know (upgrade = detach → install → attach, per
 /// plan — no cross-version adoption).
-pub const STATE_VERSION: u32 = 1;
+///
+/// **2** since `PortState::sw_if_index` was added. The field carries
+/// `serde(default)`, so a version-1 file would have parsed and yielded
+/// `None` — and adoption now *depends* on that index, which is exactly
+/// the situation this counter exists to refuse. A `serde(default)` is
+/// the right tool for a field nothing depends on; it is the wrong tool
+/// for one the adopted path cannot work without.
+///
+/// The cost of the bump is bounded and already the documented policy:
+/// an upgrade across it requires `packetframe detach --all` with the
+/// previous binary before attaching with the new one.
+pub const STATE_VERSION: u32 = 2;
 
 pub const STATE_FILE_NAME: &str = "vpp-offload.json";
 

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -167,6 +167,25 @@ pub enum Event {
     /// traffic is NOT diverted — the safe staging state, reported
     /// rather than papered over.
     SteerFailed,
+    /// MCAM rules are confirmed removed.
+    ///
+    /// Steering is only believed *down* on this acknowledgement, for
+    /// the same reason it is only believed *up* on `Steered`: an
+    /// optimistic clear meant a later teardown saw `steered == false`,
+    /// emitted no `Unsteer`, and happily released a VF that MCAM was
+    /// still pointing traffic at.
+    Unsteered,
+    /// Removing the MCAM rules failed. Traffic is still diverted to a
+    /// dataplane we are trying to stop — `steered` stays true so every
+    /// later teardown keeps trying and keeps withholding the VF.
+    UnsteerFailed,
+    /// The process survived termination (uninterruptible sleep, most
+    /// likely on a VFIO or DMA call).
+    ///
+    /// Blocks the restart: spawning a second VPP while the first still
+    /// owns the API socket and can DMA through the VF is worse than
+    /// staying down. Cleared when the pidfd finally reports the exit.
+    TerminationFailed,
     /// An aborted resync or verify has actually finished unwinding.
     ///
     /// The supervisor cannot observe this itself: the work runs in the
@@ -245,6 +264,14 @@ pub struct Supervisor {
     /// Only the caller knows when its task has truly stopped, so this
     /// is cleared by `Event::ConvergenceStopped`, not by a state change.
     converging: bool,
+    /// A previous process survived termination and may still be alive.
+    ///
+    /// Blocks the restart. Spawning a second VPP while the first still
+    /// owns the API socket and can DMA through the VF is worse than
+    /// staying down — and `ArmBackoff` alone would have let
+    /// `BackoffElapsed` do exactly that. Cleared only when the pidfd
+    /// reports the exit.
+    undead: bool,
 }
 
 impl Default for Supervisor {
@@ -261,6 +288,7 @@ impl Supervisor {
             steered: false,
             was_steered: false,
             converging: false,
+            undead: false,
         }
     }
 
@@ -405,11 +433,29 @@ impl Supervisor {
             }
 
             // --- death and wedging ---
-            (s, ProcessExited { .. }) | (s, Wedged) if s.has_process() => {
+            (s, ProcessExited { .. }) if s.has_process() => {
+                // Proof it is gone, whatever we believed before.
+                self.undead = false;
                 if self.steered {
                     self.was_steered = true;
                 }
                 self.fail()
+            }
+            // A wedge says the process is NOT scheduling; it says
+            // nothing about whether it is alive, so `undead` is left
+            // alone here.
+            (s, Wedged) if s.has_process() => {
+                if self.steered {
+                    self.was_steered = true;
+                }
+                self.fail()
+            }
+            // A late exit for a process we had already given up on. Not
+            // a new failure — but it IS the proof the restart has been
+            // waiting for.
+            (s, ProcessExited { .. }) if !s.has_process() => {
+                self.undead = false;
+                vec![]
             }
 
             // Steering could not be installed. We stay verified but
@@ -422,18 +468,31 @@ impl Supervisor {
             // suppress the Unsteer we owe on teardown.
             (Ready, SteerFailed) => vec![],
 
+            // --- steering acknowledgements ---
+            (_, Unsteered) => {
+                self.steered = false;
+                vec![]
+            }
+            // Traffic is still diverted. `steered` stays true so the
+            // next teardown tries again and keeps withholding the VF.
+            (_, UnsteerFailed) => vec![],
+
             // --- convergence bookkeeping ---
             (_, ConvergenceStopped) => {
                 self.converging = false;
+                vec![]
+            }
+            (_, TerminationFailed) => {
+                self.undead = true;
                 vec![]
             }
 
             // --- clean stop ---
             (_, StopRequested) => {
                 let mut actions = Vec::new();
+                // Same rule as `fail()`: believed down only on the ack.
                 if self.steered {
                     actions.push(Action::Unsteer);
-                    self.steered = false;
                 }
                 if self.converging {
                     actions.push(Action::AbortConvergence);
@@ -463,9 +522,14 @@ impl Supervisor {
         // Unsteer FIRST and unconditionally on the current fact, not on
         // the lifecycle state: until the MCAM rules are gone, every
         // steered packet is going to a VF nothing is servicing.
+        //
+        // `steered` is NOT cleared here. Clearing it optimistically
+        // meant a failed unsteer still recorded "not steered", so a
+        // later teardown emitted no Unsteer at all and released a VF
+        // that MCAM was still pointing traffic at. `Event::Unsteered`
+        // is the acknowledgement, symmetric with `Steered`.
         if self.steered {
             actions.push(Action::Unsteer);
-            self.steered = false;
         }
         // Tell the caller to wind down any resync/verify still running.
         // `converging` stays true until it confirms with
@@ -511,7 +575,12 @@ impl Supervisor {
     /// `BackoffElapsed`; starting another attempt would stack two loads
     /// onto one VPP.
     pub fn may_restart(&self) -> bool {
-        !self.converging
+        !self.converging && !self.undead
+    }
+
+    /// Whether a process we tried to kill may still be alive.
+    pub fn is_undead(&self) -> bool {
+        self.undead
     }
 }
 
@@ -633,6 +702,11 @@ mod tests {
             "steering must come down BEFORE the kill: {actions:?}"
         );
         assert!(actions.contains(&Action::Kill));
+        // Still believed steered until the removal is acknowledged —
+        // clearing it optimistically is what let a later teardown skip
+        // the Unsteer and release a VF MCAM still pointed at.
+        assert!(s.is_steered(), "not down until confirmed down");
+        s.on(Event::Unsteered);
         assert!(!s.is_steered());
     }
 
@@ -654,6 +728,10 @@ mod tests {
                 Some(&Action::Unsteer),
                 "{event:?} tore down without unsteering: {actions:?}"
             );
+            // Believed steered until acknowledged; the acknowledgement
+            // is what clears it.
+            assert!(s.is_steered(), "{event:?} cleared it optimistically");
+            s.on(Event::Unsteered);
             assert!(!s.is_steered(), "{event:?} left us believing we steer");
         }
     }

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -134,6 +134,15 @@ pub enum Event {
     /// Readback verification finished.
     VerifyPassed,
     VerifyFailed,
+    /// A step in the attach → resync pipeline failed outright: the
+    /// device would not attach, or the transport broke mid-drain.
+    ///
+    /// Distinct from `VerifyFailed`, which means "VPP is answering and
+    /// its FIB is wrong". This means the pipeline itself did not run.
+    /// Without it a deterministic attach failure would sit in `Syncing`
+    /// until `CONVERGENCE_BUDGET` expired — two minutes of waiting for
+    /// something already known to have failed.
+    ConvergenceFailed,
     /// Steering rules installed.
     Steered,
     /// The process exited — from pidfd, not SIGCHLD, because adoption
@@ -340,6 +349,17 @@ impl Supervisor {
             // A resync or verify that never finishes is the same trap
             // as a VPP that never answers.
             (Syncing | AdoptedResyncing | Verifying, PhaseTimedOut) => self.fail(),
+            // The pipeline broke rather than merely being slow.
+            //
+            // `converging` is deliberately NOT cleared here, unlike on
+            // `VerifyFailed`. A failed verify has *finished* — the task
+            // reported its own result, so nothing is in flight. A failed
+            // pipeline step says nothing about the other steps: an
+            // attach failure still leaves the resync that was started
+            // after it running against the transport. So `fail()` emits
+            // `AbortConvergence` and the restart waits for the caller's
+            // `ConvergenceStopped`, which is the only thing that knows.
+            (Syncing | AdoptedResyncing | Verifying, ConvergenceFailed) => self.fail(),
             (Verifying, VerifyPassed) => {
                 self.failures = 0;
                 self.converging = false;

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -211,10 +211,12 @@ pub fn verify(
     // and we steer into an interface that forwards nothing. The runbook
     // treats link-up as the bring-up pass for exactly this reason;
     // `set_admin_up` only ever asserted the administrative flag.
+    let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
     for iface in crate::attach::interfaces(t)? {
         if !owned.contains(&iface.sw_if_index) {
             continue;
         }
+        seen.insert(iface.sw_if_index);
         let (admin_up, link_up) = (iface.admin_up(), iface.link_up());
         if !admin_up || !link_up {
             out.dead_interfaces.push(DeadInterface {
@@ -225,6 +227,24 @@ pub fn verify(
             });
         }
     }
+    // An owned index that is ABSENT from the dump is not healthy by
+    // omission. Only iterating what the dump returned meant a port that
+    // disappeared after attach was invisible: if the random sample
+    // happened not to select a route through it, every probe matched and
+    // verification passed on a port that could not forward. Report each
+    // missing index as its own failure — nothing about it is up.
+    for idx in owned.iter().copied() {
+        if !seen.contains(&idx) {
+            out.dead_interfaces.push(DeadInterface {
+                sw_if_index: idx,
+                name: format!("<absent from VPP, idx {idx}>"),
+                admin_up: false,
+                link_up: false,
+            });
+        }
+    }
+    // Deterministic order so a failing verify reads the same twice.
+    out.dead_interfaces.sort_by_key(|d| d.sw_if_index);
 
     for prefix in probes {
         let reply = t.request::<IpRouteLookup, IpRouteLookupReply>(IpRouteLookup {

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -741,6 +741,38 @@ fn verify_fails_when_an_owned_interface_has_no_carrier() {
     assert!(out.summary().contains("link_up=false"), "{}", out.summary());
 }
 
+/// An owned index that VPP does not report at all is not healthy by
+/// omission. Only iterating the dump meant a port that vanished after
+/// attach was never examined — and if the random sample happened not to
+/// select a route through it, every probe matched and verify passed on a
+/// port that could not forward.
+#[test]
+fn verify_fails_when_an_owned_interface_is_absent_from_vpp() {
+    let fake = Fake::start_with(
+        "absent",
+        AttachBehaviour::default(),
+        LookupBehaviour::Found { sw_if_index: 7 },
+        // We own 7 and 9; VPP only has 7.
+        vec![(7, "octeon0/0".into(), 3)],
+    );
+    let mut t = fake.connect();
+    let (ledger, mut ports) = ledger_with(50);
+    ports.insert("eth2", None, 9);
+
+    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    assert!(
+        out.mismatches.is_empty(),
+        "every route probe still looks perfect: {:?}",
+        out.mismatches
+    );
+    assert_eq!(out.dead_interfaces.len(), 1, "{:?}", out.dead_interfaces);
+    assert_eq!(out.dead_interfaces[0].sw_if_index, 9);
+    assert!(!out.dead_interfaces[0].admin_up);
+    assert!(!out.dead_interfaces[0].link_up);
+    assert!(!out.passed(), "{}", out.summary());
+    assert!(out.summary().contains("absent"), "{}", out.summary());
+}
+
 /// An interface we do NOT own being down is not our problem and must
 /// not fail our verify — otherwise any unrelated down interface on the
 /// box blocks steering forever.

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -18,7 +18,7 @@ use std::thread;
 use std::time::Duration;
 
 use packetframe_common::fib::IpPrefix;
-use packetframe_vpp_offload::attach::{attach_ports, AttachError, PortAttach};
+use packetframe_vpp_offload::attach::{attach_ports, AttachError, AttachMode, PortAttach};
 use packetframe_vpp_offload::fib_sync::{to_prefix, PortIndex};
 use packetframe_vpp_offload::sink::{Capacity, RouteLedger};
 use packetframe_vpp_offload::verify::{verify, Mismatch};
@@ -388,7 +388,7 @@ fn attach_sends_the_three_messages_in_order() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let got = attach_ports(&mut t, &ports(), &[]).expect("attach");
+    let got = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect("attach");
 
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].port, "eth3");
@@ -426,7 +426,8 @@ fn an_sw_if_index_of_zero_is_refused_as_local0() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must refuse index 0");
+    let err =
+        attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must refuse index 0");
     assert!(matches!(err, AttachError::LocalZero { .. }), "{err:?}");
     let msg = err.to_string();
     assert!(msg.contains("local0"), "{msg}");
@@ -454,7 +455,7 @@ fn a_refused_dev_attach_reports_vpps_own_text() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_attach"), "{msg}");
     assert!(msg.contains("eth3"), "names the port: {msg}");
@@ -485,7 +486,7 @@ fn a_refused_create_port_if_names_the_step_that_failed() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[]).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_create_port_if"), "{msg}");
     assert!(msg.contains("-11"), "reports the retval: {msg}");
@@ -516,7 +517,7 @@ fn a_recorded_interface_is_reused_not_re_attached() {
     );
     let mut t = fake.connect();
     let known = vec![("eth3".to_string(), 7u32)];
-    let got = attach_ports(&mut t, &ports(), &known).expect("adopt");
+    let got = attach_ports(&mut t, &ports(), &known, AttachMode::Adopted).expect("adopt");
 
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].sw_if_index, 7);
@@ -553,12 +554,59 @@ fn a_stale_recorded_index_is_refused() {
     );
     let mut t = fake.connect();
     let known = vec![("eth3".to_string(), 7u32)];
-    let err = attach_ports(&mut t, &ports(), &known).expect_err("must refuse");
+    let err = attach_ports(&mut t, &ports(), &known, AttachMode::Adopted).expect_err("must refuse");
     assert!(matches!(err, AttachError::StaleIndex { .. }), "{err:?}");
     let msg = err.to_string();
     assert!(msg.contains("no longer has it"), "{msg}");
     let seen = fake.observed();
     assert!(!seen.contains(&"dev_attach".to_string()), "{seen:?}");
+}
+
+/// The window a schema version cannot close. Process identity is
+/// persisted at spawn; the interface index only after attach. A crash
+/// between those two writes — after `dev_create_port_if` already
+/// succeeded — leaves an adoptable process and no recorded index. The
+/// running VPP may already have the interface, so attaching would
+/// duplicate it, and the dump cannot tell ports apart.
+#[test]
+fn adopting_without_a_recorded_index_refuses_rather_than_duplicating() {
+    let fake = Fake::start_with(
+        "adoptnoidx",
+        AttachBehaviour::default(),
+        LookupBehaviour::Missing,
+        vec![(7, "octeon0/0".into(), 3)],
+    );
+    let mut t = fake.connect();
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Adopted).expect_err("must refuse");
+    assert!(
+        matches!(err, AttachError::UnknownIndexOnAdopt { .. }),
+        "{err:?}"
+    );
+    let seen = fake.observed();
+    assert!(
+        !seen.contains(&"dev_attach".to_string()),
+        "nothing may be attached against a live VPP we cannot identify: {seen:?}"
+    );
+}
+
+/// The same missing index on a FRESH process is fine — a VPP we just
+/// started has no interfaces, so attaching is the only correct move.
+#[test]
+fn a_fresh_process_with_no_recorded_index_attaches_normally() {
+    let fake = Fake::start_with(
+        "freshnoidx",
+        AttachBehaviour {
+            dev_index: 1,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![],
+    );
+    let mut t = fake.connect();
+    let got = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect("attach");
+    assert_eq!(got[0].sw_if_index, 7);
+    assert_eq!(got[0].dev_index, Some(1));
 }
 
 /// A ledger holding `n` installed prefixes, all resolvable.


### PR DESCRIPTION
Slice 4's seam — the supervisor decides *what* happens and in *what order*; this carries it out and reports back.

**Stacked on #108** (needs `attach`/`verify`). Review that first; this branch contains its commits.

## Written the other way round, deliberately

Four findings earlier in this stack were places where a test of mine asserted *what the code did* rather than *what had to be true* — the `n_paths` golden vector, the deferred-route test, the flaky reply counter, the empty verify sample. So here the invariants went in as tests first, and the interpreter was built until they passed.

The effects are a trait so the rules are checkable against a recorder instead of trusted to review:

1. **Order is preserved, nothing skipped.** That order encodes an outage: "unsteer then kill" and "kill then unsteer" differ by how long MCAM keeps pointing traffic at a VF nothing is servicing.
2. **`ReleaseResources` is withheld unless teardown actually succeeded.** A failed `Unsteer` or a `Kill` reporting `MustLeak` both forfeit it. Releasing under a live process means unbinding a VF something may still be DMAing into; releasing under live steering means handing back a VF still receiving diverted traffic. A leaked VF is a line in `status`.
3. **Nothing fails silently.** Every fallible action yields either an event the supervisor understands or a recorded failure.

A failure does **not** abandon the batch. That looks wrong and isn't: the remaining actions are usually the ones that contain the damage — if `Unsteer` fails, stopping there leaves a wedged VPP running *and* traffic pointed at it. What must not happen is the release, and that's what gets suppressed.

## The composed tests earned their place immediately

Driving supervisor and executor together — executor output fed back as supervisor input — caught a seam bug **neither half's tests could see**:

`Event::ConvergenceFailed` cleared `converging` before calling `fail()`, so no `AbortConvergence` was emitted. But an attach failure leaves the resync that ran *after* it still touching the transport. Unlike `VerifyFailed`, which has genuinely finished when it reports, a failed pipeline step says nothing about the other steps. It now waits for the caller's `ConvergenceStopped`.

That's the argument for this shape of test: each half was individually green and the composition was still wrong.

## New event

`Event::ConvergenceFailed` — without it, a deterministic attach failure sat in `Syncing` until `CONVERGENCE_BUDGET` expired. Two minutes waiting for something already known to have failed.

## Not in this PR

- **The tick loop.** Resync must proceed in bounded batches across ticks so the API ping and pidfd stay serviced — a blocking full-table drain would starve the wedge detector for ~60 s, which is why `SYNC_PING_BUDGET` exists. That's the next piece.
- **`Steer`/`Unsteer` implementations.** Trait methods only until slice 5 builds MCAM, and they will fail loudly there rather than returning `Ok(())` — a no-op steer reporting success would let the supervisor believe traffic is diverted when none is.

## Verification

385 workspace tests (23 new). Host clippy `-D warnings` clean; all four Linux cross-targets linted locally before pushing.