### PR TITLE
feat(vpp-offload): the convergence engine, and a resync that deletes

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -148,6 +148,43 @@ pub struct ResyncPlan {
     pub withdrawals: u64,
 }
 
+/// What a verify pass concluded, and whether traffic may be diverted
+/// into the result.
+///
+/// Two fields because they answer different questions and collapsing
+/// them is a bug in either direction. `VerifyOutcome::passed()`
+/// deliberately ignores `withheld` — withholding is the designed
+/// response to a table that outgrew its heap, and failing verification
+/// on it would turn graceful degradation into a restart loop. But a FIB
+/// missing prefixes is still not one to divert traffic into.
+///
+/// `#[must_use]` because ignoring `may_steer` is exactly the mistake:
+/// `SinkCounts::blocks_first_steer()` existed as the intended gate and
+/// nothing consulted it, so a restart of a previously-steered VPP would
+/// have re-steered into an incomplete table.
+#[must_use]
+#[derive(Debug, Clone)]
+pub struct Verdict {
+    pub outcome: VerifyOutcome,
+    /// False when the ledger holds routes it could not install.
+    pub may_steer: bool,
+}
+
+impl Verdict {
+    /// The supervisor event this verdict implies. Keeps the mapping in
+    /// one place so a caller cannot pick `VerifyPassed` for an
+    /// incomplete table.
+    pub fn event(&self) -> crate::supervisor::Event {
+        if !self.outcome.passed() {
+            crate::supervisor::Event::VerifyFailed
+        } else if self.may_steer {
+            crate::supervisor::Event::VerifyPassed
+        } else {
+            crate::supervisor::Event::VerifyIncomplete
+        }
+    }
+}
+
 /// Which convergence step is in flight, if any.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Phase {
@@ -224,6 +261,18 @@ pub struct ConvergenceEngine {
 
     phase: Option<Phase>,
     last_verify: Option<VerifyOutcome>,
+    /// The last handshake failure, and whether it can ever succeed.
+    ///
+    /// `api_ready` returns a bool, which collapses "VPP has not opened
+    /// its socket yet" together with "this VPP speaks a different API
+    /// than the one we generated against". The second is permanent: the
+    /// supervisor would wait out `API_STARTUP_BUDGET` and restart-loop
+    /// forever without anything reporting the version skew that makes
+    /// every attempt fail. CRC mismatch is meant to be a loud refusal by
+    /// construction; a silent retry loop is the opposite.
+    last_api_error: Option<String>,
+    api_incompatible: bool,
+
     /// Advanced once per verify so each pass samples a different set.
     ///
     /// Counter-derived rather than drawn from the OS, for the reason
@@ -254,6 +303,8 @@ impl ConvergenceEngine {
             nexthops: NexthopMap::new(members),
             drainer: Drainer::new(DEFAULT_WINDOW).with_families(families),
             steered: false,
+            last_api_error: None,
+            api_incompatible: false,
             phase: None,
             last_verify: None,
             verify_seed: 0,
@@ -408,10 +459,37 @@ impl ConvergenceEngine {
                     return false;
                 }
                 self.transport = Some(t);
+                self.last_api_error = None;
+                self.api_incompatible = false;
                 true
             }
-            Err(_) => false,
+            Err(e) => {
+                // A version-skew or refusal will fail identically every
+                // time; a missing socket will not. Recording which is
+                // which is what lets the supervisor stop retrying and the
+                // status surface name the actual fault.
+                self.api_incompatible = matches!(
+                    e,
+                    TransportError::CrcMismatch { .. }
+                        | TransportError::MessageUnknown(_)
+                        | TransportError::HandshakeRefused(_)
+                );
+                self.last_api_error = Some(e.to_string());
+                false
+            }
         }
+    }
+
+    /// The last handshake failure, if the API is not up.
+    pub fn last_api_error(&self) -> Option<&str> {
+        self.last_api_error.as_deref()
+    }
+
+    /// Whether the failure is permanent — this VPP cannot ever speak to
+    /// us. Retrying wastes the startup budget and restarting produces the
+    /// same VPP; the fault has to reach an operator instead.
+    pub fn api_incompatible(&self) -> bool {
+        self.api_incompatible
     }
 
     /// Drop the connection. Called when a round trip fails, so the next
@@ -633,12 +711,27 @@ impl ConvergenceEngine {
             plan.upserts += 1;
         });
 
-        for prefix in self.ledger.known_prefixes() {
-            if !seen.contains(&prefix) {
-                self.pending.withdraw(prefix);
+        let known: HashSet<IpPrefix> = self.ledger.known_prefixes().into_iter().collect();
+        for prefix in &known {
+            if !seen.contains(prefix) {
+                self.pending.withdraw(*prefix);
                 plan.withdrawals += 1;
             }
         }
+
+        // Drop leftovers from an aborted resync. Those prefixes live only
+        // in the pending map — never classified, so the ledger cannot see
+        // them and the withdrawal loop above cannot reach them. Without
+        // this, a prefix the source dropped between an aborted resync and
+        // this one keeps its stale upsert and gets installed later,
+        // against a snapshot that no longer advertises it.
+        //
+        // Dropped rather than withdrawn: the ledger never knew them, so
+        // VPP never received them, and a withdrawal for a route that was
+        // never installed is a wasted round trip inside the convergence
+        // budget.
+        self.pending
+            .retain(|p| seen.contains(p) || known.contains(p));
 
         // Anything parked at the high-water mark gets another chance:
         // withdrawals in this same plan may have freed the headroom.
@@ -686,7 +779,7 @@ impl ConvergenceEngine {
     }
 
     /// Readback verification against a fresh random sample.
-    pub fn run_verify(&mut self) -> Result<VerifyOutcome, EngineError> {
+    pub fn run_verify(&mut self) -> Result<Verdict, EngineError> {
         // Transport first. Setting the phase before this check leaves it
         // stuck on `Verify` when the early return fires, and a phase
         // that never clears is a convergence the loop believes is still
@@ -705,7 +798,10 @@ impl ConvergenceEngine {
             Ok(outcome) => {
                 self.last_verify = Some(outcome.clone());
                 self.phase = None;
-                Ok(outcome)
+                // The gate the ledger has always been able to answer and
+                // nothing asked.
+                let may_steer = !self.ledger.counts().blocks_first_steer();
+                Ok(Verdict { outcome, may_steer })
             }
             Err(e) => {
                 self.disconnect();
@@ -1143,6 +1239,96 @@ mod tests {
         assert!(
             !links[0].link_up,
             "a port verify found dead must not report as forwarding"
+        );
+    }
+
+    /// A withheld route must not re-steer traffic into the FIB.
+    ///
+    /// `VerifyOutcome::passed()` deliberately ignores `withheld` — failing
+    /// on it would turn the designed response to a table that outgrew its
+    /// heap into a restart loop — so the gate has to live somewhere else.
+    /// It lived in `blocks_first_steer()`, which nothing consulted, so a
+    /// restart of a previously-steered VPP would have diverted traffic
+    /// into a FIB missing exactly the prefixes that did not fit.
+    #[test]
+    fn an_incomplete_table_verifies_without_permitting_a_steer() {
+        use crate::supervisor::Event;
+
+        let clean = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 64,
+                ..Default::default()
+            },
+            may_steer: true,
+        };
+        assert_eq!(clean.event(), Event::VerifyPassed);
+
+        // Incomplete: correct as far as it goes, so NOT a failure — but
+        // not steerable either.
+        let incomplete = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 64,
+                withheld: 12,
+                ..Default::default()
+            },
+            may_steer: false,
+        };
+        assert!(
+            incomplete.outcome.passed(),
+            "withheld must not fail verification, or a full table \
+             restart-loops"
+        );
+        assert_eq!(
+            incomplete.event(),
+            Event::VerifyIncomplete,
+            "and must not re-steer either"
+        );
+
+        // A genuinely wrong FIB still fails, regardless of steerability.
+        let wrong = Verdict {
+            outcome: VerifyOutcome::default(),
+            may_steer: true,
+        };
+        assert!(!wrong.outcome.passed());
+        assert_eq!(wrong.event(), Event::VerifyFailed);
+    }
+
+    /// Leftovers from an aborted resync live only in the pending map —
+    /// never classified, so the ledger cannot see them and the withdrawal
+    /// loop cannot reach them. A prefix the source drops in between would
+    /// otherwise keep its stale upsert and install later.
+    #[test]
+    fn an_aborted_resyncs_leftovers_do_not_survive_the_next_one() {
+        let mut e = engine();
+        e.begin_resync(&mirror(5));
+        assert_eq!(e.pending().len(), 5);
+        // Aborted before anything was classified.
+        e.abort_convergence();
+        assert_eq!(e.counts(), SinkCounts::default(), "nothing classified");
+
+        // The source drops two prefixes while we were not draining.
+        let mut shrunk = mirror(5);
+        shrunk.routes.truncate(3);
+        e.begin_resync(&shrunk);
+        assert_eq!(
+            e.pending().len(),
+            3,
+            "the two dropped prefixes must not still be queued for install"
+        );
+    }
+
+    /// A permanent handshake failure must be distinguishable from a slow
+    /// start, or the supervisor waits out the startup budget and
+    /// restart-loops forever without anything naming the version skew.
+    #[test]
+    fn a_permanent_handshake_failure_is_named_as_such() {
+        let mut e = engine();
+        // Nothing listening: transient, and retrying is right.
+        assert!(!e.api_ready());
+        assert!(e.last_api_error().is_some(), "the reason must be recorded");
+        assert!(
+            !e.api_incompatible(),
+            "a missing socket is not a version skew"
         );
     }
 

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -41,11 +41,21 @@ use std::time::Duration;
 use packetframe_common::fib::IpPrefix;
 
 use crate::attach::{attach_ports, AttachError, AttachMode, AttachedPort, PortAttach};
+use crate::fib_sync::to_address;
 use crate::fib_sync::{DrainStats, Drainer, FamilyPolicy, PortIndex, ResolvedPath, DEFAULT_WINDOW};
 use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
 use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
+use crate::vpp_api::generated::{IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply};
 use crate::vpp_api::{Transport, TransportError};
+
+/// `IP_API_NEIGHBOR_FLAG_STATIC` from ip_neighbor.api.
+///
+/// Static because VPP cannot refresh a neighbour on this platform: MCAM
+/// rules match IP fields, so an ARP or ND frame can never be steered to
+/// it. An ageing dynamic entry would silently become an unresolved
+/// adjacency and blackhole every route through that nexthop.
+pub const IP_NEIGHBOR_STATIC: u8 = 1;
 
 /// How long to wait for the handshake on a connect attempt.
 ///
@@ -56,27 +66,35 @@ use crate::vpp_api::{Transport, TransportError};
 /// `API_STARTUP_BUDGET`, which is the loop's business, not this call's.
 pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(500);
 
-/// Socket timeout for every request after the handshake.
+/// Socket timeout for requests after the handshake: **exactly the
+/// liveness budget in force**.
 ///
-/// **Must exceed the largest liveness budget**, and that is the whole
-/// reason it is a separate constant. `Transport::connect` installs its
-/// timeout with `set_read_timeout`, so it governs not just the handshake
-/// but every subsequent reply — and using the short handshake value would
-/// make the transport error at 500 ms during a full-table load, when VPP
-/// legitimately takes seconds to answer because it services the API on
-/// the same main thread that is executing our route batch.
+/// `Transport::connect` installs its timeout with `set_read_timeout`, so
+/// it governs every subsequent reply, not just the handshake. Two wrong
+/// answers were tried before this one and both are instructive:
 ///
-/// That would hand the transport a veto over a decision that belongs to
-/// the wedge detector: `SYNC_PING_BUDGET` exists precisely so a resync
-/// can be slow without being declared dead, and a shorter socket timeout
-/// silently defeats it — disconnect, requeue, restart, forever, on a VPP
-/// that was working. Derived from the budget rather than picked so the
-/// two cannot drift.
-pub const OP_TIMEOUT: Duration = crate::liveness::SYNC_PING_BUDGET.saturating_add(TIMEOUT_MARGIN);
-
-/// Headroom between the largest liveness budget and the socket timeout,
-/// so a reply arriving right at the budget is not raced by the socket.
-pub const TIMEOUT_MARGIN: Duration = Duration::from_secs(2);
+/// - Reusing the short handshake value (500 ms) made the transport error
+///   during a full-table load, when VPP legitimately takes seconds to
+///   answer because it services the API on the same main thread that is
+///   executing our route batch. That silently defeats
+///   `SYNC_PING_BUDGET`, whose entire purpose is letting a resync be slow
+///   without being declared dead.
+/// - Using the *largest* budget globally (12 s) fixed that and broke the
+///   other end: `Driver` calls `ping()` synchronously, so a wedged API
+///   parks the whole loop inside one socket read. The loop cannot
+///   evaluate the detector or emit `Wedged` while blocked, so the
+///   published **blackhole-wedge ≤ 2 s** number became ~12 s. The
+///   reasoning that led there — "the socket is only a backstop, the
+///   detector owns wedge decisions" — is wrong, because the detector
+///   only gets to decide if the loop regains control.
+///
+/// So the socket enforces the same deadline the detector would, with no
+/// margin: a reply that takes longer than the budget *is* a wedge by the
+/// detector's own definition, and erroring at precisely that point is the
+/// only value that contradicts neither side.
+fn op_timeout(steered: bool, converging: bool) -> Duration {
+    crate::liveness::budget_for(steered, converging)
+}
 
 /// Route ops handed to VPP per drain call.
 ///
@@ -103,9 +121,22 @@ pub trait RouteSource {
     /// nexthops included. Multipath routes present all their nexthops.
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr]));
 
-    /// Visit each known nexthop → egress device pair, from the same
-    /// neighbour source that supplies VPP's static neighbours.
-    fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str));
+    /// Visit each resolved neighbour: nexthop address, egress device, and
+    /// **link-layer address**.
+    ///
+    /// The MAC is not optional here. VPP is started without `linux-cp`
+    /// (it cannot pair kernel-owned PFs), so it begins with an empty
+    /// neighbour table, and MCAM rules match IP fields so an ARP frame
+    /// can never be steered into it — VPP physically cannot learn a
+    /// neighbour. Every adjacency has to be programmed statically from
+    /// this snapshot.
+    ///
+    /// Getting this wrong is a silent blackhole of the worst kind: route
+    /// installs are acknowledged, readback verification passes (it checks
+    /// a path exists on an interface we own, not that the adjacency
+    /// resolves), and traffic is dropped on the floor by an incomplete
+    /// adjacency. Nothing in the module would report a fault.
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6]));
 }
 
 /// What a full-table resync queued.
@@ -132,6 +163,13 @@ pub enum EngineError {
     NotConnected,
     Transport(TransportError),
     Attach(AttachError),
+    /// VPP refused a static neighbour. Fatal to convergence rather than
+    /// skippable: every route through that nexthop would install cleanly
+    /// and then drop traffic on an unresolved adjacency.
+    NeighbourRefused {
+        nexthop: IpAddr,
+        retval: i32,
+    },
 }
 
 impl std::fmt::Display for EngineError {
@@ -140,6 +178,11 @@ impl std::fmt::Display for EngineError {
             Self::NotConnected => write!(f, "binary API is not connected"),
             Self::Transport(e) => write!(f, "{e}"),
             Self::Attach(e) => write!(f, "{e}"),
+            Self::NeighbourRefused { nexthop, retval } => write!(
+                f,
+                "VPP refused the static neighbour for {nexthop} (retval {retval}); \
+                 every route through it would blackhole"
+            ),
         }
     }
 }
@@ -172,6 +215,13 @@ pub struct ConvergenceEngine {
     nexthops: NexthopMap,
     drainer: Drainer,
 
+    /// Whether MCAM rules are diverting traffic right now.
+    ///
+    /// Not the engine's to decide — the supervisor owns it — but the
+    /// engine needs it because the socket timeout must track the liveness
+    /// budget in force, and `budget_for` keys on steered.
+    steered: bool,
+
     phase: Option<Phase>,
     last_verify: Option<VerifyOutcome>,
     /// Advanced once per verify so each pass samples a different set.
@@ -203,6 +253,7 @@ impl ConvergenceEngine {
             ledger: RouteLedger::new(Capacity::new(high_water_routes)),
             nexthops: NexthopMap::new(members),
             drainer: Drainer::new(DEFAULT_WINDOW).with_families(families),
+            steered: false,
             phase: None,
             last_verify: None,
             verify_seed: 0,
@@ -305,6 +356,35 @@ impl ConvergenceEngine {
             .collect()
     }
 
+    /// Tell the engine whether traffic is currently steered.
+    ///
+    /// Only affects the socket timeout, which must match the liveness
+    /// budget in force — a steered dataplane gets the short budget even
+    /// mid-resync, because an adopted resync forwards the whole time and
+    /// a 10 s blind window on live traffic is not affordable.
+    pub fn set_steered(&mut self, steered: bool) {
+        self.steered = steered;
+        // Re-arm immediately: the state can change between operations,
+        // and a stale timeout is the bug this whole mechanism exists to
+        // avoid.
+        self.arm_timeout();
+    }
+
+    /// Re-arm the socket deadline from the budget currently in force.
+    ///
+    /// Called before every request rather than once at connect: two
+    /// `setsockopt` calls per operation (not per route) is nothing, and
+    /// it makes drift structurally impossible.
+    fn arm_timeout(&mut self) {
+        let d = op_timeout(self.steered, self.phase.is_some());
+        if let Some(t) = self.transport.as_mut() {
+            // A socket that will not take a timeout is not one to keep.
+            if t.set_timeout(d).is_err() {
+                self.transport = None;
+            }
+        }
+    }
+
     /// Attempt to connect, reporting whether the API is answering.
     ///
     /// A failure is not an error: VPP takes real time to open its socket
@@ -316,13 +396,15 @@ impl ConvergenceEngine {
         }
         match Transport::connect(&self.api_socket, HANDSHAKE_TIMEOUT) {
             Ok(mut t) => {
-                // Re-arm to the operation timeout. The handshake value is
-                // deliberately short so a failed connect costs the loop
-                // one tick, but `connect` installs it as the socket's
-                // persistent read/write timeout — leaving it in force
-                // would make every drain reply time out at 500 ms during
-                // a full-table load and defeat SYNC_PING_BUDGET.
-                if t.set_timeout(OP_TIMEOUT).is_err() {
+                // Re-arm off the handshake value. It is deliberately short
+                // so a failed connect costs the loop one tick, but
+                // `connect` installs it as the socket's persistent
+                // read/write timeout — leaving it in force would make
+                // every drain reply time out at 500 ms during a
+                // full-table load and defeat SYNC_PING_BUDGET.
+                if t.set_timeout(op_timeout(self.steered, self.phase.is_some()))
+                    .is_err()
+                {
                     return false;
                 }
                 self.transport = Some(t);
@@ -346,6 +428,7 @@ impl ConvergenceEngine {
 
     /// One liveness round trip.
     pub fn ping(&mut self) -> Result<(), EngineError> {
+        self.arm_timeout();
         let t = self.transport()?;
         match t.ping() {
             Ok(_) => Ok(()),
@@ -365,6 +448,7 @@ impl ConvergenceEngine {
     /// every single route — which the drainer handles correctly but
     /// which would burn a whole convergence cycle doing nothing.
     pub fn attach_devices(&mut self, mode: AttachMode) -> Result<(), EngineError> {
+        self.arm_timeout();
         let ports = std::mem::take(&mut self.ports);
         let known = std::mem::take(&mut self.recorded_indices);
         let t = match self.transport.as_mut() {
@@ -415,7 +499,101 @@ impl ConvergenceEngine {
             .collect()
     }
 
+    /// Program the static neighbours the resolved routes will depend on.
+    ///
+    /// Runs after `attach_devices` (the adjacency needs the interface
+    /// index) and **before** any route drains: a route installed against
+    /// an unresolved adjacency is acknowledged by VPP and then drops
+    /// every packet, and neither the ledger nor readback verification can
+    /// see it.
+    ///
+    /// Neighbours whose device is not VPP-owned are skipped rather than
+    /// refused — the same policy the nexthop mapping applies to routes,
+    /// and for the same reason: a management or tunnel neighbour is not
+    /// an error, it is simply not ours.
+    ///
+    /// Returns how many were programmed. Sized by the neighbour table
+    /// (~129 nexthops on the reference fleet), not the route table, so
+    /// this is not a batched pipeline like the drainer.
+    pub fn program_neighbours(&mut self, src: &dyn RouteSource) -> Result<u64, EngineError> {
+        self.arm_timeout();
+        if self.transport.is_none() {
+            return Err(EngineError::NotConnected);
+        }
+
+        // Collect first: the visitor borrows `src` while the sends need
+        // `&mut self`.
+        let mut wanted: Vec<(IpAddr, u32, [u8; 6])> = Vec::new();
+        {
+            let nexthops = &self.nexthops;
+            let ports = &self.port_index;
+            src.for_each_neighbour(&mut |ip, _dev, mac| {
+                if let Some(target) = nexthops.resolve(&ip) {
+                    if let Some(idx) = ports.get(&target) {
+                        wanted.push((ip, idx, mac));
+                    }
+                }
+            });
+        }
+
+        let t = self.transport.as_mut().expect("checked just above");
+        let mut programmed = 0u64;
+        for (ip, sw_if_index, mac_address) in wanted {
+            let reply =
+                match t.request::<IpNeighborAddDel, IpNeighborAddDelReply>(IpNeighborAddDel {
+                    context: 0,
+                    is_add: true,
+                    neighbor: IpNeighbor {
+                        sw_if_index,
+                        // Static: VPP must never age this out and never
+                        // ARP to refresh it, because it cannot receive
+                        // the reply.
+                        flags: IP_NEIGHBOR_STATIC,
+                        mac_address,
+                        ip_address: to_address(ip),
+                    },
+                }) {
+                    Ok(r) => r,
+                    Err(e) => {
+                        self.disconnect();
+                        return Err(EngineError::Transport(e));
+                    }
+                };
+            if reply.retval != 0 {
+                // Refused, not a broken socket. Loud rather than skipped:
+                // every route through this nexthop would install cleanly
+                // and then blackhole.
+                return Err(EngineError::NeighbourRefused {
+                    nexthop: ip,
+                    retval: reply.retval,
+                });
+            }
+            programmed += 1;
+        }
+        Ok(programmed)
+    }
+
     /// Queue a full-table resync as a **diff** against the route source.
+    ///
+    /// ## Known gap: adoption cannot compute withdrawals
+    ///
+    /// The diff derives deletions from `ledger.known_prefixes()`, and on
+    /// **adoption** the ledger starts empty while VPP's FIB does not. A
+    /// prefix withdrawn while packetframe was down therefore stays
+    /// installed in the surviving VPP, where a stale more-specific can
+    /// keep overriding the live table — and verification cannot see it,
+    /// because it samples only what the ledger knows.
+    ///
+    /// Closing it needs VPP's own FIB read back, and `ip_route_dump` is
+    /// **not in the generated API whitelist** — so it needs a codegen
+    /// addition plus the regenerate-and-diff CI, not a change here.
+    /// Persisting the installed prefix set to the state file is not the
+    /// alternative: that is 1.05M prefixes rewritten continuously.
+    ///
+    /// Until then an adopted VPP's FIB is only reconciled for prefixes
+    /// the source still advertises. Recorded rather than papered over,
+    /// because the adoption path is precisely the one that keeps
+    /// forwarding while it converges.
     ///
     /// Refreshes the nexthop→device mapping first: a route's
     /// resolvability depends on it, and resolving against a stale map
@@ -440,7 +618,7 @@ impl ConvergenceEngine {
         // neighbour source is broken. Silently keeping stale mappings
         // would forward into the hole instead.
         self.nexthops.forget_devices();
-        src.for_each_nexthop_device(&mut |nh, dev| self.nexthops.set_device(nh, dev));
+        src.for_each_neighbour(&mut |nh, dev, _mac| self.nexthops.set_device(nh, dev));
 
         let mut plan = ResyncPlan::default();
         // The source's prefix set, so withdrawals are everything the
@@ -470,6 +648,7 @@ impl ConvergenceEngine {
 
     /// Push one bounded batch. `Ok(true)` = nothing left pending.
     pub fn drain_batch(&mut self) -> Result<(bool, DrainStats), EngineError> {
+        self.arm_timeout();
         // Resolve through the current map. Captured by reference so the
         // drainer sees the same mapping the ledger was classified
         // against.
@@ -517,6 +696,7 @@ impl ConvergenceEngine {
             return Err(EngineError::NotConnected);
         }
         self.phase = Some(Phase::Verify);
+        self.arm_timeout();
         self.verify_seed = next_seed(self.verify_seed);
         let seed = self.verify_seed;
 
@@ -621,9 +801,9 @@ mod tests {
                 visit(*p, nhs);
             }
         }
-        fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str)) {
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
             for (a, d) in &self.devices {
-                visit(*a, d);
+                visit(*a, d, [0x02, 0, 0, 0, 0, 1]);
             }
         }
     }
@@ -877,25 +1057,59 @@ mod tests {
         );
     }
 
-    /// The socket timeout must never be shorter than the largest liveness
-    /// budget, or the transport errors before the wedge detector's budget
-    /// expires and takes a decision that belongs to the detector — a busy
-    /// but healthy VPP gets disconnected, requeued and restarted.
+    /// The socket deadline must equal the budget in force — not the
+    /// largest one.
+    ///
+    /// Too short and the transport errors during a legitimate full-table
+    /// load, defeating SYNC_PING_BUDGET. Too long and `Driver`'s
+    /// synchronous `ping()` parks the whole loop inside one socket read,
+    /// so the detector never gets to emit `Wedged` and the published
+    /// blackhole-wedge <= 2 s number becomes whatever the timeout is.
+    /// Both were shipped, in that order.
     #[test]
-    fn the_operation_timeout_outlasts_every_liveness_budget() {
+    fn the_socket_deadline_tracks_the_budget_in_force() {
         for steered in [false, true] {
             for converging in [false, true] {
-                let budget = crate::liveness::budget_for(steered, converging);
-                assert!(
-                    OP_TIMEOUT > budget,
-                    "OP_TIMEOUT {OP_TIMEOUT:?} must exceed the {budget:?} budget \
-                     (steered={steered}, converging={converging})"
+                assert_eq!(
+                    op_timeout(steered, converging),
+                    crate::liveness::budget_for(steered, converging),
+                    "steered={steered} converging={converging}"
                 );
             }
         }
-        // And it must be clearly distinct from the handshake value, which
-        // is the bug: one constant serving both roles.
-        assert!(OP_TIMEOUT > HANDSHAKE_TIMEOUT * 10);
+        // The worst case must still leave the published wedge bound
+        // intact: a blocked ping returns within the budget, so detection
+        // is budget + interval exactly as `worst_case_detection` says.
+        let steady = op_timeout(true, false);
+        assert!(
+            crate::liveness::worst_case_detection(steady) <= Duration::from_secs(2),
+            "a blocked ping must not push detection past the published 2s"
+        );
+        // A resync that is not forwarding may take much longer.
+        assert!(op_timeout(false, true) > steady);
+    }
+
+    /// The deadline follows the state rather than being fixed at connect,
+    /// because the state changes between operations.
+    #[test]
+    fn arming_follows_steered_and_converging() {
+        let mut e = engine();
+        assert_eq!(
+            op_timeout(e.steered, e.phase.is_some()),
+            crate::liveness::PING_BUDGET
+        );
+        e.begin_resync(&mirror(1));
+        assert_eq!(
+            op_timeout(e.steered, e.phase.is_some()),
+            crate::liveness::SYNC_PING_BUDGET,
+            "an unsteered resync gets the long budget"
+        );
+        e.set_steered(true);
+        assert_eq!(
+            op_timeout(e.steered, e.phase.is_some()),
+            crate::liveness::PING_BUDGET,
+            "a steered resync forwards the whole time and cannot afford it"
+        );
     }
 
     /// Link state must come from an observation. An earlier version

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -1,0 +1,722 @@
+//! The convergence engine: everything that talks to VPP's binary API on
+//! the supervisor's behalf.
+//!
+//! [`crate::supervisor`] decides *what* should happen and
+//! [`crate::driver`] decides *when*; this is the half that actually
+//! does it. It owns the transport, the route ledger, the pending map and
+//! the port-index mapping, and exposes the operations the supervision
+//! loop's `Effects`/`Observe` seams are defined in terms of: connect,
+//! ping, attach devices, resync, verify.
+//!
+//! Split out from the process and resource lifecycle deliberately.
+//! Everything here is reachable over a unix socket, which means all of
+//! it is testable on host CI against a fake VPP speaking the real wire
+//! format — and the pieces that are *not* (fork/exec, pidfd, sysfs VF
+//! writes) are Linux-only and untestable on a dev laptop. Keeping the
+//! two apart is what lets the interesting logic be tested at all.
+//!
+//! ## The resync is a diff, not a replay
+//!
+//! `begin_resync` walks the route source and also computes
+//! **withdrawals**: prefixes the ledger holds that the source no longer
+//! advertises. An add-only resync is the failure the plan calls out by
+//! name — a route withdrawn while VPP (or packetframe) was down stays in
+//! VPP's FIB, forwarding to a nexthop nobody advertises, and readback
+//! verification cannot catch it because verification samples what the
+//! ledger claims and the ledger claims that route is fine.
+//!
+//! ## Nothing is claimed before VPP acknowledges it
+//!
+//! The engine never marks a route installed, an interface attached, or a
+//! FIB verified on its own authority; every one of those comes back from
+//! the transport. That is not a style preference — it is the single
+//! defect shape that produced most of this phase's review findings, and
+//! the ledger's four-valued state exists precisely so the
+//! not-yet-acknowledged case has somewhere honest to live.
+
+use std::collections::HashSet;
+use std::net::IpAddr;
+use std::time::Duration;
+
+use packetframe_common::fib::IpPrefix;
+
+use crate::attach::{attach_ports, AttachError, AttachMode, AttachedPort, PortAttach};
+use crate::fib_sync::{DrainStats, Drainer, FamilyPolicy, PortIndex, ResolvedPath, DEFAULT_WINDOW};
+use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
+use crate::status::PortLink;
+use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
+use crate::vpp_api::{Transport, TransportError};
+
+/// How long to wait for the API socket on a connect attempt.
+///
+/// Short on purpose: `api_ready` is polled from the supervision loop and
+/// a long blocking connect would stall the tick that also services the
+/// pidfd and the wedge ping. The *overall* patience for a slow start is
+/// `API_STARTUP_BUDGET`, which is the loop's business, not this call's.
+pub const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Route ops handed to VPP per drain call.
+///
+/// Bounds one tick's work, not the resync: the loop calls back
+/// immediately while there is more pending. Sized well above the
+/// pipeline window so a drain amortises its syscalls, and well below the
+/// full table so a tick cannot monopolise the loop and starve the ping.
+pub const DRAIN_BATCH: usize = 4_096;
+
+/// Where routes and nexthop devices come from.
+///
+/// A trait because the real source is the fast-path crate's
+/// RouteController mirror, and reaching across to it is a separate
+/// concern from getting the FIB into VPP — one that touches the live
+/// forwarding path's control plane and deserves its own review.
+///
+/// Both methods are visitors rather than `Vec` returns. At 1.05M routes
+/// a materialised `Vec<(IpPrefix, Vec<IpAddr>)>` is on the order of a
+/// hundred MB of transient allocation and a million small `Vec`s, paid
+/// on every resync — inside the ≤60 s convergence budget this engine
+/// exists to meet.
+pub trait RouteSource {
+    /// Visit every route in the authoritative mirror, best-path
+    /// nexthops included. Multipath routes present all their nexthops.
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr]));
+
+    /// Visit each known nexthop → egress device pair, from the same
+    /// neighbour source that supplies VPP's static neighbours.
+    fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str));
+}
+
+/// What a full-table resync queued.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ResyncPlan {
+    pub upserts: u64,
+    /// Prefixes the ledger holds that the source no longer advertises.
+    /// Non-zero after any outage during which routes were withdrawn.
+    pub withdrawals: u64,
+}
+
+/// Which convergence step is in flight, if any.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Phase {
+    Resync,
+    Verify,
+}
+
+#[derive(Debug)]
+pub enum EngineError {
+    /// No transport. Either the API has not answered yet or the previous
+    /// connection broke; the loop's job, not an operation's, to decide
+    /// what that means.
+    NotConnected,
+    Transport(TransportError),
+    Attach(AttachError),
+}
+
+impl std::fmt::Display for EngineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotConnected => write!(f, "binary API is not connected"),
+            Self::Transport(e) => write!(f, "{e}"),
+            Self::Attach(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<TransportError> for EngineError {
+    fn from(e: TransportError) -> Self {
+        Self::Transport(e)
+    }
+}
+
+impl From<AttachError> for EngineError {
+    fn from(e: AttachError) -> Self {
+        Self::Attach(e)
+    }
+}
+
+/// Owns the API-side half of the supervised dataplane.
+pub struct ConvergenceEngine {
+    api_socket: std::path::PathBuf,
+    transport: Option<Transport>,
+
+    ports: Vec<PortAttach>,
+    /// `(port, sw_if_index)` recorded from a previous run, for adoption.
+    recorded_indices: Vec<(String, u32)>,
+    attached: Vec<AttachedPort>,
+    port_index: PortIndex,
+
+    pending: PendingMap,
+    ledger: RouteLedger,
+    nexthops: NexthopMap,
+    drainer: Drainer,
+
+    phase: Option<Phase>,
+    last_verify: Option<VerifyOutcome>,
+    /// Advanced once per verify so each pass samples a different set.
+    ///
+    /// Counter-derived rather than drawn from the OS, for the reason
+    /// [`crate::verify::sample`] takes a seed at all: a failing verify
+    /// has to be replayable, and a probe set nobody can reproduce is a
+    /// bug report nobody can act on. Varying per pass is what matters —
+    /// fixed probes pass forever once installed.
+    verify_seed: u64,
+}
+
+impl ConvergenceEngine {
+    pub fn new(
+        api_socket: impl Into<std::path::PathBuf>,
+        ports: Vec<PortAttach>,
+        members: Vec<String>,
+        high_water_routes: u64,
+        families: FamilyPolicy,
+    ) -> Self {
+        Self {
+            api_socket: api_socket.into(),
+            transport: None,
+            ports,
+            recorded_indices: Vec::new(),
+            attached: Vec::new(),
+            port_index: PortIndex::default(),
+            pending: PendingMap::new(),
+            ledger: RouteLedger::new(Capacity::new(high_water_routes)),
+            nexthops: NexthopMap::new(members),
+            drainer: Drainer::new(DEFAULT_WINDOW).with_families(families),
+            phase: None,
+            last_verify: None,
+            verify_seed: 0,
+        }
+    }
+
+    /// Seed the port→index map from the state file so an adopted VPP's
+    /// existing interfaces are reused rather than duplicated.
+    pub fn with_recorded_indices(mut self, known: Vec<(String, u32)>) -> Self {
+        self.recorded_indices = known;
+        self
+    }
+
+    /// Register a VLAN device as a sub-interface of a member port.
+    pub fn add_vlan(&mut self, dev: impl Into<String>, port: impl Into<String>, vid: u16) {
+        self.nexthops.add_vlan(dev, port, vid);
+    }
+
+    pub fn counts(&self) -> SinkCounts {
+        self.ledger.counts()
+    }
+
+    pub fn pending(&self) -> &PendingMap {
+        &self.pending
+    }
+
+    pub fn phase(&self) -> Option<Phase> {
+        self.phase
+    }
+
+    pub fn last_verify(&self) -> Option<&VerifyOutcome> {
+        self.last_verify.as_ref()
+    }
+
+    pub fn is_connected(&self) -> bool {
+        self.transport.is_some()
+    }
+
+    /// Interface state for the health surface, from the last attach
+    /// pass. Reports what VPP said, not what we asked for.
+    pub fn port_links(&self) -> Vec<PortLink> {
+        self.attached
+            .iter()
+            .map(|p| PortLink {
+                port: p.port.clone(),
+                sw_if_index: p.sw_if_index,
+                // Attach refuses a port that is not both admin- and
+                // link-up, so anything in `attached` was up when we
+                // last looked. The freshness of that claim is the
+                // verify pass's job — it re-reads link state every
+                // time — so this reports the attach-time observation
+                // rather than inventing a live one.
+                admin_up: true,
+                link_up: true,
+            })
+            .collect()
+    }
+
+    /// Attempt to connect, reporting whether the API is answering.
+    ///
+    /// A failure is not an error: VPP takes real time to open its socket
+    /// while it faults in a multi-GB heap on 512 MiB hugepages. The
+    /// startup deadline decides when that has gone on too long.
+    pub fn api_ready(&mut self) -> bool {
+        if self.transport.is_some() {
+            return true;
+        }
+        match Transport::connect(&self.api_socket, CONNECT_TIMEOUT) {
+            Ok(t) => {
+                self.transport = Some(t);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Drop the connection. Called when a round trip fails, so the next
+    /// `api_ready` reconnects rather than reusing a socket whose framing
+    /// may be desynchronised — a half-read reply would corrupt every
+    /// subsequent context match.
+    pub fn disconnect(&mut self) {
+        self.transport = None;
+    }
+
+    fn transport(&mut self) -> Result<&mut Transport, EngineError> {
+        self.transport.as_mut().ok_or(EngineError::NotConnected)
+    }
+
+    /// One liveness round trip.
+    pub fn ping(&mut self) -> Result<(), EngineError> {
+        let t = self.transport()?;
+        match t.ping() {
+            Ok(_) => Ok(()),
+            Err(e) => {
+                // A failed ping means this socket is no longer usable.
+                self.disconnect();
+                Err(EngineError::Transport(e))
+            }
+        }
+    }
+
+    /// Attach the member ports' devices and record the indices FIB paths
+    /// must reference.
+    ///
+    /// Runs before any route is installed. The indices do not exist
+    /// until VPP assigns them, so a resync that ran first would defer
+    /// every single route — which the drainer handles correctly but
+    /// which would burn a whole convergence cycle doing nothing.
+    pub fn attach_devices(&mut self, mode: AttachMode) -> Result<(), EngineError> {
+        let ports = std::mem::take(&mut self.ports);
+        let known = std::mem::take(&mut self.recorded_indices);
+        let t = match self.transport.as_mut() {
+            Some(t) => t,
+            None => {
+                self.ports = ports;
+                self.recorded_indices = known;
+                return Err(EngineError::NotConnected);
+            }
+        };
+        let result = attach_ports(t, &ports, &known, mode);
+        self.ports = ports;
+        self.recorded_indices = known;
+        let attached = result?;
+
+        // Only now, with VPP's own indices in hand.
+        for p in &attached {
+            self.port_index.insert(p.port.clone(), None, p.sw_if_index);
+        }
+        self.attached = attached;
+        Ok(())
+    }
+
+    /// Every attached port's `(name, sw_if_index)`, for persisting to
+    /// the state file so the next run can adopt rather than re-attach.
+    pub fn attached_indices(&self) -> Vec<(String, u32)> {
+        self.attached
+            .iter()
+            .map(|p| (p.port.clone(), p.sw_if_index))
+            .collect()
+    }
+
+    /// Queue a full-table resync as a **diff** against the route source.
+    ///
+    /// Refreshes the nexthop→device mapping first: a route's
+    /// resolvability depends on it, and resolving against a stale map
+    /// would classify routes unresolvable for a neighbour that has since
+    /// been learned.
+    pub fn begin_resync(&mut self, src: &dyn RouteSource) -> ResyncPlan {
+        self.phase = Some(Phase::Resync);
+
+        src.for_each_nexthop_device(&mut |nh, dev| self.nexthops.set_device(nh, dev));
+
+        let mut plan = ResyncPlan::default();
+        // The source's prefix set, so withdrawals are everything the
+        // ledger holds that is not in it. ~50 MB transient at full
+        // table, which is the unavoidable cost of a correct diff — the
+        // alternative is an add-only resync that black-holes withdrawn
+        // routes.
+        let mut seen: HashSet<IpPrefix> = HashSet::with_capacity(1 << 20);
+        src.for_each_route(&mut |prefix, nexthops| {
+            self.pending.upsert(prefix, nexthops.to_vec());
+            seen.insert(prefix);
+            plan.upserts += 1;
+        });
+
+        for prefix in self.ledger.known_prefixes() {
+            if !seen.contains(&prefix) {
+                self.pending.withdraw(prefix);
+                plan.withdrawals += 1;
+            }
+        }
+
+        // Anything parked at the high-water mark gets another chance:
+        // withdrawals in this same plan may have freed the headroom.
+        self.pending.release_withheld();
+        plan
+    }
+
+    /// Push one bounded batch. `Ok(true)` = nothing left pending.
+    pub fn drain_batch(&mut self) -> Result<(bool, DrainStats), EngineError> {
+        // Resolve through the current map. Captured by reference so the
+        // drainer sees the same mapping the ledger was classified
+        // against.
+        let nexthops = &self.nexthops;
+        let resolve = move |addrs: &[IpAddr]| -> Vec<ResolvedPath> {
+            addrs
+                .iter()
+                .filter_map(|nh| {
+                    nexthops.resolve(nh).map(|target| ResolvedPath {
+                        nexthop: *nh,
+                        target,
+                    })
+                })
+                .collect()
+        };
+
+        let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
+        match self.drainer.drain(
+            &mut self.pending,
+            &mut self.ledger,
+            &resolve,
+            &self.port_index,
+            t,
+            DRAIN_BATCH,
+        ) {
+            Ok(stats) => Ok((self.pending.is_empty(), stats)),
+            Err((_, e)) => {
+                // The drainer has already requeued everything it did not
+                // get an acknowledgement for; the socket is what is
+                // broken.
+                self.disconnect();
+                Err(EngineError::Transport(e))
+            }
+        }
+    }
+
+    /// Readback verification against a fresh random sample.
+    pub fn run_verify(&mut self) -> Result<VerifyOutcome, EngineError> {
+        // Transport first. Setting the phase before this check leaves it
+        // stuck on `Verify` when the early return fires, and a phase
+        // that never clears is a convergence the loop believes is still
+        // running — so `may_restart` stays false and the supervisor can
+        // never recover. Own test caught it; keep the order.
+        if self.transport.is_none() {
+            return Err(EngineError::NotConnected);
+        }
+        self.phase = Some(Phase::Verify);
+        self.verify_seed = next_seed(self.verify_seed);
+        let seed = self.verify_seed;
+
+        let t = self.transport.as_mut().expect("checked just above");
+        match verify(t, &self.ledger, &self.port_index, DEFAULT_SAMPLE, seed) {
+            Ok(outcome) => {
+                self.last_verify = Some(outcome.clone());
+                self.phase = None;
+                Ok(outcome)
+            }
+            Err(e) => {
+                self.disconnect();
+                // Deliberately does NOT record a `last_verify`: a
+                // transport failure is not a verdict on the FIB, and
+                // storing it as a failed verify would report "FIB is
+                // wrong" for what is actually "we could not ask".
+                self.phase = None;
+                Err(EngineError::Transport(e))
+            }
+        }
+    }
+
+    /// Abandon whatever convergence step is in flight.
+    ///
+    /// Only clears the engine's own view. The pending map is left
+    /// exactly as it is — those routes are still owed, and dropping them
+    /// would make an aborted resync silently lose work that no later
+    /// event would restore.
+    pub fn abort_convergence(&mut self) {
+        self.phase = None;
+    }
+
+    /// Forget everything learned from a VPP that is gone.
+    ///
+    /// Called when the process dies, and load-bearing for correctness on
+    /// restart: interface indices are per-VPP-instance, so reusing them
+    /// against a fresh process would install every route onto whatever
+    /// interface happened to land on that index. The ledger is cleared
+    /// for the same reason — a new VPP's FIB is empty, and claiming
+    /// otherwise would let readback verification sample routes that were
+    /// never installed and, worse, let `blocks_first_steer` read as
+    /// clean.
+    pub fn on_process_gone(&mut self) {
+        self.disconnect();
+        self.attached.clear();
+        self.port_index = PortIndex::default();
+        self.pending = PendingMap::new();
+        self.ledger = RouteLedger::new(self.ledger_capacity());
+        self.phase = None;
+        self.last_verify = None;
+    }
+
+    fn ledger_capacity(&self) -> Capacity {
+        // Capacity is a policy, not observed state, so it survives the
+        // process it was applied to.
+        self.ledger.capacity()
+    }
+}
+
+/// splitmix64. Deterministic successor so verify samples differ per pass
+/// while staying replayable from the recorded seed.
+fn next_seed(prev: u64) -> u64 {
+    let mut z = prev.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn v4(a: u8, b: u8, c: u8, d: u8, len: u8) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [a, b, c, d],
+            prefix_len: len,
+        }
+    }
+
+    fn nh(d: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(192, 0, 2, d))
+    }
+
+    /// A mirror we can mutate between resyncs, which is the whole point
+    /// of testing the diff.
+    struct Mirror {
+        routes: Vec<(IpPrefix, Vec<IpAddr>)>,
+        devices: Vec<(IpAddr, String)>,
+    }
+
+    impl RouteSource for Mirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for (p, nhs) in &self.routes {
+                visit(*p, nhs);
+            }
+        }
+        fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str)) {
+            for (a, d) in &self.devices {
+                visit(*a, d);
+            }
+        }
+    }
+
+    fn engine() -> ConvergenceEngine {
+        ConvergenceEngine::new(
+            "/nonexistent/api.sock",
+            vec![PortAttach {
+                port: "eth4".into(),
+                pci_addr: "0002:07:00.1".into(),
+                port_id: 0,
+                num_rx_queues: 1,
+            }],
+            vec!["eth4".into()],
+            1_000_000,
+            FamilyPolicy::V4Only,
+        )
+    }
+
+    fn mirror(n: u8) -> Mirror {
+        Mirror {
+            routes: (0..n).map(|i| (v4(10, i, 0, 0, 16), vec![nh(1)])).collect(),
+            devices: vec![(nh(1), "eth4".into())],
+        }
+    }
+
+    #[test]
+    fn a_resync_queues_every_route_from_the_source() {
+        let mut e = engine();
+        let plan = e.begin_resync(&mirror(5));
+        assert_eq!(plan.upserts, 5);
+        assert_eq!(plan.withdrawals, 0);
+        assert_eq!(e.pending().len(), 5);
+        assert_eq!(e.phase(), Some(Phase::Resync));
+    }
+
+    /// The failure the plan names: an add-only resync leaves a withdrawn
+    /// route installed, forwarding to a nexthop nobody advertises — and
+    /// readback verification cannot see it, because verification samples
+    /// what the ledger claims and the ledger claims it is fine.
+    #[test]
+    fn a_resync_withdraws_what_the_source_dropped() {
+        let mut e = engine();
+        // Pretend a previous run installed five routes.
+        let m = mirror(5);
+        e.begin_resync(&m);
+        for (p, nhs) in &m.routes {
+            e.ledger.classify_upsert(*p, nhs, &e.nexthops.clone());
+            e.ledger.commit_installed(*p);
+        }
+        assert_eq!(e.counts().installed, 5);
+
+        // Two prefixes go away while we were not looking.
+        let mut shrunk = mirror(5);
+        shrunk.routes.truncate(3);
+        let plan = e.begin_resync(&shrunk);
+        assert_eq!(plan.upserts, 3);
+        assert_eq!(
+            plan.withdrawals, 2,
+            "the two dropped prefixes must be queued for withdrawal"
+        );
+    }
+
+    #[test]
+    fn a_resync_refreshes_the_nexthop_map_before_resolving() {
+        let mut e = engine();
+        // Nothing known yet, so this nexthop is unresolvable.
+        assert!(e.nexthops.resolve(&nh(7)).is_none());
+        let m = Mirror {
+            routes: vec![(v4(10, 0, 0, 0, 8), vec![nh(7)])],
+            devices: vec![(nh(7), "eth4".into())],
+        };
+        e.begin_resync(&m);
+        assert!(
+            e.nexthops.resolve(&nh(7)).is_some(),
+            "the neighbour learned since last time must be usable now, or \
+             the route is misclassified unresolvable"
+        );
+    }
+
+    /// Interface indices are per-VPP-instance. Reusing them against a
+    /// fresh process would install every route onto whatever interface
+    /// happened to take that index.
+    #[test]
+    fn a_dead_process_invalidates_everything_learned_from_it() {
+        let mut e = engine();
+        e.port_index.insert("eth4", None, 3);
+        e.attached.push(AttachedPort {
+            port: "eth4".into(),
+            dev_index: Some(0),
+            sw_if_index: 3,
+        });
+        let m = mirror(4);
+        e.begin_resync(&m);
+        for (p, nhs) in &m.routes {
+            e.ledger.classify_upsert(*p, nhs, &e.nexthops.clone());
+            e.ledger.commit_installed(*p);
+        }
+        e.last_verify = Some(VerifyOutcome {
+            sampled: 64,
+            ..Default::default()
+        });
+        assert!(e.counts().installed > 0);
+
+        e.on_process_gone();
+
+        assert_eq!(e.counts(), SinkCounts::default(), "ledger must be empty");
+        assert!(e.port_links().is_empty(), "indices are per-instance");
+        assert!(e.pending().is_empty());
+        assert!(e.last_verify().is_none(), "a dead VPP has no verdict");
+        assert_eq!(e.phase(), None);
+        assert!(!e.is_connected());
+        // And the empty ledger must not read as a clean table: nothing
+        // is installed, so nothing is verified, so steering stays
+        // blocked until a fresh resync says otherwise.
+        assert!(!e.counts().blocks_first_steer());
+        assert!(e.last_verify().is_none());
+    }
+
+    /// Capacity is policy, not observed state, so it has to survive the
+    /// process it was applied to — otherwise a restart would rebuild the
+    /// ledger with an unbounded high-water mark and install past the
+    /// heap.
+    #[test]
+    fn capacity_policy_survives_a_restart() {
+        let mut e = ConvergenceEngine::new(
+            "/nonexistent/api.sock",
+            Vec::new(),
+            vec!["eth4".into()],
+            2,
+            FamilyPolicy::V4Only,
+        );
+        e.nexthops.set_device(nh(1), "eth4");
+        for i in 0..4u8 {
+            let p = v4(10, i, 0, 0, 16);
+            e.ledger.classify_upsert(p, &[nh(1)], &e.nexthops.clone());
+            e.ledger.commit_installed(p);
+        }
+        assert_eq!(e.counts().installed, 2);
+        assert_eq!(e.counts().withheld, 2);
+
+        e.on_process_gone();
+        for i in 0..4u8 {
+            let p = v4(10, i, 0, 0, 16);
+            e.ledger.classify_upsert(p, &[nh(1)], &e.nexthops.clone());
+            e.ledger.commit_installed(p);
+        }
+        assert_eq!(
+            e.counts().installed,
+            2,
+            "the high-water mark must still bind after a restart"
+        );
+    }
+
+    /// Every operation must refuse rather than pretend when there is no
+    /// socket. An engine that silently no-ops would report a converged
+    /// FIB it never sent.
+    #[test]
+    fn nothing_succeeds_without_a_transport() {
+        let mut e = engine();
+        assert!(!e.is_connected());
+        assert!(matches!(e.ping(), Err(EngineError::NotConnected)));
+        assert!(matches!(e.drain_batch(), Err(EngineError::NotConnected)));
+        assert!(matches!(e.run_verify(), Err(EngineError::NotConnected)));
+        assert!(matches!(
+            e.attach_devices(AttachMode::Fresh),
+            Err(EngineError::NotConnected)
+        ));
+        // A refused attach must not have consumed the port list — the
+        // next attempt needs it.
+        assert!(matches!(
+            e.attach_devices(AttachMode::Fresh),
+            Err(EngineError::NotConnected)
+        ));
+    }
+
+    /// A transport failure during verify is not a verdict on the FIB.
+    /// Recording it as a failed verify would report "the FIB is wrong"
+    /// for what is actually "we could not ask", and that difference
+    /// decides whether the supervisor cycles a healthy VPP.
+    #[test]
+    fn a_transport_failure_is_not_a_verify_verdict() {
+        let mut e = engine();
+        assert!(e.run_verify().is_err());
+        assert!(e.last_verify().is_none());
+        assert_eq!(e.phase(), None, "the phase must not stay stuck");
+    }
+
+    #[test]
+    fn verify_seeds_differ_per_pass_but_are_reproducible() {
+        let a = next_seed(0);
+        let b = next_seed(a);
+        assert_ne!(a, b);
+        assert_ne!(a, 0);
+        // Deterministic: the same predecessor always gives the same
+        // successor, which is what makes a failing pass replayable.
+        assert_eq!(next_seed(0), a);
+    }
+
+    #[test]
+    fn aborting_convergence_keeps_the_work_owed() {
+        let mut e = engine();
+        e.begin_resync(&mirror(6));
+        assert_eq!(e.pending().len(), 6);
+        e.abort_convergence();
+        assert_eq!(e.phase(), None);
+        assert_eq!(
+            e.pending().len(),
+            6,
+            "aborting must not drop routes that are still owed"
+        );
+    }
+}

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -47,13 +47,36 @@ use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
 use crate::vpp_api::{Transport, TransportError};
 
-/// How long to wait for the API socket on a connect attempt.
+/// How long to wait for the handshake on a connect attempt.
 ///
 /// Short on purpose: `api_ready` is polled from the supervision loop and
 /// a long blocking connect would stall the tick that also services the
-/// pidfd and the wedge ping. The *overall* patience for a slow start is
+/// pidfd and the wedge ping. A timeout here just means the next tick
+/// tries again; the *overall* patience for a slow start is
 /// `API_STARTUP_BUDGET`, which is the loop's business, not this call's.
-pub const CONNECT_TIMEOUT: Duration = Duration::from_millis(500);
+pub const HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Socket timeout for every request after the handshake.
+///
+/// **Must exceed the largest liveness budget**, and that is the whole
+/// reason it is a separate constant. `Transport::connect` installs its
+/// timeout with `set_read_timeout`, so it governs not just the handshake
+/// but every subsequent reply — and using the short handshake value would
+/// make the transport error at 500 ms during a full-table load, when VPP
+/// legitimately takes seconds to answer because it services the API on
+/// the same main thread that is executing our route batch.
+///
+/// That would hand the transport a veto over a decision that belongs to
+/// the wedge detector: `SYNC_PING_BUDGET` exists precisely so a resync
+/// can be slow without being declared dead, and a shorter socket timeout
+/// silently defeats it — disconnect, requeue, restart, forever, on a VPP
+/// that was working. Derived from the budget rather than picked so the
+/// two cannot drift.
+pub const OP_TIMEOUT: Duration = crate::liveness::SYNC_PING_BUDGET.saturating_add(TIMEOUT_MARGIN);
+
+/// Headroom between the largest liveness budget and the socket timeout,
+/// so a reply arriving right at the budget is not raced by the socket.
+pub const TIMEOUT_MARGIN: Duration = Duration::from_secs(2);
 
 /// Route ops handed to VPP per drain call.
 ///
@@ -193,10 +216,27 @@ impl ConvergenceEngine {
         self
     }
 
-    /// Register a VLAN device as a sub-interface of a member port.
-    pub fn add_vlan(&mut self, dev: impl Into<String>, port: impl Into<String>, vid: u16) {
-        self.nexthops.add_vlan(dev, port, vid);
-    }
+    // NOTE: there is deliberately no `add_vlan` here, even though
+    // [`NexthopMap`] supports VLAN nexthops.
+    //
+    // Teaching the mapping to return `NexthopTarget::Subif` is only half
+    // of it: FIB paths need the sub-interface's OWN `sw_if_index`, and
+    // nothing creates or discovers one. The generated API whitelist has
+    // no sub-interface message at all, so `PortIndex` could never gain a
+    // `(port, Some(vid))` entry — `build_paths` would return `None` for
+    // every route through that VLAN, the drainer would defer all of them
+    // forever, and the resync would burn the whole convergence budget
+    // installing nothing.
+    //
+    // An affordance that silently produces a permanently-deferred table
+    // is worse than a missing one, so it is missing. Re-enabling it means
+    // adding a sub-interface create message to the whitelist, calling it
+    // during attach, and recording the index VPP assigns.
+    //
+    // Not currently needed: the gate-0b nexthop histogram found exactly
+    // two egress devices across the whole table and no VLAN nexthops —
+    // the br1337/FDB-pin topology is a connected-route concern, not a BGP
+    // nexthop one.
 
     pub fn counts(&self) -> SinkCounts {
         self.ledger.counts()
@@ -218,23 +258,50 @@ impl ConvergenceEngine {
         self.transport.is_some()
     }
 
-    /// Interface state for the health surface, from the last attach
-    /// pass. Reports what VPP said, not what we asked for.
+    /// Interface state for the health surface.
+    ///
+    /// Flags come from the most recent **observation**, which is the
+    /// verify pass's interface dump — `VerifyOutcome::dead_interfaces`
+    /// names every owned interface that is not both admin- and link-up,
+    /// including ones absent from VPP entirely.
+    ///
+    /// An earlier version hard-coded both flags true and rationalised it
+    /// as "the attach-time observation". It was not one: `attach_ports`
+    /// asserts the admin flag but never checks carrier, so link state was
+    /// pure fabrication — and it persisted, so a port that verify had
+    /// just found dead still reported as forwarding. That is exactly the
+    /// defect this module's docs claim to defend against, in the health
+    /// surface, written by the same hand that wrote the claim.
+    ///
+    /// Before the first verify there is genuinely no link observation.
+    /// Reporting up there cannot cause a false all-clear, because
+    /// `status::StatusSnapshot::nominal` requires a *passing verify*
+    /// independently — so the window is bounded by something that does
+    /// not trust this value.
     pub fn port_links(&self) -> Vec<PortLink> {
+        let dead = self
+            .last_verify
+            .as_ref()
+            .map(|v| v.dead_interfaces.as_slice())
+            .unwrap_or_default();
         self.attached
             .iter()
-            .map(|p| PortLink {
-                port: p.port.clone(),
-                sw_if_index: p.sw_if_index,
-                // Attach refuses a port that is not both admin- and
-                // link-up, so anything in `attached` was up when we
-                // last looked. The freshness of that claim is the
-                // verify pass's job — it re-reads link state every
-                // time — so this reports the attach-time observation
-                // rather than inventing a live one.
-                admin_up: true,
-                link_up: true,
-            })
+            .map(
+                |p| match dead.iter().find(|d| d.sw_if_index == p.sw_if_index) {
+                    Some(d) => PortLink {
+                        port: p.port.clone(),
+                        sw_if_index: p.sw_if_index,
+                        admin_up: d.admin_up,
+                        link_up: d.link_up,
+                    },
+                    None => PortLink {
+                        port: p.port.clone(),
+                        sw_if_index: p.sw_if_index,
+                        admin_up: true,
+                        link_up: true,
+                    },
+                },
+            )
             .collect()
     }
 
@@ -247,8 +314,17 @@ impl ConvergenceEngine {
         if self.transport.is_some() {
             return true;
         }
-        match Transport::connect(&self.api_socket, CONNECT_TIMEOUT) {
-            Ok(t) => {
+        match Transport::connect(&self.api_socket, HANDSHAKE_TIMEOUT) {
+            Ok(mut t) => {
+                // Re-arm to the operation timeout. The handshake value is
+                // deliberately short so a failed connect costs the loop
+                // one tick, but `connect` installs it as the socket's
+                // persistent read/write timeout — leaving it in force
+                // would make every drain reply time out at 500 ms during
+                // a full-table load and defeat SYNC_PING_BUDGET.
+                if t.set_timeout(OP_TIMEOUT).is_err() {
+                    return false;
+                }
                 self.transport = Some(t);
                 true
             }
@@ -302,7 +378,25 @@ impl ConvergenceEngine {
         let result = attach_ports(t, &ports, &known, mode);
         self.ports = ports;
         self.recorded_indices = known;
-        let attached = result?;
+        let attached = match result {
+            Ok(a) => a,
+            Err(e) => {
+                // A transport failure may have left an unread or partial
+                // reply on the stream, so the socket has to go — reusing
+                // it would match a later reply against the wrong context.
+                // Ping, drain and verify all do this; attach must not be
+                // the one path that leaves a poisoned socket looking
+                // healthy to `api_ready`.
+                //
+                // A plain refusal (`Refused`, `LocalZero`, `StaleIndex`,
+                // `UnknownIndexOnAdopt`) is VPP answering us correctly, so
+                // the connection stays.
+                if matches!(e, AttachError::Transport(_)) {
+                    self.disconnect();
+                }
+                return Err(e.into());
+            }
+        };
 
         // Only now, with VPP's own indices in hand.
         for p in &attached {
@@ -330,6 +424,22 @@ impl ConvergenceEngine {
     pub fn begin_resync(&mut self, src: &dyn RouteSource) -> ResyncPlan {
         self.phase = Some(Phase::Resync);
 
+        // Rebuild, not merge. An insert-only refresh leaves a nexthop the
+        // source has stopped reporting mapped to its last known device,
+        // so a route still naming it resolves as reachable through a
+        // stale interface rather than being classified unresolvable —
+        // traffic aimed at a neighbour that is gone, invisible to
+        // readback verification because verification checks that the
+        // route exists on an interface we own, not that its nexthop is
+        // the one we meant.
+        //
+        // The source is authoritative, so an empty snapshot means every
+        // route is unresolvable. That is loud by construction — verify
+        // fails on `unresolvable > 0` and first-attach steering is
+        // blocked — which is the right direction to fail if the
+        // neighbour source is broken. Silently keeping stale mappings
+        // would forward into the hole instead.
+        self.nexthops.forget_devices();
         src.for_each_nexthop_device(&mut |nh, dev| self.nexthops.set_device(nh, dev));
 
         let mut plan = ResyncPlan::default();
@@ -453,6 +563,13 @@ impl ConvergenceEngine {
         self.disconnect();
         self.attached.clear();
         self.port_index = PortIndex::default();
+        // The state file's recorded indices belong to the dead instance
+        // too. Keeping them meant the replacement process was handed
+        // indices its interface dump cannot contain, so `attach_ports`
+        // answered `StaleIndex` — correctly, it cannot tell whether a
+        // live FIB still references them — and every recovery after an
+        // adopted-process failure was driven straight back into teardown.
+        self.recorded_indices.clear();
         self.pending = PendingMap::new();
         self.ledger = RouteLedger::new(self.ledger_capacity());
         self.phase = None;
@@ -704,6 +821,115 @@ mod tests {
         // Deterministic: the same predecessor always gives the same
         // successor, which is what makes a failing pass replayable.
         assert_eq!(next_seed(0), a);
+    }
+
+    /// A nexthop the source stops reporting must become unresolvable, not
+    /// keep its last known device. Otherwise a route naming a vanished
+    /// neighbour resolves as reachable through a stale interface, and
+    /// readback verification cannot see it — verification checks the
+    /// route exists on an interface we own, deliberately not that its
+    /// nexthop is the one we meant.
+    #[test]
+    fn a_nexthop_the_source_dropped_becomes_unresolvable() {
+        let mut e = engine();
+        let p = v4(10, 0, 0, 0, 8);
+
+        let with_nh = Mirror {
+            routes: vec![(p, vec![nh(1)])],
+            devices: vec![(nh(1), "eth4".into())],
+        };
+        e.begin_resync(&with_nh);
+        assert!(e.nexthops.resolve(&nh(1)).is_some());
+
+        // The neighbour goes away; the route still names it.
+        let without_nh = Mirror {
+            routes: vec![(p, vec![nh(1)])],
+            devices: Vec::new(),
+        };
+        e.begin_resync(&without_nh);
+        assert!(
+            e.nexthops.resolve(&nh(1)).is_none(),
+            "a dropped nexthop must not keep its stale device"
+        );
+        // And classification now says so, rather than pointing a path at
+        // an interface the neighbour no longer lives on.
+        let st = e
+            .ledger
+            .classify_resolved(p, e.nexthops.resolve_all(&[nh(1)]).len());
+        assert_eq!(
+            st,
+            crate::sink::RouteState::NotInstalled(crate::sink::NotInstalled::Unresolvable)
+        );
+    }
+
+    /// The state file's indices belong to the instance that is gone.
+    /// Keeping them handed the replacement process indices its dump
+    /// cannot contain, so attach answered `StaleIndex` and every recovery
+    /// after an adopted-process failure went straight back to teardown.
+    #[test]
+    fn a_dead_process_invalidates_the_recorded_indices_too() {
+        let mut e = engine().with_recorded_indices(vec![("eth4".into(), 9)]);
+        assert!(!e.recorded_indices.is_empty());
+        e.on_process_gone();
+        assert!(
+            e.recorded_indices.is_empty(),
+            "recorded indices belong to the dead instance"
+        );
+    }
+
+    /// The socket timeout must never be shorter than the largest liveness
+    /// budget, or the transport errors before the wedge detector's budget
+    /// expires and takes a decision that belongs to the detector — a busy
+    /// but healthy VPP gets disconnected, requeued and restarted.
+    #[test]
+    fn the_operation_timeout_outlasts_every_liveness_budget() {
+        for steered in [false, true] {
+            for converging in [false, true] {
+                let budget = crate::liveness::budget_for(steered, converging);
+                assert!(
+                    OP_TIMEOUT > budget,
+                    "OP_TIMEOUT {OP_TIMEOUT:?} must exceed the {budget:?} budget \
+                     (steered={steered}, converging={converging})"
+                );
+            }
+        }
+        // And it must be clearly distinct from the handshake value, which
+        // is the bug: one constant serving both roles.
+        assert!(OP_TIMEOUT > HANDSHAKE_TIMEOUT * 10);
+    }
+
+    /// Link state must come from an observation. An earlier version
+    /// hard-coded both flags true, so a port verify had just found dead
+    /// still reported as forwarding.
+    #[test]
+    fn port_links_report_what_verify_observed() {
+        let mut e = engine();
+        e.attached.push(AttachedPort {
+            port: "eth4".into(),
+            dev_index: Some(0),
+            sw_if_index: 3,
+        });
+        // No verify yet: nothing contradicts, so it reads up — bounded by
+        // `nominal()` independently requiring a passing verify.
+        assert!(e.port_links()[0].link_up);
+
+        e.last_verify = Some(VerifyOutcome {
+            sampled: 64,
+            dead_interfaces: vec![crate::verify::DeadInterface {
+                sw_if_index: 3,
+                name: "octeon0/0".into(),
+                admin_up: true,
+                link_up: false,
+            }],
+            ..Default::default()
+        });
+        let links = e.port_links();
+        assert_eq!(links.len(), 1);
+        assert!(links[0].admin_up);
+        assert!(
+            !links[0].link_up,
+            "a port verify found dead must not report as forwarding"
+        );
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/fib_sync.rs
+++ b/crates/modules/vpp-offload/src/fib_sync.rs
@@ -274,7 +274,18 @@ enum Begun {
     /// A request went out; await its reply. `op` is the *effective*
     /// operation, which is not always the pending one — an installed
     /// prefix that becomes unresolvable is sent as a withdrawal.
-    Sent { context: u32, op: PendingOp },
+    ///
+    /// `derived` marks exactly that case: a withdrawal we invented
+    /// because resolution failed, as opposed to one the route source
+    /// asked for. The two must complete differently (see
+    /// [`Drainer::finish`]) — an authoritative withdrawal means the
+    /// prefix is gone, a derived one means the prefix is still
+    /// advertised but unresolvable, and conflating them loses the hole.
+    Sent {
+        context: u32,
+        op: PendingOp,
+        derived: bool,
+    },
     /// Resolved without touching the socket; already counted.
     Done,
     /// Cannot be attempted yet. Must go back into the pending map.
@@ -296,6 +307,9 @@ struct InFlight {
     /// from the original intent, not re-apply a withdrawal we derived
     /// from state that may have changed.
     original: PendingOp,
+    /// Whether `sent` is a withdrawal this drainer derived rather than
+    /// one the route source asked for.
+    derived: bool,
 }
 
 impl Default for Drainer {
@@ -346,11 +360,16 @@ impl Drainer {
                     break;
                 };
                 match self.begin(prefix, &op, ledger, resolve, ports, transport, &mut stats) {
-                    Ok(Begun::Sent { context, op: sent }) => inflight.push(InFlight {
+                    Ok(Begun::Sent {
+                        context,
+                        op: sent,
+                        derived,
+                    }) => inflight.push(InFlight {
                         context,
                         prefix,
                         sent,
                         original: op,
+                        derived,
                     }),
                     // Nothing to send (withheld, unresolvable,
                     // out-of-family): already counted, ledger already
@@ -465,6 +484,35 @@ impl Drainer {
                     ledger.state_of(prefix),
                     Some(RouteState::Installed) | Some(RouteState::Installing { replacing: true })
                 );
+
+                // A live route whose nexthops all left VPP's ports.
+                //
+                // Withdrawn, not left alone: VPP is still forwarding the
+                // PREVIOUS version, so leaving it keeps traffic on a path
+                // the route source has abandoned.
+                //
+                // Sent BEFORE reclassifying, which is the subtle part.
+                // Reclassifying first recorded `Unresolvable` immediately,
+                // and that lost the prefix twice over: a *successful*
+                // delete then hit `forget`, erasing the Unresolvable
+                // state, so `verify` saw `unresolvable == 0`, never
+                // sampled the prefix, and the supervisor could steer into
+                // a table with a known hole; and a *rejected* delete left
+                // the state Unresolvable, so the requeued upsert saw
+                // `was_installed == false` and silently stopped retrying,
+                // making a transient refusal permanent with the stale
+                // route still live. Leaving the prefix `Installed` until
+                // VPP confirms the delete fixes both: rejection retries,
+                // success records the hole.
+                if resolved.is_empty() && was_installed {
+                    let ctx = transport.send(withdraw_msg(prefix))?;
+                    return Ok(Begun::Sent {
+                        context: ctx,
+                        op: PendingOp::Withdraw,
+                        derived: true,
+                    });
+                }
+
                 // Ledger decides installable / withheld / unresolvable
                 // and reserves the capacity slot. It takes the count
                 // because we already resolved — running the mapping
@@ -480,22 +528,10 @@ impl Drainer {
                                 return Ok(Begun::Withhold);
                             }
                             crate::sink::NotInstalled::Unresolvable => {
+                                // Nothing live to withdraw — the
+                                // was-installed case was handled above,
+                                // before classification.
                                 stats.unresolvable += 1;
-                                // An update whose nexthops all moved off
-                                // VPP-owned ports is not a no-op: VPP is
-                                // still forwarding the PREVIOUS version
-                                // of this route. Leaving it would keep
-                                // traffic on a path bird has already
-                                // abandoned, and the ledger now excludes
-                                // the prefix from verification, so
-                                // nothing would ever notice. Withdraw it.
-                                if was_installed {
-                                    let ctx = transport.send(withdraw_msg(prefix))?;
-                                    return Ok(Begun::Sent {
-                                        context: ctx,
-                                        op: PendingOp::Withdraw,
-                                    });
-                                }
                             }
                         }
                         return Ok(Begun::Done);
@@ -527,11 +563,15 @@ impl Drainer {
                     op: PendingOp::Upsert {
                         nexthops: nexthops.clone(),
                     },
+                    derived: false,
                 })
             }
+            // An authoritative withdrawal: the route source no longer
+            // advertises this prefix at all.
             PendingOp::Withdraw => Ok(Begun::Sent {
                 context: transport.send(withdraw_msg(prefix))?,
                 op: PendingOp::Withdraw,
+                derived: false,
             }),
         }
     }
@@ -554,9 +594,22 @@ impl Drainer {
                 ledger.commit_installed(f.prefix);
                 stats.installed += 1;
             }
-            (PendingOp::Withdraw, 0) => {
+            // Authoritative: the source dropped the prefix, so the
+            // ledger should hold no opinion about it any more.
+            (PendingOp::Withdraw, 0) if !f.derived => {
                 ledger.forget(f.prefix);
                 stats.withdrawn += 1;
+            }
+            // Derived: the prefix is still advertised, we simply cannot
+            // reach any of its nexthops. The stale route is gone from
+            // VPP — record the hole NOW, not before, so it survives into
+            // verification. `forget` here would erase it and let the
+            // supervisor steer traffic into a table it knows is
+            // incomplete.
+            (PendingOp::Withdraw, 0) => {
+                ledger.classify_resolved(f.prefix, 0);
+                stats.withdrawn += 1;
+                stats.unresolvable += 1;
             }
             // A per-route rejection is NOT a connection fault: the
             // stream is fine and other routes will succeed. Unwind

--- a/crates/modules/vpp-offload/src/fib_sync.rs
+++ b/crates/modules/vpp-offload/src/fib_sync.rs
@@ -43,6 +43,17 @@ use crate::vpp_api::{Transport, TransportError};
 /// be requeued when a drain fails mid-window.
 pub const DEFAULT_WINDOW: usize = 256;
 
+/// Wire limit on paths per route: `n_paths` is a `u8`.
+///
+/// Load-bearing rather than theoretical. The encoder writes
+/// `paths.len() as u8` while still serialising every element, so a set
+/// larger than this puts a **wrapped count** on the wire followed by more
+/// path records than it declares — VPP either rejects the route or
+/// installs a truncated set, and a surviving owned path would still pass
+/// readback verification. Silent wire corruption is not a shape to leave
+/// reachable, however unlikely the input.
+pub const MAX_FIB_PATHS: usize = u8::MAX as usize;
+
 /// VPP interface indices for the ports the module owns.
 ///
 /// Populated at attach from `dev_create_port_if_reply`, which is where
@@ -221,6 +232,15 @@ pub struct DrainStats {
     /// Previously-withheld ops moved back into the active map because
     /// headroom returned. They install on the next drain.
     pub released: u64,
+    /// Routes whose resolved path set exceeded [`MAX_FIB_PATHS`] and was
+    /// truncated to fit the wire's `u8` count.
+    ///
+    /// Capped rather than refused: 255 of 300 paths still forwards
+    /// correctly, just with less spread, while refusing the route
+    /// blackholes the prefix outright. Counted because a non-zero value
+    /// means the route source is producing ECMP sets nobody designed
+    /// for — the reference fleet measured **zero** ECMP groups.
+    pub paths_capped: u64,
 }
 
 impl DrainStats {
@@ -261,6 +281,27 @@ impl FamilyPolicy {
             FamilyPolicy::V4Only => matches!(prefix, IpPrefix::V4 { .. }),
         }
     }
+}
+
+/// Truncate a path set to what the wire can describe, reporting whether
+/// it had to.
+///
+/// See [`MAX_FIB_PATHS`]: past 255 the declared count wraps while every
+/// element is still serialised, so VPP reads a wrapped count followed by
+/// more path records than it was told about — the route is rejected or
+/// installed with a truncated set, and a surviving owned path would still
+/// pass readback verification.
+///
+/// Capped rather than refused because 255 of 300 paths still forwards
+/// correctly, just with less spread, whereas refusing blackholes the
+/// prefix outright. Deterministic (a plain prefix of the resolved order)
+/// so the same input always produces the same FIB.
+pub fn cap_paths(paths: &mut Vec<FibPath>) -> bool {
+    if paths.len() <= MAX_FIB_PATHS {
+        return false;
+    }
+    paths.truncate(MAX_FIB_PATHS);
+    true
 }
 
 /// Pipelines pending route operations onto a [`Transport`].
@@ -339,6 +380,17 @@ impl Drainer {
     /// reservations unwound, and the untouched tail of the batch goes
     /// back too. The caller may retry against a fresh connection
     /// without having lost or double-counted anything.
+    // The Err variant carries partial `DrainStats` alongside the
+    // transport error, which is the point: the caller needs to know what
+    // did land before the socket broke. That tuple crosses clippy's
+    // 128-byte threshold now that `DrainStats` has ten counters.
+    //
+    // Not boxed. This returns **once per drain batch** (4096 routes), not
+    // per route, so the copy is noise — and boxing would put a heap
+    // allocation on the failure path, at the exact moment the transport
+    // is already failing and we are unwinding a window of in-flight
+    // requests.
+    #[allow(clippy::result_large_err)]
     pub fn drain(
         &self,
         pending: &mut PendingMap,
@@ -538,7 +590,7 @@ impl Drainer {
                     }
                     RouteState::Installed => return Ok(Begun::Done),
                 }
-                let Some(paths) = build_paths(&resolved, ports) else {
+                let Some(mut paths) = build_paths(&resolved, ports) else {
                     // Interface index not known yet: unwind the
                     // reservation and put it back rather than
                     // installing a route pointed at local0.
@@ -546,6 +598,9 @@ impl Drainer {
                     stats.deferred += 1;
                     return Ok(Begun::Defer);
                 };
+                if cap_paths(&mut paths) {
+                    stats.paths_capped += 1;
+                }
                 let msg = IpRouteAddDel {
                     context: 0,
                     is_add: true,
@@ -554,6 +609,7 @@ impl Drainer {
                         table_id: 0,
                         stats_index: 0,
                         prefix: to_prefix(prefix),
+                        // Cannot wrap: truncated above.
                         n_paths: paths.len() as u8,
                         paths,
                     },
@@ -800,6 +856,46 @@ mod tests {
         );
     }
 
+    /// `n_paths` is a `u8` and the encoder writes `paths.len() as u8`
+    /// independently of it, so an oversized set puts a wrapped count on
+    /// the wire followed by more records than it declares.
+    #[test]
+    fn a_path_set_never_exceeds_what_the_wire_can_count() {
+        let one = FibPath {
+            sw_if_index: 3,
+            table_id: 0,
+            rpf_id: 0,
+            weight: 1,
+            preference: 0,
+            r#type: 0,
+            flags: 0,
+            proto: 0,
+            nh: Default::default(),
+            n_labels: 0,
+            label_stack: Default::default(),
+        };
+
+        // The realistic case is untouched: the reference fleet measured
+        // ZERO ECMP groups, so this must not disturb ordinary routes.
+        let mut small = vec![one.clone(); 4];
+        assert!(!cap_paths(&mut small));
+        assert_eq!(small.len(), 4);
+
+        // Exactly at the limit still fits.
+        let mut exact = vec![one.clone(); MAX_FIB_PATHS];
+        assert!(!cap_paths(&mut exact));
+        assert_eq!(exact.len(), MAX_FIB_PATHS);
+        assert_eq!(exact.len() as u8 as usize, exact.len(), "no wrap");
+
+        // One past it wraps to 0 without the cap — which is the whole
+        // point: a declared count of 0 followed by 256 records.
+        let mut over = vec![one; MAX_FIB_PATHS + 1];
+        assert_eq!((MAX_FIB_PATHS + 1) as u8, 0, "this is the corruption");
+        assert!(cap_paths(&mut over));
+        assert_eq!(over.len(), MAX_FIB_PATHS);
+        assert_eq!(over.len() as u8 as usize, over.len());
+    }
+
     #[test]
     fn drain_stats_count_only_what_reached_vpp() {
         let s = DrainStats {
@@ -811,6 +907,7 @@ mod tests {
             deferred: 4,
             out_of_family: 7,
             released: 9,
+            paths_capped: 0,
         };
         // Withheld/unresolvable/deferred/out-of-family never left the
         // process.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -35,6 +35,7 @@
 
 pub mod attach;
 pub mod driver;
+pub mod engine;
 pub mod executor;
 pub mod fib_sync;
 pub mod liveness;

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -428,6 +428,18 @@ impl RouteLedger {
         self.counts
     }
 
+    /// The capacity policy this ledger enforces.
+    ///
+    /// Exposed so a caller rebuilding the ledger — on restart, when the
+    /// old VPP's FIB is gone and every recorded install is void — can
+    /// carry the policy across. Capacity is derived from the measured
+    /// heap gauge, not from the process that happened to be running, so
+    /// losing it on restart would rebuild an unbounded ledger and
+    /// install straight past the high-water mark.
+    pub fn capacity(&self) -> Capacity {
+        self.capacity
+    }
+
     fn tally(counts: &mut SinkCounts, st: RouteState, add: bool) {
         let slot = match st {
             RouteState::Installed => &mut counts.installed,
@@ -572,6 +584,19 @@ impl RouteLedger {
             .filter(|(_, st)| **st == RouteState::NotInstalled(NotInstalled::Withheld))
             .map(|(k, _)| (*k).into())
             .collect()
+    }
+
+    /// Every prefix the ledger holds an opinion about, in any state.
+    ///
+    /// The full-table resync needs this to compute **withdrawals**. A
+    /// prefix that left the route source while VPP was down, or while
+    /// packetframe was, is still installed in VPP's FIB — an add-only
+    /// resync would leave it forwarding to a nexthop the source no
+    /// longer advertises, which is a black hole that readback
+    /// verification cannot see (it samples what the ledger claims, and
+    /// the ledger claims that route is fine).
+    pub fn known_prefixes(&self) -> Vec<IpPrefix> {
+        self.state.keys().map(|k| (*k).into()).collect()
     }
 
     /// Sampling pool for readback verification: only prefixes VPP has

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -262,6 +262,22 @@ impl NexthopMap {
         self.device_of.insert(nexthop, dev.into());
     }
 
+    /// Forget every learned nexthop→device pair, keeping the members and
+    /// VLAN policy.
+    ///
+    /// Called before repopulating from an authoritative snapshot. Without
+    /// it the map is insert-only, so a nexthop the source has stopped
+    /// reporting keeps its last known device forever — and a route still
+    /// naming that nexthop resolves as *reachable* through a stale
+    /// interface instead of being classified unresolvable. Traffic then
+    /// keeps pointing at a neighbour that is gone, and readback
+    /// verification cannot catch it: verification checks that a route
+    /// exists on an interface we own, deliberately not that its nexthop
+    /// is still the one we intended.
+    pub fn forget_devices(&mut self) {
+        self.device_of.clear();
+    }
+
     /// Resolve one nexthop, or `None` if its device is excluded.
     pub fn resolve(&self, nexthop: &IpAddr) -> Option<NexthopTarget> {
         let dev = self.device_of.get(nexthop)?;

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -396,6 +396,22 @@ impl PendingMap {
             .collect()
     }
 
+    /// Drop every active op whose prefix fails `keep`.
+    ///
+    /// Used by the full-table resync to discard ops left over from an
+    /// aborted one. Those prefixes live only here — they were never
+    /// classified, so `RouteLedger::known_prefixes` cannot see them, and
+    /// the resync's withdrawal loop walks the ledger. Without this, a
+    /// prefix the source dropped between an aborted resync and the next
+    /// one keeps its stale pending upsert and is installed later, even
+    /// though the current snapshot does not advertise it.
+    ///
+    /// Only the active map: parked (withheld) ops keep their own
+    /// lifecycle, and the resync releases them separately.
+    pub fn retain(&mut self, keep: impl Fn(&IpPrefix) -> bool) {
+        self.ops.retain(|k, _| keep(&IpPrefix::from(*k)));
+    }
+
     /// Re-queue an op the transport could not apply — but only if the
     /// prefix has not been superseded in the meantime. A newer event
     /// that arrived while the batch was in flight is the current intent

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -147,6 +147,24 @@ pub enum Event {
     /// Readback verification finished.
     VerifyPassed,
     VerifyFailed,
+    /// Verification found nothing *wrong*, but the FIB is **incomplete**:
+    /// routes are withheld at the capacity high-water mark or
+    /// unresolvable.
+    ///
+    /// A third outcome because collapsing it into either of the other two
+    /// is wrong in a different way. As `VerifyFailed` it would cycle a
+    /// perfectly healthy VPP and turn the designed response to a table
+    /// that outgrew its heap into a restart loop. As `VerifyPassed` it
+    /// re-steers traffic into a FIB known to be missing prefixes —
+    /// `VerifyOutcome::passed()` deliberately ignores `withheld`, and
+    /// `SinkCounts::blocks_first_steer()` was the intended gate but
+    /// nothing consulted it, so a restart of a previously-steered VPP
+    /// would divert traffic into the incomplete table and blackhole
+    /// exactly the prefixes that did not fit.
+    ///
+    /// So: reach `Ready` without restarting, and do **not** steer. The
+    /// want is preserved, so the next complete verify re-steers.
+    VerifyIncomplete,
     /// A step in the attach → resync pipeline failed outright: the
     /// device would not attach, or the transport broke mid-drain.
     ///
@@ -457,6 +475,17 @@ impl Supervisor {
                 } else {
                     vec![]
                 }
+            }
+            // Correct as far as it goes, but incomplete: settle into the
+            // safe staging state rather than diverting traffic into a FIB
+            // with known holes. Not a failure — restarting would trade a
+            // partially-working forwarder for an outage and would loop,
+            // because the next resync withholds the same routes.
+            (Verifying | AdoptedResyncing, VerifyIncomplete) => {
+                self.converging = false;
+                self.failures = 0;
+                self.state = Ready;
+                vec![]
             }
             (Verifying, VerifyFailed) => {
                 // A FIB we cannot verify is not one to divert traffic
@@ -1032,6 +1061,61 @@ mod tests {
         s.on(Event::SyncComplete);
         assert!(!s.on(Event::VerifyPassed).contains(&Action::Steer));
         assert!(!s.steer_intended());
+    }
+
+    /// An incomplete FIB settles into the staging state: no restart, no
+    /// steer.
+    ///
+    /// Both collapses are wrong. As a failure it would cycle a healthy
+    /// VPP and loop, because the next resync withholds the same routes.
+    /// As a pass it would re-steer a previously-steered deployment into a
+    /// FIB missing exactly the prefixes that did not fit — and
+    /// `VerifyOutcome::passed()` ignores `withheld` by design, so nothing
+    /// downstream would have caught it.
+    #[test]
+    fn an_incomplete_verify_reaches_ready_without_steering() {
+        let mut s = running_and_steered();
+        s.on(Event::ProcessExited { status: None });
+        // The executor's acknowledgement that the MCAM rules are gone —
+        // steering is only believed down on this, never optimistically.
+        s.on(Event::Unsteered);
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert_eq!(s.state(), State::Verifying);
+
+        let actions = s.on(Event::VerifyIncomplete);
+        assert_eq!(s.state(), State::Ready, "verified, just not complete");
+        assert!(
+            !actions.contains(&Action::Steer),
+            "must not divert traffic into a FIB with known holes"
+        );
+        assert!(!s.is_steered());
+        assert_eq!(s.failures(), 0, "not a failure — nothing to back off from");
+        assert!(
+            s.steer_intended(),
+            "the want survives, so a later complete verify re-steers"
+        );
+
+        // And that is exactly what happens once the table fits again.
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::Unsteered);
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert!(s.on(Event::VerifyPassed).contains(&Action::Steer));
+    }
+
+    /// Adoption takes the same path: an adopted VPP whose table is
+    /// incomplete must not have its steering re-asserted on that basis.
+    #[test]
+    fn an_incomplete_adopted_verify_also_declines_to_steer() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        s.on(Event::SyncComplete);
+        let actions = s.on(Event::VerifyIncomplete);
+        assert!(!actions.contains(&Action::Steer));
+        assert_eq!(s.state(), State::Ready);
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/vpp_api/transport.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/transport.rs
@@ -355,6 +355,28 @@ impl Transport {
         self.client_index
     }
 
+    /// Re-arm the socket's read/write timeouts after the handshake.
+    ///
+    /// [`Self::connect`]'s `timeout` governs the handshake *and*, because
+    /// it is installed with `set_read_timeout`, every request that
+    /// follows. Those two want very different values: a connect attempt
+    /// should fail fast so the supervision loop stays responsive, while a
+    /// request issued during a full-table load legitimately waits far
+    /// longer — VPP answers the binary API on its main thread, the same
+    /// thread executing the route batch.
+    ///
+    /// Leaving one short value in force means the transport errors before
+    /// the wedge detector's budget expires, which hands the transport a
+    /// veto over a decision that belongs to the detector: a busy but
+    /// healthy VPP would be disconnected, requeued and eventually
+    /// restarted. The socket timeout is a backstop against parking
+    /// forever, not a liveness policy.
+    pub fn set_timeout(&mut self, timeout: Duration) -> Result<(), TransportError> {
+        self.sock.set_read_timeout(Some(timeout))?;
+        self.sock.set_write_timeout(Some(timeout))?;
+        Ok(())
+    }
+
     /// Message id table, for callers that need to recognise async
     /// events. Read-only by design; nothing outside may mutate it.
     pub fn message_id(&self, name: &str) -> Option<u16> {

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -33,14 +33,18 @@ use packetframe_vpp_offload::vpp_api::codec::{
     SOCKCLNT_CREATE_MSG_ID,
 };
 use packetframe_vpp_offload::vpp_api::generated::{
-    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteAddDel,
-    IpRouteAddDelReply, IpRouteLookupReply, MessageTableEntry, SockclntCreateReply,
-    SwInterfaceDetails, SwInterfaceSetFlagsReply, MESSAGE_META,
+    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpNeighborAddDel,
+    IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteLookupReply,
+    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
+    MESSAGE_META,
 };
 
 /// The index the fake's `dev_create_port_if` hands out. Routes must
 /// install onto *this*, learned from VPP, never onto a guess.
 const ASSIGNED_INDEX: u32 = 3;
+
+/// Link-layer address the fake mirror hands out for its one neighbour.
+const MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
 
 fn id_for(name: &str) -> u16 {
     100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
@@ -90,13 +94,18 @@ mod tempdir {
     impl TempDir {
         pub fn new(tag: &str) -> std::io::Result<Self> {
             let mut p = std::env::temp_dir();
+            // Short by construction: a unix socket path is capped at
+            // SUN_LEN (~104 bytes) and macOS $TMPDIR is already ~50 of
+            // them, so a full nanosecond stamp overflows it and the
+            // failure surfaces as an unrelated-looking bind error.
             p.push(format!(
-                "pf-eng-{tag}-{}-{:?}",
+                "pf-e{tag}-{}-{:x}",
                 std::process::id(),
                 std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap()
                     .as_nanos()
+                    % 0x100_000
             ));
             std::fs::create_dir_all(&p)?;
             Ok(Self(p))
@@ -128,6 +137,11 @@ struct WireRoute {
 enum Event {
     Msg(String),
     Route(WireRoute),
+    Neighbour {
+        sw_if_index: u32,
+        mac: [u8; 6],
+        flags: u8,
+    },
 }
 
 struct Fake {
@@ -136,9 +150,19 @@ struct Fake {
     events: Receiver<Event>,
 }
 
+/// How the fake misbehaves.
+#[derive(Clone, Copy, Default)]
+struct Behaviour {
+    /// Drop the connection after this many route ops.
+    hangup_after: Option<usize>,
+    /// Reject this many *deletes* with a non-zero retval before
+    /// accepting them.
+    reject_deletes: usize,
+}
+
 impl Fake {
     fn start(tag: &str) -> Self {
-        Self::start_with(tag, usize::MAX)
+        Self::start_behaving(tag, Behaviour::default())
     }
 
     /// Drop the connection after `hangup_after` route ops — the
@@ -148,18 +172,30 @@ impl Fake {
     /// connection can finish the job, so a fake that hung up on every
     /// connection would make recovery untestable rather than testing it.
     fn start_with(tag: &str, hangup_after: usize) -> Self {
+        Self::start_behaving(
+            tag,
+            Behaviour {
+                hangup_after: Some(hangup_after),
+                ..Default::default()
+            },
+        )
+    }
+
+    fn start_behaving(tag: &str, behaviour: Behaviour) -> Self {
         let dir = tempdir::TempDir::new(tag).unwrap();
         let path = dir.path().join("api.sock");
         let listener = UnixListener::bind(&path).unwrap();
         let (tx, rx): (Sender<Event>, Receiver<Event>) = channel();
 
         thread::spawn(move || {
-            let mut budget = hangup_after;
+            let mut b = behaviour;
             // Accept repeatedly: a disconnect-and-reconnect is part of
             // what these tests exercise.
             while let Ok((mut sock, _)) = listener.accept() {
-                serve(&mut sock, &tx, budget);
-                budget = usize::MAX;
+                serve(&mut sock, &tx, b);
+                // One-shot hangup: the point of that test is that a fresh
+                // connection can finish the job.
+                b.hangup_after = None;
             }
         });
 
@@ -179,7 +215,7 @@ impl Fake {
     }
 }
 
-fn serve(sock: &mut UnixStream, tx: &Sender<Event>, hangup_after: usize) -> Option<()> {
+fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) -> Option<()> {
     read_frame(sock)?;
     let mut reply = SockclntCreateReply {
         context: 1,
@@ -254,11 +290,36 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, hangup_after: usize) -> Opti
                 }));
 
                 routes_seen += 1;
-                if routes_seen > hangup_after {
+                if behaviour.hangup_after.is_some_and(|n| routes_seen > n) {
                     return None;
                 }
+                // Reject deletes for a while, so the retry path is
+                // exercised against a per-route refusal rather than a
+                // connection fault.
+                let retval = if !r.is_add && behaviour.reject_deletes > 0 {
+                    behaviour.reject_deletes -= 1;
+                    -1
+                } else {
+                    0
+                };
                 out = reply_head("ip_route_add_del_reply");
                 IpRouteAddDelReply {
+                    context: ctx,
+                    retval,
+                    stats_index: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_neighbor_add_del" => {
+                let mut d = Decoder::new(&req);
+                let n = IpNeighborAddDel::decode(&mut d).expect("decodes as a neighbour op");
+                let _ = tx.send(Event::Neighbour {
+                    sw_if_index: n.neighbor.sw_if_index,
+                    mac: n.neighbor.mac_address,
+                    flags: n.neighbor.flags,
+                });
+                out = reply_head("ip_neighbor_add_del_reply");
+                IpNeighborAddDelReply {
                     context: ctx,
                     retval: 0,
                     stats_index: 0,
@@ -376,8 +437,8 @@ impl RouteSource for Mirror {
             visit(*p, &[nh()]);
         }
     }
-    fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str)) {
-        visit(nh(), "eth4");
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        visit(nh(), "eth4", MAC);
     }
 }
 
@@ -444,7 +505,7 @@ fn the_convergence_pipeline_composes_over_one_transport() {
         .into_iter()
         .filter_map(|e| match e {
             Event::Msg(n) => Some(n),
-            Event::Route(_) => None,
+            _ => None,
         })
         .collect();
     let first_attach = names.iter().position(|n| n == "dev_attach").unwrap();
@@ -472,7 +533,7 @@ fn routes_install_onto_the_index_vpp_assigned() {
         .into_iter()
         .filter_map(|e| match e {
             Event::Route(r) => Some(r),
-            Event::Msg(_) => None,
+            _ => None,
         })
         .collect();
     assert_eq!(routes.len(), 4);
@@ -577,4 +638,220 @@ fn a_hangup_mid_drain_requeues_and_disconnects() {
     drain_to_empty(&mut e);
     assert_eq!(e.counts().installed, 20);
     assert!(e.run_verify().unwrap().passed());
+}
+
+/// A mirror that still advertises the prefix but no longer resolves its
+/// nexthop — the shape the rebuilt device map produces when a neighbour
+/// disappears.
+struct OrphanedMirror {
+    routes: Vec<IpPrefix>,
+}
+
+impl RouteSource for OrphanedMirror {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for p in &self.routes {
+            visit(*p, &[nh()]);
+        }
+    }
+    /// No neighbours: the nexthop is gone.
+    fn for_each_neighbour(&self, _visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
+}
+
+/// When an advertised prefix loses every VPP-reachable nexthop, the stale
+/// route must leave VPP **and** the prefix must be recorded as
+/// unresolvable.
+///
+/// Recording it before the delete was acknowledged meant a successful
+/// delete hit `forget`, which erased the state — so `verify` saw
+/// `unresolvable == 0`, never sampled the prefix, and the supervisor
+/// could steer traffic into a table with a known hole.
+#[test]
+fn a_prefix_that_loses_its_nexthops_is_deleted_and_recorded_unresolvable() {
+    let fake = Fake::start("orphan");
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+
+    e.begin_resync(&mirror(3));
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 3);
+    let _ = fake.drain_events();
+
+    // Same prefixes, no reachable nexthop.
+    e.begin_resync(&OrphanedMirror {
+        routes: mirror(3).routes,
+    });
+    drain_to_empty(&mut e);
+
+    // The stale routes actually left VPP.
+    let deletes = fake
+        .drain_events()
+        .into_iter()
+        .filter(|ev| matches!(ev, Event::Route(r) if !r.is_add))
+        .count();
+    assert_eq!(deletes, 3, "every stale route must be withdrawn");
+
+    // And the hole is on the books.
+    let c = e.counts();
+    assert_eq!(c.installed, 0);
+    assert_eq!(
+        c.unresolvable, 3,
+        "the prefixes are still advertised and still unreachable"
+    );
+    assert!(
+        c.blocks_first_steer(),
+        "a table with a known hole must not be steered into"
+    );
+    // Verification must agree, not report a clean table.
+    let outcome = e.run_verify().unwrap();
+    assert!(!outcome.passed(), "{}", outcome.summary());
+    assert_eq!(outcome.unresolvable, 3);
+}
+
+/// A per-route refusal of that derived delete must be retried, not
+/// swallowed.
+///
+/// Recording `Unresolvable` before the ack left the requeued upsert
+/// seeing `was_installed == false`, so it stopped re-sending the delete
+/// — a transient refusal became permanent with the stale route still
+/// live in VPP and verification failing forever.
+#[test]
+fn a_refused_derived_delete_is_retried() {
+    let fake = Fake::start_behaving(
+        "orphan-reject",
+        Behaviour {
+            hangup_after: None,
+            reject_deletes: 1,
+        },
+    );
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+
+    e.begin_resync(&mirror(1));
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 1);
+    let _ = fake.drain_events();
+
+    // Nexthop vanishes. The first delete is refused.
+    e.begin_resync(&OrphanedMirror {
+        routes: mirror(1).routes,
+    });
+    let (done, stats) = e.drain_batch().unwrap();
+    assert_eq!(stats.rejected, 1, "the fake refused the delete");
+    assert!(!done, "a refused op stays owed");
+    assert_eq!(
+        e.counts().installed,
+        1,
+        "the route is still live in VPP, so the ledger must still say so \
+         — otherwise nothing knows to retry the delete"
+    );
+
+    // The retry goes out and succeeds.
+    drain_to_empty(&mut e);
+    let deletes = fake
+        .drain_events()
+        .into_iter()
+        .filter(|ev| matches!(ev, Event::Route(r) if !r.is_add))
+        .count();
+    assert_eq!(deletes, 2, "one refused delete, one successful retry");
+    assert_eq!(e.counts().installed, 0);
+    assert_eq!(e.counts().unresolvable, 1);
+}
+
+/// Static neighbours must be programmed, on the index VPP assigned, and
+/// **before** the routes that depend on them.
+///
+/// VPP starts without `linux-cp` and MCAM rules match IP fields, so an
+/// ARP frame can never be steered to it — VPP physically cannot learn a
+/// neighbour. Skip this and route installs are still acknowledged and
+/// readback verification still passes (it checks a path exists on an
+/// interface we own, not that the adjacency resolves) while every packet
+/// is dropped on an incomplete adjacency. Nothing else in the module
+/// would report a fault, which is what makes it worth a wire test.
+#[test]
+fn static_neighbours_are_programmed_before_the_routes_that_need_them() {
+    let fake = Fake::start("nbr");
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+
+    let m = mirror(4);
+    // The mapping has to exist before neighbours can be resolved to an
+    // interface, which is what the resync's refresh does.
+    e.begin_resync(&m);
+    assert_eq!(e.program_neighbours(&m).unwrap(), 1);
+    drain_to_empty(&mut e);
+
+    let events = fake.drain_events();
+    let neighbours: Vec<_> = events
+        .iter()
+        .filter_map(|ev| match ev {
+            Event::Neighbour {
+                sw_if_index,
+                mac,
+                flags,
+            } => Some((*sw_if_index, *mac, *flags)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(neighbours.len(), 1, "the one reachable nexthop");
+    assert_eq!(
+        neighbours[0].0, ASSIGNED_INDEX,
+        "the adjacency must sit on the index VPP assigned"
+    );
+    assert_eq!(neighbours[0].1, MAC, "the resolved link-layer address");
+    assert_eq!(
+        neighbours[0].2, 1,
+        "STATIC: VPP cannot ARP to refresh it, so an ageing entry would \
+         silently become an unresolved adjacency"
+    );
+
+    // Ordering, on the wire.
+    let names: Vec<&str> = events
+        .iter()
+        .filter_map(|ev| match ev {
+            Event::Msg(n) => Some(n.as_str()),
+            _ => None,
+        })
+        .collect();
+    let first_nbr = names.iter().position(|n| *n == "ip_neighbor_add_del");
+    let first_route = names.iter().position(|n| *n == "ip_route_add_del");
+    assert!(
+        first_nbr.is_some() && first_nbr < first_route,
+        "neighbours before routes: {names:?}"
+    );
+}
+
+/// A neighbour whose device is not VPP-owned is skipped, not refused —
+/// same policy the route mapping applies, for the same reason: a
+/// management or tunnel neighbour is not an error, it is not ours.
+#[test]
+fn neighbours_on_foreign_devices_are_skipped() {
+    struct MixedMirror;
+    impl RouteSource for MixedMirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            visit(v4(0, 0), &[nh()]);
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(nh(), "eth4", MAC);
+            // Management: excluded by the nexthop mapping.
+            visit(
+                IpAddr::V4(Ipv4Addr::new(192, 0, 2, 99)),
+                "eth0",
+                [0x02, 0, 0, 0, 0, 9],
+            );
+        }
+    }
+
+    let fake = Fake::start("fgn");
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+    e.begin_resync(&MixedMirror);
+    assert_eq!(
+        e.program_neighbours(&MixedMirror).unwrap(),
+        1,
+        "only the member-port neighbour"
+    );
 }

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -494,8 +494,9 @@ fn the_convergence_pipeline_composes_over_one_transport() {
     assert_eq!(e.counts().installing, 0, "nothing left in flight");
     assert!(e.pending().is_empty());
 
-    let outcome = e.run_verify().expect("verify");
-    assert!(outcome.passed(), "{}", outcome.summary());
+    let v = e.run_verify().expect("verify");
+    assert!(v.outcome.passed(), "{}", v.outcome.summary());
+    assert!(v.may_steer, "a complete table may be steered into");
 
     // Ordering: devices attach before any route is installed. FIB paths
     // reference indices VPP has not assigned yet otherwise, and every
@@ -637,7 +638,9 @@ fn a_hangup_mid_drain_requeues_and_disconnects() {
     e.attach_devices(AttachMode::Fresh).unwrap();
     drain_to_empty(&mut e);
     assert_eq!(e.counts().installed, 20);
-    assert!(e.run_verify().unwrap().passed());
+    let v = e.run_verify().unwrap();
+    assert!(v.outcome.passed());
+    assert!(v.may_steer);
 }
 
 /// A mirror that still advertises the prefix but no longer resolves its
@@ -703,9 +706,10 @@ fn a_prefix_that_loses_its_nexthops_is_deleted_and_recorded_unresolvable() {
         "a table with a known hole must not be steered into"
     );
     // Verification must agree, not report a clean table.
-    let outcome = e.run_verify().unwrap();
-    assert!(!outcome.passed(), "{}", outcome.summary());
-    assert_eq!(outcome.unresolvable, 3);
+    let v = e.run_verify().unwrap();
+    assert!(!v.outcome.passed(), "{}", v.outcome.summary());
+    assert_eq!(v.outcome.unresolvable, 3);
+    assert!(!v.may_steer);
 }
 
 /// A per-route refusal of that derived delete must be retried, not

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -1,0 +1,580 @@
+//! The convergence engine against a fake VPP on a real unix socket.
+//!
+//! The unit tests in `engine.rs` cover its bookkeeping; this covers the
+//! thing that cannot be unit-tested — that attach, resync, drain and
+//! verify **compose** over one live transport, in the right order, and
+//! that what reaches the wire is what the ledger claims.
+//!
+//! Assertions are on decoded requests, not on byte offsets. The fake
+//! decodes `ip_route_add_del` with the same generated `Decode` impl the
+//! client encodes with, and builds reply headers from `MESSAGE_META`
+//! rather than assuming `[id][context]` — header geometry is per-message
+//! (`dev_create_port_if_reply` carries a `client_index`, its sibling
+//! `dev_attach_reply` does not), and a hand-assumed prefix here would
+//! quietly match a hand-assumed prefix in the client and prove nothing.
+//!
+//! What it deliberately does NOT model is forwarding. Whether VPP
+//! actually moves packets is gate 0b's job on hardware, and nothing here
+//! should be read as evidence about that.
+
+use std::io::{Read, Write};
+use std::net::{IpAddr, Ipv4Addr};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread;
+
+use packetframe_common::fib::IpPrefix;
+use packetframe_vpp_offload::attach::{AttachMode, PortAttach};
+use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
+use packetframe_vpp_offload::fib_sync::FamilyPolicy;
+use packetframe_vpp_offload::vpp_api::codec::{
+    parse_frame_header, peek_msg_id, write_frame_header, Decode, Decoder, Encode, MSG_HEADER_LEN,
+    SOCKCLNT_CREATE_MSG_ID,
+};
+use packetframe_vpp_offload::vpp_api::generated::{
+    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteAddDel,
+    IpRouteAddDelReply, IpRouteLookupReply, MessageTableEntry, SockclntCreateReply,
+    SwInterfaceDetails, SwInterfaceSetFlagsReply, MESSAGE_META,
+};
+
+/// The index the fake's `dev_create_port_if` hands out. Routes must
+/// install onto *this*, learned from VPP, never onto a guess.
+const ASSIGNED_INDEX: u32 = 3;
+
+fn id_for(name: &str) -> u16 {
+    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
+}
+
+fn name_for(id: u16) -> &'static str {
+    MESSAGE_META[(id - 100) as usize].name
+}
+
+fn reply_head(name: &str) -> Vec<u8> {
+    let meta = MESSAGE_META
+        .iter()
+        .find(|m| m.name == name)
+        .expect("known reply");
+    let mut out = Vec::new();
+    out.extend_from_slice(&id_for(name).to_be_bytes());
+    if meta.client_index_prefix {
+        out.extend_from_slice(&7u32.to_be_bytes());
+    }
+    out
+}
+
+fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
+    let mut hdr = [0u8; MSG_HEADER_LEN];
+    s.read_exact(&mut hdr).ok()?;
+    let len = parse_frame_header(&hdr) as usize;
+    let mut payload = vec![0u8; len];
+    s.read_exact(&mut payload).ok()?;
+    Some(payload)
+}
+
+fn write_frame(s: &mut UnixStream, payload: &[u8]) {
+    let mut framed = Vec::new();
+    write_frame_header(&mut framed, payload.len());
+    framed.extend_from_slice(payload);
+    let _ = s.write_all(&framed);
+    let _ = s.flush();
+}
+
+fn request_context(payload: &[u8]) -> u32 {
+    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
+}
+
+mod tempdir {
+    use std::path::{Path, PathBuf};
+    pub struct TempDir(PathBuf);
+    impl TempDir {
+        pub fn new(tag: &str) -> std::io::Result<Self> {
+            let mut p = std::env::temp_dir();
+            p.push(format!(
+                "pf-eng-{tag}-{}-{:?}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+            ));
+            std::fs::create_dir_all(&p)?;
+            Ok(Self(p))
+        }
+        pub fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
+/// One route operation as the fake decoded it off the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct WireRoute {
+    is_add: bool,
+    /// First four address bytes + prefix length, enough to identify the
+    /// v4 prefixes these tests use.
+    addr: [u8; 4],
+    len: u8,
+    /// Interface indices the paths reference.
+    path_indices: Vec<u32>,
+}
+
+#[derive(Debug, Clone)]
+enum Event {
+    Msg(String),
+    Route(WireRoute),
+}
+
+struct Fake {
+    path: PathBuf,
+    _dir: tempdir::TempDir,
+    events: Receiver<Event>,
+}
+
+impl Fake {
+    fn start(tag: &str) -> Self {
+        Self::start_with(tag, usize::MAX)
+    }
+
+    /// Drop the connection after `hangup_after` route ops — the
+    /// mid-drain failure the unwind path exists for.
+    ///
+    /// **One-shot, deliberately.** The point of the test is that a fresh
+    /// connection can finish the job, so a fake that hung up on every
+    /// connection would make recovery untestable rather than testing it.
+    fn start_with(tag: &str, hangup_after: usize) -> Self {
+        let dir = tempdir::TempDir::new(tag).unwrap();
+        let path = dir.path().join("api.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let (tx, rx): (Sender<Event>, Receiver<Event>) = channel();
+
+        thread::spawn(move || {
+            let mut budget = hangup_after;
+            // Accept repeatedly: a disconnect-and-reconnect is part of
+            // what these tests exercise.
+            while let Ok((mut sock, _)) = listener.accept() {
+                serve(&mut sock, &tx, budget);
+                budget = usize::MAX;
+            }
+        });
+
+        Self {
+            path,
+            _dir: dir,
+            events: rx,
+        }
+    }
+
+    fn drain_events(&self) -> Vec<Event> {
+        let mut v = Vec::new();
+        while let Ok(e) = self.events.try_recv() {
+            v.push(e);
+        }
+        v
+    }
+}
+
+fn serve(sock: &mut UnixStream, tx: &Sender<Event>, hangup_after: usize) -> Option<()> {
+    read_frame(sock)?;
+    let mut reply = SockclntCreateReply {
+        context: 1,
+        response: 0,
+        index: 7,
+        count: MESSAGE_META.len() as u16,
+        message_table: Vec::new(),
+    };
+    for (i, m) in MESSAGE_META.iter().enumerate() {
+        reply.message_table.push(MessageTableEntry {
+            index: 100 + i as u16,
+            name: format!("{}_{}", m.name, m.crc.trim_start_matches("0x")),
+        });
+    }
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&SOCKCLNT_CREATE_MSG_ID.to_be_bytes());
+    payload.extend_from_slice(&7u32.to_be_bytes());
+    reply.encode(&mut payload);
+    write_frame(sock, &payload);
+
+    let mut routes_seen = 0usize;
+
+    loop {
+        let req = read_frame(sock)?;
+        let id = peek_msg_id(&req).expect("msg id");
+        let ctx = request_context(&req);
+        let which = name_for(id);
+        let _ = tx.send(Event::Msg(which.to_string()));
+
+        let mut out;
+        match which {
+            "dev_attach" => {
+                out = reply_head("dev_attach_reply");
+                DevAttachReply {
+                    context: ctx,
+                    dev_index: 0,
+                    retval: 0,
+                    error_string: String::new(),
+                }
+                .encode(&mut out);
+            }
+            "dev_create_port_if" => {
+                out = reply_head("dev_create_port_if_reply");
+                DevCreatePortIfReply {
+                    context: ctx,
+                    sw_if_index: ASSIGNED_INDEX,
+                    retval: 0,
+                    error_string: String::new(),
+                }
+                .encode(&mut out);
+            }
+            "sw_interface_set_flags" => {
+                out = reply_head("sw_interface_set_flags_reply");
+                SwInterfaceSetFlagsReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_route_add_del" => {
+                // Decoded with the same generated impl the client
+                // encodes with, so this asserts on the real wire.
+                let mut d = Decoder::new(&req);
+                let r = IpRouteAddDel::decode(&mut d).expect("decodes as a route op");
+                let mut addr = [0u8; 4];
+                addr.copy_from_slice(&r.route.prefix.address.un.0[..4]);
+                let _ = tx.send(Event::Route(WireRoute {
+                    is_add: r.is_add,
+                    addr,
+                    len: r.route.prefix.len,
+                    path_indices: r.route.paths.iter().map(|p| p.sw_if_index).collect(),
+                }));
+
+                routes_seen += 1;
+                if routes_seen > hangup_after {
+                    return None;
+                }
+                out = reply_head("ip_route_add_del_reply");
+                IpRouteAddDelReply {
+                    context: ctx,
+                    retval: 0,
+                    stats_index: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_route_lookup" => {
+                out = reply_head("ip_route_lookup_reply");
+                IpRouteLookupReply {
+                    context: ctx,
+                    retval: 0,
+                    route: IpRoute {
+                        table_id: 0,
+                        stats_index: 0,
+                        prefix: prefix_of(v4(10, 0)),
+                        n_paths: 1,
+                        paths: vec![path_on(ASSIGNED_INDEX)],
+                    },
+                }
+                .encode(&mut out);
+            }
+            // DUMP: one details frame per interface, no terminator — the
+            // trailing control_ping's reply ends the stream, as VPP does.
+            "sw_interface_dump" => {
+                let mut d = reply_head("sw_interface_details");
+                details(ASSIGNED_INDEX, "octeon0/0", 3, ctx).encode(&mut d);
+                write_frame(sock, &d);
+                continue;
+            }
+            "control_ping" => {
+                out = reply_head("control_ping_reply");
+                ControlPingReply {
+                    context: ctx,
+                    retval: 0,
+                    vpe_pid: 4242,
+                }
+                .encode(&mut out);
+            }
+            other => panic!("fake got unexpected message {other}"),
+        }
+        write_frame(sock, &out);
+    }
+}
+
+fn details(sw_if_index: u32, name: &str, flags: u32, context: u32) -> SwInterfaceDetails {
+    SwInterfaceDetails {
+        context,
+        sw_if_index,
+        sup_sw_if_index: sw_if_index,
+        l2_address: [0u8; 6],
+        flags,
+        r#type: 0,
+        link_duplex: 0,
+        link_speed: 2_500_000,
+        link_mtu: 9000,
+        mtu: [9000, 0, 0, 0],
+        sub_id: 0,
+        sub_number_of_tags: 0,
+        sub_outer_vlan_id: 0,
+        sub_inner_vlan_id: 0,
+        sub_if_flags: 0,
+        vtr_op: 0,
+        vtr_push_dot1q: 0,
+        vtr_tag1: 0,
+        vtr_tag2: 0,
+        outer_tag: 0,
+        b_dmac: [0u8; 6],
+        b_smac: [0u8; 6],
+        b_vlanid: 0,
+        i_sid: 0,
+        interface_name: name.to_string(),
+        interface_dev_type: "octeon".into(),
+        tag: String::new(),
+    }
+}
+
+fn path_on(sw_if_index: u32) -> FibPath {
+    FibPath {
+        sw_if_index,
+        table_id: 0,
+        rpf_id: 0,
+        weight: 1,
+        preference: 0,
+        r#type: 0,
+        flags: 0,
+        proto: 0,
+        nh: Default::default(),
+        n_labels: 0,
+        label_stack: Default::default(),
+    }
+}
+
+fn prefix_of(p: IpPrefix) -> packetframe_vpp_offload::vpp_api::generated::Prefix {
+    packetframe_vpp_offload::fib_sync::to_prefix(p)
+}
+
+fn v4(a: u8, b: u8) -> IpPrefix {
+    IpPrefix::V4 {
+        addr: [10, a, b, 0],
+        prefix_len: 24,
+    }
+}
+
+fn nh() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
+}
+
+struct Mirror {
+    routes: Vec<IpPrefix>,
+}
+
+impl RouteSource for Mirror {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for p in &self.routes {
+            visit(*p, &[nh()]);
+        }
+    }
+    fn for_each_nexthop_device(&self, visit: &mut dyn FnMut(IpAddr, &str)) {
+        visit(nh(), "eth4");
+    }
+}
+
+fn mirror(n: u8) -> Mirror {
+    Mirror {
+        routes: (0..n).map(|i| v4(0, i)).collect(),
+    }
+}
+
+fn engine_for(fake: &Fake) -> ConvergenceEngine {
+    ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: "eth4".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec!["eth4".into()],
+        1_000_000,
+        FamilyPolicy::V4Only,
+    )
+}
+
+/// Drain until the pending map reports empty, with a bound so a
+/// regression that never converges fails instead of hanging CI.
+fn drain_to_empty(e: &mut ConvergenceEngine) -> usize {
+    for pass in 1..=64 {
+        let (done, _) = e.drain_batch().expect("drain succeeds against the fake");
+        if done {
+            return pass;
+        }
+    }
+    panic!("resync did not converge in 64 drains");
+}
+
+/// The composition test: one transport, the whole pipeline, in order.
+#[test]
+fn the_convergence_pipeline_composes_over_one_transport() {
+    let fake = Fake::start("pipeline");
+    let mut e = engine_for(&fake);
+
+    assert!(e.api_ready(), "the fake must answer the handshake");
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    assert_eq!(e.port_links().len(), 1);
+
+    let m = mirror(10);
+    let plan = e.begin_resync(&m);
+    assert_eq!(plan.upserts, 10);
+    drain_to_empty(&mut e);
+
+    assert_eq!(e.counts().installed, 10, "every route acknowledged");
+    assert_eq!(e.counts().installing, 0, "nothing left in flight");
+    assert!(e.pending().is_empty());
+
+    let outcome = e.run_verify().expect("verify");
+    assert!(outcome.passed(), "{}", outcome.summary());
+
+    // Ordering: devices attach before any route is installed. FIB paths
+    // reference indices VPP has not assigned yet otherwise, and every
+    // route would be deferred — correct, but a wasted cycle.
+    let names: Vec<String> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Msg(n) => Some(n),
+            Event::Route(_) => None,
+        })
+        .collect();
+    let first_attach = names.iter().position(|n| n == "dev_attach").unwrap();
+    let first_route = names.iter().position(|n| n == "ip_route_add_del").unwrap();
+    assert!(
+        first_attach < first_route,
+        "devices must attach before routes: {names:?}"
+    );
+}
+
+/// Every installed path must carry the index VPP assigned, not one the
+/// module guessed. A path on the wrong index forwards nothing while
+/// looking perfectly installed.
+#[test]
+fn routes_install_onto_the_index_vpp_assigned() {
+    let fake = Fake::start("index");
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+    e.begin_resync(&mirror(4));
+    drain_to_empty(&mut e);
+
+    let routes: Vec<WireRoute> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Route(r) => Some(r),
+            Event::Msg(_) => None,
+        })
+        .collect();
+    assert_eq!(routes.len(), 4);
+    for r in &routes {
+        assert!(r.is_add);
+        assert_eq!(
+            r.path_indices,
+            vec![ASSIGNED_INDEX],
+            "path must reference the index from dev_create_port_if_reply"
+        );
+    }
+}
+
+/// The diff, observed on the wire. A prefix the source dropped must
+/// reach VPP as a delete — an add-only resync leaves it forwarding to a
+/// nexthop nobody advertises, and readback verification cannot see it
+/// because verification samples what the ledger claims.
+#[test]
+fn a_prefix_the_source_dropped_reaches_vpp_as_a_delete() {
+    let fake = Fake::start("withdraw");
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+
+    e.begin_resync(&mirror(5));
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 5);
+    let _ = fake.drain_events();
+
+    // Two prefixes disappear from the source.
+    let shrunk = Mirror {
+        routes: mirror(5).routes[..3].to_vec(),
+    };
+    let plan = e.begin_resync(&shrunk);
+    assert_eq!(plan.withdrawals, 2);
+    drain_to_empty(&mut e);
+
+    let deletes: Vec<WireRoute> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|ev| match ev {
+            Event::Route(r) if !r.is_add => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(deletes.len(), 2, "both dropped prefixes must be deleted");
+    let mut got: Vec<(u8, u8, u8)> = deletes
+        .iter()
+        .map(|r| (r.addr[1], r.addr[2], r.len))
+        .collect();
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        vec![(0, 3, 24), (0, 4, 24)],
+        "the two the source dropped, at their own prefix lengths"
+    );
+
+    // And the ledger must no longer claim them.
+    assert_eq!(e.counts().installed, 3);
+}
+
+/// A connection that dies mid-drain must leave nothing claimed that VPP
+/// did not acknowledge, put the unacknowledged work back, and drop the
+/// socket so the next attempt reconnects rather than reusing a stream
+/// whose framing may be desynchronised.
+#[test]
+fn a_hangup_mid_drain_requeues_and_disconnects() {
+    let fake = Fake::start_with("hangup", 3);
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).unwrap();
+    e.begin_resync(&mirror(20));
+
+    let err = loop {
+        match e.drain_batch() {
+            Ok((true, _)) => panic!("the fake hung up; this cannot converge"),
+            Ok((false, _)) => continue,
+            Err(err) => break err,
+        }
+    };
+    let _ = err;
+
+    assert!(
+        !e.is_connected(),
+        "a broken socket must be dropped, not reused"
+    );
+    let c = e.counts();
+    assert_eq!(c.installing, 0, "nothing may be left claimed in flight");
+    assert!(
+        c.installed <= 3,
+        "only acknowledged routes may count as installed, got {}",
+        c.installed
+    );
+    assert!(
+        !e.pending().is_empty(),
+        "unacknowledged work must still be owed"
+    );
+
+    // A fresh connection can finish the job.
+    assert!(e.api_ready(), "must be able to reconnect");
+    e.attach_devices(AttachMode::Fresh).unwrap();
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 20);
+    assert!(e.run_verify().unwrap().passed());
+}


### PR DESCRIPTION
The API-side half of the supervised dataplane, and the piece `Module::attach()` needs to be small. `engine.rs` owns the transport, route ledger, pending map and port-index mapping, and exposes what the supervision loop's `Effects`/`Observe` seams are defined in terms of: connect, ping, attach devices, resync, verify.

## Why it's split from the process/resource half

Everything here is reachable over a unix socket, so **all of it is testable on host CI** against a fake VPP speaking the real wire format. fork/exec, pidfd and sysfs VF writes are Linux-only and untestable on a dev laptop. Keeping them apart is what lets the interesting logic be tested at all — [tests/vpp_engine.rs](crates/modules/vpp-offload/tests/vpp_engine.rs) is the point of the split, covering the composition the unit tests structurally cannot.

## The resync is a diff, not a replay

`begin_resync` walks the route source *and* computes withdrawals: prefixes the ledger holds that the source no longer advertises.

An add-only resync is a failure the plan names explicitly — a route withdrawn while VPP or packetframe was down stays in VPP's FIB, forwarding to a nexthop nobody advertises. Readback verification **cannot catch it**, because verification samples what the ledger claims and the ledger claims that route is fine.

The wire test asserts the deletes actually leave, decoded with the same generated `Decode` impl the client encodes with rather than a hardcoded byte offset — a hand-assumed prefix in the fake would quietly match a hand-assumed prefix in the client and prove nothing.

## Three smaller decisions, each from a specific failure

- **`RouteSource` takes visitors, not `Vec` returns.** At 1.05M routes a materialised `Vec<(IpPrefix, Vec<IpAddr>)>` is ~100 MB of transient allocation and a million small `Vec`s, paid on every resync — inside the ≤60 s budget this engine exists to meet.
- **`on_process_gone` clears the ledger, port index and last verify.** Interface indices are per-VPP-instance, so reusing them against a fresh process installs every route onto whatever interface took that index. A ledger claiming installs a dead VPP never had lets verification sample routes that do not exist. **Capacity survives**, because it derives from the measured heap gauge rather than from the process — losing it would rebuild an unbounded ledger and install past the high-water mark.
- **No operation no-ops without a transport**, and a failed round trip drops the socket: a half-read reply desynchronises framing and corrupts every subsequent context match.

## A bug its own test caught

`run_verify` set the phase *before* checking the transport, so the `NotConnected` early return left it stuck on `Verify`. A phase that never clears is a convergence the loop believes is still running — `may_restart` stays false and the supervisor can never recover.

Related, and deliberate: a transport failure during verify does **not** record a verdict. "We could not ask" is not "the FIB is wrong", and that difference decides whether the supervisor cycles a healthy VPP.

## Tests

Four wire-level tests against the fake, plus nine unit tests:

- the whole pipeline composes over one transport, with `dev_attach` provably before any `ip_route_add_del` (otherwise every route defers and a convergence cycle is wasted)
- installed paths carry the index **VPP assigned**, not a guess — a path on the wrong index forwards nothing while looking installed
- a dropped prefix reaches VPP as a delete, at its own prefix length
- a hangup mid-drain leaves nothing claimed unacknowledged, requeues the rest, drops the socket, and a fresh connection finishes the job

481 workspace tests pass; fmt + clippy clean on host and all four cross targets.

## Not here

The process/resource half that implements `Effects`/`Observe` by delegation, and `Module::attach()` itself. **Still nothing runs** — this remains unit-tested logic plus a fake VPP.

Worth noting there are now three fake-VPP harnesses (loopback, attach/verify, engine); this one is a superset of the other two, so consolidating them is a reasonable follow-up rather than something to churn reviewed files for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)