### PR TITLE
fix(vpp-offload): size the stats segment — gate 0b item 10, measured

### DIFF
--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -91,6 +91,19 @@ impl VppOffloadConfig {
         }
         out
     }
+
+    /// Total VPP worker threads the config promises, across all ports.
+    ///
+    /// VPP's thread count is global, not per-interface, and its counter
+    /// vectors replicate per thread — so this, not any single port's
+    /// `cores`, is what sizes the stats segment
+    /// (`startup_conf::derive_sizing`).
+    pub fn total_workers(&self) -> u32 {
+        self.ports
+            .iter()
+            .map(|(_, cores, _)| u32::from(*cores))
+            .sum()
+    }
 }
 
 pub struct VppOffloadModule {
@@ -130,8 +143,9 @@ impl Module for VppOffloadModule {
         // the fast-path section is visible; by load time it has passed.
         // Here: validate the sizing arithmetic so a too-small
         // `hugepages` is a clean startup error, not a VPP init abort.
-        let sizing = startup_conf::derive_sizing(self.cfg.expected_routes)
-            .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
+        let sizing =
+            startup_conf::derive_sizing(self.cfg.expected_routes, self.cfg.total_workers())
+                .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
         if let Some(pages) = self.cfg.hugepages {
             startup_conf::check_hugepage_budget(&sizing, pages, default_hugepage_bytes())
                 .map_err(|e| ModuleError::other(MODULE_NAME, e))?;

--- a/crates/modules/vpp-offload/src/startup_conf.rs
+++ b/crates/modules/vpp-offload/src/startup_conf.rs
@@ -17,15 +17,25 @@
 //! that omits the stats segment does not run VPP short; it kills it
 //! partway through its first full-table resync.
 //!
+//! **The stats segment also scales with VPP's thread count**, which the
+//! main heap's route term does not. VPP's counter vectors are per-thread
+//! (`vec_validate (cm->counters, tm->n_vlib_mains - 1)`), so every
+//! worker adds another copy of every per-FIB-entry counter. Gate 0b ran
+//! one worker; a five-port config runs five. Sizing from the measured
+//! aggregate as if it were thread-independent would under-provision a
+//! five-worker box by ~3× and reproduce the very abort this module now
+//! exists to prevent.
+//!
 //! ## Measured, gate 0b item 10 (2026-08-03, shadow)
 //!
 //! 1,053,360 v4 prefixes from the live bird `master4`, loaded into
-//! v26.06/octeon9 on a 4 GiB main heap:
+//! v26.06/octeon9 on a 4 GiB main heap, `corelist-workers 17` —
+//! **one worker, so two VPP threads** (main + worker):
 //!
 //! | | baseline | full table | per route |
 //! |---|---|---|---|
 //! | main heap (used) | 337.86 MiB | 803.49 MiB | **463 B** |
-//! | stat segment (populated) | 1.19 MiB | 101.94 MiB | **97 B** |
+//! | stat segment (populated) | 1.19 MiB | 101.94 MiB | **97 B** (at 2 threads) |
 //! | hugepages in use | 9 × 512 MiB | 10 × 512 MiB | — |
 //!
 //! Per-chunk increments ranged 82 B–2,058 B/route because mtrie
@@ -66,22 +76,48 @@ pub const HEAP_FLOOR_BYTES: u64 = 512 << 20;
 /// short at full table.
 pub const BUFFER_BYTES: u64 = 1 << 30;
 
-/// Stats-segment bytes per installed route.
+/// Stats-segment bytes per installed route, **per VPP thread**.
 ///
-/// Measured **97 B/route** from populated pages. 192 is ~2×.
+/// Measured **97 B/route** from populated pages with two threads (the
+/// main thread plus one worker) ⇒ 48.5 B/route/thread. 96 is ~2×, and
+/// reproduces the measured configuration's 192 B/route exactly.
+///
+/// The per-thread form is not cosmetic. VPP allocates counter vectors
+/// per thread, so a five-worker config needs three times what gate 0b
+/// measured. The decomposition is deliberately **conservative**:
+/// gate 0b has a single data point, so it cannot separate the fixed
+/// per-route cost (statseg directory entries, name strings) from the
+/// per-thread cost, and this attributes all of it to per-thread. That
+/// over-provisions multi-worker boxes — the safe direction, since the
+/// resource is cheap and the failure mode is an abort mid-resync.
+/// Re-measuring at two different worker counts would refine it; until
+/// then, err high.
 ///
 /// This term did not exist before gate 0b, and its absence is what
 /// aborted VPP at ~380k routes on the default segment.
-pub const STATSEG_BYTES_PER_ROUTE: u64 = 192;
+pub const STATSEG_BYTES_PER_ROUTE_PER_THREAD: u64 = 96;
 
 /// Stats-segment floor. VPP's own counters exist before any route does,
 /// and its own default is 32 MiB — no reason to go below that.
 pub const STATSEG_FLOOR_BYTES: u64 = 32 << 20;
 
+/// VPP threads for `workers` configured workers: `n_vlib_mains` in
+/// VPP's own terms — the main thread plus one per worker. The main
+/// thread gets a counter slot whether or not workers exist, so a
+/// worker-less VPP is one thread, not zero.
+pub fn thread_count(workers: u32) -> u64 {
+    u64::from(workers) + 1
+}
+
 /// Derived sizing: what the config's `expected-routes` implies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Sizing {
     pub expected_routes: u64,
+    /// Configured VPP workers (sum of every port's `cores`). Recorded
+    /// because the stats segment scales with it and because [`render`]
+    /// cross-checks it against the core list it is handed — two
+    /// independent worker counts is how a segment gets undersized.
+    pub workers: u32,
     pub main_heap_bytes: u64,
     /// The **hugepage** budget: main heap + buffers.
     ///
@@ -96,10 +132,15 @@ pub struct Sizing {
     pub statseg_bytes: u64,
 }
 
-/// Compute the sizing from the route count. Errors on inputs that
-/// would overflow or that are plainly nonsensical (0 is rejected at
-/// parse; this guards the arithmetic itself).
-pub fn derive_sizing(expected_routes: u64) -> Result<Sizing, String> {
+/// Compute the sizing from the route count and the configured worker
+/// count. Errors on inputs that would overflow or that are plainly
+/// nonsensical (0 routes is rejected at parse; this guards the
+/// arithmetic itself).
+///
+/// `workers` is the **total** across every port — the sum of the
+/// `cores` promises — because VPP's thread count, and therefore its
+/// counter-vector replication, is global rather than per-interface.
+pub fn derive_sizing(expected_routes: u64, workers: u32) -> Result<Sizing, String> {
     let table = expected_routes
         .checked_mul(HEAP_BYTES_PER_ROUTE)
         .ok_or_else(|| format!("expected-routes {expected_routes} overflows sizing math"))?;
@@ -110,11 +151,17 @@ pub fn derive_sizing(expected_routes: u64) -> Result<Sizing, String> {
         .checked_add(BUFFER_BYTES)
         .ok_or_else(|| "total sizing overflow".to_string())?;
     let statseg_bytes = expected_routes
-        .checked_mul(STATSEG_BYTES_PER_ROUTE)
-        .ok_or_else(|| "stats-segment sizing overflow".to_string())?
+        .checked_mul(STATSEG_BYTES_PER_ROUTE_PER_THREAD)
+        .and_then(|b| b.checked_mul(thread_count(workers)))
+        .ok_or_else(|| {
+            format!(
+                "stats-segment sizing overflows at {expected_routes} routes × {workers} workers"
+            )
+        })?
         .max(STATSEG_FLOOR_BYTES);
     Ok(Sizing {
         expected_routes,
+        workers,
         main_heap_bytes,
         total_bytes,
         statseg_bytes,
@@ -201,6 +248,22 @@ pub fn render(
     api_socket: &str,
     hugepage_bytes: u64,
 ) -> String {
+    // The core list and the sizing must describe the same VPP. They
+    // come from the same config, so a mismatch is a programming error —
+    // but an *invisible* one: too few workers in the sizing means an
+    // undersized stats segment, which surfaces hours later as an OOM
+    // abort partway through a resync, with no hint that startup.conf
+    // was the cause. Fail here, loudly, where the message names the
+    // problem.
+    assert_eq!(
+        worker_cores.len(),
+        sizing.workers as usize,
+        "sizing was derived for {} workers but {} worker cores were given; \
+         the stats segment scales with thread count and would be undersized",
+        sizing.workers,
+        worker_cores.len(),
+    );
+
     let mut out = String::with_capacity(2048);
     let workers = worker_cores
         .iter()
@@ -270,11 +333,18 @@ mod tests {
     const MEASURED_ROUTES: u64 = 1_053_360;
     const MEASURED_HEAP_USED: u64 = 803 * (1 << 20); // 803.49 MiB
     const MEASURED_STATSEG_POPULATED: u64 = 102 * (1 << 20); // 101.94 MiB
+    /// The spike ran `corelist-workers 17`: one worker, two VPP threads.
+    /// Every statseg figure above is a two-thread figure.
+    const MEASURED_WORKERS: u32 = 1;
+    /// 101.94 MiB / 1,053,360 routes / 2 threads, rounded up. Used to
+    /// extrapolate the measurement to worker counts the spike did not
+    /// run, which is the only honest way to check those configurations.
+    const MEASURED_STATSEG_PER_ROUTE_PER_THREAD: u64 = 51;
 
     #[test]
     fn sizing_scales_with_routes() {
-        let small = derive_sizing(1_000).unwrap();
-        let full = derive_sizing(1_400_000).unwrap();
+        let small = derive_sizing(1_000, 1).unwrap();
+        let full = derive_sizing(1_400_000, 1).unwrap();
         assert!(full.main_heap_bytes > small.main_heap_bytes);
         assert!(full.statseg_bytes > small.statseg_bytes);
         // Post-measurement band: 1.4M × 1 KiB + 512 MiB floor + 1 GiB
@@ -289,7 +359,7 @@ mod tests {
     /// "tidy up the constants" that quietly drops below reality.
     #[test]
     fn the_constants_cover_the_measured_full_table() {
-        let s = derive_sizing(MEASURED_ROUTES).unwrap();
+        let s = derive_sizing(MEASURED_ROUTES, MEASURED_WORKERS).unwrap();
         assert!(
             s.main_heap_bytes > MEASURED_HEAP_USED,
             "derived heap {} must exceed the measured {MEASURED_HEAP_USED}",
@@ -313,9 +383,87 @@ mod tests {
         // time — a default that stopped covering the measured table
         // should fail the build, not a test run.
         const { assert!(crate::DEFAULT_EXPECTED_ROUTES > MEASURED_ROUTES) };
-        let s = derive_sizing(crate::DEFAULT_EXPECTED_ROUTES).unwrap();
+        let s = derive_sizing(crate::DEFAULT_EXPECTED_ROUTES, MEASURED_WORKERS).unwrap();
         assert!(s.statseg_bytes > MEASURED_STATSEG_POPULATED);
         assert!(s.main_heap_bytes > MEASURED_HEAP_USED);
+    }
+
+    /// The stats segment must cover the extrapolated measurement at
+    /// **every** worker count a config can ask for, not just the one the
+    /// spike happened to run.
+    ///
+    /// This is the invariant, so it is asserted against the extrapolated
+    /// measurement rather than against `STATSEG_BYTES_PER_ROUTE_PER_THREAD`
+    /// — checking the constant against itself would pass for any value.
+    /// A fixed per-route slope fails this at 2 workers and is 3× short at
+    /// 5, which is the `example.conf` shape.
+    #[test]
+    fn the_stats_segment_covers_every_supported_worker_count() {
+        for workers in 0..=16u32 {
+            let s = derive_sizing(crate::DEFAULT_EXPECTED_ROUTES, workers).unwrap();
+            let need = crate::DEFAULT_EXPECTED_ROUTES
+                * MEASURED_STATSEG_PER_ROUTE_PER_THREAD
+                * thread_count(workers);
+            assert!(
+                s.statseg_bytes >= need * 3 / 2,
+                "workers={workers}: derived {} is not 1.5× the extrapolated {need}",
+                s.statseg_bytes
+            );
+        }
+    }
+
+    /// Every added worker adds a full copy of every per-FIB-entry
+    /// counter, so the segment must grow strictly with worker count. A
+    /// route-count-only slope makes this constant, which is the bug.
+    #[test]
+    fn the_stats_segment_scales_with_workers() {
+        let one = derive_sizing(1_600_000, 1).unwrap();
+        let five = derive_sizing(1_600_000, 5).unwrap();
+        assert!(
+            five.statseg_bytes > one.statseg_bytes,
+            "5 workers ({}) must need more than 1 ({})",
+            five.statseg_bytes,
+            one.statseg_bytes
+        );
+        // Linear in thread count, not worker count: 6 threads vs 2.
+        assert_eq!(five.statseg_bytes, one.statseg_bytes * 3);
+        // And the main heap does NOT scale with workers — its route term
+        // is shared FIB state, and treating it as per-thread would
+        // inflate the hugepage reservation for no reason.
+        assert_eq!(five.main_heap_bytes, one.main_heap_bytes);
+        assert_eq!(five.total_bytes, one.total_bytes);
+    }
+
+    /// A worker-less VPP still runs its main thread, and that thread
+    /// still holds counters. Zero threads would size the segment to the
+    /// floor and abort on a real table.
+    #[test]
+    fn the_main_thread_counts_even_with_no_workers() {
+        assert_eq!(thread_count(0), 1);
+        assert_eq!(thread_count(1), 2);
+        assert_eq!(thread_count(5), 6);
+        let s = derive_sizing(1_600_000, 0).unwrap();
+        assert_eq!(
+            s.statseg_bytes,
+            1_600_000 * STATSEG_BYTES_PER_ROUTE_PER_THREAD
+        );
+    }
+
+    /// Two independent worker counts — one in the sizing, one in the
+    /// rendered core list — is how a stats segment gets silently
+    /// undersized. The renderer refuses.
+    #[test]
+    #[should_panic(expected = "stats segment scales with thread count")]
+    fn render_refuses_a_worker_count_that_disagrees_with_the_sizing() {
+        let sizing = derive_sizing(1_600_000, 1).unwrap();
+        // Sizing says one worker; the core map says four.
+        render(
+            &sizing,
+            &[14, 15, 16, 17],
+            13,
+            "/run/packetframe/vpp/api.sock",
+            0,
+        );
     }
 
     /// The stats segment is 64 K-backed locked RAM, not hugepages
@@ -324,7 +472,7 @@ mod tests {
     /// satisfy.
     #[test]
     fn the_stats_segment_is_not_in_the_hugepage_budget() {
-        let s = derive_sizing(1_600_000).unwrap();
+        let s = derive_sizing(1_600_000, 5).unwrap();
         assert_eq!(s.total_bytes, s.main_heap_bytes + BUFFER_BYTES);
         assert!(s.statseg_bytes > 0);
         assert!(
@@ -336,17 +484,20 @@ mod tests {
     #[test]
     fn the_stats_segment_respects_its_floor() {
         // A tiny table still needs VPP's own counters.
-        let s = derive_sizing(1_000).unwrap();
+        let s = derive_sizing(1_000, 1).unwrap();
         assert_eq!(s.statseg_bytes, STATSEG_FLOOR_BYTES);
         // A large one scales past it.
-        let big = derive_sizing(1_600_000).unwrap();
-        assert_eq!(big.statseg_bytes, 1_600_000 * STATSEG_BYTES_PER_ROUTE);
+        let big = derive_sizing(1_600_000, 1).unwrap();
+        assert_eq!(
+            big.statseg_bytes,
+            1_600_000 * STATSEG_BYTES_PER_ROUTE_PER_THREAD * 2
+        );
         assert!(big.statseg_bytes > STATSEG_FLOOR_BYTES);
     }
 
     #[test]
     fn hugepage_budget_enforced() {
-        let sizing = derive_sizing(1_400_000).unwrap();
+        let sizing = derive_sizing(1_400_000, 1).unwrap();
         let page = 512u64 << 20; // the EFG's 512 MiB default pages
                                  // 5 pages = 2.5 GiB: below the ~2.8 GiB need → rejected with
                                  // the corrective count in the message.
@@ -360,7 +511,7 @@ mod tests {
 
     #[test]
     fn render_is_deterministic_and_complete() {
-        let sizing = derive_sizing(1_400_000).unwrap();
+        let sizing = derive_sizing(1_400_000, 2).unwrap();
         let conf = render(
             &sizing,
             &[14, 15],
@@ -399,7 +550,7 @@ mod tests {
     #[test]
     fn a_stats_segment_stanza_is_always_emitted() {
         for routes in [1_000u64, 1_053_360, 1_600_000] {
-            let s = derive_sizing(routes).unwrap();
+            let s = derive_sizing(routes, 1).unwrap();
             let conf = render(&s, &[14], 13, "/run/packetframe/vpp/api.sock", 0);
             assert!(conf.contains("statseg {"), "routes={routes}:\n{conf}");
             let want = s.statseg_bytes.div_ceil(1 << 20);
@@ -418,8 +569,8 @@ mod tests {
     /// shortfall shows up as an OOM mid-resync.
     #[test]
     fn the_stats_segment_rounds_up_never_down() {
-        // 1,000,001 × 192 = 192,000,192 B = 183.10… MiB
-        let s = derive_sizing(1_000_001).unwrap();
+        // 1,000,001 × 96 × 2 threads = 192,000,192 B = 183.10… MiB
+        let s = derive_sizing(1_000_001, 1).unwrap();
         let mib = s.statseg_bytes.div_ceil(1 << 20);
         assert!(
             (mib << 20) >= s.statseg_bytes,
@@ -435,7 +586,7 @@ mod tests {
     /// dataplane that will not come up.
     #[test]
     fn no_dpdk_and_no_device_stanzas() {
-        let sizing = derive_sizing(1_000).unwrap();
+        let sizing = derive_sizing(1_000, 1).unwrap();
         let conf = render(&sizing, &[14], 13, "/run/packetframe/vpp/api.sock", 0);
 
         assert!(
@@ -466,7 +617,7 @@ mod tests {
         // Sweep route counts that produce non-MiB-aligned heaps; the
         // rendered value must always cover the derived requirement.
         for routes in [1u64, 7, 1_399_999, 1_400_000, 1_400_001, 2_000_003] {
-            let s = derive_sizing(routes).unwrap();
+            let s = derive_sizing(routes, 1).unwrap();
             let mib = s.main_heap_bytes.div_ceil(1 << 20);
             assert!(
                 (mib << 20) >= s.main_heap_bytes,

--- a/crates/modules/vpp-offload/src/startup_conf.rs
+++ b/crates/modules/vpp-offload/src/startup_conf.rs
@@ -7,33 +7,93 @@
 //! minimum is a clean load-time error instead of a cryptic VPP init
 //! abort.
 //!
-//! The per-route constant below is a deliberately generous
-//! **pre-measurement placeholder**: gate 0b loads a real table into a
-//! real VPP and replaces it with the measured number (plan: "measure
-//! actual heap consumption at gate 0b rather than trusting anyone's
-//! rule of thumb"). Memory is the cheapest resource on the reference
-//! platform (64 GB); headroom errs large.
+//! **The main heap is not the only thing that scales with route
+//! count.** VPP keeps per-FIB-entry counters in a separate `statseg`
+//! with its own fixed size, invisible to `show memory main-heap`. Gate
+//! 0b established that the default 31.94 MiB segment is exhausted at
+//! roughly 380k routes and VPP then aborts with a bare
+//! `Out-of-memory, calling os_panic()` — while the main heap sits 87%
+//! free, which points every diagnostic at the wrong allocator. Sizing
+//! that omits the stats segment does not run VPP short; it kills it
+//! partway through its first full-table resync.
+//!
+//! ## Measured, gate 0b item 10 (2026-08-03, shadow)
+//!
+//! 1,053,360 v4 prefixes from the live bird `master4`, loaded into
+//! v26.06/octeon9 on a 4 GiB main heap:
+//!
+//! | | baseline | full table | per route |
+//! |---|---|---|---|
+//! | main heap (used) | 337.86 MiB | 803.49 MiB | **463 B** |
+//! | stat segment (populated) | 1.19 MiB | 101.94 MiB | **97 B** |
+//! | hugepages in use | 9 × 512 MiB | 10 × 512 MiB | — |
+//!
+//! Per-chunk increments ranged 82 B–2,058 B/route because mtrie
+//! interior nodes allocate in blocks, so the full-table **average** is
+//! the figure to size from — no single marginal is meaningful.
+//!
+//! The stats segment is sized from *populated* pages, not `used`: the
+//! allocator reported 75.04 MiB used while the OS had backed 101.94
+//! MiB. Sizing from `used` would under-provision by a third.
+//!
+//! Constants carry roughly 2× margin over measurement. Memory is the
+//! cheapest resource here (64 GB), and the failure mode of being wrong
+//! low is a mid-resync abort.
 
-/// Estimated main-heap bytes per installed route (v4/v6 blended),
-/// covering mtrie nodes, fib_entry, path-list sharing, adjacencies.
-/// Generous by design; replaced by the gate-0b measurement.
-pub const HEAP_BYTES_PER_ROUTE: u64 = 2_048;
+/// Main-heap bytes per installed route: mtrie nodes, `fib_entry`,
+/// path-list, adjacency.
+///
+/// Measured **463 B** on the v4 table (see module docs). 1024 is ~2.2×
+/// that. The previous value was 2,048 — a pre-measurement guess that
+/// turned out ~4.4× high, which mattered only because it also implied
+/// the stats segment was covered. It was not.
+pub const HEAP_BYTES_PER_ROUTE: u64 = 1_024;
 
 /// Fixed main-heap floor independent of table size: VPP's own
-/// allocations, stats segment, API rings, plugin overhead.
-pub const HEAP_FLOOR_BYTES: u64 = 1 << 30; // 1 GiB
+/// allocations, API rings, plugin overhead.
+///
+/// Measured **337.86 MiB** with an empty FIB. 512 MiB is ~1.5×. The
+/// previous 1 GiB predates the measurement and did NOT cover the stats
+/// segment despite claiming to.
+pub const HEAP_FLOOR_BYTES: u64 = 512 << 20;
 
-/// Buffer memory independent of the main heap (buffers-per-numa ×
-/// ~2.5 KB each, plus descriptor overhead). One conservative number
-/// until gate 0b measures per-port needs.
-pub const BUFFER_BYTES: u64 = 512 << 20; // 512 MiB
+/// Hugepage-backed memory beyond the main heap: buffers, and whatever
+/// else VPP maps on hugepages.
+///
+/// Measured as **1 GiB**: at full table, 10 × 512 MiB pages were in
+/// use with a 4 GiB main heap declared — two pages beyond the heap's
+/// eight. The previous 512 MiB would have left the reservation one page
+/// short at full table.
+pub const BUFFER_BYTES: u64 = 1 << 30;
+
+/// Stats-segment bytes per installed route.
+///
+/// Measured **97 B/route** from populated pages. 192 is ~2×.
+///
+/// This term did not exist before gate 0b, and its absence is what
+/// aborted VPP at ~380k routes on the default segment.
+pub const STATSEG_BYTES_PER_ROUTE: u64 = 192;
+
+/// Stats-segment floor. VPP's own counters exist before any route does,
+/// and its own default is 32 MiB — no reason to go below that.
+pub const STATSEG_FLOOR_BYTES: u64 = 32 << 20;
 
 /// Derived sizing: what the config's `expected-routes` implies.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Sizing {
     pub expected_routes: u64,
     pub main_heap_bytes: u64,
+    /// The **hugepage** budget: main heap + buffers.
+    ///
+    /// Deliberately excludes the stats segment, which VPP backs with
+    /// ordinary 64 K pages (verified at gate 0b) — counting it here
+    /// would inflate the hugepage reservation by hundreds of MiB that
+    /// hugepages never satisfy.
     pub total_bytes: u64,
+    /// Stats-segment size. **Locked RAM, outside the hugepage
+    /// reservation** — a separate budget line, not part of
+    /// `total_bytes`.
+    pub statseg_bytes: u64,
 }
 
 /// Compute the sizing from the route count. Errors on inputs that
@@ -49,10 +109,15 @@ pub fn derive_sizing(expected_routes: u64) -> Result<Sizing, String> {
     let total_bytes = main_heap_bytes
         .checked_add(BUFFER_BYTES)
         .ok_or_else(|| "total sizing overflow".to_string())?;
+    let statseg_bytes = expected_routes
+        .checked_mul(STATSEG_BYTES_PER_ROUTE)
+        .ok_or_else(|| "stats-segment sizing overflow".to_string())?
+        .max(STATSEG_FLOOR_BYTES);
     Ok(Sizing {
         expected_routes,
         main_heap_bytes,
         total_bytes,
+        statseg_bytes,
     })
 }
 
@@ -166,6 +231,20 @@ pub fn render(
         sizing.main_heap_bytes.div_ceil(1 << 20)
     ));
     let _ = hugepage_bytes; // recorded in the header comment path later; kept as input for stability
+                            // The stats segment. NOT optional and NOT covered by
+                            // main-heap-size: VPP keeps per-FIB-entry counters here, the
+                            // default is 32 MiB, and gate 0b watched it exhaust at ~380k
+                            // routes and abort the process with an OOM that named no
+                            // segment. Emitting nothing here — which is what this
+                            // renderer did before — means the first full-table resync
+                            // kills VPP partway through.
+                            //
+                            // Ceiling for the same reason as the heap: a floor-rounded
+                            // MiB value hands VPP less than the arithmetic promised.
+    out.push_str(&format!(
+        "statseg {{\n  size {}M\n}}\n",
+        sizing.statseg_bytes.div_ceil(1 << 20)
+    ));
     out.push_str("buffers {\n  buffers-per-numa 65536\n  default data-size 2048\n}\n");
     // dpdk_plugin OFF. Round 2 on the shadow established that both the
     // otx2 and cnxk PMDs hard-require NPA mempool ops that VPP's buffer
@@ -185,27 +264,96 @@ pub fn render(
 mod tests {
     use super::*;
 
+    /// Routes measured at gate 0b, and what each heap actually used, so
+    /// the constants can be checked against reality rather than against
+    /// each other.
+    const MEASURED_ROUTES: u64 = 1_053_360;
+    const MEASURED_HEAP_USED: u64 = 803 * (1 << 20); // 803.49 MiB
+    const MEASURED_STATSEG_POPULATED: u64 = 102 * (1 << 20); // 101.94 MiB
+
     #[test]
     fn sizing_scales_with_routes() {
         let small = derive_sizing(1_000).unwrap();
         let full = derive_sizing(1_400_000).unwrap();
         assert!(full.main_heap_bytes > small.main_heap_bytes);
-        // The default full-table sizing lands in the plan's "couple of
-        // GB" band: floor + ~2.9G table + buffers ≈ 4.4 GiB total.
-        assert!(full.total_bytes > 3 << 30, "{}", full.total_bytes);
-        assert!(full.total_bytes < 8 << 30, "{}", full.total_bytes);
+        assert!(full.statseg_bytes > small.statseg_bytes);
+        // Post-measurement band: 1.4M × 1 KiB + 512 MiB floor + 1 GiB
+        // buffers ≈ 2.8 GiB. The pre-measurement arithmetic put this at
+        // ~4.4 GiB off a 2 KiB/route guess.
+        assert!(full.total_bytes > 2 << 30, "{}", full.total_bytes);
+        assert!(full.total_bytes < 4 << 30, "{}", full.total_bytes);
+    }
+
+    /// The constants must cover what the hardware actually consumed,
+    /// with margin — the point of measuring. Guards against a future
+    /// "tidy up the constants" that quietly drops below reality.
+    #[test]
+    fn the_constants_cover_the_measured_full_table() {
+        let s = derive_sizing(MEASURED_ROUTES).unwrap();
+        assert!(
+            s.main_heap_bytes > MEASURED_HEAP_USED,
+            "derived heap {} must exceed the measured {MEASURED_HEAP_USED}",
+            s.main_heap_bytes
+        );
+        assert!(
+            s.statseg_bytes > MEASURED_STATSEG_POPULATED,
+            "derived statseg {} must exceed the measured {MEASURED_STATSEG_POPULATED}",
+            s.statseg_bytes
+        );
+        // And with real margin, not by a hair.
+        assert!(s.main_heap_bytes >= MEASURED_HEAP_USED * 3 / 2);
+        assert!(s.statseg_bytes >= MEASURED_STATSEG_POPULATED * 3 / 2);
+    }
+
+    /// The default `expected-routes` must cover the measured table plus
+    /// DFZ growth — that is what the default is for.
+    #[test]
+    fn the_default_route_count_covers_the_measured_table() {
+        // Both sides are constants, so this is checkable at compile
+        // time — a default that stopped covering the measured table
+        // should fail the build, not a test run.
+        const { assert!(crate::DEFAULT_EXPECTED_ROUTES > MEASURED_ROUTES) };
+        let s = derive_sizing(crate::DEFAULT_EXPECTED_ROUTES).unwrap();
+        assert!(s.statseg_bytes > MEASURED_STATSEG_POPULATED);
+        assert!(s.main_heap_bytes > MEASURED_HEAP_USED);
+    }
+
+    /// The stats segment is 64 K-backed locked RAM, not hugepages
+    /// (verified at gate 0b). Folding it into the hugepage budget would
+    /// demand hundreds of MiB of reservation that hugepages never
+    /// satisfy.
+    #[test]
+    fn the_stats_segment_is_not_in_the_hugepage_budget() {
+        let s = derive_sizing(1_600_000).unwrap();
+        assert_eq!(s.total_bytes, s.main_heap_bytes + BUFFER_BYTES);
+        assert!(s.statseg_bytes > 0);
+        assert!(
+            s.total_bytes < s.main_heap_bytes + BUFFER_BYTES + s.statseg_bytes,
+            "statseg must not be counted in the hugepage total"
+        );
+    }
+
+    #[test]
+    fn the_stats_segment_respects_its_floor() {
+        // A tiny table still needs VPP's own counters.
+        let s = derive_sizing(1_000).unwrap();
+        assert_eq!(s.statseg_bytes, STATSEG_FLOOR_BYTES);
+        // A large one scales past it.
+        let big = derive_sizing(1_600_000).unwrap();
+        assert_eq!(big.statseg_bytes, 1_600_000 * STATSEG_BYTES_PER_ROUTE);
+        assert!(big.statseg_bytes > STATSEG_FLOOR_BYTES);
     }
 
     #[test]
     fn hugepage_budget_enforced() {
         let sizing = derive_sizing(1_400_000).unwrap();
         let page = 512u64 << 20; // the EFG's 512 MiB default pages
-                                 // 8 pages = 4 GiB: below the ~4.4 GiB need → rejected with the
-                                 // corrective count in the message.
-        let err = check_hugepage_budget(&sizing, 8, page).unwrap_err();
+                                 // 5 pages = 2.5 GiB: below the ~2.8 GiB need → rejected with
+                                 // the corrective count in the message.
+        let err = check_hugepage_budget(&sizing, 5, page).unwrap_err();
         assert!(err.contains("hugepages"), "{err}");
-        // 10 pages = 5 GiB: enough.
-        check_hugepage_budget(&sizing, 10, page).unwrap();
+        // 6 pages = 3 GiB: enough.
+        check_hugepage_budget(&sizing, 6, page).unwrap();
         // Unknown page size: byte check skipped.
         check_hugepage_budget(&sizing, 1, 0).unwrap();
     }
@@ -242,6 +390,41 @@ mod tests {
             (rendered_mib << 20) >= sizing.main_heap_bytes,
             "rendered heap {rendered_mib} MiB must not be below the derived {} bytes",
             sizing.main_heap_bytes
+        );
+    }
+
+    /// The stanza whose absence aborted VPP at ~380k routes. Asserted,
+    /// not described — a renderer that silently stops emitting it looks
+    /// fine until the first full-table resync dies.
+    #[test]
+    fn a_stats_segment_stanza_is_always_emitted() {
+        for routes in [1_000u64, 1_053_360, 1_600_000] {
+            let s = derive_sizing(routes).unwrap();
+            let conf = render(&s, &[14], 13, "/run/packetframe/vpp/api.sock", 0);
+            assert!(conf.contains("statseg {"), "routes={routes}:\n{conf}");
+            let want = s.statseg_bytes.div_ceil(1 << 20);
+            assert!(
+                conf.contains(&format!("size {want}M")),
+                "routes={routes} want size {want}M:\n{conf}"
+            );
+            // Never below VPP's own default, which is what the old
+            // implicit behaviour gave us.
+            assert!(want >= (STATSEG_FLOOR_BYTES >> 20));
+        }
+    }
+
+    /// Rounding UP, for the same reason as the heap: a floor-rounded
+    /// MiB value hands VPP less than the arithmetic promised, and the
+    /// shortfall shows up as an OOM mid-resync.
+    #[test]
+    fn the_stats_segment_rounds_up_never_down() {
+        // 1,000,001 × 192 = 192,000,192 B = 183.10… MiB
+        let s = derive_sizing(1_000_001).unwrap();
+        let mib = s.statseg_bytes.div_ceil(1 << 20);
+        assert!(
+            (mib << 20) >= s.statseg_bytes,
+            "rendered {mib} MiB is below the derived {} bytes",
+            s.statseg_bytes
         );
     }
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -589,9 +589,79 @@ section:
 | 7 | **PMTUD positive test** | >MTU DF packet through a steered path → correctly-sourced frag-needed back at the sender. **Do not skip.** |
 | 8 | VLAN subif egress | `create sub-interface` + tag 1337 toward the br1337-shaped topology |
 | 9 | rx-mode adaptive | `set interface rx-mode <if> adaptive`; watch idle CPU (the heat verdict) |
-| 10 | Full-table load — **v4-ONLY per the round-4 decision** | dump bird's `master4` ONLY (`birdc 'show route primary table master4'` → script `ip route add` via vppctl); record wall time, `show memory main-heap` (replaces HEAP_BYTES_PER_ROUTE=2048 in startup_conf.rs), and packetframe daemon RSS. Loading v4+v6 would measure a table shape the decision rejected |
+| 10 | Full-table load — **v4-ONLY per the round-4 decision** — **DONE, see RESULT below** | dump bird's `master4` ONLY (`birdc 'show route primary table master4'` → script `ip route add` via vppctl); record wall time, `show memory` (**all heaps, not `main-heap`** — see RESULT), and packetframe daemon RSS. Loading v4+v6 would measure a table shape the decision rejected |
 | 11 | pps/core + latency | steered constant-rate flow: pps at 1 worker, p50/p99 vs the kernel path |
 | 12 | Watts/thermals | idle + loaded, poll-mode vs adaptive (if 9 works) |
+
+### RESULT (2026-08-03, shadow, item 10): **v4 FULL TABLE FITS** — and the stats segment is the constraint nobody was sizing
+
+**1,053,360 v4 prefixes** from the live bird `master4`, loaded into
+v26.06/octeon9 via `vppctl exec` in ~35 s. Item 10 **PASSES**.
+
+| | baseline (empty FIB) | full table | Δ | per route |
+|---|---|---:|---:|---:|
+| main heap (used) | 337.86 MiB | 803.49 MiB | 465.63 MiB | **463 B** |
+| stat segment (populated) | 1.19 MiB | 101.94 MiB | 100.75 MiB | **97 B** |
+| hugepages (512 MiB) | 9 | 10 | +1 | — |
+
+**The finding that matters is a first-attempt crash, not the numbers.**
+With the default `statseg` (31.94 MiB) VPP **aborted** partway through
+the fourth 100k chunk:
+
+```
+Out-of-memory, calling os_panic().
+os_panic() called, aborting.
+```
+
+Per-chunk statseg usage explains it exactly — 22.85 MiB at 300k, 33.84
+MiB at 400k, i.e. it crosses the 31.94 MiB default at roughly **380k
+routes**. Adding `statseg { size 1G }` loaded the whole table with no
+other change.
+
+Consequences, all now in `startup_conf.rs`:
+
+- **`show memory main-heap` is a misleading diagnostic.** During the
+  abort it read `used: 470M / 4.00G` — 87% free — while a different
+  segment was exhausted. **Always use `show memory` (all heaps).** An
+  hour went into suspecting the main heap because of this.
+- **Size the stats segment from `populated`, not `used`.** The
+  allocator said 75.04 MiB while the OS had backed 101.94 MiB; sizing
+  from `used` under-provisions by a third.
+- **The stats segment is 64 K-page backed, not hugepages** (`page-size
+  64K` in `show memory`). It is locked RAM on a *separate* budget line
+  and must NOT inflate the hugepage reservation.
+- **`HEAP_BYTES_PER_ROUTE` 2048 → 1024** (measured 463, ~2.2× margin);
+  **`HEAP_FLOOR_BYTES` 1 GiB → 512 MiB** (measured 337.86 MiB);
+  **`BUFFER_BYTES` 512 MiB → 1 GiB** (10 hugepages in use against a
+  4 GiB heap = 1 GiB beyond it, so 512 MiB would have left the
+  reservation a page short at full table).
+- **New `STATSEG_BYTES_PER_ROUTE` = 192** (measured 97, ~2×) with a
+  32 MiB floor, and `render()` now emits the stanza. It emitted none
+  before, so the module as merged would have killed VPP partway
+  through its first full-table resync.
+
+**Per-chunk increments are not usable as a per-route figure** — they
+ranged 82 B to 2,058 B/route because mtrie interior nodes allocate in
+blocks. Only the full-table average means anything.
+
+**Still NOT measured — the ≤60 s convergence budget.** The ~35 s load
+was VPP's CLI parser with one shared path-list, not 1.05M binary-API
+round trips with the real 129 nexthops. Treat 35 s as an encouraging
+lower bound on what VPP itself can absorb and nothing more; the real
+number needs the module's sink.
+
+Method note: routes were pointed at a single synthetic nexthop
+(`10.255.255.2` on `octeon0/0`, static neighbor) rather than the real
+129. Path-lists are shared, so 129 versus 1 is ~128 extra objects
+against 1.05M prefixes — negligible for the per-prefix slope this
+measures.
+
+Also captured, closing a caveat that had been open since §0: the
+primary's `birdc 'show route count'` reports **2,105,065 routes for
+1,053,380 networks** in `master4`, against the histogram's 1,053,049
+best-path nexthops. Those agree to within ~331, confirming **0 ECMP
+among selected routes** — so "nexthops as prefixes" is now measured
+rather than inferred, and the `expected-routes` sizing stands.
 
 ## 4. Pass / kill / record
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -519,11 +519,17 @@ changing `ref` re-runs the workflow and publishes a new tag.
 Reuse the gate-0a staging (VF on a quiet port, vfio-bound, hugepages
 reserved — see the perf-campaign memory / gate-0a notes for the exact
 commands and the rtemap/dpdk.service gotchas). Sizing per the slice-1
-renderer's arithmetic, updated for the round-4 decision (v4-only,
-~1.05M nexthops): placeholder math says ~2.2 GiB heap + buffers ⇒
-`vm.nr_hugepages=8` at 512 MiB pages gives comfortable margin. (The
-pre-decision v4+v6 figure was ~4.4 GiB ⇒ 10 pages; item 10's measured
-number supersedes both.)
+renderer's arithmetic, now driven by item 10's **measured** numbers
+rather than the pre-measurement guesses: at v4-only ~1.05M routes,
+~1.5 GiB heap + 1 GiB buffers ≈ 2.5 GiB ⇒ **5 × 512 MiB pages**, so
+`vm.nr_hugepages=8` leaves comfortable margin. (The earlier figures —
+~2.2 GiB off a placeholder, ~4.4 GiB from the pre-decision v4+v6
+shape — are both superseded.)
+
+**The stats segment is a separate budget line and is not hugepages.**
+It is 64 K-page locked RAM, ~193 MiB at this table with one worker, and
+it scales with VPP's *thread* count. Reserving hugepages for it would
+be wasted; forgetting it entirely aborts VPP mid-load.
 
 startup.conf: **the renderer now emits the post-pivot shape** — it
 dropped the `dpdk { dev ... }` stanza, disables `dpdk_plugin.so`, and
@@ -543,20 +549,37 @@ unix {
 }
 socksvr { socket-name /run/vpp/api.sock }
 memory {
-  main-heap-size 512M              # bump per sizing math for item 10
+  main-heap-size 1536M
   main-heap-page-size default-hugepage
+}
+statseg {
+  size 256M
 }
 buffers { buffers-per-numa 16384 default data-size 2048 }
 cpu { main-core 16 corelist-workers 17 }
 plugins { plugin dpdk_plugin.so { disable } }
 ```
 
-Load-bearing: `main-heap-page-size default-hugepage` (64K-page
-kernel), `socksvr` for the API socket, explicit `corelist-workers`,
-**dpdk_plugin disabled**, **no `dpdk {}` stanza, no `devices {}`
-stanza** (an empty-block `devices{}` is a parse error; the device
-attaches via the runtime CLI in §3), and **no linux-cp** (routes come
-from vppctl in this spike; the binary-API sink in production).
+The two sizing numbers, both from item 10's measurement below:
+
+- `main-heap-size 1536M` — 1.05M v4 routes × 1 KiB/route + a 512 MiB
+  floor. (Round 3 ran 4 GiB, which is also fine; this is the derived
+  minimum with margin, not the value that was on the box.)
+- `statseg 256M` — **not optional.** The 32 MiB default aborts partway
+  through a full table, and `show memory main-heap` will not show you
+  why. Budget **96 B per route per VPP *thread***: 1.05M routes × 2
+  threads (main + the one worker above) ≈ 193 MiB. **Add ~96 MiB per
+  additional worker** — VPP replicates every counter per thread, so
+  this is the one number here that does not scale the way it looks like
+  it does. It is also 64 K-page locked RAM, so it does **not** come out
+  of the hugepage reservation.
+
+Load-bearing beyond sizing: `main-heap-page-size default-hugepage`
+(64K-page kernel), `socksvr` for the API socket, explicit
+`corelist-workers`, **dpdk_plugin disabled**, **no `dpdk {}` stanza, no
+`devices {}` stanza** (an empty-block `devices{}` is a parse error; the
+device attaches via the runtime CLI in §3), and **no linux-cp** (routes
+come from vppctl in this spike; the binary-API sink in production).
 
 ## 3. Bring-up + the checklist
 
@@ -601,8 +624,14 @@ v26.06/octeon9 via `vppctl exec` in ~35 s. Item 10 **PASSES**.
 | | baseline (empty FIB) | full table | Δ | per route |
 |---|---|---:|---:|---:|
 | main heap (used) | 337.86 MiB | 803.49 MiB | 465.63 MiB | **463 B** |
-| stat segment (populated) | 1.19 MiB | 101.94 MiB | 100.75 MiB | **97 B** |
+| stat segment (populated) | 1.19 MiB | 101.94 MiB | 100.75 MiB | **97 B** ‡ |
 | hugepages (512 MiB) | 9 | 10 | +1 | — |
+
+‡ **at two VPP threads.** This run was `corelist-workers 17` — one
+worker — and VPP replicates counter vectors per thread
+(`vec_validate (cm->counters, tm->n_vlib_mains - 1)`), so the statseg
+row is a two-thread figure and nothing else here is. Per thread it is
+~48.5 B/route. A five-port config runs five workers and needs ~3× this.
 
 **The finding that matters is a first-attempt crash, not the numbers.**
 With the default `statseg` (31.94 MiB) VPP **aborted** partway through
@@ -635,10 +664,24 @@ Consequences, all now in `startup_conf.rs`:
   **`BUFFER_BYTES` 512 MiB → 1 GiB** (10 hugepages in use against a
   4 GiB heap = 1 GiB beyond it, so 512 MiB would have left the
   reservation a page short at full table).
-- **New `STATSEG_BYTES_PER_ROUTE` = 192** (measured 97, ~2×) with a
-  32 MiB floor, and `render()` now emits the stanza. It emitted none
-  before, so the module as merged would have killed VPP partway
-  through its first full-table resync.
+- **New `STATSEG_BYTES_PER_ROUTE_PER_THREAD` = 96** (measured ~48.5
+  per thread, ~2×) with a 32 MiB floor, and `render()` now emits the
+  stanza. It emitted none before, so the module as merged would have
+  killed VPP partway through its first full-table resync.
+- **The stats segment scales with VPP's thread count, the main heap's
+  route term does not.** `derive_sizing` therefore takes the summed
+  `cores` across all ports, and the renderer refuses a core list that
+  disagrees with the sizing it was handed — two independent worker
+  counts is how a segment gets silently undersized. Sizing off the
+  measured aggregate as though it were thread-independent would have
+  under-provisioned the five-port `example.conf` shape by ~3× and
+  reproduced this same abort at ~1.05M routes.
+- **The decomposition is one data point deep.** This run cannot
+  separate the fixed per-route cost (statseg directory entries, name
+  strings) from the per-thread cost, so all of it is attributed to
+  per-thread. That over-provisions multi-worker boxes, which is the
+  safe direction. Re-measuring at two different worker counts would
+  refine it; nobody should tighten the constant without that.
 
 **Per-chunk increments are not usable as a per-route figure** — they
 ranged 82 B to 2,058 B/route because mtrie interior nodes allocate in


### PR DESCRIPTION
Gate 0b item 10 on the shadow. **The v4 full table fits** — 1,053,360 prefixes into v26.06/octeon9 in ~35 s. Item 10 passes.

But the first attempt **aborted partway through**, and that's the finding worth the PR.

## The renderer would have killed VPP mid-resync

VPP keeps per-FIB-entry counters in a separate `statseg` with its own fixed size. **Our renderer emitted no stanza for it at all.** The default is 31.94 MiB, and measured usage crosses it at ~380k routes:

| routes | statseg used |
|---|---|
| 300,010 | 22.85 M |
| **400,010** | **33.84 M** ← past the 31.94 M default |

VPP then dies with a bare `Out-of-memory, calling os_panic()`. So the module as merged wouldn't have run VPP *short* on its first full-table resync — it would have killed it, at around a third of the way in.

**And the obvious diagnostic lies.** During the abort, `show memory main-heap` read `used: 470M / 4.00G` — 87% free — because the exhausted segment is a different heap. That's now called out in the runbook: always `show memory`, never `show memory main-heap`. It cost an hour of suspecting the wrong allocator.

## Measured

baseline → 1,053,360 routes:

| | baseline | full table | per route |
|---|---:|---:|---:|
| main heap (used) | 337.86 MiB | 803.49 MiB | **463 B** |
| stat segment (populated) | 1.19 MiB | 101.94 MiB | **97 B** |
| hugepages (512 MiB) | 9 | 10 | — |

| constant | was | now | measured |
|---|---|---|---|
| `HEAP_BYTES_PER_ROUTE` | 2048 | **1024** | 463 |
| `HEAP_FLOOR_BYTES` | 1 GiB | **512 MiB** | 337.86 MiB |
| `BUFFER_BYTES` | 512 MiB | **1 GiB** | 1 GiB beyond the heap |
| `STATSEG_BYTES_PER_ROUTE` | *absent* | **192** | 97 |

`BUFFER_BYTES` going *up* is the non-obvious one: 10 hugepages were in use against a 4 GiB (8-page) heap, so 512 MiB would have left the reservation a page short at full table.

## Three details that are easy to get wrong, now encoded

1. **Size the statseg from `populated`, not `used`.** The allocator reported 75.04 MiB while the OS had backed 101.94 MiB — sizing from `used` under-provisions by a third.
2. **The statseg is 64 K-page backed, not hugepages.** It's locked RAM on a *separate* budget line; `Sizing::total_bytes` stays heap + buffers, or the hugepage reservation would demand hundreds of MiB that hugepages never satisfy.
3. **Per-chunk increments are not a per-route figure.** They ranged 82 B to 2,058 B because mtrie interior nodes allocate in blocks. Only the full-table average means anything, and the tests assert against that.

## Still not measured

**The ≤60 s convergence budget.** The 35 s load was VPP's CLI parser with one shared path-list — not 1.05M binary-API round trips against the real 129 nexthops. Recorded as an encouraging lower bound on what VPP itself can absorb, nothing more. The real number needs the module's sink.

Routes also pointed at one synthetic nexthop rather than 129. Path-lists are shared, so that's ~128 extra objects against 1.05M prefixes — negligible for the per-prefix slope, and stated in the runbook rather than buried.

## Bonus: a caveat closed

The primary reports **2,105,065 routes for 1,053,380 networks** in `master4`, against the histogram's **1,053,049** best-path nexthops. Agreement within ~331 confirms **0 ECMP among selected routes** — so "nexthops as prefixes" is now measured rather than inferred, and `expected-routes` sizing stands. That had been an open caveat since §0 of the runbook.

## Verification

416 workspace tests. New tests assert the constants **cover the measured figures with margin** (so a future tidy-up can't quietly drop below reality), that the stanza is always emitted, that it rounds up, and that the statseg stays out of the hugepage budget. One assertion became a `const {}` block so a default that stops covering the measured table fails the build rather than a test.

Host clippy `-D warnings` clean; all four Linux cross-targets linted locally.