### PR TITLE
test(vpp-offload): measure the convergence budget nobody has measured

### DIFF
--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -223,6 +223,7 @@ jobs:
           cross build --release --target "${TARGET}" \
             --tests --bins \
             -p packetframe-fast-path -p packetframe-probe -p packetframe-cli \
+            -p packetframe-vpp-offload \
             --message-format=json | tee build.json >/dev/null
 
       - name: Stage bundle
@@ -293,6 +294,18 @@ jobs:
               sys.exit("no test executables found in build.json")
           if "packetframe" not in staged_bins:
               sys.exit("packetframe CLI binary missing from build.json")
+          # Named explicitly, because "it is in the workspace" is not why
+          # a binary ends up here — the cross-build takes an explicit
+          # `-p` list, and a test whose package is missing from it is
+          # silently absent rather than failing anything. The convergence
+          # bench measures the plan's ≤60 s budget and is hardware-only,
+          # so an empty bundle would be discovered on the router.
+          for required in ("vpp_convergence_bench",):
+              if required not in staged_tests:
+                  sys.exit(
+                      f"{required} missing from the bundle — is its package "
+                      "in the cross-build's -p list?"
+                  )
           print("tests:", " ".join(sorted(staged_tests)))
           print("bins: ", " ".join(sorted(staged_bins)))
           PY

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -1,0 +1,356 @@
+//! Convergence measurement against a **real VPP**, on hardware.
+//!
+//! Gate 0b item 10 measured what VPP's *CLI parser* costs to absorb the
+//! v4 table: ~35 s for 1,053,360 routes through `vppctl exec`, with one
+//! shared path-list. That number was recorded as an encouraging lower
+//! bound and explicitly not as the convergence figure, because the
+//! production path is 1.05M binary-API round trips against the real
+//! nexthop set, driven by [`ConvergenceEngine`]. **The ≤60 s budget in
+//! the phase-4 plan has never been measured.** This measures it.
+//!
+//! Skipped unless `PACKETFRAME_VPP_API_SOCK` is set, so CI and the qemu
+//! verifier ignore it entirely. It ships to the router inside the
+//! `hardware-artifacts` bundle like every other test binary.
+//!
+//! ## What it exercises
+//!
+//! The real code path, not a rehearsal of it: connect and handshake,
+//! `attach_devices`, `program_neighbours`, the diffing resync, the
+//! bounded drain loop, and readback verification. Everything the last
+//! three review rounds argued about runs here against a VPP that can
+//! disagree.
+//!
+//! ## What it does NOT prove
+//!
+//! That packets move. Nothing here steers traffic, and VPP forwarding is
+//! gate 0b's job with a peer. A clean run means the table went in and
+//! read back — not that the dataplane works.
+//!
+//! ## Inputs
+//!
+//! | env | meaning |
+//! |---|---|
+//! | `PACKETFRAME_VPP_API_SOCK` | VPP's binary API socket. **Required**; absent = skip. |
+//! | `PACKETFRAME_VPP_ROUTES` | `<prefix> <nexthop>[,<nexthop>…]` per line |
+//! | `PACKETFRAME_VPP_NEIGH` | `<ip> <dev> <mac>` per line |
+//! | `PACKETFRAME_VPP_PORT` | member port name, e.g. `eth3` |
+//! | `PACKETFRAME_VPP_PCI` | VF PCI address, e.g. `0002:07:00.1` |
+//! | `PACKETFRAME_VPP_BUDGET_S` | override the 60 s budget |
+//! | `PACKETFRAME_VPP_ADOPT` | set if VPP already has the interface attached |
+//!
+//! The runbook carries the commands that produce the two files.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use packetframe_common::fib::IpPrefix;
+use packetframe_vpp_offload::attach::{AttachMode, PortAttach};
+use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
+use packetframe_vpp_offload::fib_sync::FamilyPolicy;
+
+/// The plan's published convergence budget.
+const DEFAULT_BUDGET: Duration = Duration::from_secs(60);
+
+/// Capacity high-water mark for the run. Deliberately generous: this
+/// measures convergence, and a withheld route would change what is being
+/// timed without saying so.
+const HIGH_WATER: u64 = 4_000_000;
+
+struct FileSource {
+    routes: Vec<(IpPrefix, Vec<IpAddr>)>,
+    neighbours: Vec<(IpAddr, String, [u8; 6])>,
+}
+
+impl RouteSource for FileSource {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for (p, nhs) in &self.routes {
+            visit(*p, nhs);
+        }
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        for (ip, dev, mac) in &self.neighbours {
+            visit(*ip, dev, *mac);
+        }
+    }
+}
+
+fn parse_prefix(s: &str) -> Option<IpPrefix> {
+    let (addr, len) = s.split_once('/')?;
+    let len: u8 = len.parse().ok()?;
+    match addr.parse::<IpAddr>().ok()? {
+        IpAddr::V4(v4) => (len <= 32).then_some(IpPrefix::V4 {
+            addr: v4.octets(),
+            prefix_len: len,
+        }),
+        IpAddr::V6(v6) => (len <= 128).then_some(IpPrefix::V6 {
+            addr: v6.octets(),
+            prefix_len: len,
+        }),
+    }
+}
+
+fn parse_mac(s: &str) -> Option<[u8; 6]> {
+    let mut out = [0u8; 6];
+    let mut n = 0;
+    for byte in s.split(':') {
+        if n == 6 {
+            return None;
+        }
+        out[n] = u8::from_str_radix(byte, 16).ok()?;
+        n += 1;
+    }
+    (n == 6).then_some(out)
+}
+
+/// Load the route file, collapsing duplicate prefixes into one multipath
+/// entry — bird prints one line per path.
+fn load_routes(path: &PathBuf) -> FileSource {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading routes from {}: {e}", path.display()));
+
+    let mut by_prefix: BTreeMap<String, (IpPrefix, Vec<IpAddr>)> = BTreeMap::new();
+    let mut skipped = 0usize;
+    for line in text.lines() {
+        let mut f = line.split_whitespace();
+        let (Some(p), Some(nh)) = (f.next(), f.next()) else {
+            continue;
+        };
+        let Some(prefix) = parse_prefix(p) else {
+            skipped += 1;
+            continue;
+        };
+        let nexthops: Vec<IpAddr> = nh.split(',').filter_map(|a| a.parse().ok()).collect();
+        if nexthops.is_empty() {
+            skipped += 1;
+            continue;
+        }
+        by_prefix
+            .entry(p.to_string())
+            .and_modify(|(_, existing)| {
+                for a in &nexthops {
+                    if !existing.contains(a) {
+                        existing.push(*a);
+                    }
+                }
+            })
+            .or_insert((prefix, nexthops));
+    }
+    assert_eq!(
+        skipped, 0,
+        "{skipped} route lines did not parse — fix the dump rather than \
+         measuring a table that is quietly short"
+    );
+
+    FileSource {
+        routes: by_prefix.into_values().collect(),
+        neighbours: Vec::new(),
+    }
+}
+
+fn load_neighbours(path: &PathBuf) -> Vec<(IpAddr, String, [u8; 6])> {
+    let text = std::fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("reading neighbours from {}: {e}", path.display()));
+    let mut out = Vec::new();
+    for line in text.lines() {
+        let mut f = line.split_whitespace();
+        let (Some(ip), Some(dev), Some(mac)) = (f.next(), f.next(), f.next()) else {
+            continue;
+        };
+        let (Ok(ip), Some(mac)) = (ip.parse::<IpAddr>(), parse_mac(mac)) else {
+            continue;
+        };
+        out.push((ip, dev.to_string(), mac));
+    }
+    out
+}
+
+fn env(name: &str) -> Option<String> {
+    std::env::var(name).ok().filter(|v| !v.is_empty())
+}
+
+fn required(name: &str) -> String {
+    env(name).unwrap_or_else(|| panic!("{name} must be set for this run"))
+}
+
+fn secs(d: Duration) -> String {
+    format!("{:.2}s", d.as_secs_f64())
+}
+
+#[test]
+fn full_table_convergence_against_a_real_vpp() {
+    let Some(sock) = env("PACKETFRAME_VPP_API_SOCK") else {
+        // Not a silent pass: say why, so a run that was meant to measure
+        // something and measured nothing is obvious in the log.
+        println!(
+            "SKIP: PACKETFRAME_VPP_API_SOCK unset — this measures convergence \
+             against a live VPP and does nothing without one."
+        );
+        return;
+    };
+
+    let port = env("PACKETFRAME_VPP_PORT").unwrap_or_else(|| "eth3".into());
+    let pci = required("PACKETFRAME_VPP_PCI");
+    let budget = env("PACKETFRAME_VPP_BUDGET_S")
+        .and_then(|v| v.parse().ok())
+        .map(Duration::from_secs)
+        .unwrap_or(DEFAULT_BUDGET);
+    let mode = if env("PACKETFRAME_VPP_ADOPT").is_some() {
+        AttachMode::Adopted
+    } else {
+        AttachMode::Fresh
+    };
+
+    let mut src = load_routes(&PathBuf::from(required("PACKETFRAME_VPP_ROUTES")));
+    src.neighbours = load_neighbours(&PathBuf::from(required("PACKETFRAME_VPP_NEIGH")));
+
+    println!("== convergence bench ==");
+    println!("  socket     {sock}");
+    println!("  port       {port} ({pci}), mode {mode:?}");
+    println!("  routes     {}", src.routes.len());
+    println!("  neighbours {}", src.neighbours.len());
+    println!("  budget     {}", secs(budget));
+    assert!(!src.routes.is_empty(), "an empty table measures nothing");
+
+    let mut e = ConvergenceEngine::new(
+        &sock,
+        vec![PortAttach {
+            port: port.clone(),
+            pci_addr: pci,
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec![port.clone()],
+        HIGH_WATER,
+        FamilyPolicy::V4Only,
+    );
+
+    // --- connect
+    let t_connect = Instant::now();
+    assert!(
+        e.api_ready(),
+        "no answer on {sock}: {}",
+        e.last_api_error().unwrap_or("(no error recorded)")
+    );
+    let d_connect = t_connect.elapsed();
+
+    // --- attach
+    let t_attach = Instant::now();
+    e.attach_devices(mode)
+        .unwrap_or_else(|err| panic!("attach: {err}"));
+    let d_attach = t_attach.elapsed();
+
+    // --- the measured window starts here: everything from this point is
+    // what a restart has to redo before traffic can be re-steered.
+    let t_total = Instant::now();
+
+    let t_resync = Instant::now();
+    let plan = e.begin_resync(&src);
+    let d_plan = t_resync.elapsed();
+
+    let t_neigh = Instant::now();
+    let programmed = e
+        .program_neighbours(&src)
+        .unwrap_or_else(|err| panic!("neighbours: {err}"));
+    let d_neigh = t_neigh.elapsed();
+
+    // --- drain
+    let t_drain = Instant::now();
+    let mut passes = 0u64;
+    let mut installed = 0u64;
+    let mut deferred = 0u64;
+    loop {
+        let (done, stats) = e
+            .drain_batch()
+            .unwrap_or_else(|err| panic!("drain (pass {passes}): {err}"));
+        passes += 1;
+        installed += stats.installed;
+        deferred += stats.deferred;
+        if done {
+            break;
+        }
+        assert!(
+            t_drain.elapsed() < budget * 10,
+            "drain has run {} with {installed} installed — not converging",
+            secs(t_drain.elapsed())
+        );
+    }
+    let d_drain = t_drain.elapsed();
+
+    // --- verify
+    let t_verify = Instant::now();
+    let verdict = e.run_verify().unwrap_or_else(|err| panic!("verify: {err}"));
+    let d_verify = t_verify.elapsed();
+
+    let d_total = t_total.elapsed();
+    let c = e.counts();
+
+    // Print the whole picture BEFORE asserting the budget: a run that
+    // blows it is exactly the run whose phase breakdown matters, and a
+    // panic that hides it wastes the trip to the hardware.
+    println!("-- phases --");
+    println!("  connect       {}", secs(d_connect));
+    println!("  attach        {}", secs(d_attach));
+    println!(
+        "  resync plan   {}  ({} upserts, {} withdrawals)",
+        secs(d_plan),
+        plan.upserts,
+        plan.withdrawals
+    );
+    println!(
+        "  neighbours    {}  ({programmed} programmed)",
+        secs(d_neigh)
+    );
+    println!(
+        "  drain         {}  ({passes} passes, {installed} acked, {deferred} deferred)",
+        secs(d_drain)
+    );
+    println!(
+        "  verify        {}  ({} probes)",
+        secs(d_verify),
+        verdict.outcome.sampled
+    );
+    println!(
+        "  TOTAL         {}   budget {}",
+        secs(d_total),
+        secs(budget)
+    );
+    println!("-- ledger --");
+    println!(
+        "  installed {} / installing {} / withheld {} / unresolvable {}",
+        c.installed, c.installing, c.withheld, c.unresolvable
+    );
+    println!("  {}", verdict.outcome.summary());
+    println!("  may_steer {}", verdict.may_steer);
+    if d_drain.as_secs_f64() > 0.0 {
+        println!(
+            "-- rate --\n  {:.0} routes/s over the drain",
+            installed as f64 / d_drain.as_secs_f64()
+        );
+    }
+
+    // Correctness first: a fast run that installed the wrong table is
+    // worse than a slow one that installed the right table.
+    assert!(
+        verdict.outcome.passed(),
+        "readback verification failed: {}",
+        verdict.outcome.summary()
+    );
+    assert_eq!(
+        c.installed as usize,
+        src.routes.len(),
+        "every route in the source must be installed before the number means anything"
+    );
+    assert!(
+        verdict.may_steer,
+        "table incomplete — withheld {} / unresolvable {}",
+        c.withheld, c.unresolvable
+    );
+    assert!(
+        d_total <= budget,
+        "CONVERGENCE OVER BUDGET: {} > {}",
+        secs(d_total),
+        secs(budget)
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -26,6 +26,23 @@
 //! gate 0b's job with a peer. A clean run means the table went in and
 //! read back — not that the dataplane works.
 //!
+//! **Nor that the route file is the table.** This measures whatever it is
+//! handed; it cannot tell a complete dump from one that ended cleanly
+//! halfway. `PACKETFRAME_VPP_EXPECT_ROUTES` is the operator asserting the
+//! size, and it is only worth anything if it came from a source
+//! *independent* of the file — bird's own `show route count`, per the
+//! runbook. An expectation derived from the same pipeline it validates
+//! agrees with a truncated dump perfectly, which is worse than no check
+//! at all because it manufactures confidence. An earlier revision of the
+//! runbook did exactly that.
+//!
+//! The measured set is **best-path routes carrying a `via` nexthop**.
+//! Connected, blackhole and unreachable primaries have no nexthop that
+//! could map to a VPP-owned port, so the sink would classify them
+//! unresolvable — excluding them measures what production installs, but
+//! it does mean this is not literally every row in `master4`, and the
+//! runbook has the operator record the excluded count.
+//!
 //! ## Inputs
 //!
 //! | env | meaning |
@@ -36,7 +53,7 @@
 //! | `PACKETFRAME_VPP_PORT` | member port names, comma-separated: `eth2,eth3` |
 //! | `PACKETFRAME_VPP_PCI` | VF PCI addresses, comma-separated, **paired by position** with PORT |
 //! | `PACKETFRAME_VPP_SWIFINDEX` | recorded `sw_if_index` per port, required only for adopt |
-//! | `PACKETFRAME_VPP_EXPECT_ROUTES` | **required** — distinct prefixes the dump must contain |
+//! | `PACKETFRAME_VPP_EXPECT_ROUTES` | **required** — distinct prefixes the dump must contain, reconciled against bird's own count (see the runbook) |
 //! | `PACKETFRAME_VPP_BUDGET_S` | override the 60 s budget |
 //! | `PACKETFRAME_VPP_ADOPT` | adopt interfaces VPP already has (needs SWIFINDEX) |
 //!
@@ -206,7 +223,7 @@ fn secs(d: Duration) -> String {
 }
 
 #[test]
-fn full_table_convergence_against_a_real_vpp() {
+fn measured_convergence_against_a_real_vpp() {
     let Some(sock) = env("PACKETFRAME_VPP_API_SOCK") else {
         // Not a silent pass: say why, so a run that was meant to measure
         // something and measured nothing is obvious in the log.
@@ -298,7 +315,8 @@ fn full_table_convergence_against_a_real_vpp() {
         src.routes.len(),
         expect,
         "loaded {} distinct prefixes, expected {expect} — the dump is not \
-         the table you think it is",
+         the table you think it is (and if {expect} came from this same \
+         file, it never could have been)",
         src.routes.len()
     );
 

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -36,6 +36,7 @@
 //! | `PACKETFRAME_VPP_PORT` | member port names, comma-separated: `eth2,eth3` |
 //! | `PACKETFRAME_VPP_PCI` | VF PCI addresses, comma-separated, **paired by position** with PORT |
 //! | `PACKETFRAME_VPP_SWIFINDEX` | recorded `sw_if_index` per port, required only for adopt |
+//! | `PACKETFRAME_VPP_EXPECT_ROUTES` | **required** — distinct prefixes the dump must contain |
 //! | `PACKETFRAME_VPP_BUDGET_S` | override the 60 s budget |
 //! | `PACKETFRAME_VPP_ADOPT` | adopt interfaces VPP already has (needs SWIFINDEX) |
 //!
@@ -141,11 +142,17 @@ fn load_routes(path: &PathBuf) -> FileSource {
             skipped += 1;
             continue;
         };
-        let nexthops: Vec<IpAddr> = nh.split(',').filter_map(|a| a.parse().ok()).collect();
-        if nexthops.is_empty() {
+        // Every comma-separated nexthop must parse. Dropping only the
+        // bad ones leaves a non-empty vector, so `skipped` stays zero and
+        // a silently shortened multipath route sails past the integrity
+        // assertion below — the route installs, verification passes, and
+        // the measurement is of a table nobody meant to load.
+        let parsed: Vec<Option<IpAddr>> = nh.split(',').map(|a| a.parse().ok()).collect();
+        if parsed.is_empty() || parsed.iter().any(|a| a.is_none()) {
             skipped += 1;
             continue;
         }
+        let nexthops: Vec<IpAddr> = parsed.into_iter().flatten().collect();
         by_prefix
             .entry(p.to_string())
             .and_modify(|(_, existing)| {
@@ -276,25 +283,61 @@ fn full_table_convergence_against_a_real_vpp() {
     println!("  routes     {}", src.routes.len());
     println!("  neighbours {}", src.neighbours.len());
     println!("  budget     {}", secs(budget));
-    assert!(!src.routes.is_empty(), "an empty table measures nothing");
 
-    // Every device the neighbour file names must be a member, or its
-    // routes are unresolvable and verification fails — which is the
-    // correct behaviour, since a packet whose best path exits an unowned
-    // port would blackhole. Check it here rather than discovering it
-    // 1.05M routes later.
-    let devices: std::collections::BTreeSet<&str> =
-        src.neighbours.iter().map(|(_, d, _)| d.as_str()).collect();
-    let unowned: Vec<&str> = devices
+    // A dump truncated at a line boundary is syntactically perfect and
+    // would produce a clean, fast, entirely meaningless "convergence"
+    // result for a fraction of the table — and the installed-count
+    // assertion later would agree, because it only proves every route in
+    // the file went in. This measurement exists to validate the
+    // *full-table* budget, so the expected size is an input, not an
+    // inference. The runbook shows how to compute it from the dump.
+    let expect: usize = required("PACKETFRAME_VPP_EXPECT_ROUTES")
+        .parse()
+        .expect("PACKETFRAME_VPP_EXPECT_ROUTES must be a number");
+    assert_eq!(
+        src.routes.len(),
+        expect,
+        "loaded {} distinct prefixes, expected {expect} — the dump is not \
+         the table you think it is",
+        src.routes.len()
+    );
+
+    // Every nexthop the ROUTES use must land on a member port, or those
+    // routes are unresolvable and verification fails — correctly, since a
+    // packet whose best path exits a port VPP does not own would
+    // blackhole. Checked here rather than discovered 1.05M routes later.
+    //
+    // Scoped to nexthops the routes actually reference, deliberately. The
+    // neighbour dump is the router's whole ARP table and legitimately
+    // contains management and tunnel neighbours; `program_neighbours`
+    // skips those by design, so asserting on every device in the file
+    // would abort the run over entries the engine is built to ignore.
+    // An earlier revision did exactly that — the assertion contradicted
+    // the policy written one file over.
+    let dev_of: std::collections::HashMap<IpAddr, &str> = src
+        .neighbours
         .iter()
-        .copied()
-        .filter(|d| !ports.iter().any(|p| p == d))
+        .map(|(ip, d, _)| (*ip, d.as_str()))
         .collect();
+    let mut unusable: Vec<String> = Vec::new();
+    for (prefix, nexthops) in &src.routes {
+        for nh in nexthops {
+            match dev_of.get(nh) {
+                Some(d) if ports.iter().any(|p| p == d) => {}
+                Some(d) => unusable.push(format!("{nh} on {d} (used by {prefix:?})")),
+                None => unusable.push(format!("{nh} absent from the neighbour file")),
+            }
+        }
+    }
+    unusable.sort();
+    unusable.dedup();
     assert!(
-        unowned.is_empty(),
-        "neighbour file names device(s) {unowned:?} which are not member ports \
-         {ports:?} — add a VF for each, or rewrite the device column onto an \
-         owned port and record the run as reduced"
+        unusable.is_empty(),
+        "{} route nexthop(s) do not resolve to a member port {ports:?}; first few: {:?} \
+         — add a VF per device, or rewrite the neighbour device column onto an owned \
+         port and record the run as reduced",
+        unusable.len(),
+        &unusable[..unusable.len().min(5)]
     );
 
     let mut e = ConvergenceEngine::new(
@@ -337,6 +380,31 @@ fn full_table_convergence_against_a_real_vpp() {
     e.attach_devices(mode)
         .unwrap_or_else(|err| panic!("attach: {err}"));
     let d_attach = t_attach.elapsed();
+
+    // Emit the port→index mapping an adopted re-run needs.
+    //
+    // It cannot be reconstructed afterwards: `sw_interface_dump` reports
+    // indistinguishable `octeonN/P` names with no PCI identity, so an
+    // operator reading `show interface` cannot tell which index belongs
+    // to which member port. Getting the order wrong would program
+    // neighbours and routes through the opposite VFs — and verification
+    // would still pass, because it checks that paths use *an* owned
+    // index, not the intended one per path. Printing it here is the only
+    // moment the mapping is actually known.
+    let idx = e.attached_indices();
+    let ordered: Vec<String> = ports
+        .iter()
+        .map(|p| {
+            idx.iter()
+                .find(|(name, _)| name == p)
+                .map(|(_, i)| i.to_string())
+                .unwrap_or_else(|| panic!("attach reported no index for {p}"))
+        })
+        .collect();
+    println!(
+        "  to re-run adopted:  PACKETFRAME_VPP_ADOPT=1 PACKETFRAME_VPP_SWIFINDEX={}",
+        ordered.join(",")
+    );
 
     let t_resync = Instant::now();
     let plan = e.begin_resync(&src);

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -33,10 +33,21 @@
 //! | `PACKETFRAME_VPP_API_SOCK` | VPP's binary API socket. **Required**; absent = skip. |
 //! | `PACKETFRAME_VPP_ROUTES` | `<prefix> <nexthop>[,<nexthop>…]` per line |
 //! | `PACKETFRAME_VPP_NEIGH` | `<ip> <dev> <mac>` per line |
-//! | `PACKETFRAME_VPP_PORT` | member port name, e.g. `eth3` |
-//! | `PACKETFRAME_VPP_PCI` | VF PCI address, e.g. `0002:07:00.1` |
+//! | `PACKETFRAME_VPP_PORT` | member port names, comma-separated: `eth2,eth3` |
+//! | `PACKETFRAME_VPP_PCI` | VF PCI addresses, comma-separated, **paired by position** with PORT |
+//! | `PACKETFRAME_VPP_SWIFINDEX` | recorded `sw_if_index` per port, required only for adopt |
 //! | `PACKETFRAME_VPP_BUDGET_S` | override the 60 s budget |
-//! | `PACKETFRAME_VPP_ADOPT` | set if VPP already has the interface attached |
+//! | `PACKETFRAME_VPP_ADOPT` | adopt interfaces VPP already has (needs SWIFINDEX) |
+//!
+//! **Every device that appears in the neighbour file must be a member
+//! port with its own VF.** The reference `master4` table egresses via two
+//! devices, so a single-port run leaves the other device's routes
+//! unresolvable and verification fails by design — correctly, since a
+//! packet whose best path exits an unowned port would blackhole. If only
+//! one VF is available, rewrite the neighbour file's device column onto
+//! that port and record the run as a **reduced** measurement: the drain,
+//! wire encoding and VPP-side insert are fully exercised, but every
+//! adjacency lands on one interface.
 //!
 //! The runbook carries the commands that produce the two files.
 
@@ -113,8 +124,17 @@ fn load_routes(path: &PathBuf) -> FileSource {
     let mut by_prefix: BTreeMap<String, (IpPrefix, Vec<IpAddr>)> = BTreeMap::new();
     let mut skipped = 0usize;
     for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
         let mut f = line.split_whitespace();
         let (Some(p), Some(nh)) = (f.next(), f.next()) else {
+            // A non-blank line that is not `<prefix> <nexthop>` — a
+            // truncated dump, most likely. Counted, not skipped past:
+            // the assertion below exists so a damaged input cannot
+            // produce a trusted measurement, and quietly dropping short
+            // lines is exactly how it would.
+            skipped += 1;
             continue;
         };
         let Some(prefix) = parse_prefix(p) else {
@@ -190,8 +210,21 @@ fn full_table_convergence_against_a_real_vpp() {
         return;
     };
 
-    let port = env("PACKETFRAME_VPP_PORT").unwrap_or_else(|| "eth3".into());
-    let pci = required("PACKETFRAME_VPP_PCI");
+    let ports: Vec<String> = required("PACKETFRAME_VPP_PORT")
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    let pcis: Vec<String> = required("PACKETFRAME_VPP_PCI")
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+    assert_eq!(
+        ports.len(),
+        pcis.len(),
+        "PACKETFRAME_VPP_PORT and PACKETFRAME_VPP_PCI pair by position"
+    );
     let budget = env("PACKETFRAME_VPP_BUDGET_S")
         .and_then(|v| v.parse().ok())
         .map(Duration::from_secs)
@@ -201,30 +234,86 @@ fn full_table_convergence_against_a_real_vpp() {
     } else {
         AttachMode::Fresh
     };
+    // Adoption reuses interfaces VPP already has, and `attach_ports`
+    // refuses a port whose index it was not told — correctly, since
+    // attaching blind would duplicate an interface the live FIB may
+    // reference. Without this the documented adopt path panics on every
+    // run, so the indices are an input rather than an afterthought.
+    let recorded: Vec<(String, u32)> = match env("PACKETFRAME_VPP_SWIFINDEX") {
+        Some(list) => {
+            let idx: Vec<u32> = list
+                .split(',')
+                .filter_map(|s| s.trim().parse().ok())
+                .collect();
+            assert_eq!(
+                idx.len(),
+                ports.len(),
+                "PACKETFRAME_VPP_SWIFINDEX must give one index per port \
+                 (from `vppctl show interface`)"
+            );
+            ports.iter().cloned().zip(idx).collect()
+        }
+        None => {
+            assert!(
+                mode == AttachMode::Fresh,
+                "PACKETFRAME_VPP_ADOPT needs PACKETFRAME_VPP_SWIFINDEX — \
+                 adoption cannot attach an interface whose index is unknown"
+            );
+            Vec::new()
+        }
+    };
 
     let mut src = load_routes(&PathBuf::from(required("PACKETFRAME_VPP_ROUTES")));
     src.neighbours = load_neighbours(&PathBuf::from(required("PACKETFRAME_VPP_NEIGH")));
 
     println!("== convergence bench ==");
     println!("  socket     {sock}");
-    println!("  port       {port} ({pci}), mode {mode:?}");
+    println!(
+        "  ports      {} / {} , mode {mode:?}",
+        ports.join(","),
+        pcis.join(",")
+    );
     println!("  routes     {}", src.routes.len());
     println!("  neighbours {}", src.neighbours.len());
     println!("  budget     {}", secs(budget));
     assert!(!src.routes.is_empty(), "an empty table measures nothing");
 
+    // Every device the neighbour file names must be a member, or its
+    // routes are unresolvable and verification fails — which is the
+    // correct behaviour, since a packet whose best path exits an unowned
+    // port would blackhole. Check it here rather than discovering it
+    // 1.05M routes later.
+    let devices: std::collections::BTreeSet<&str> =
+        src.neighbours.iter().map(|(_, d, _)| d.as_str()).collect();
+    let unowned: Vec<&str> = devices
+        .iter()
+        .copied()
+        .filter(|d| !ports.iter().any(|p| p == d))
+        .collect();
+    assert!(
+        unowned.is_empty(),
+        "neighbour file names device(s) {unowned:?} which are not member ports \
+         {ports:?} — add a VF for each, or rewrite the device column onto an \
+         owned port and record the run as reduced"
+    );
+
     let mut e = ConvergenceEngine::new(
         &sock,
-        vec![PortAttach {
-            port: port.clone(),
-            pci_addr: pci,
-            port_id: 0,
-            num_rx_queues: 1,
-        }],
-        vec![port.clone()],
+        ports
+            .iter()
+            .zip(&pcis)
+            .map(|(port, pci)| PortAttach {
+                port: port.clone(),
+                pci_addr: pci.clone(),
+                port_id: 0,
+                num_rx_queues: 1,
+            })
+            .collect(),
+        ports.clone(),
         HIGH_WATER,
         FamilyPolicy::V4Only,
-    );
+    )
+    .with_recorded_indices(recorded);
 
     // --- connect
     let t_connect = Instant::now();
@@ -235,15 +324,19 @@ fn full_table_convergence_against_a_real_vpp() {
     );
     let d_connect = t_connect.elapsed();
 
-    // --- attach
+    // --- the measured window starts HERE, before attach.
+    //
+    // The plan defines convergence as attach → resync → verify, and a
+    // restart genuinely has to recreate its interfaces before traffic can
+    // be re-steered. Starting the clock after attach would let a slow
+    // attach hide a budget overrun: the reported TOTAL could pass at 60 s
+    // while the sequence an operator waits through did not.
+    let t_total = Instant::now();
+
     let t_attach = Instant::now();
     e.attach_devices(mode)
         .unwrap_or_else(|err| panic!("attach: {err}"));
     let d_attach = t_attach.elapsed();
-
-    // --- the measured window starts here: everything from this point is
-    // what a restart has to redo before traffic can be re-steered.
-    let t_total = Instant::now();
 
     let t_resync = Instant::now();
     let plan = e.begin_resync(&src);
@@ -290,8 +383,11 @@ fn full_table_convergence_against_a_real_vpp() {
     // blows it is exactly the run whose phase breakdown matters, and a
     // panic that hides it wastes the trip to the hardware.
     println!("-- phases --");
-    println!("  connect       {}", secs(d_connect));
-    println!("  attach        {}", secs(d_attach));
+    println!(
+        "  connect       {}  (outside the budget: one-time socket setup)",
+        secs(d_connect)
+    );
+    println!("  attach        {}  (inside)", secs(d_attach));
     println!(
         "  resync plan   {}  ({} upserts, {} withdrawals)",
         secs(d_plan),

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -726,54 +726,61 @@ kernel export was dropped at custom-fib cutover, so `ip route show` is
 deliberately near-empty.
 
 ```sh
-birdc -r 'show route primary table master4' \
-  | awk '/^[0-9]/ { pfx=$1 } /via/ { for (i=1;i<=NF;i++) if ($i=="via") print pfx, $(i+1) }' \
-  | sort -u > /tmp/pf-routes.txt
-wc -l /tmp/pf-routes.txt
+birdc 'show route table master4 count' | tee /tmp/pf-count.txt
 ```
+
+Note the `networks` figure. That is **bird's own count, independent of the
+extraction below**, and it is what makes the check meaningful — an
+expectation derived from the same pipeline it is meant to validate proves
+nothing, because a `birdc` that ends cleanly halfway produces a shortened
+file and a shortened count that agree with each other perfectly.
+
+Now extract, and reconcile against that independent figure:
+
+```sh
+birdc 'show route primary table master4' > /tmp/pf-raw.txt
+awk '/^[0-9]/ { pfx=$1; nets++ } /via/ { for (i=1;i<=NF;i++) if ($i=="via") print pfx, $(i+1) } END { print "networks_seen", nets > "/tmp/pf-nets.txt" }' /tmp/pf-raw.txt | sort -u > /tmp/pf-routes.txt
+BIRD_NETS=$(awk '{ for (i=1;i<=NF;i++) if ($i=="networks") print $(i-1) }' /tmp/pf-count.txt)
+SEEN_NETS=$(awk '{print $2}' /tmp/pf-nets.txt)
+VIA_NETS=$(awk '{print $1}' /tmp/pf-routes.txt | sort -u | wc -l)
+echo "bird reports   : ${BIRD_NETS} networks"
+echo "dump contained : ${SEEN_NETS} networks"
+echo "with a via     : ${VIA_NETS}  <-- PACKETFRAME_VPP_EXPECT_ROUTES"
+echo "excluded       : $((SEEN_NETS - VIA_NETS)) (connected/blackhole/unreachable)"
+[ "${BIRD_NETS}" = "${SEEN_NETS}" ] && echo "OK: dump is complete" || echo "TRUNCATED — do not measure this"
+```
+
+**Stop if that last line says TRUNCATED.** The whole point of the
+expectation is that a partial dump cannot produce a clean result.
+
+**This is a via-nexthop measurement, not literally every route class.**
+The `excluded` figure is real — `master4` carries connected, blackhole and
+unreachable primaries that have no `via`, and the §0 numbers show the gap
+(1,053,380 networks against 1,053,049 best-path via-nexthops, so ~331).
+Those are exactly the routes the sink would classify unresolvable, since
+they present no nexthop that can map to a VPP-owned port, so excluding
+them measures what production installs rather than hiding a shortfall.
+Record `excluded` alongside the timings so the scope of the number is on
+the record rather than implied.
 
 ```sh
 ip -4 neigh show \
   | awk '$1 !~ /:/ && $5 ~ /:/ && $NF != "FAILED" && $NF != "INCOMPLETE" { print $1, $3, $5 }' \
-  > /tmp/pf-neigh.txt
-wc -l /tmp/pf-neigh.txt
+  > /tmp/pf-neigh-all.txt
+awk 'NR==FNR { for (n=split($2,a,","); n>0; n--) want[a[n]]=1; next } want[$1]' \
+  /tmp/pf-routes.txt /tmp/pf-neigh-all.txt > /tmp/pf-neigh.txt
+wc -l /tmp/pf-neigh-all.txt /tmp/pf-neigh.txt
 ```
 
-Count the distinct prefixes — the bench requires this as an input, so a
-dump truncated at a line boundary fails loudly instead of producing a
-clean, fast, meaningless result for a fraction of the table:
-
-```sh
-awk '{print $1}' /tmp/pf-routes.txt | sort -u | wc -l
-```
+The second step keeps only neighbours the routes actually use. Management
+and tunnel entries are harmless to the *bench* — it checks ownership only
+for route nexthops — but they matter for the one-VF rewrite below, where
+rewriting them onto the member port would make `program_neighbours` treat
+them as owned and program them into VPP. Extra work at best, and a
+refusal aborts the run.
 
 **Every device carrying a route nexthop must be a member port with its own
-VF.** Unrelated management and tunnel neighbours in the dump are fine —
-`program_neighbours` skips anything not on a member port. The
-`master4` table egresses via two devices, so a single-port run leaves the
-other device's routes unresolvable and verification fails — correctly: a
-packet whose best path exits a port VPP does not own would blackhole. The
-bench refuses up front rather than discovering it 1.05M routes later.
-
-With only one VF bound, rewrite the device column onto that port and
-record the run as a **reduced** measurement — the drain, wire encoding and
-VPP-side insert are fully exercised, but every adjacency lands on one
-interface:
-
-```sh
-awk '{ print $1, "eth3", $3 }' /tmp/pf-neigh.txt > /tmp/pf-neigh-one.txt
-```
-
-Copy both to the shadow, then check the nexthops the routes name are
-actually covered by the neighbour file — an uncovered nexthop is an
-`unresolvable` route, which fails verification by design:
-
-```sh
-comm -23 <(awk '{print $2}' /tmp/pf-routes.txt | tr ',' '\n' | sort -u) \
-         <(awk '{print $1}' /tmp/pf-neigh.txt | sort -u) | head
-```
-
-### Run
+VF.** The### Run
 
 VPP must already be up with its sized `startup.conf` (§2 — **including
 the `statseg` stanza**, or it aborts partway through). The test attaches

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -739,7 +739,17 @@ ip -4 neigh show \
 wc -l /tmp/pf-neigh.txt
 ```
 
-**Every device in column 2 must be a member port with its own VF.** The
+Count the distinct prefixes — the bench requires this as an input, so a
+dump truncated at a line boundary fails loudly instead of producing a
+clean, fast, meaningless result for a fraction of the table:
+
+```sh
+awk '{print $1}' /tmp/pf-routes.txt | sort -u | wc -l
+```
+
+**Every device carrying a route nexthop must be a member port with its own
+VF.** Unrelated management and tunnel neighbours in the dump are fine —
+`program_neighbours` skips anything not on a member port. The
 `master4` table egresses via two devices, so a single-port run leaves the
 other device's routes unresolvable and verification fails — correctly: a
 packet whose best path exits a port VPP does not own would blackhole. The
@@ -780,6 +790,7 @@ PACKETFRAME_VPP_PORT=eth2,eth3 \
 PACKETFRAME_VPP_PCI=0002:07:00.0,0002:07:00.1 \
 PACKETFRAME_VPP_ROUTES=/tmp/pf-routes.txt \
 PACKETFRAME_VPP_NEIGH=/tmp/pf-neigh.txt \
+PACKETFRAME_VPP_EXPECT_ROUTES=<the count from above> \
   ./tests/vpp_convergence_bench --include-ignored --nocapture
 ```
 
@@ -790,11 +801,17 @@ and forwards nothing after a `--` — it would try to execute `--` and
 succeeded.
 
 Re-running against a VPP that already has the interfaces needs adoption
-plus the indices VPP assigned (`vppctl show interface`), because attach
-refuses to reuse an index it was not told:
+plus the indices VPP assigned, because attach refuses to reuse an index
+it was not told. **Take them from the line the fresh run printed**, not
+from `show interface`: the dump reports indistinguishable `octeonN/P`
+names with no PCI identity, so it cannot tell you which index belongs to
+which member port, and supplying them in the wrong order programs
+neighbours and routes through the opposite VFs — which verification will
+*not* catch, because it checks that paths use an owned index, not the
+intended one. The fresh run prints exactly the line to reuse:
 
-```sh
-PACKETFRAME_VPP_ADOPT=1 PACKETFRAME_VPP_SWIFINDEX=3,4 ... # plus the vars above
+```
+  to re-run adopted:  PACKETFRAME_VPP_ADOPT=1 PACKETFRAME_VPP_SWIFINDEX=3,4
 ```
 
 Restarting VPP between runs is simpler and is what the timings above

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -733,9 +733,25 @@ wc -l /tmp/pf-routes.txt
 ```
 
 ```sh
-ip -4 neigh show nud reachable nud stale nud permanent \
-  | awk '$1 !~ /:/ && $5 ~ /:/ { print $1, $3, $5 }' > /tmp/pf-neigh.txt
+ip -4 neigh show \
+  | awk '$1 !~ /:/ && $5 ~ /:/ && $NF != "FAILED" && $NF != "INCOMPLETE" { print $1, $3, $5 }' \
+  > /tmp/pf-neigh.txt
 wc -l /tmp/pf-neigh.txt
+```
+
+**Every device in column 2 must be a member port with its own VF.** The
+`master4` table egresses via two devices, so a single-port run leaves the
+other device's routes unresolvable and verification fails — correctly: a
+packet whose best path exits a port VPP does not own would blackhole. The
+bench refuses up front rather than discovering it 1.05M routes later.
+
+With only one VF bound, rewrite the device column onto that port and
+record the run as a **reduced** measurement — the drain, wire encoding and
+VPP-side insert are fully exercised, but every adjacency lands on one
+interface:
+
+```sh
+awk '{ print $1, "eth3", $3 }' /tmp/pf-neigh.txt > /tmp/pf-neigh-one.txt
 ```
 
 Copy both to the shadow, then check the nexthops the routes name are
@@ -755,14 +771,34 @@ the device itself, so do **not** pre-run the §3 `vppctl device attach`
 sequence; set `PACKETFRAME_VPP_ADOPT=1` if the interface is already
 attached from an earlier run.
 
+`PORT` and `PCI` are comma-separated and **pair by position**; give one
+VF per member device.
+
 ```sh
 PACKETFRAME_VPP_API_SOCK=/run/vpp/api.sock \
-PACKETFRAME_VPP_PORT=eth3 \
-PACKETFRAME_VPP_PCI=0002:07:00.1 \
+PACKETFRAME_VPP_PORT=eth2,eth3 \
+PACKETFRAME_VPP_PCI=0002:07:00.0,0002:07:00.1 \
 PACKETFRAME_VPP_ROUTES=/tmp/pf-routes.txt \
 PACKETFRAME_VPP_NEIGH=/tmp/pf-neigh.txt \
-  ./run-tests.sh vpp_convergence_bench -- --nocapture
+  ./tests/vpp_convergence_bench --include-ignored --nocapture
 ```
+
+Run the staged binary directly, **not** via `run-tests.sh`: that driver
+takes only test names, supplies `--include-ignored --nocapture` itself,
+and forwards nothing after a `--` — it would try to execute `--` and
+`--nocapture` as test binaries and fail the run even when the bench
+succeeded.
+
+Re-running against a VPP that already has the interfaces needs adoption
+plus the indices VPP assigned (`vppctl show interface`), because attach
+refuses to reuse an index it was not told:
+
+```sh
+PACKETFRAME_VPP_ADOPT=1 PACKETFRAME_VPP_SWIFINDEX=3,4 ... # plus the vars above
+```
+
+Restarting VPP between runs is simpler and is what the timings above
+assume.
 
 ### Reading the result
 

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -706,6 +706,87 @@ best-path nexthops. Those agree to within ~331, confirming **0 ECMP
 among selected routes** — so "nexthops as prefixes" is now measured
 rather than inferred, and the `expected-routes` sizing stands.
 
+## 3b. Convergence over the binary API (the ≤60 s budget)
+
+**This is the number item 10 explicitly did NOT measure.** Item 10 timed
+VPP's *CLI parser* absorbing the table — ~35 s for 1,053,360 routes via
+`vppctl exec`, with one shared path-list — and recorded it as a lower
+bound only. Production is 1.05M **binary-API round trips** driven by the
+module's `ConvergenceEngine`, against the real nexthop set. The plan
+publishes ≤60 s; nothing has ever checked it.
+
+Needs **no traffic peer**: nothing is steered, so this can run on the
+shadow any time VPP is up.
+
+### Inputs
+
+Two plain files, produced on the **primary** (bird has the table) and
+copied to the shadow. Note the source is bird, not the kernel — bird's
+kernel export was dropped at custom-fib cutover, so `ip route show` is
+deliberately near-empty.
+
+```sh
+birdc -r 'show route primary table master4' \
+  | awk '/^[0-9]/ { pfx=$1 } /via/ { for (i=1;i<=NF;i++) if ($i=="via") print pfx, $(i+1) }' \
+  | sort -u > /tmp/pf-routes.txt
+wc -l /tmp/pf-routes.txt
+```
+
+```sh
+ip -4 neigh show nud reachable nud stale nud permanent \
+  | awk '$1 !~ /:/ && $5 ~ /:/ { print $1, $3, $5 }' > /tmp/pf-neigh.txt
+wc -l /tmp/pf-neigh.txt
+```
+
+Copy both to the shadow, then check the nexthops the routes name are
+actually covered by the neighbour file — an uncovered nexthop is an
+`unresolvable` route, which fails verification by design:
+
+```sh
+comm -23 <(awk '{print $2}' /tmp/pf-routes.txt | tr ',' '\n' | sort -u) \
+         <(awk '{print $1}' /tmp/pf-neigh.txt | sort -u) | head
+```
+
+### Run
+
+VPP must already be up with its sized `startup.conf` (§2 — **including
+the `statseg` stanza**, or it aborts partway through). The test attaches
+the device itself, so do **not** pre-run the §3 `vppctl device attach`
+sequence; set `PACKETFRAME_VPP_ADOPT=1` if the interface is already
+attached from an earlier run.
+
+```sh
+PACKETFRAME_VPP_API_SOCK=/run/vpp/api.sock \
+PACKETFRAME_VPP_PORT=eth3 \
+PACKETFRAME_VPP_PCI=0002:07:00.1 \
+PACKETFRAME_VPP_ROUTES=/tmp/pf-routes.txt \
+PACKETFRAME_VPP_NEIGH=/tmp/pf-neigh.txt \
+  ./run-tests.sh vpp_convergence_bench -- --nocapture
+```
+
+### Reading the result
+
+The phase breakdown prints **before** any budget assertion, deliberately:
+a run that blows the budget is exactly the one whose breakdown matters,
+and a panic that hid it would waste the trip. Record `connect / attach /
+resync plan / neighbours / drain / verify / TOTAL`, the routes/s rate,
+and the ledger line.
+
+Failure modes worth recognising rather than debugging from scratch:
+
+- **`unresolvable > 0`** — the neighbour file does not cover every
+  nexthop the routes name. Verification fails by design; fix the input,
+  do not lower the bar.
+- **`deferred` large** — interface indices were not known when the drain
+  started, i.e. attach did not land. The attach step failing is louder;
+  check `show interface` first.
+- **drain not converging** — the run aborts after 10× budget rather than
+  hanging.
+- **abort with `Out-of-memory, calling os_panic()`** — the `statseg` is
+  undersized. Use `show memory` (**all** heaps), never
+  `show memory main-heap`, which reads mostly free during exactly this
+  failure. See the item-10 RESULT.
+
 ## 4. Pass / kill / record
 
 - **Pass:** items 1, 2, 7, 10 all WORK (delivery, egress, PMTUD,

--- a/docs/runbooks/vpp-offload-spike.md
+++ b/docs/runbooks/vpp-offload-spike.md
@@ -738,20 +738,36 @@ file and a shortened count that agree with each other perfectly.
 Now extract, and reconcile against that independent figure:
 
 ```sh
+set -o pipefail
 birdc 'show route primary table master4' > /tmp/pf-raw.txt
-awk '/^[0-9]/ { pfx=$1; nets++ } /via/ { for (i=1;i<=NF;i++) if ($i=="via") print pfx, $(i+1) } END { print "networks_seen", nets > "/tmp/pf-nets.txt" }' /tmp/pf-raw.txt | sort -u > /tmp/pf-routes.txt
+awk '/^[0-9]/ { pfx=$1; nets++ } /via/ { if (!(pfx in seen)) { seen[pfx]=1; vias++ } for (i=1;i<=NF;i++) if ($i=="via") print pfx, $(i+1) } END { print nets, vias > "/tmp/pf-nets.txt" }' /tmp/pf-raw.txt | sort -u > /tmp/pf-routes.txt || echo "EXTRACTION FAILED"
 BIRD_NETS=$(awk '{ for (i=1;i<=NF;i++) if ($i=="networks") print $(i-1) }' /tmp/pf-count.txt)
-SEEN_NETS=$(awk '{print $2}' /tmp/pf-nets.txt)
-VIA_NETS=$(awk '{print $1}' /tmp/pf-routes.txt | sort -u | wc -l)
-echo "bird reports   : ${BIRD_NETS} networks"
-echo "dump contained : ${SEEN_NETS} networks"
-echo "with a via     : ${VIA_NETS}  <-- PACKETFRAME_VPP_EXPECT_ROUTES"
-echo "excluded       : $((SEEN_NETS - VIA_NETS)) (connected/blackhole/unreachable)"
-[ "${BIRD_NETS}" = "${SEEN_NETS}" ] && echo "OK: dump is complete" || echo "TRUNCATED — do not measure this"
+SEEN_NETS=$(awk '{print $1}' /tmp/pf-nets.txt)
+VIA_RAW=$(awk '{print $2}' /tmp/pf-nets.txt)
+VIA_FILE=$(awk '{print $1}' /tmp/pf-routes.txt | sort -u | wc -l | tr -d ' ')
+echo "bird reports    : ${BIRD_NETS} networks"
+echo "raw dump had    : ${SEEN_NETS} networks, ${VIA_RAW} with a via"
+echo "routes file has : ${VIA_FILE} prefixes  <-- PACKETFRAME_VPP_EXPECT_ROUTES"
+echo "excluded        : $((SEEN_NETS - VIA_RAW)) (connected/blackhole/unreachable)"
+[ "${BIRD_NETS}" = "${SEEN_NETS}" ] || echo "!! DUMP TRUNCATED — do not measure this"
+[ "${VIA_RAW}" = "${VIA_FILE}" ] || echo "!! EXTRACTION LOST RECORDS — do not measure this"
+[ "${BIRD_NETS}" = "${SEEN_NETS}" ] && [ "${VIA_RAW}" = "${VIA_FILE}" ] && echo "OK: chain verified"
 ```
 
-**Stop if that last line says TRUNCATED.** The whole point of the
-expectation is that a partial dump cannot produce a clean result.
+**Stop unless the last line says `OK: chain verified`.** Two separate
+things are being checked, and each closes a different way for a partial
+table to look complete:
+
+- `BIRD_NETS == SEEN_NETS` — bird's own count against the raw dump, so a
+  `birdc` that ends cleanly halfway is caught.
+- `VIA_RAW == VIA_FILE` — the via count computed **from the raw dump**
+  against the extracted file, so an `awk | sort` that loses records (disk
+  full, a failed `sort`) is caught too. `VIA_RAW` is what makes this
+  non-circular: it never touches `pf-routes.txt`.
+
+An expectation taken from the file it is meant to validate agrees with a
+truncated file perfectly. An earlier revision of this section did that
+with `wc -l`, and a revision after it validated only the raw dump.
 
 **This is a via-nexthop measurement, not literally every route class.**
 The `excluded` figure is real — `master4` carries connected, blackhole and
@@ -780,7 +796,31 @@ them as owned and program them into VPP. Extra work at best, and a
 refusal aborts the run.
 
 **Every device carrying a route nexthop must be a member port with its own
-VF.** The### Run
+VF.** The bench refuses up front if a route nexthop resolves to a device
+that is not a member — failing there is correct rather than something to
+work around, since a packet whose best path exits a port VPP does not own
+would blackhole.
+
+#### If only one VF is bound
+
+Rewrite the device column of the **filtered** neighbour file onto the one
+owned port, and record the run as a **reduced** measurement: the drain,
+wire encoding and VPP-side insert are all fully exercised, but every
+adjacency lands on a single interface, so it does not exercise the
+multi-port mapping.
+
+```sh
+awk '{ print $1, "eth3", $3 }' /tmp/pf-neigh.txt > /tmp/pf-neigh-one.txt
+```
+
+Rewrite `/tmp/pf-neigh.txt` (route-referenced only), never
+`/tmp/pf-neigh-all.txt` — the router-wide file carries management and
+tunnel neighbours, and relabelling those onto the member port would make
+`program_neighbours` treat them as owned and push them into VPP. Then use
+`PACKETFRAME_VPP_NEIGH=/tmp/pf-neigh-one.txt` with a single-entry
+`PORT`/`PCI` below.
+
+### Run
 
 VPP must already be up with its sized `startup.conf` (§2 — **including
 the `statseg` stanza**, or it aborts partway through). The test attaches


### PR DESCRIPTION
Fifteen review findings across three rounds landed on #115, and the two worst were things review caught that *more* review would not have: a step I'd omitted entirely, and a fix of mine that traded one broken bound for another. The engine now needs a VPP that can disagree with it more than it needs another pass.

This is the cheapest way to get one.

## What it measures

Gate 0b item 10 timed VPP's **CLI parser** absorbing the v4 table — ~35 s for 1,053,360 routes via `vppctl exec`, with one shared path-list — and recorded it as a lower bound, explicitly *not* as the convergence figure. Production is 1.05M **binary-API round trips** against the real nexthop set, driven by `ConvergenceEngine`. The plan publishes **≤60 s** and nothing has ever checked it.

## Why it can run now

- Env-gated on `PACKETFRAME_VPP_API_SOCK`, so CI and the qemu verifier skip it.
- Ships to the router in the existing `hardware-artifacts` bundle like every other test binary — no new workflow.
- **No traffic peer needed**, because nothing is steered. That's what makes it runnable today rather than whenever a peer frees up.

It drives the real sequence rather than a rehearsal of it: connect + handshake, `attach_devices`, `program_neighbours`, the diffing resync, the bounded drain loop, readback verification. Every path the last three review rounds argued about executes here against something that can say no.

## Two deliberate reporting choices

**The phase breakdown prints before any budget assertion.** A run that blows the budget is exactly the run whose breakdown matters; a panic that hid it would waste the trip to the hardware.

**Correctness is asserted before speed.** Verification must pass and every source route must be installed before the timing means anything — a fast run that loaded the wrong table is worse than a slow one that loaded the right table, and this is a measurement whose entire value is being trustworthy.

## Output shape

```
== convergence bench ==
  routes     1053360
  neighbours 129
-- phases --
  connect / attach / resync plan / neighbours / drain / verify / TOTAL
-- ledger --
  installed / installing / withheld / unresolvable
-- rate --
  N routes/s over the drain
```

## Runbook

New §3b in [vpp-offload-spike.md](docs/runbooks/vpp-offload-spike.md): the two input-file commands (sourced from **bird**, not the kernel — the kernel export was dropped at custom-fib cutover, so `ip route show` is deliberately near-empty), a check that the neighbour file covers every nexthop the routes name, and the failure modes worth recognising rather than debugging from scratch:

- `unresolvable > 0` → the neighbour file is short; fix the input, don't lower the bar
- large `deferred` → attach didn't land
- OOM abort → the `statseg` is undersized, and `show memory main-heap` will read mostly free while it happens

497 workspace tests pass; clean on host and all four cross targets. The bench itself skips with a printed reason, so a run that measured nothing is obvious in the log rather than looking like a pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)