### PR TITLE
feat(vpp-offload): supervision-loop deadlines, with an observer per field

### DIFF
--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -30,6 +30,7 @@ pub mod fib_sync;
 pub mod liveness;
 pub mod process;
 pub mod resources;
+pub mod schedule;
 pub mod sink;
 pub mod startup_conf;
 pub mod supervisor;

--- a/crates/modules/vpp-offload/src/liveness.rs
+++ b/crates/modules/vpp-offload/src/liveness.rs
@@ -117,6 +117,14 @@ impl WedgeDetector {
         now.duration_since(self.last_attempt) >= PING_INTERVAL
     }
 
+    /// When the next ping is due, for a caller computing how long it
+    /// may sleep. Without this the loop would have to poll to discover
+    /// that [`Self::ping_due`] became true, which is the busy-wait the
+    /// scheduler exists to avoid.
+    pub fn next_ping_at(&self) -> Instant {
+        self.last_attempt + PING_INTERVAL
+    }
+
     pub fn on_ping_sent(&mut self, now: Instant) {
         self.last_attempt = now;
     }

--- a/crates/modules/vpp-offload/src/schedule.rs
+++ b/crates/modules/vpp-offload/src/schedule.rs
@@ -1,0 +1,332 @@
+//! Deadlines for the supervision loop: when a phase has run too long,
+//! when a backoff has elapsed, and how long the loop may sleep.
+//!
+//! Split out from the loop itself because it is the part that can be
+//! tested. The loop's I/O — polling a pidfd, draining a batch, writing
+//! a ping — needs a live VPP; deciding *when* those should happen is
+//! arithmetic over an injected clock, exactly like [`crate::supervisor`]
+//! and [`crate::liveness`].
+//!
+//! **Every field here is paired with the one observation allowed to
+//! change it.** That rule is not stylistic: the recurring defect in
+//! this subsystem has been state recorded at the moment an effect was
+//! *requested* rather than when it was *observed* — steering cleared on
+//! emitting `Unsteer`, convergence cleared on a partial failure,
+//! termination assumed on issuing `Kill`. A loop is nothing but
+//! requests whose completion arrives later, so anything without an
+//! observer does not get a field.
+//!
+//! | Field | Observer |
+//! |---|---|
+//! | `phase_deadline` | a supervisor state change, via [`Schedule::arm_phase`] |
+//! | `backoff_until` | `Action::ArmBackoff`, via [`Schedule::arm_backoff`] |
+//!
+//! The ping deadline deliberately is NOT a field here — it belongs to
+//! [`crate::liveness::WedgeDetector`], whose observation is a pong.
+//! Duplicating it would create two answers to one question.
+
+use std::time::{Duration, Instant};
+
+use crate::supervisor::Event;
+
+/// Armed deadlines for the current supervisor state.
+#[derive(Debug, Default, Clone)]
+pub struct Schedule {
+    /// When the current phase stops being merely slow and becomes hung.
+    ///
+    /// Armed from `Supervisor::phase_budget()` on every state change; a
+    /// state with no budget (`Ready`, `Steered`, `Stopped`) disarms it.
+    phase_deadline: Option<Instant>,
+    /// When the restart backoff expires.
+    backoff_until: Option<Instant>,
+}
+
+impl Schedule {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Re-arm the phase deadline for a (possibly new) state.
+    ///
+    /// Call on **every** transition, passing `Supervisor::phase_budget()`
+    /// — including when it returns `None`, which disarms. Arming only on
+    /// entry to a timed state would leave a stale deadline behind after
+    /// leaving one, and it would fire against a state it does not
+    /// describe.
+    pub fn arm_phase(&mut self, now: Instant, budget: Option<Duration>) {
+        self.phase_deadline = budget.map(|b| now + b);
+    }
+
+    /// Arm the restart backoff, from `Action::ArmBackoff`.
+    ///
+    /// Also disarms the phase deadline: the backoff states have no phase
+    /// budget, so a surviving deadline could only fire a `PhaseTimedOut`
+    /// describing a phase we already left. The supervisor would ignore
+    /// it, but an event that means nothing is still noise in a log
+    /// somebody reads during an outage.
+    pub fn arm_backoff(&mut self, now: Instant, delay: Duration) {
+        self.backoff_until = Some(now + delay);
+        self.phase_deadline = None;
+    }
+
+    /// Clear everything. For a clean stop, where no deadline applies.
+    pub fn disarm(&mut self) {
+        self.phase_deadline = None;
+        self.backoff_until = None;
+    }
+
+    pub fn phase_deadline(&self) -> Option<Instant> {
+        self.phase_deadline
+    }
+
+    pub fn backoff_until(&self) -> Option<Instant> {
+        self.backoff_until
+    }
+
+    /// Events whose deadlines have elapsed by `now`.
+    ///
+    /// **Consuming**: each deadline fires at most once. A deadline left
+    /// armed after firing would produce the same event on every tick,
+    /// and since both events route through the supervisor's failure
+    /// path, that is a spin through teardown-and-restart rather than a
+    /// single recovery.
+    pub fn fired(&mut self, now: Instant) -> Vec<Event> {
+        let mut out = Vec::new();
+        if let Some(d) = self.phase_deadline {
+            if now >= d {
+                self.phase_deadline = None;
+                out.push(Event::PhaseTimedOut);
+            }
+        }
+        if let Some(d) = self.backoff_until {
+            if now >= d {
+                self.backoff_until = None;
+                out.push(Event::BackoffElapsed);
+            }
+        }
+        out
+    }
+
+    /// How long the loop may sleep before something needs attention.
+    ///
+    /// `None` = nothing is armed, so the loop may block on its fds
+    /// indefinitely. `Some(ZERO)` = something is already due, so tick
+    /// again immediately — which is not a busy loop precisely because
+    /// [`Self::fired`] consumes what it reports.
+    ///
+    /// `ping_due_at` comes from
+    /// [`crate::liveness::WedgeDetector::next_ping_at`] and is passed in
+    /// rather than stored, so there is exactly one owner of that
+    /// deadline.
+    pub fn next_wakeup(&self, now: Instant, ping_due_at: Option<Instant>) -> Option<Duration> {
+        [self.phase_deadline, self.backoff_until, ping_due_at]
+            .into_iter()
+            .flatten()
+            .map(|d| d.saturating_duration_since(now))
+            .min()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::supervisor::{API_STARTUP_BUDGET, CONVERGENCE_BUDGET};
+
+    fn at(base: Instant, ms: u64) -> Instant {
+        base + Duration::from_millis(ms)
+    }
+
+    // ---- Firing, and firing once ----
+
+    /// The invariant that keeps a single timeout from becoming a loop.
+    /// Both events route through the supervisor's failure path, so a
+    /// deadline that re-fires every tick is a teardown-restart spin.
+    #[test]
+    fn a_deadline_fires_exactly_once() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(Duration::from_secs(10)));
+
+        assert!(s.fired(at(t0, 9_999)).is_empty(), "not yet");
+        assert_eq!(s.fired(at(t0, 10_000)), vec![Event::PhaseTimedOut]);
+        assert!(
+            s.fired(at(t0, 10_001)).is_empty(),
+            "a fired deadline must be consumed"
+        );
+        assert!(s.fired(at(t0, 60_000)).is_empty());
+    }
+
+    #[test]
+    fn backoff_fires_once_too() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_backoff(t0, Duration::from_millis(250));
+
+        assert!(s.fired(at(t0, 249)).is_empty());
+        assert_eq!(s.fired(at(t0, 250)), vec![Event::BackoffElapsed]);
+        assert!(s.fired(at(t0, 500)).is_empty());
+    }
+
+    /// Re-arming on every transition is what stops a deadline from
+    /// outliving the phase it describes.
+    #[test]
+    fn a_state_with_no_budget_disarms_the_phase_deadline() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(API_STARTUP_BUDGET));
+        assert!(s.phase_deadline().is_some());
+
+        // Ready/Steered/Stopped report no budget.
+        s.arm_phase(at(t0, 100), None);
+        assert!(s.phase_deadline().is_none());
+        assert!(s.fired(at(t0, 999_999)).is_empty());
+    }
+
+    /// Moving between timed phases restarts the clock rather than
+    /// carrying the previous phase's remaining time.
+    #[test]
+    fn re_arming_replaces_rather_than_keeps_the_earlier_deadline() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(API_STARTUP_BUDGET));
+
+        // 59 s later the API comes up; the convergence budget starts now.
+        let t1 = at(t0, 59_000);
+        s.arm_phase(t1, Some(CONVERGENCE_BUDGET));
+        assert!(
+            s.fired(at(t0, 60_001)).is_empty(),
+            "the startup budget must not still fire after the phase changed"
+        );
+        assert_eq!(s.phase_deadline(), Some(t1 + CONVERGENCE_BUDGET));
+    }
+
+    /// Entering backoff drops the phase deadline: it could only fire an
+    /// event describing a phase already left.
+    #[test]
+    fn arming_backoff_drops_a_stale_phase_deadline() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(Duration::from_secs(1)));
+        s.arm_backoff(t0, Duration::from_secs(30));
+
+        assert!(s.phase_deadline().is_none());
+        assert!(
+            !s.fired(at(t0, 2_000)).contains(&Event::PhaseTimedOut),
+            "no event for a phase we are no longer in"
+        );
+    }
+
+    #[test]
+    fn disarm_clears_everything() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(Duration::from_secs(1)));
+        s.arm_backoff(t0, Duration::from_secs(1));
+        s.disarm();
+        assert!(s.fired(at(t0, 10_000)).is_empty());
+        assert_eq!(s.next_wakeup(t0, None), None);
+    }
+
+    // ---- Sleeping: never miss, never spin ----
+
+    /// Nothing armed and no ping pending means the loop may block on
+    /// its fds. Returning `Some(ZERO)` here would spin a core for
+    /// nothing — the failure mode that matters on a box where every
+    /// core is accounted for.
+    #[test]
+    fn an_idle_schedule_permits_blocking_indefinitely() {
+        let t0 = Instant::now();
+        assert_eq!(Schedule::new().next_wakeup(t0, None), None);
+    }
+
+    /// The wakeup must be the EARLIEST deadline. Sleeping past any
+    /// armed one would delay a timeout by however long the others had
+    /// left to run.
+    #[test]
+    fn the_wakeup_is_the_earliest_of_every_deadline() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some(Duration::from_secs(120)));
+        s.arm_backoff(t0, Duration::from_secs(30));
+        // Ping is soonest of the three.
+        let ping = at(t0, 500);
+
+        assert_eq!(
+            s.next_wakeup(t0, Some(ping)),
+            Some(Duration::from_millis(500))
+        );
+        // Without the ping, the backoff is next.
+        assert_eq!(s.next_wakeup(t0, None), Some(Duration::from_secs(30)));
+    }
+
+    /// An already-elapsed deadline asks for an immediate tick, and that
+    /// does not spin because `fired` consumes it.
+    #[test]
+    fn an_elapsed_deadline_asks_for_an_immediate_tick_then_stops() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_backoff(t0, Duration::from_millis(100));
+
+        let late = at(t0, 5_000);
+        assert_eq!(s.next_wakeup(late, None), Some(Duration::ZERO));
+        assert_eq!(s.fired(late), vec![Event::BackoffElapsed]);
+        assert_eq!(
+            s.next_wakeup(late, None),
+            None,
+            "consuming the deadline must end the immediate-tick request"
+        );
+    }
+
+    /// A ping deadline alone is enough to schedule a wakeup, so a
+    /// steady-state loop with no timers still pings on interval.
+    #[test]
+    fn a_ping_alone_schedules_a_wakeup() {
+        let t0 = Instant::now();
+        let s = Schedule::new();
+        assert_eq!(
+            s.next_wakeup(t0, Some(at(t0, 500))),
+            Some(Duration::from_millis(500))
+        );
+    }
+
+    // ---- Composed with the wedge detector ----
+
+    /// The ping deadline has exactly one owner. Reading it back through
+    /// the detector rather than storing a copy is what keeps the two
+    /// from disagreeing.
+    #[test]
+    fn the_ping_deadline_comes_from_the_detector() {
+        use crate::liveness::{WedgeDetector, PING_INTERVAL};
+        let t0 = Instant::now();
+        let mut d = WedgeDetector::started(t0);
+        let s = Schedule::new();
+
+        assert_eq!(
+            s.next_wakeup(t0, Some(d.next_ping_at())),
+            Some(PING_INTERVAL)
+        );
+
+        // After a ping goes out, the next one is an interval later.
+        d.on_ping_sent(at(t0, 500));
+        assert_eq!(
+            s.next_wakeup(at(t0, 500), Some(d.next_ping_at())),
+            Some(PING_INTERVAL)
+        );
+    }
+
+    /// The steady-state loop wakes on the ping interval, which is well
+    /// inside the published wedge-detection bound — the scheduler must
+    /// not be what makes that number miss.
+    #[test]
+    fn steady_state_wakeups_are_frequent_enough_for_the_wedge_bound() {
+        use crate::liveness::{worst_case_detection, WedgeDetector, PING_BUDGET};
+        let t0 = Instant::now();
+        let d = WedgeDetector::started(t0);
+        let s = Schedule::new();
+        let sleep = s.next_wakeup(t0, Some(d.next_ping_at())).unwrap();
+        assert!(
+            sleep < worst_case_detection(PING_BUDGET),
+            "sleeping {sleep:?} would blow the detection bound"
+        );
+    }
+}

--- a/crates/modules/vpp-offload/src/schedule.rs
+++ b/crates/modules/vpp-offload/src/schedule.rs
@@ -27,17 +27,24 @@
 
 use std::time::{Duration, Instant};
 
-use crate::supervisor::Event;
+use crate::supervisor::{Event, PhaseKind};
 
 /// Armed deadlines for the current supervisor state.
 #[derive(Debug, Default, Clone)]
 pub struct Schedule {
     /// When the current phase stops being merely slow and becomes hung.
     ///
-    /// Armed from `Supervisor::phase_budget()` on every state change; a
-    /// state with no budget (`Ready`, `Steered`, `Stopped`) disarms it.
+    /// Armed from `Supervisor::phase()` on every state change; a state
+    /// with no budget (`Ready`, `Steered`, `Stopped`) disarms it.
     phase_deadline: Option<Instant>,
+    /// Which phase `phase_deadline` belongs to, so transitions *within*
+    /// a phase keep one deadline instead of restarting the clock.
+    phase_kind: Option<PhaseKind>,
     /// When the restart backoff expires.
+    ///
+    /// Survives elapsing: see [`Schedule::fired`]. Cleared only when the
+    /// restart it authorises is actually permitted and reported — the
+    /// observer is "the retry may proceed", not "time passed".
     backoff_until: Option<Instant>,
 }
 
@@ -48,13 +55,31 @@ impl Schedule {
 
     /// Re-arm the phase deadline for a (possibly new) state.
     ///
-    /// Call on **every** transition, passing `Supervisor::phase_budget()`
-    /// — including when it returns `None`, which disarms. Arming only on
+    /// Call on **every** transition, passing `Supervisor::phase()` —
+    /// including when it returns `None`, which disarms. Arming only on
     /// entry to a timed state would leave a stale deadline behind after
     /// leaving one, and it would fire against a state it does not
     /// describe.
-    pub fn arm_phase(&mut self, now: Instant, budget: Option<Duration>) {
-        self.phase_deadline = budget.map(|b| now + b);
+    ///
+    /// A transition *within* the same [`PhaseKind`] keeps the existing
+    /// deadline. `CONVERGENCE_BUDGET` bounds a resync **plus** verify, so
+    /// `Syncing → Verifying` must not restart it: doing so would let the
+    /// resync spend nearly the whole budget and then hand verification a
+    /// fresh one, making the effective bound twice the documented number.
+    pub fn arm_phase(&mut self, now: Instant, phase: Option<(PhaseKind, Duration)>) {
+        match phase {
+            None => {
+                self.phase_deadline = None;
+                self.phase_kind = None;
+            }
+            Some((kind, budget)) => {
+                let continuing = self.phase_kind == Some(kind) && self.phase_deadline.is_some();
+                if !continuing {
+                    self.phase_deadline = Some(now + budget);
+                    self.phase_kind = Some(kind);
+                }
+            }
+        }
     }
 
     /// Arm the restart backoff, from `Action::ArmBackoff`.
@@ -67,11 +92,13 @@ impl Schedule {
     pub fn arm_backoff(&mut self, now: Instant, delay: Duration) {
         self.backoff_until = Some(now + delay);
         self.phase_deadline = None;
+        self.phase_kind = None;
     }
 
     /// Clear everything. For a clean stop, where no deadline applies.
     pub fn disarm(&mut self) {
         self.phase_deadline = None;
+        self.phase_kind = None;
         self.backoff_until = None;
     }
 
@@ -85,21 +112,32 @@ impl Schedule {
 
     /// Events whose deadlines have elapsed by `now`.
     ///
-    /// **Consuming**: each deadline fires at most once. A deadline left
-    /// armed after firing would produce the same event on every tick,
-    /// and since both events route through the supervisor's failure
-    /// path, that is a spin through teardown-and-restart rather than a
-    /// single recovery.
-    pub fn fired(&mut self, now: Instant) -> Vec<Event> {
+    /// `may_restart` is `Supervisor::may_restart()`. It gates the backoff
+    /// because **an elapsed backoff must survive being un-actionable.**
+    /// A restart can be forbidden when the deadline expires — an aborted
+    /// convergence still unwinding, or a killed process that has not
+    /// died — and the supervisor deliberately has no other retry
+    /// trigger. Reporting `BackoffElapsed` for the caller to discard
+    /// would consume the only one and strand the supervisor in `Backoff`
+    /// forever. So the deadline stays armed until the retry is actually
+    /// permitted, and fires on the first tick after
+    /// `ConvergenceStopped` or `ProcessExited` clears the block.
+    ///
+    /// The phase deadline is unconditional, so it is consumed on firing.
+    /// Both are consumed exactly once: left armed, they would re-emit
+    /// every tick, and since both route through the supervisor's failure
+    /// path that is a teardown-restart spin rather than one recovery.
+    pub fn fired(&mut self, now: Instant, may_restart: bool) -> Vec<Event> {
         let mut out = Vec::new();
         if let Some(d) = self.phase_deadline {
             if now >= d {
                 self.phase_deadline = None;
+                self.phase_kind = None;
                 out.push(Event::PhaseTimedOut);
             }
         }
         if let Some(d) = self.backoff_until {
-            if now >= d {
+            if now >= d && may_restart {
                 self.backoff_until = None;
                 out.push(Event::BackoffElapsed);
             }
@@ -109,17 +147,29 @@ impl Schedule {
 
     /// How long the loop may sleep before something needs attention.
     ///
-    /// `None` = nothing is armed, so the loop may block on its fds
+    /// `None` = nothing needs a timer, so the loop may block on its fds
     /// indefinitely. `Some(ZERO)` = something is already due, so tick
-    /// again immediately — which is not a busy loop precisely because
-    /// [`Self::fired`] consumes what it reports.
+    /// again immediately — not a busy loop, because [`Self::fired`]
+    /// consumes what it reports.
+    ///
+    /// An **elapsed but blocked** backoff is excluded, and that is the
+    /// subtle half: it stays armed by design, so counting it would ask
+    /// for an immediate tick on every pass and spin a core until the
+    /// block cleared. What unblocks it is an event on an fd, not the
+    /// passage of time, so there is nothing to wake up *for*.
     ///
     /// `ping_due_at` comes from
     /// [`crate::liveness::WedgeDetector::next_ping_at`] and is passed in
     /// rather than stored, so there is exactly one owner of that
     /// deadline.
-    pub fn next_wakeup(&self, now: Instant, ping_due_at: Option<Instant>) -> Option<Duration> {
-        [self.phase_deadline, self.backoff_until, ping_due_at]
+    pub fn next_wakeup(
+        &self,
+        now: Instant,
+        ping_due_at: Option<Instant>,
+        may_restart: bool,
+    ) -> Option<Duration> {
+        let backoff = self.backoff_until.filter(|d| *d > now || may_restart);
+        [self.phase_deadline, backoff, ping_due_at]
             .into_iter()
             .flatten()
             .map(|d| d.saturating_duration_since(now))
@@ -145,15 +195,15 @@ mod tests {
     fn a_deadline_fires_exactly_once() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(Duration::from_secs(10)));
+        s.arm_phase(t0, Some((PhaseKind::Convergence, Duration::from_secs(10))));
 
-        assert!(s.fired(at(t0, 9_999)).is_empty(), "not yet");
-        assert_eq!(s.fired(at(t0, 10_000)), vec![Event::PhaseTimedOut]);
+        assert!(s.fired(at(t0, 9_999), true).is_empty(), "not yet");
+        assert_eq!(s.fired(at(t0, 10_000), true), vec![Event::PhaseTimedOut]);
         assert!(
-            s.fired(at(t0, 10_001)).is_empty(),
+            s.fired(at(t0, 10_001), true).is_empty(),
             "a fired deadline must be consumed"
         );
-        assert!(s.fired(at(t0, 60_000)).is_empty());
+        assert!(s.fired(at(t0, 60_000), true).is_empty());
     }
 
     #[test]
@@ -162,9 +212,9 @@ mod tests {
         let mut s = Schedule::new();
         s.arm_backoff(t0, Duration::from_millis(250));
 
-        assert!(s.fired(at(t0, 249)).is_empty());
-        assert_eq!(s.fired(at(t0, 250)), vec![Event::BackoffElapsed]);
-        assert!(s.fired(at(t0, 500)).is_empty());
+        assert!(s.fired(at(t0, 249), true).is_empty());
+        assert_eq!(s.fired(at(t0, 250), true), vec![Event::BackoffElapsed]);
+        assert!(s.fired(at(t0, 500), true).is_empty());
     }
 
     /// Re-arming on every transition is what stops a deadline from
@@ -173,13 +223,13 @@ mod tests {
     fn a_state_with_no_budget_disarms_the_phase_deadline() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(API_STARTUP_BUDGET));
+        s.arm_phase(t0, Some((PhaseKind::Startup, API_STARTUP_BUDGET)));
         assert!(s.phase_deadline().is_some());
 
         // Ready/Steered/Stopped report no budget.
         s.arm_phase(at(t0, 100), None);
         assert!(s.phase_deadline().is_none());
-        assert!(s.fired(at(t0, 999_999)).is_empty());
+        assert!(s.fired(at(t0, 999_999), true).is_empty());
     }
 
     /// Moving between timed phases restarts the clock rather than
@@ -188,13 +238,13 @@ mod tests {
     fn re_arming_replaces_rather_than_keeps_the_earlier_deadline() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(API_STARTUP_BUDGET));
+        s.arm_phase(t0, Some((PhaseKind::Startup, API_STARTUP_BUDGET)));
 
         // 59 s later the API comes up; the convergence budget starts now.
         let t1 = at(t0, 59_000);
-        s.arm_phase(t1, Some(CONVERGENCE_BUDGET));
+        s.arm_phase(t1, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
         assert!(
-            s.fired(at(t0, 60_001)).is_empty(),
+            s.fired(at(t0, 60_001), true).is_empty(),
             "the startup budget must not still fire after the phase changed"
         );
         assert_eq!(s.phase_deadline(), Some(t1 + CONVERGENCE_BUDGET));
@@ -206,12 +256,12 @@ mod tests {
     fn arming_backoff_drops_a_stale_phase_deadline() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(Duration::from_secs(1)));
+        s.arm_phase(t0, Some((PhaseKind::Convergence, Duration::from_secs(1))));
         s.arm_backoff(t0, Duration::from_secs(30));
 
         assert!(s.phase_deadline().is_none());
         assert!(
-            !s.fired(at(t0, 2_000)).contains(&Event::PhaseTimedOut),
+            !s.fired(at(t0, 2_000), true).contains(&Event::PhaseTimedOut),
             "no event for a phase we are no longer in"
         );
     }
@@ -220,11 +270,157 @@ mod tests {
     fn disarm_clears_everything() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(Duration::from_secs(1)));
+        s.arm_phase(t0, Some((PhaseKind::Convergence, Duration::from_secs(1))));
         s.arm_backoff(t0, Duration::from_secs(1));
         s.disarm();
-        assert!(s.fired(at(t0, 10_000)).is_empty());
-        assert_eq!(s.next_wakeup(t0, None), None);
+        assert!(s.fired(at(t0, 10_000), true).is_empty());
+        assert_eq!(s.next_wakeup(t0, None, true), None);
+    }
+
+    // ---- An elapsed backoff must survive being un-actionable ----
+
+    /// The supervisor has exactly one retry trigger. If the backoff
+    /// elapses while a restart is forbidden — an aborted convergence
+    /// still unwinding, or a killed process that has not died —
+    /// reporting it for the caller to discard would consume that
+    /// trigger and strand the supervisor in `Backoff` forever.
+    #[test]
+    fn an_elapsed_backoff_is_withheld_not_consumed_while_blocked() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_backoff(t0, Duration::from_millis(250));
+
+        // Elapsed, but a restart is not permitted yet.
+        assert!(
+            s.fired(at(t0, 300), false).is_empty(),
+            "must not report a retry that cannot be taken"
+        );
+        assert!(
+            s.backoff_until().is_some(),
+            "and must not lose it either — this is the only trigger"
+        );
+        // Still blocked several ticks later.
+        assert!(s.fired(at(t0, 5_000), false).is_empty());
+        assert!(s.backoff_until().is_some());
+
+        // ConvergenceStopped / ProcessExited unblocks it; now it fires.
+        assert_eq!(s.fired(at(t0, 5_001), true), vec![Event::BackoffElapsed]);
+        assert!(s.backoff_until().is_none(), "consumed once taken");
+        assert!(s.fired(at(t0, 6_000), true).is_empty());
+    }
+
+    /// The other half: a withheld backoff must not ask for an immediate
+    /// tick on every pass. What unblocks it arrives on an fd, not from
+    /// the clock, so there is nothing to wake up for — and asking would
+    /// spin a core until the block cleared.
+    #[test]
+    fn a_withheld_backoff_does_not_request_a_busy_tick() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_backoff(t0, Duration::from_millis(250));
+        let late = at(t0, 5_000);
+
+        assert!(s.fired(late, false).is_empty());
+        assert_eq!(
+            s.next_wakeup(late, None, false),
+            None,
+            "blocked: sleep on the fds instead of spinning"
+        );
+        // Once permitted, it is due immediately.
+        assert_eq!(
+            s.next_wakeup(late, None, true),
+            Some(Duration::ZERO),
+            "unblocked: tick now"
+        );
+    }
+
+    /// A backoff still in the future is scheduled normally whether or
+    /// not a restart is currently permitted — by the time it elapses the
+    /// block may well be gone.
+    #[test]
+    fn a_future_backoff_is_scheduled_regardless_of_the_block() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_backoff(t0, Duration::from_secs(30));
+        assert_eq!(
+            s.next_wakeup(t0, None, false),
+            Some(Duration::from_secs(30))
+        );
+    }
+
+    // ---- One budget across the convergence cycle ----
+
+    /// `CONVERGENCE_BUDGET` bounds a resync PLUS verify. Re-arming on
+    /// the `Syncing → Verifying` transition would let the resync spend
+    /// nearly all of it and hand verification a fresh one, making the
+    /// real bound twice the documented number.
+    #[test]
+    fn moving_between_convergence_substates_keeps_one_deadline() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
+        let armed = s.phase_deadline().expect("armed");
+
+        // 119 s of resync, then SyncComplete → Verifying, same kind.
+        let t1 = at(t0, 119_000);
+        s.arm_phase(t1, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
+        assert_eq!(
+            s.phase_deadline(),
+            Some(armed),
+            "the cycle's deadline must not restart for the verify"
+        );
+        assert_eq!(
+            s.fired(at(t0, 120_001), true),
+            vec![Event::PhaseTimedOut],
+            "the whole cycle is bounded, not each substate"
+        );
+    }
+
+    /// But entering convergence from startup DOES start a fresh clock —
+    /// they are different phases with different budgets.
+    #[test]
+    fn entering_convergence_from_startup_restarts_the_clock() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some((PhaseKind::Startup, API_STARTUP_BUDGET)));
+        let t1 = at(t0, 30_000);
+        s.arm_phase(t1, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
+        assert_eq!(s.phase_deadline(), Some(t1 + CONVERGENCE_BUDGET));
+    }
+
+    /// And a cycle that ended and began again gets a fresh deadline,
+    /// rather than inheriting the previous attempt's remaining time.
+    #[test]
+    fn a_new_convergence_after_a_gap_starts_fresh() {
+        let t0 = Instant::now();
+        let mut s = Schedule::new();
+        s.arm_phase(t0, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
+        // Failure → Backoff (no phase), then a new attempt.
+        s.arm_phase(at(t0, 10_000), None);
+        let t2 = at(t0, 20_000);
+        s.arm_phase(t2, Some((PhaseKind::Convergence, CONVERGENCE_BUDGET)));
+        assert_eq!(s.phase_deadline(), Some(t2 + CONVERGENCE_BUDGET));
+    }
+
+    /// The supervisor is the source of the grouping, so check the real
+    /// states agree rather than only the enum.
+    #[test]
+    fn the_supervisors_convergence_states_share_a_kind() {
+        use crate::supervisor::{Event as E, Supervisor};
+        let mut sup = Supervisor::new();
+        sup.on(E::StartRequested);
+        assert_eq!(sup.phase().map(|(k, _)| k), Some(PhaseKind::Startup));
+        sup.on(E::ApiUp);
+        let syncing = sup.phase();
+        assert_eq!(syncing.map(|(k, _)| k), Some(PhaseKind::Convergence));
+        sup.on(E::SyncComplete);
+        assert_eq!(
+            sup.phase(),
+            syncing,
+            "Syncing and Verifying must report the same phase and budget"
+        );
+        sup.on(E::VerifyPassed);
+        assert_eq!(sup.phase(), None, "Ready has no deadline");
     }
 
     // ---- Sleeping: never miss, never spin ----
@@ -236,7 +432,7 @@ mod tests {
     #[test]
     fn an_idle_schedule_permits_blocking_indefinitely() {
         let t0 = Instant::now();
-        assert_eq!(Schedule::new().next_wakeup(t0, None), None);
+        assert_eq!(Schedule::new().next_wakeup(t0, None, true), None);
     }
 
     /// The wakeup must be the EARLIEST deadline. Sleeping past any
@@ -246,17 +442,17 @@ mod tests {
     fn the_wakeup_is_the_earliest_of_every_deadline() {
         let t0 = Instant::now();
         let mut s = Schedule::new();
-        s.arm_phase(t0, Some(Duration::from_secs(120)));
+        s.arm_phase(t0, Some((PhaseKind::Convergence, Duration::from_secs(120))));
         s.arm_backoff(t0, Duration::from_secs(30));
         // Ping is soonest of the three.
         let ping = at(t0, 500);
 
         assert_eq!(
-            s.next_wakeup(t0, Some(ping)),
+            s.next_wakeup(t0, Some(ping), true),
             Some(Duration::from_millis(500))
         );
         // Without the ping, the backoff is next.
-        assert_eq!(s.next_wakeup(t0, None), Some(Duration::from_secs(30)));
+        assert_eq!(s.next_wakeup(t0, None, true), Some(Duration::from_secs(30)));
     }
 
     /// An already-elapsed deadline asks for an immediate tick, and that
@@ -268,10 +464,10 @@ mod tests {
         s.arm_backoff(t0, Duration::from_millis(100));
 
         let late = at(t0, 5_000);
-        assert_eq!(s.next_wakeup(late, None), Some(Duration::ZERO));
-        assert_eq!(s.fired(late), vec![Event::BackoffElapsed]);
+        assert_eq!(s.next_wakeup(late, None, true), Some(Duration::ZERO));
+        assert_eq!(s.fired(late, true), vec![Event::BackoffElapsed]);
         assert_eq!(
-            s.next_wakeup(late, None),
+            s.next_wakeup(late, None, true),
             None,
             "consuming the deadline must end the immediate-tick request"
         );
@@ -284,7 +480,7 @@ mod tests {
         let t0 = Instant::now();
         let s = Schedule::new();
         assert_eq!(
-            s.next_wakeup(t0, Some(at(t0, 500))),
+            s.next_wakeup(t0, Some(at(t0, 500)), true),
             Some(Duration::from_millis(500))
         );
     }
@@ -302,14 +498,14 @@ mod tests {
         let s = Schedule::new();
 
         assert_eq!(
-            s.next_wakeup(t0, Some(d.next_ping_at())),
+            s.next_wakeup(t0, Some(d.next_ping_at()), true),
             Some(PING_INTERVAL)
         );
 
         // After a ping goes out, the next one is an interval later.
         d.on_ping_sent(at(t0, 500));
         assert_eq!(
-            s.next_wakeup(at(t0, 500), Some(d.next_ping_at())),
+            s.next_wakeup(at(t0, 500), Some(d.next_ping_at()), true),
             Some(PING_INTERVAL)
         );
     }
@@ -323,7 +519,7 @@ mod tests {
         let t0 = Instant::now();
         let d = WedgeDetector::started(t0);
         let s = Schedule::new();
-        let sleep = s.next_wakeup(t0, Some(d.next_ping_at())).unwrap();
+        let sleep = s.next_wakeup(t0, Some(d.next_ping_at()), true).unwrap();
         assert!(
             sleep < worst_case_detection(PING_BUDGET),
             "sleeping {sleep:?} would blow the detection bound"

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -68,6 +68,19 @@ pub const API_STARTUP_BUDGET: Duration = Duration::from_secs(60);
 /// exceeding it means something is wrong, not merely slow.
 pub const CONVERGENCE_BUDGET: Duration = Duration::from_secs(120);
 
+/// A group of states that share one deadline.
+///
+/// Exists so a multi-state phase is bounded as a whole rather than
+/// per-state. Startup is one state today, but naming it keeps the
+/// schedule from having to infer the grouping from a duration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhaseKind {
+    /// Spawned, waiting for the API to answer.
+    Startup,
+    /// Attach → resync → verify, budgeted as one cycle.
+    Convergence,
+}
+
 /// Where the supervised VPP is in its lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum State {
@@ -558,9 +571,29 @@ impl Supervisor {
     /// clock — but the *budget* belongs here, next to the states it
     /// bounds.
     pub fn phase_budget(&self) -> Option<Duration> {
+        self.phase().map(|(_, budget)| budget)
+    }
+
+    /// The current phase and its budget, or `None` when no deadline
+    /// applies.
+    ///
+    /// The **kind** matters as much as the duration. `CONVERGENCE_BUDGET`
+    /// is documented as covering a resync *plus* verify, but `Syncing`,
+    /// `AdoptedResyncing` and `Verifying` are three distinct states —
+    /// so re-arming a fresh budget on each transition would hand out
+    /// 120 s for the resync and another 120 s for the verify, twice the
+    /// number the constant claims to be. States that share a kind share
+    /// one deadline, and only a change of kind restarts the clock.
+    ///
+    /// Which states share a deadline is supervisor knowledge, so it
+    /// lives here rather than in [`crate::schedule::Schedule`], which
+    /// only does the arithmetic.
+    pub fn phase(&self) -> Option<(PhaseKind, Duration)> {
         match self.state {
-            State::Starting => Some(API_STARTUP_BUDGET),
-            State::Syncing | State::AdoptedResyncing | State::Verifying => Some(CONVERGENCE_BUDGET),
+            State::Starting => Some((PhaseKind::Startup, API_STARTUP_BUDGET)),
+            State::Syncing | State::AdoptedResyncing | State::Verifying => {
+                Some((PhaseKind::Convergence, CONVERGENCE_BUDGET))
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
The timing core of slice 4's tick loop. Off `main`, no stack.

Split from the loop itself because this is the half that **can** be tested: the I/O (polling a pidfd, draining a batch, writing a ping) needs a live VPP, but deciding *when* those happen is arithmetic over an injected clock — same shape as `supervisor` and `liveness`.

## Built to a rule this stack earned

Nine of the last thirteen review findings on these PRs were the same mistake: **state recorded when an effect was requested rather than when it was observed.**

- `steered` cleared on *emitting* `Unsteer`
- `converging` cleared because *one* pipeline step failed
- termination assumed on *issuing* `Kill`
- `sw_if_index` defaulted as optional when the adopted path depended on it

A loop is nothing but requests whose completion arrives later, so it's the most likely place for a tenth. Every field here is documented with the one observation permitted to change it, and **anything without an observer didn't get a field**:

| Field | Observer |
|---|---|
| `phase_deadline` | a supervisor state change, via `arm_phase` |
| `backoff_until` | `Action::ArmBackoff`, via `arm_backoff` |

That rule decided the design twice:

- **The ping deadline is not stored here.** It belongs to `WedgeDetector`, whose observation is a pong. A copy would be a second answer to one question, and the two would drift. It's passed in.
- **`fired()` consumes what it reports.** A deadline left armed emits the same event every tick — and since both events route through the supervisor's failure path, that's a teardown-restart *spin* rather than one recovery. Tested directly.

## Not spinning, not missing

`next_wakeup` returns `None` when nothing is armed, so an idle loop blocks on its fds rather than burning a core — which matters on a box where every core is already allocated (and where poll-mode already costs one per VPP worker, permanently).

It returns the **earliest** of all armed deadlines, because sleeping past any one would delay that timeout by however long the others had left.

## Two tests that reach outside the arithmetic

- A steady-state wakeup must be shorter than `worst_case_detection(PING_BUDGET)` — the scheduler must not be what makes the published ≤2 s wedge bound miss.
- Re-arming across a phase change must not let the previous phase's deadline fire (59 s into a 60 s startup budget, the API comes up and the convergence budget starts fresh).

## Verification

403 workspace tests (12 new). Host clippy `-D warnings` clean; all four Linux cross-targets linted locally before pushing.

**Next:** the loop body that uses this — incremental batch draining so the ping and pidfd stay serviced, then the VppSink health/metrics surface. `Steer`/`Unsteer` remain slice 5.