### PR TITLE
feat(vpp-offload): the runtime — Observe and Effects made real

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -42,6 +42,21 @@
 
 use std::time::{Duration, Instant};
 
+/// How often to poll `api_ready` while a process exists but the API has
+/// not answered yet.
+///
+/// Load-bearing, not a tuning nicety. In that window there is no
+/// detector (it must not exist before the first pong, or startup counts
+/// as silence) and the only armed deadline is the 60 s startup budget —
+/// so without this cap, `Tick::sleep` says "wake me at the deadline",
+/// and a loop that honours it never calls `api_ready` again. The next
+/// tick then queues `PhaseTimedOut` ahead of the `ApiUp` observed on
+/// the very same pass, and a perfectly healthy VPP that was merely slow
+/// to fault in its heap is killed and restarted, every 60 s, forever.
+/// The driver is the thing that knows polling is how progress happens
+/// here, so the cadence lives in the driver, not in every caller.
+pub const API_POLL_INTERVAL: Duration = Duration::from_millis(250);
+
 use crate::executor::{execute, Effects, Outcome};
 use crate::liveness::{budget_for, WedgeDetector};
 use crate::schedule::Schedule;
@@ -225,6 +240,18 @@ impl Driver {
         }
 
         tick.sleep = self.sleep(now);
+        // A process whose API has not answered yet has exactly one
+        // source of progress: polling `api_ready`. Nothing wakes the
+        // loop for that — no detector exists yet, and the only armed
+        // deadline is the startup budget itself — so cap the sleep at
+        // the poll cadence, or a sleep-honouring caller dozes to the
+        // deadline and kills a VPP whose API came up in the meantime.
+        if self.sup.state().has_process() && self.detector.is_none() {
+            tick.sleep = Some(
+                tick.sleep
+                    .map_or(API_POLL_INTERVAL, |s| s.min(API_POLL_INTERVAL)),
+            );
+        }
         // A partly-drained table must not wait for the ping interval.
         // At ~256 routes a batch, one batch per 500 ms would take the
         // full v4 table over half an hour against a 60 s budget.
@@ -726,6 +753,50 @@ mod tests {
         assert!(t.events.contains(&Event::PhaseTimedOut), "{:?}", t.events);
         assert_eq!(d.state(), State::Backoff);
         assert!(fx.calls.contains(&"kill"));
+    }
+
+    /// While a process exists but the API has not answered, the sleep
+    /// must be the poll cadence — never the startup deadline. A
+    /// sleep-honouring loop offered the deadline would wake exactly
+    /// there, queue `PhaseTimedOut` ahead of the `ApiUp` observed on
+    /// the same pass, and kill a healthy VPP that was merely slow to
+    /// fault in its heap — every 60 s, forever.
+    #[test]
+    fn starting_polls_for_the_api_instead_of_sleeping_to_the_deadline() {
+        let mut d = Driver::new();
+        let mut w = World::default(); // api: false
+        let mut fx = Fx::default();
+        let t0 = Instant::now();
+
+        // Both entry points must cap: the injected start (whose settle
+        // path had exactly this bug shape before, per its doc) and the
+        // ordinary tick.
+        let it = d.inject(t0, Event::StartRequested, &mut fx);
+        assert!(
+            it.sleep.is_some_and(|s| s <= API_POLL_INTERVAL),
+            "inject offered {:?}, letting a caller doze past api_ready",
+            it.sleep
+        );
+        let t = d.tick(at(t0, 1), &mut w, &mut fx);
+        assert!(
+            t.sleep.is_some_and(|s| s <= API_POLL_INTERVAL),
+            "tick offered {:?}",
+            t.sleep
+        );
+
+        // The API answers mid-budget; a loop honouring the advertised
+        // cadence reaches ApiUp long before any timeout fires.
+        w.api = true;
+        let t = d.tick(at(t0, 260), &mut w, &mut fx);
+        assert!(
+            t.events.contains(&Event::ApiUp),
+            "the poll must observe the API coming up: {:?}",
+            t.events
+        );
+        assert_eq!(d.state(), State::Syncing);
+        // (The tick that transitioned asks for an immediate re-run —
+        // that is settle behaviour, covered by its own tests. The cap
+        // itself no longer applies once the detector exists.)
     }
 
     /// The loop must not spin. In steady state the only timer is the

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -41,6 +41,7 @@ pub mod fib_sync;
 pub mod liveness;
 pub mod process;
 pub mod resources;
+pub mod runtime;
 pub mod schedule;
 pub mod sink;
 pub mod startup_conf;

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1,0 +1,681 @@
+//! The runtime: [`Observe`] and [`Effects`] implemented by delegation
+//! to the real machinery — [`VppProcess`] for the process,
+//! [`ConvergenceEngine`] for everything reachable over the API socket,
+//! and a [`Steering`] seam for the MCAM rules that land in slice 5.
+//!
+//! This is the last layer of pure wiring before `Module::attach()`. It
+//! deliberately contains **no policy**: every decision lives in the
+//! supervisor, every deadline in the schedule, and this module's only
+//! job is to make requests happen and report what was observed. The one
+//! rule inherited from the driver applies with full force here —
+//! *nothing is recorded as done because it was requested* — and each
+//! method below says which side of that line it sits on.
+//!
+//! ## One machine, two traits, and why there is a `RefCell`
+//!
+//! [`Driver::tick`](crate::driver::Driver::tick) takes `Observe` and
+//! `Effects` as two separate `&mut` receivers, which is right for tests
+//! and right conceptually. But in the real system both traits terminate
+//! in the same state — the engine owns the socket that `ping` (observe)
+//! and `start_resync` (effect) both use — so one struct cannot be handed
+//! out as two exclusive borrows. [`Runtime::views`] therefore yields two
+//! lightweight views over a shared `RefCell` core. That is sound because
+//! the driver's call pattern is strictly sequential: no `Observe` call
+//! is made while an `Effects` call is in progress or vice versa, so a
+//! borrow never overlaps. A re-entrant borrow panic here would mean the
+//! driver broke that contract, and a loud panic is the correct report.
+//!
+//! ## What is deliberately NOT here
+//!
+//! - **Resource acquisition** (hugepages → VF → vfio → startup.conf).
+//!   That is `attach()`-time setup with its own ordering and rollback,
+//!   already implemented in [`crate::resources`]; the wiring PR owns it.
+//! - **State-file I/O.** The runtime reports identity changes through
+//!   [`IdentityStore`] at the moment they are observed, but what a
+//!   record means on disk belongs to the owner of the
+//!   [`ResourceState`](crate::resources::ResourceState) — the same
+//!   attach wiring. A [`NullStore`] exists for tests only.
+//! - **MCAM steering.** [`Steering`] is a seam; the ETHTOOL
+//!   implementation is slice 5. The placeholder here refuses in both
+//!   directions — see [`SteeringUnavailable`] for why refusing to
+//!   *unsteer* is the load-bearing half.
+
+use std::cell::RefCell;
+use std::path::PathBuf;
+use std::rc::Rc;
+use std::time::Duration;
+
+use crate::driver::Observe;
+use crate::engine::{ConvergenceEngine, RouteSource};
+use crate::executor::Effects;
+use crate::process::{terminate_or_leak, Disposition, VppProcess};
+use crate::supervisor::Event;
+
+/// How long a SIGTERM gets before escalation, on top of the bounded
+/// SIGKILL wait inside [`VppProcess::terminate`].
+///
+/// Short: by the time `Kill` is issued, steering is already down (rule
+/// 2), so nothing is lost by being brisk — and the recovery clock is
+/// running against the published ≤90 s number.
+pub const TERM_GRACE: Duration = Duration::from_secs(3);
+
+/// The `(pid, start_ticks, boot_id)` triple that makes a recorded
+/// process identity safe to act on across restarts and PID reuse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessIdentity {
+    pub pid: i32,
+    pub start_ticks: u64,
+    pub boot_id: Option<String>,
+}
+
+/// Where observed identity changes are recorded.
+///
+/// A trait rather than direct file I/O because the runtime does not own
+/// the state file — the attach wiring does, along with the hugepage and
+/// VF records that live in the same [`crate::resources::ResourceState`].
+/// The contract is *observed, then recorded*: these are called at the
+/// moment the fact becomes true, never in anticipation of it.
+pub trait IdentityStore {
+    /// The supervised process changed: `Some` after a successful spawn,
+    /// `None` once it is confirmed gone.
+    fn process_changed(&mut self, identity: Option<ProcessIdentity>) -> Result<(), String>;
+
+    /// VPP acknowledged these interfaces (`(port, sw_if_index)`).
+    /// Persisting them is what lets the next daemon adopt instead of
+    /// blind-attaching.
+    fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String>;
+}
+
+/// Store that records nothing. Tests only — a production runtime with a
+/// null store produces orphans no future daemon can adopt.
+#[derive(Debug, Default)]
+pub struct NullStore;
+
+impl IdentityStore for NullStore {
+    fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+        Ok(())
+    }
+    fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// The MCAM steering seam. Real implementation lands in slice 5
+/// (ETHTOOL_SRXCLSRLINS, ring_cookie `(vf+1)<<32`, loc budgeting).
+pub trait Steering {
+    /// Install the rules. `Ok` means they are confirmed in the NIC.
+    fn steer(&mut self) -> Result<(), String>;
+    /// Remove the rules. `Ok` means they are confirmed gone — and only
+    /// then, because the supervisor releases VFs on the strength of it.
+    fn unsteer(&mut self) -> Result<(), String>;
+}
+
+/// The placeholder until slice 5: refuses both directions.
+///
+/// `steer` refusing is obvious. `unsteer` refusing is the half that
+/// matters: `Ok` from unsteer becomes `Event::Unsteered`, which clears
+/// `steered` and unblocks `ReleaseResources` — so a placeholder that
+/// faked success would let the supervisor release a VF that MCAM rules
+/// from a previous run might still be pointing traffic at. Refusing
+/// keeps `steered` true and the VF withheld, which is the designed
+/// behaviour for "rules exist that we cannot manage". A config with
+/// every port `steer off` never reaches either path.
+#[derive(Debug, Default)]
+pub struct SteeringUnavailable;
+
+impl Steering for SteeringUnavailable {
+    fn steer(&mut self) -> Result<(), String> {
+        Err("MCAM steering is not implemented until slice 5; port stays unsteered".into())
+    }
+    fn unsteer(&mut self) -> Result<(), String> {
+        Err("MCAM steering is not implemented until slice 5; cannot confirm rules removed".into())
+    }
+}
+
+/// Everything both trait views share.
+struct Core {
+    engine: ConvergenceEngine,
+    /// `None` when nothing is supervised: before the first spawn, after
+    /// a confirmed exit, or after a clean kill. Kept across `MustLeak`,
+    /// because the pidfd is the only way the late exit will ever be
+    /// observed.
+    process: Option<VppProcess>,
+    source: Box<dyn RouteSource>,
+    steering: Box<dyn Steering>,
+    store: Box<dyn IdentityStore>,
+    vpp_binary: PathBuf,
+    startup_conf: PathBuf,
+    /// Whether this convergence adopts interfaces VPP already has.
+    /// Set by the attach wiring alongside the injected `Adopted` event;
+    /// reset to `Fresh` once the process it described is gone.
+    attach_mode: crate::attach::AttachMode,
+    /// Events produced by completed work, waiting for the loop to
+    /// inject them. The verify verdict travels this way: `start_verify`
+    /// is an effect, its outcome is an observation of what VPP
+    /// answered, and the loop feeds it back through
+    /// [`Driver::inject`](crate::driver::Driver::inject) — the same
+    /// path every driver test uses.
+    pending: Vec<Event>,
+    /// The last identity-store failure on a path that could not refuse
+    /// (an observed exit is a fact whether or not it can be recorded).
+    /// Surfaced for status; never blocks the loop.
+    last_store_error: Option<String>,
+}
+
+/// Owner handle. Create once, then [`Runtime::views`] per tick.
+pub struct Runtime {
+    core: Rc<RefCell<Core>>,
+}
+
+/// The `Observe` half. See the module docs for why this is a view.
+pub struct ObserveView {
+    core: Rc<RefCell<Core>>,
+}
+
+/// The `Effects` half.
+pub struct EffectsView {
+    core: Rc<RefCell<Core>>,
+}
+
+impl Runtime {
+    pub fn new(
+        engine: ConvergenceEngine,
+        source: Box<dyn RouteSource>,
+        steering: Box<dyn Steering>,
+        store: Box<dyn IdentityStore>,
+        vpp_binary: impl Into<PathBuf>,
+        startup_conf: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            core: Rc::new(RefCell::new(Core {
+                engine,
+                process: None,
+                source,
+                steering,
+                store,
+                vpp_binary: vpp_binary.into(),
+                startup_conf: startup_conf.into(),
+                attach_mode: crate::attach::AttachMode::Fresh,
+                pending: Vec::new(),
+                last_store_error: None,
+            })),
+        }
+    }
+
+    /// Hand over an adopted process. The caller injects
+    /// `Event::Adopted { steered }` itself — adoption is an external
+    /// fact, not something the runtime infers — and this records the
+    /// matching handle and switches the next attach to `Adopted` so
+    /// recorded interface indices are reused rather than duplicated.
+    pub fn adopt_process(&self, p: VppProcess) {
+        let mut c = self.core.borrow_mut();
+        c.process = Some(p);
+        c.attach_mode = crate::attach::AttachMode::Adopted;
+    }
+
+    /// The two trait views the driver's tick takes.
+    pub fn views(&self) -> (ObserveView, EffectsView) {
+        (
+            ObserveView {
+                core: Rc::clone(&self.core),
+            },
+            EffectsView {
+                core: Rc::clone(&self.core),
+            },
+        )
+    }
+
+    /// Drain events produced by completed work (verify verdicts), for
+    /// the loop to feed through `Driver::inject`.
+    pub fn take_pending(&self) -> Vec<Event> {
+        std::mem::take(&mut self.core.borrow_mut().pending)
+    }
+
+    /// Keep the engine's socket deadline keyed to the budget in force.
+    /// Called by the loop after every tick with
+    /// `driver.supervisor().is_steered()`.
+    pub fn set_steered(&self, steered: bool) {
+        self.core.borrow_mut().engine.set_steered(steered);
+    }
+
+    /// Whether the API handshake failed in a way retrying cannot fix
+    /// (CRC mismatch, unknown message, refusal). The loop uses this to
+    /// stop burning the startup budget on a VPP that can never answer.
+    pub fn api_incompatible(&self) -> bool {
+        self.core.borrow().engine.api_incompatible()
+    }
+
+    /// Status inputs, observed: last verify, counts, port links, the
+    /// last API error, and any store failure from a path that could not
+    /// refuse.
+    pub fn status(&self) -> RuntimeStatus {
+        let c = self.core.borrow();
+        RuntimeStatus {
+            counts: c.engine.counts(),
+            pending_ops: c.engine.pending().len() as u64,
+            parked_ops: c.engine.pending().withheld_len() as u64,
+            last_verify: c.engine.last_verify().cloned(),
+            port_links: c.engine.port_links(),
+            api_error: c.engine.last_api_error().map(str::to_string),
+            store_error: c.last_store_error.clone(),
+        }
+    }
+}
+
+/// One coherent snapshot of the runtime's observable state, for the
+/// health surface. Everything in it came from an observation.
+#[derive(Debug, Clone)]
+pub struct RuntimeStatus {
+    pub counts: crate::sink::SinkCounts,
+    pub pending_ops: u64,
+    pub parked_ops: u64,
+    pub last_verify: Option<crate::verify::VerifyOutcome>,
+    pub port_links: Vec<crate::status::PortLink>,
+    pub api_error: Option<String>,
+    pub store_error: Option<String>,
+}
+
+impl Core {
+    /// The process is confirmed gone: invalidate everything learned
+    /// from it. Indices are per-instance, the ledger describes a FIB
+    /// that no longer exists, and the socket belongs to the dead
+    /// process. The next spawn starts from nothing — including
+    /// `AttachMode::Fresh`, because the recorded indices died with the
+    /// instance (the engine clears its own copy for the same reason).
+    fn process_gone(&mut self) {
+        self.process = None;
+        self.attach_mode = crate::attach::AttachMode::Fresh;
+        self.engine.on_process_gone();
+        if let Err(e) = self.store.process_changed(None) {
+            // The exit is a fact whether or not it can be recorded;
+            // surface the failure, do not block on it.
+            self.last_store_error = Some(e);
+        }
+    }
+}
+
+impl Observe for ObserveView {
+    fn poll_exit(&mut self) -> Option<Option<i32>> {
+        let mut c = self.core.borrow_mut();
+        let p = c.process.as_mut()?;
+        match p.poll_exit(Duration::ZERO) {
+            Ok(Some(status)) => {
+                // Observed dead: report it exactly once, and clean up
+                // now — the handle has nothing more to say.
+                c.process_gone();
+                Some(status)
+            }
+            Ok(None) => None,
+            // A pidfd read error is indistinguishable from "cannot
+            // observe" — report nothing rather than invent an exit.
+            // The wedge detector covers a process that is silently
+            // broken.
+            Err(_) => None,
+        }
+    }
+
+    fn api_ready(&mut self) -> bool {
+        self.core.borrow_mut().engine.api_ready()
+    }
+
+    fn ping(&mut self) -> Result<(), String> {
+        self.core
+            .borrow_mut()
+            .engine
+            .ping()
+            .map_err(|e| e.to_string())
+    }
+
+    fn drain_batch(&mut self) -> Result<bool, String> {
+        self.core
+            .borrow_mut()
+            .engine
+            .drain_batch()
+            .map(|(done, _stats)| done)
+            .map_err(|e| e.to_string())
+    }
+}
+
+impl Effects for EffectsView {
+    fn spawn(&mut self) -> Result<(), String> {
+        let mut c = self.core.borrow_mut();
+        if c.process.is_some() {
+            // Two processes cannot share the VF and the API socket. If
+            // the supervisor asks for a spawn while a handle exists,
+            // something upstream is wrong — refuse rather than orphan
+            // the first.
+            return Err("refusing to spawn: a supervised process already exists".into());
+        }
+        let (binary, conf) = (c.vpp_binary.clone(), c.startup_conf.clone());
+        let mut p = VppProcess::spawn(&binary, &conf).map_err(|e| format!("spawning VPP: {e}"))?;
+
+        let identity = ProcessIdentity {
+            pid: p.pid(),
+            start_ticks: p.start_ticks(),
+            boot_id: crate::process::boot_id().ok(),
+        };
+        if let Err(e) = c.store.process_changed(Some(identity)) {
+            // Persist-or-kill. A VPP whose identity is not on disk
+            // cannot be adopted after a daemon restart: it survives as
+            // an orphan holding the VF, unkillable by anything that
+            // respects the identity check. Better one failed spawn now
+            // than that later.
+            let _ = terminate_or_leak(&mut p, Duration::from_secs(1));
+            return Err(format!(
+                "spawned pid {} but could not record it: {e}",
+                p.pid()
+            ));
+        }
+        c.process = Some(p);
+        Ok(())
+    }
+
+    fn unsteer(&mut self) -> Result<(), String> {
+        self.core.borrow_mut().steering.unsteer()
+    }
+
+    fn steer(&mut self) -> Result<(), String> {
+        self.core.borrow_mut().steering.steer()
+    }
+
+    fn kill(&mut self) -> Disposition {
+        let mut c = self.core.borrow_mut();
+        let Some(p) = c.process.as_mut() else {
+            // Nothing supervised: nothing holds the resources.
+            return Disposition::SafeToRelease;
+        };
+        match terminate_or_leak(p, TERM_GRACE) {
+            Disposition::SafeToRelease => {
+                c.process_gone();
+                Disposition::SafeToRelease
+            }
+            Disposition::MustLeak => {
+                // The process survived SIGKILL — most likely parked in
+                // an uninterruptible VFIO/DMA call. Keep the handle:
+                // the pidfd is the only observer that will ever report
+                // the late exit, and dropping it would leave the
+                // supervisor's `undead` flag with no way to clear.
+                // Identity stays recorded for the same reason.
+                Disposition::MustLeak
+            }
+        }
+    }
+
+    fn attach_devices(&mut self) -> Result<(), String> {
+        let mut c = self.core.borrow_mut();
+        let mode = c.attach_mode;
+        c.engine.attach_devices(mode).map_err(|e| e.to_string())?;
+        let indices = c.engine.attached_indices();
+        if let Err(e) = c.store.interfaces_attached(&indices) {
+            // Unlike spawn, do not tear anything down: the interfaces
+            // exist and work. The cost of a lost record is one refused
+            // adoption after a daemon restart (UnknownIndexOnAdopt →
+            // clean restart), which is the designed safe fallback.
+            // Surfaced, not fatal.
+            c.last_store_error = Some(e);
+        }
+        Ok(())
+    }
+
+    fn start_resync(&mut self) -> Result<(), String> {
+        let mut c = self.core.borrow_mut();
+        // Split borrow: the engine walks the source while both live in
+        // the same core.
+        let Core { engine, source, .. } = &mut *c;
+        let _plan = engine.begin_resync(source.as_ref());
+        // Neighbours between attach and the first drain, and fatal on
+        // refusal: a route through an unprogrammed adjacency installs
+        // cleanly, verifies cleanly, and drops every packet.
+        engine
+            .program_neighbours(source.as_ref())
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
+
+    fn start_verify(&mut self) -> Result<(), String> {
+        let mut c = self.core.borrow_mut();
+        match c.engine.run_verify() {
+            Ok(verdict) => {
+                // The verdict is an observation of what VPP answered.
+                // It reaches the supervisor through the loop's inject,
+                // not from inside this Effects call — the same seam
+                // every driver test drives.
+                let event = verdict.event();
+                c.pending.push(event);
+                Ok(())
+            }
+            Err(e) => Err(e.to_string()),
+        }
+    }
+
+    fn abort_convergence(&mut self) {
+        let mut c = self.core.borrow_mut();
+        c.engine.abort_convergence();
+        // The abort is complete as soon as the engine forgets its
+        // phase — nothing here runs on another thread — so the
+        // supervisor's `converging` flag can be cleared immediately.
+        // Without this the flag never clears (nothing else emits the
+        // event) and `may_restart` stays false forever.
+        c.pending.push(Event::ConvergenceStopped);
+    }
+
+    fn arm_backoff(&mut self, _delay: Duration) {
+        // The Driver arms its own Schedule from the same action (see
+        // Driver::apply); this hook exists for callers without one.
+        // Doing it twice would be two clocks for one deadline.
+    }
+
+    fn release_resources(&mut self) -> Result<(), String> {
+        // Owned by the attach wiring, which holds the ResourceState
+        // and the sysfs paths. The runtime cannot release what it
+        // never acquired; wiring this to a no-op Ok would report
+        // resources freed that are still held.
+        Err("resource release is owned by the attach wiring (not yet built)".into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::fib_sync::FamilyPolicy;
+    use packetframe_common::fib::IpPrefix;
+    use std::net::IpAddr;
+    // Only the Linux-gated process tests need these.
+    #[cfg(target_os = "linux")]
+    use std::sync::{Arc, Mutex};
+
+    struct EmptySource;
+    impl RouteSource for EmptySource {
+        fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, _: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
+    }
+
+    fn engine() -> ConvergenceEngine {
+        ConvergenceEngine::new(
+            "/nonexistent/api.sock",
+            Vec::new(),
+            vec!["eth4".into()],
+            1_000,
+            FamilyPolicy::V4Only,
+        )
+    }
+
+    fn runtime() -> Runtime {
+        Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(SteeringUnavailable),
+            Box::new(NullStore),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        )
+    }
+
+    /// The placeholder must refuse BOTH directions. `unsteer` faking
+    /// success would emit `Unsteered`, clear `steered`, and unblock the
+    /// release of a VF that rules from a previous run might still be
+    /// pointing traffic at.
+    #[test]
+    fn steering_placeholder_refuses_both_directions() {
+        let rt = runtime();
+        let (_, mut fx) = rt.views();
+        assert!(fx.steer().is_err());
+        assert!(
+            fx.unsteer().is_err(),
+            "a faked Unsteered releases a VF that MCAM may still target"
+        );
+    }
+
+    /// A verify verdict travels through `take_pending` to be injected —
+    /// never applied from inside the Effects call. And a transport
+    /// failure produces no verdict at all: "could not ask" is not an
+    /// answer about the FIB.
+    #[test]
+    fn verify_failure_produces_no_pending_verdict() {
+        let rt = runtime();
+        let (_, mut fx) = rt.views();
+        assert!(
+            fx.start_verify().is_err(),
+            "no transport → the effect fails"
+        );
+        assert!(
+            rt.take_pending().is_empty(),
+            "a failed verify must not leave a verdict to inject"
+        );
+    }
+
+    /// `abort_convergence` must deliver `ConvergenceStopped`, because
+    /// nothing else ever will: the engine's abort is synchronous, and a
+    /// supervisor whose `converging` flag never clears can never
+    /// restart.
+    #[test]
+    fn abort_delivers_convergence_stopped() {
+        let rt = runtime();
+        let (_, mut fx) = rt.views();
+        fx.abort_convergence();
+        assert_eq!(rt.take_pending(), vec![Event::ConvergenceStopped]);
+        assert!(rt.take_pending().is_empty(), "delivered exactly once");
+    }
+
+    /// With nothing supervised, `kill` reports the resources safe —
+    /// there is no process to be holding them.
+    #[test]
+    fn kill_with_no_process_is_safe_to_release() {
+        let rt = runtime();
+        let (_, mut fx) = rt.views();
+        assert_eq!(fx.kill(), Disposition::SafeToRelease);
+    }
+
+    /// `release_resources` refuses rather than no-ops: reporting
+    /// resources freed that the (unbuilt) attach wiring still holds is
+    /// the requested-vs-observed bug in its purest form.
+    #[test]
+    fn release_refuses_until_the_owner_exists() {
+        let rt = runtime();
+        let (_, mut fx) = rt.views();
+        assert!(fx.release_resources().is_err());
+    }
+
+    /// Observe calls with no process/transport report absence rather
+    /// than failing or inventing.
+    #[test]
+    fn observations_with_nothing_to_observe_report_nothing() {
+        let rt = runtime();
+        let (mut obs, _) = rt.views();
+        assert_eq!(obs.poll_exit(), None);
+        assert!(!obs.api_ready(), "nothing is listening");
+        assert!(obs.ping().is_err());
+        assert!(obs.drain_batch().is_err());
+    }
+
+    /// A store that fails at spawn time must kill the child. A VPP
+    /// whose identity is not on disk cannot be adopted after a daemon
+    /// restart — it survives as an orphan holding the VF.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn spawn_kills_the_child_if_identity_cannot_be_recorded() {
+        struct FailingStore;
+        impl IdentityStore for FailingStore {
+            fn process_changed(&mut self, id: Option<ProcessIdentity>) -> Result<(), String> {
+                if id.is_some() {
+                    Err("disk full".into())
+                } else {
+                    Ok(())
+                }
+            }
+            fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Ok(())
+            }
+        }
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(SteeringUnavailable),
+            Box::new(FailingStore),
+            // Any spawnable binary will do; it is killed immediately.
+            "/bin/sleep",
+            "/dev/null",
+        );
+        let (mut obs, mut fx) = rt.views();
+        let err = fx.spawn().expect_err("persist-or-kill");
+        assert!(err.contains("could not record"), "{err}");
+        // The handle must NOT be retained: the spawn failed as far as
+        // the supervisor is concerned, and a kept process would leak.
+        assert_eq!(obs.poll_exit(), None, "no supervised process remains");
+    }
+
+    /// Identity recorded on spawn, cleared on observed exit — each at
+    /// the moment it became true.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn identity_is_recorded_on_spawn_and_cleared_on_exit() {
+        #[derive(Default)]
+        struct Recording(Arc<Mutex<Vec<Option<i32>>>>);
+        impl IdentityStore for Recording {
+            fn process_changed(&mut self, id: Option<ProcessIdentity>) -> Result<(), String> {
+                self.0.lock().unwrap().push(id.map(|i| i.pid));
+                Ok(())
+            }
+            fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Ok(())
+            }
+        }
+        let log = Arc::new(Mutex::new(Vec::new()));
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(SteeringUnavailable),
+            Box::new(Recording(Arc::clone(&log))),
+            // `VppProcess::spawn(binary, conf)` execs `binary -c conf`;
+            // /bin/true exits immediately regardless of arguments,
+            // which is exactly what this test wants.
+            "/bin/true",
+            "/dev/null",
+        );
+        let (mut obs, mut fx) = rt.views();
+        fx.spawn().expect("spawn /bin/true");
+        {
+            let l = log.lock().unwrap();
+            assert_eq!(l.len(), 1);
+            assert!(l[0].is_some(), "identity recorded with a real pid");
+        }
+        // The child exits at once; the pidfd reports it, and the exit
+        // clears the record.
+        let mut exited = None;
+        for _ in 0..100 {
+            if let Some(status) = obs.poll_exit() {
+                exited = Some(status);
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(exited.is_some(), "the exit must be observed via the pidfd");
+        assert_eq!(
+            log.lock().unwrap().last().unwrap(),
+            &None,
+            "identity cleared once the exit was observed"
+        );
+        // And only once.
+        assert_eq!(obs.poll_exit(), None);
+    }
+}

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -54,10 +54,18 @@ use crate::supervisor::Event;
 /// How long a SIGTERM gets before escalation, on top of the bounded
 /// SIGKILL wait inside [`VppProcess::terminate`].
 ///
-/// Short: by the time `Kill` is issued, steering is already down (rule
-/// 2), so nothing is lost by being brisk — and the recovery clock is
-/// running against the published ≤90 s number.
-pub const TERM_GRACE: Duration = Duration::from_secs(3);
+/// SIGTERM here is a courtesy, not a correctness need: by the time
+/// `Kill` is issued steering is already down (rule 2), and VPP holds no
+/// durable state — its FIB is reconstructed from the mirror on every
+/// start. So the grace is sized against the `Module::detach` contract
+/// (< 1 s, SPEC.md §3.2), which this kill path sits inside: 500 ms of
+/// courtesy keeps the cooperative case within the contract. The
+/// uninterruptible-sleep case (VFIO/DMA, SIGKILL cannot bite) exceeds
+/// any budget by nature; `terminate` bounds that wait at 2 s and
+/// reports `MustLeak` rather than hanging, which is the documented
+/// best-effort relaxation from slice 2 — detach fails loudly instead of
+/// blocking forever on a process the kernel will not release.
+pub const TERM_GRACE: Duration = Duration::from_millis(500);
 
 /// The `(pid, start_ticks, boot_id)` triple that makes a recorded
 /// process identity safe to act on across restarts and PID reuse.
@@ -276,6 +284,38 @@ pub struct RuntimeStatus {
 }
 
 impl Core {
+    /// A freshly spawned child whose identity cannot be made durable —
+    /// the store refused it, or its boot_id could not be read — must
+    /// not survive unrecorded, and must not be *forgotten* either.
+    ///
+    /// Termination is attempted; the disposition decides everything.
+    /// `SafeToRelease`: the child is gone and the spawn simply failed.
+    /// `MustLeak`: the child survived SIGKILL (VFIO/DMA), and the first
+    /// version of this path dropped the handle anyway — discarding the
+    /// one observer (the pidfd) that will ever report the late exit,
+    /// and leaving `SpawnFailed`'s retry free to start a second VPP
+    /// over a VF the survivor may still be DMAing through. Now the
+    /// handle is retained (so `spawn` refuses while it exists) and
+    /// `TerminationFailed` is queued so the supervisor's `undead` flag
+    /// blocks the restart through the designed mechanism rather than by
+    /// accident of backoff timing.
+    fn abandon_spawn(&mut self, mut p: VppProcess, why: String) -> String {
+        let pid = p.pid();
+        match terminate_or_leak(&mut p, TERM_GRACE) {
+            Disposition::SafeToRelease => {
+                format!("spawned pid {pid} but {why}; the child was terminated")
+            }
+            Disposition::MustLeak => {
+                self.process = Some(p);
+                self.pending.push(Event::TerminationFailed);
+                format!(
+                    "spawned pid {pid} but {why}; the child SURVIVED termination — \
+                     handle retained, restart blocked until its exit is observed"
+                )
+            }
+        }
+    }
+
     /// The process is confirmed gone: invalidate everything learned
     /// from it. Indices are per-instance, the ledger describes a FIB
     /// that no longer exists, and the socket belongs to the dead
@@ -347,24 +387,33 @@ impl Effects for EffectsView {
             return Err("refusing to spawn: a supervised process already exists".into());
         }
         let (binary, conf) = (c.vpp_binary.clone(), c.startup_conf.clone());
-        let mut p = VppProcess::spawn(&binary, &conf).map_err(|e| format!("spawning VPP: {e}"))?;
+        let p = VppProcess::spawn(&binary, &conf).map_err(|e| format!("spawning VPP: {e}"))?;
 
+        // The boot_id is not optional in spirit: `VppProcess::adopt`
+        // refuses an identity without one (a `(pid, ticks)` pair is
+        // forgeable across a reboot), so recording `None` here would
+        // manufacture a live VPP no future daemon can ever adopt — an
+        // orphan holding the VF. An unreadable boot_id therefore gets
+        // the same treatment as a store failure: the child does not
+        // survive unrecorded.
+        let boot_id = match crate::process::boot_id() {
+            Ok(b) => b,
+            Err(e) => {
+                return Err(c.abandon_spawn(
+                    p,
+                    format!("its boot_id could not be read ({e}), making it unadoptable"),
+                ))
+            }
+        };
         let identity = ProcessIdentity {
             pid: p.pid(),
             start_ticks: p.start_ticks(),
-            boot_id: crate::process::boot_id().ok(),
+            boot_id: Some(boot_id),
         };
         if let Err(e) = c.store.process_changed(Some(identity)) {
-            // Persist-or-kill. A VPP whose identity is not on disk
-            // cannot be adopted after a daemon restart: it survives as
-            // an orphan holding the VF, unkillable by anything that
-            // respects the identity check. Better one failed spawn now
-            // than that later.
-            let _ = terminate_or_leak(&mut p, Duration::from_secs(1));
-            return Err(format!(
-                "spawned pid {} but could not record it: {e}",
-                p.pid()
-            ));
+            // Persist-or-kill: a VPP whose identity is not on disk
+            // cannot be adopted after a daemon restart.
+            return Err(c.abandon_spawn(p, format!("could not record it: {e}")));
         }
         c.process = Some(p);
         Ok(())

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -210,15 +210,29 @@ impl Runtime {
         }
     }
 
-    /// Hand over an adopted process. The caller injects
-    /// `Event::Adopted { steered }` itself — adoption is an external
-    /// fact, not something the runtime infers — and this records the
-    /// matching handle and switches the next attach to `Adopted` so
-    /// recorded interface indices are reused rather than duplicated.
-    pub fn adopt_process(&self, p: VppProcess) {
+    /// Hand over an adopted process, with the steering fact attached.
+    ///
+    /// The caller injects `Event::Adopted { steered }` itself — adoption
+    /// is an external fact, not something the runtime infers — and MUST
+    /// call this first, passing the same `steered`. This records the
+    /// handle, switches the next attach to `Adopted` so recorded
+    /// interface indices are reused rather than duplicated, and applies
+    /// the steering fact to the engine's socket deadline **atomically
+    /// with the handover**.
+    ///
+    /// The last part is why `steered` is a parameter here instead of the
+    /// loop's post-tick `set_steered` sync: `Driver::inject(Adopted)`
+    /// synchronously runs `AttachDevices` and `StartResync` before any
+    /// post-tick call can happen, and an adopted VPP is the one case
+    /// still carrying live traffic while it converges. With the engine
+    /// still thinking `steered == false`, those requests would run under
+    /// the relaxed 10 s resync budget — a stall the published ≤ 2 s
+    /// wedge bound is supposed to catch while packets are on VPP.
+    pub fn adopt_process(&self, p: VppProcess, steered: bool) {
         let mut c = self.core.borrow_mut();
         c.process = Some(p);
         c.attach_mode = crate::attach::AttachMode::Adopted;
+        c.engine.set_steered(steered);
     }
 
     /// The two trait views the driver's tick takes.
@@ -294,11 +308,20 @@ impl Core {
     /// version of this path dropped the handle anyway — discarding the
     /// one observer (the pidfd) that will ever report the late exit,
     /// and leaving `SpawnFailed`'s retry free to start a second VPP
-    /// over a VF the survivor may still be DMAing through. Now the
-    /// handle is retained (so `spawn` refuses while it exists) and
-    /// `TerminationFailed` is queued so the supervisor's `undead` flag
-    /// blocks the restart through the designed mechanism rather than by
-    /// accident of backoff timing.
+    /// over a VF the survivor may still be DMAing through. The handle
+    /// is retained, so `spawn` refuses while it exists.
+    ///
+    /// Deliberately, **no `TerminationFailed` is queued here.** The
+    /// `SpawnFailed` this returns drives the supervisor's `fail()`,
+    /// whose `Kill` action re-runs termination against the retained
+    /// handle — and the *executor* emits `TerminationFailed` if that
+    /// kill still reports `MustLeak`. Queuing one here as well was a
+    /// second clock for one deadline, and a stale one: if the child
+    /// died between the two kills, the second returned `SafeToRelease`
+    /// and dropped the handle, and the queued event then set `undead`
+    /// with no pidfd left alive to ever clear it — permanently
+    /// suppressing restarts. Letting the kill path be the sole emitter
+    /// means the event exists exactly when the survivor does.
     fn abandon_spawn(&mut self, mut p: VppProcess, why: String) -> String {
         let pid = p.pid();
         match terminate_or_leak(&mut p, TERM_GRACE) {
@@ -307,10 +330,9 @@ impl Core {
             }
             Disposition::MustLeak => {
                 self.process = Some(p);
-                self.pending.push(Event::TerminationFailed);
                 format!(
                     "spawned pid {pid} but {why}; the child SURVIVED termination — \
-                     handle retained, restart blocked until its exit is observed"
+                     handle retained, the follow-up kill will report it"
                 )
             }
         }

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -1,0 +1,418 @@
+//! The shared fake VPP: a real unix socket speaking the real wire
+//! format, built from the same generated types the client encodes with.
+//!
+//! Extracted from `vpp_engine.rs` so new integration tests do not grow a
+//! fourth divergent copy (loopback and attach_verify predate it and
+//! still carry their own — migrating them is recorded follow-up work).
+//! Reply headers come from `MESSAGE_META` because header geometry is
+//! per-message; a hand-assumed prefix here would quietly match a
+//! hand-assumed prefix in the client and prove nothing.
+#![allow(dead_code)]
+
+use std::io::{Read, Write};
+use std::os::unix::net::{UnixListener, UnixStream};
+use std::path::PathBuf;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::thread;
+
+use packetframe_common::fib::IpPrefix;
+use std::net::{IpAddr, Ipv4Addr};
+
+use packetframe_vpp_offload::vpp_api::codec::{
+    parse_frame_header, peek_msg_id, write_frame_header, Decode, Decoder, Encode, MSG_HEADER_LEN,
+    SOCKCLNT_CREATE_MSG_ID,
+};
+use packetframe_vpp_offload::vpp_api::generated::{
+    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpNeighborAddDel,
+    IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteLookupReply,
+    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
+    MESSAGE_META,
+};
+
+/// The index the fake's `dev_create_port_if` hands out. Routes must
+/// install onto *this*, learned from VPP, never onto a guess.
+pub const ASSIGNED_INDEX: u32 = 3;
+
+/// Link-layer address the fake mirror hands out for its one neighbour.
+pub const MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
+
+fn id_for(name: &str) -> u16 {
+    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
+}
+
+fn name_for(id: u16) -> &'static str {
+    MESSAGE_META[(id - 100) as usize].name
+}
+
+fn reply_head(name: &str) -> Vec<u8> {
+    let meta = MESSAGE_META
+        .iter()
+        .find(|m| m.name == name)
+        .expect("known reply");
+    let mut out = Vec::new();
+    out.extend_from_slice(&id_for(name).to_be_bytes());
+    if meta.client_index_prefix {
+        out.extend_from_slice(&7u32.to_be_bytes());
+    }
+    out
+}
+
+fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
+    let mut hdr = [0u8; MSG_HEADER_LEN];
+    s.read_exact(&mut hdr).ok()?;
+    let len = parse_frame_header(&hdr) as usize;
+    let mut payload = vec![0u8; len];
+    s.read_exact(&mut payload).ok()?;
+    Some(payload)
+}
+
+fn write_frame(s: &mut UnixStream, payload: &[u8]) {
+    let mut framed = Vec::new();
+    write_frame_header(&mut framed, payload.len());
+    framed.extend_from_slice(payload);
+    let _ = s.write_all(&framed);
+    let _ = s.flush();
+}
+
+fn request_context(payload: &[u8]) -> u32 {
+    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
+}
+
+mod tempdir {
+    use std::path::{Path, PathBuf};
+    pub struct TempDir(PathBuf);
+    impl TempDir {
+        pub fn new(tag: &str) -> std::io::Result<Self> {
+            let mut p = std::env::temp_dir();
+            // Short by construction: a unix socket path is capped at
+            // SUN_LEN (~104 bytes) and macOS $TMPDIR is already ~50 of
+            // them, so a full nanosecond stamp overflows it and the
+            // failure surfaces as an unrelated-looking bind error.
+            p.push(format!(
+                "pf-e{tag}-{}-{:x}",
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos()
+                    % 0x100_000
+            ));
+            std::fs::create_dir_all(&p)?;
+            Ok(Self(p))
+        }
+        pub fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+}
+
+/// One route operation as the fake decoded it off the wire.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WireRoute {
+    pub is_add: bool,
+    /// First four address bytes + prefix length, enough to identify the
+    /// v4 prefixes these tests use.
+    pub addr: [u8; 4],
+    pub len: u8,
+    /// Interface indices the paths reference.
+    pub path_indices: Vec<u32>,
+}
+
+#[derive(Debug, Clone)]
+pub enum Event {
+    Msg(String),
+    Route(WireRoute),
+    Neighbour {
+        sw_if_index: u32,
+        mac: [u8; 6],
+        flags: u8,
+    },
+}
+
+pub struct Fake {
+    pub path: PathBuf,
+    _dir: tempdir::TempDir,
+    events: Receiver<Event>,
+}
+
+/// How the fake misbehaves.
+#[derive(Clone, Copy, Default)]
+pub struct Behaviour {
+    /// Drop the connection after this many route ops.
+    pub hangup_after: Option<usize>,
+    /// Reject this many *deletes* with a non-zero retval before
+    /// accepting them.
+    pub reject_deletes: usize,
+}
+
+impl Fake {
+    pub fn start(tag: &str) -> Self {
+        Self::start_behaving(tag, Behaviour::default())
+    }
+
+    /// Drop the connection after `hangup_after` route ops — the
+    /// mid-drain failure the unwind path exists for.
+    ///
+    /// **One-shot, deliberately.** The point of the test is that a fresh
+    /// connection can finish the job, so a fake that hung up on every
+    /// connection would make recovery untestable rather than testing it.
+    pub fn start_with(tag: &str, hangup_after: usize) -> Self {
+        Self::start_behaving(
+            tag,
+            Behaviour {
+                hangup_after: Some(hangup_after),
+                ..Default::default()
+            },
+        )
+    }
+
+    pub fn start_behaving(tag: &str, behaviour: Behaviour) -> Self {
+        let dir = tempdir::TempDir::new(tag).unwrap();
+        let path = dir.path().join("api.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let (tx, rx): (Sender<Event>, Receiver<Event>) = channel();
+
+        thread::spawn(move || {
+            let mut b = behaviour;
+            // Accept repeatedly: a disconnect-and-reconnect is part of
+            // what these tests exercise.
+            while let Ok((mut sock, _)) = listener.accept() {
+                serve(&mut sock, &tx, b);
+                // One-shot hangup: the point of that test is that a fresh
+                // connection can finish the job.
+                b.hangup_after = None;
+            }
+        });
+
+        Self {
+            path,
+            _dir: dir,
+            events: rx,
+        }
+    }
+
+    pub fn drain_events(&self) -> Vec<Event> {
+        let mut v = Vec::new();
+        while let Ok(e) = self.events.try_recv() {
+            v.push(e);
+        }
+        v
+    }
+}
+
+fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) -> Option<()> {
+    read_frame(sock)?;
+    let mut reply = SockclntCreateReply {
+        context: 1,
+        response: 0,
+        index: 7,
+        count: MESSAGE_META.len() as u16,
+        message_table: Vec::new(),
+    };
+    for (i, m) in MESSAGE_META.iter().enumerate() {
+        reply.message_table.push(MessageTableEntry {
+            index: 100 + i as u16,
+            name: format!("{}_{}", m.name, m.crc.trim_start_matches("0x")),
+        });
+    }
+    let mut payload = Vec::new();
+    payload.extend_from_slice(&SOCKCLNT_CREATE_MSG_ID.to_be_bytes());
+    payload.extend_from_slice(&7u32.to_be_bytes());
+    reply.encode(&mut payload);
+    write_frame(sock, &payload);
+
+    let mut routes_seen = 0usize;
+
+    loop {
+        let req = read_frame(sock)?;
+        let id = peek_msg_id(&req).expect("msg id");
+        let ctx = request_context(&req);
+        let which = name_for(id);
+        let _ = tx.send(Event::Msg(which.to_string()));
+
+        let mut out;
+        match which {
+            "dev_attach" => {
+                out = reply_head("dev_attach_reply");
+                DevAttachReply {
+                    context: ctx,
+                    dev_index: 0,
+                    retval: 0,
+                    error_string: String::new(),
+                }
+                .encode(&mut out);
+            }
+            "dev_create_port_if" => {
+                out = reply_head("dev_create_port_if_reply");
+                DevCreatePortIfReply {
+                    context: ctx,
+                    sw_if_index: ASSIGNED_INDEX,
+                    retval: 0,
+                    error_string: String::new(),
+                }
+                .encode(&mut out);
+            }
+            "sw_interface_set_flags" => {
+                out = reply_head("sw_interface_set_flags_reply");
+                SwInterfaceSetFlagsReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_route_add_del" => {
+                // Decoded with the same generated impl the client
+                // encodes with, so this asserts on the real wire.
+                let mut d = Decoder::new(&req);
+                let r = IpRouteAddDel::decode(&mut d).expect("decodes as a route op");
+                let mut addr = [0u8; 4];
+                addr.copy_from_slice(&r.route.prefix.address.un.0[..4]);
+                let _ = tx.send(Event::Route(WireRoute {
+                    is_add: r.is_add,
+                    addr,
+                    len: r.route.prefix.len,
+                    path_indices: r.route.paths.iter().map(|p| p.sw_if_index).collect(),
+                }));
+
+                routes_seen += 1;
+                if behaviour.hangup_after.is_some_and(|n| routes_seen > n) {
+                    return None;
+                }
+                // Reject deletes for a while, so the retry path is
+                // exercised against a per-route refusal rather than a
+                // connection fault.
+                let retval = if !r.is_add && behaviour.reject_deletes > 0 {
+                    behaviour.reject_deletes -= 1;
+                    -1
+                } else {
+                    0
+                };
+                out = reply_head("ip_route_add_del_reply");
+                IpRouteAddDelReply {
+                    context: ctx,
+                    retval,
+                    stats_index: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_neighbor_add_del" => {
+                let mut d = Decoder::new(&req);
+                let n = IpNeighborAddDel::decode(&mut d).expect("decodes as a neighbour op");
+                let _ = tx.send(Event::Neighbour {
+                    sw_if_index: n.neighbor.sw_if_index,
+                    mac: n.neighbor.mac_address,
+                    flags: n.neighbor.flags,
+                });
+                out = reply_head("ip_neighbor_add_del_reply");
+                IpNeighborAddDelReply {
+                    context: ctx,
+                    retval: 0,
+                    stats_index: 0,
+                }
+                .encode(&mut out);
+            }
+            "ip_route_lookup" => {
+                out = reply_head("ip_route_lookup_reply");
+                IpRouteLookupReply {
+                    context: ctx,
+                    retval: 0,
+                    route: IpRoute {
+                        table_id: 0,
+                        stats_index: 0,
+                        prefix: prefix_of(v4(10, 0)),
+                        n_paths: 1,
+                        paths: vec![path_on(ASSIGNED_INDEX)],
+                    },
+                }
+                .encode(&mut out);
+            }
+            // DUMP: one details frame per interface, no terminator — the
+            // trailing control_ping's reply ends the stream, as VPP does.
+            "sw_interface_dump" => {
+                let mut d = reply_head("sw_interface_details");
+                details(ASSIGNED_INDEX, "octeon0/0", 3, ctx).encode(&mut d);
+                write_frame(sock, &d);
+                continue;
+            }
+            "control_ping" => {
+                out = reply_head("control_ping_reply");
+                ControlPingReply {
+                    context: ctx,
+                    retval: 0,
+                    vpe_pid: 4242,
+                }
+                .encode(&mut out);
+            }
+            other => panic!("fake got unexpected message {other}"),
+        }
+        write_frame(sock, &out);
+    }
+}
+
+fn details(sw_if_index: u32, name: &str, flags: u32, context: u32) -> SwInterfaceDetails {
+    SwInterfaceDetails {
+        context,
+        sw_if_index,
+        sup_sw_if_index: sw_if_index,
+        l2_address: [0u8; 6],
+        flags,
+        r#type: 0,
+        link_duplex: 0,
+        link_speed: 2_500_000,
+        link_mtu: 9000,
+        mtu: [9000, 0, 0, 0],
+        sub_id: 0,
+        sub_number_of_tags: 0,
+        sub_outer_vlan_id: 0,
+        sub_inner_vlan_id: 0,
+        sub_if_flags: 0,
+        vtr_op: 0,
+        vtr_push_dot1q: 0,
+        vtr_tag1: 0,
+        vtr_tag2: 0,
+        outer_tag: 0,
+        b_dmac: [0u8; 6],
+        b_smac: [0u8; 6],
+        b_vlanid: 0,
+        i_sid: 0,
+        interface_name: name.to_string(),
+        interface_dev_type: "octeon".into(),
+        tag: String::new(),
+    }
+}
+
+fn path_on(sw_if_index: u32) -> FibPath {
+    FibPath {
+        sw_if_index,
+        table_id: 0,
+        rpf_id: 0,
+        weight: 1,
+        preference: 0,
+        r#type: 0,
+        flags: 0,
+        proto: 0,
+        nh: Default::default(),
+        n_labels: 0,
+        label_stack: Default::default(),
+    }
+}
+
+fn prefix_of(p: IpPrefix) -> packetframe_vpp_offload::vpp_api::generated::Prefix {
+    packetframe_vpp_offload::fib_sync::to_prefix(p)
+}
+
+pub fn v4(a: u8, b: u8) -> IpPrefix {
+    IpPrefix::V4 {
+        addr: [10, a, b, 0],
+        prefix_len: 24,
+    }
+}
+
+pub fn nh() -> IpAddr {
+    IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1,0 +1,234 @@
+//! The whole supervision loop against the fake VPP: `Driver` + `Runtime`
+//! + a real unix socket, host CI.
+//!
+//! Every previous test drove one layer with the others faked. This is
+//! the first composition of all of them — the driver's tick loop,
+//! the runtime's delegation, the engine's transport, the drainer's
+//! pipeline — with the only fake being VPP itself, and that fake speaks
+//! the real wire format from the same generated types.
+//!
+//! The loop harness here (`run_until`) is the same shape the attach
+//! wiring will use: tick, then drain `take_pending` into
+//! `Driver::inject`, then honour `sleep`. If that shape cannot converge
+//! a five-route table here, it cannot converge a million-route one on
+//! the router.
+
+#[path = "common/fake_vpp.rs"]
+mod fake_vpp;
+
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+use fake_vpp::{Fake, ASSIGNED_INDEX, MAC};
+use packetframe_common::fib::IpPrefix;
+use packetframe_vpp_offload::attach::PortAttach;
+use packetframe_vpp_offload::driver::Driver;
+use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
+use packetframe_vpp_offload::fib_sync::FamilyPolicy;
+use packetframe_vpp_offload::runtime::{NullStore, Runtime, SteeringUnavailable};
+use packetframe_vpp_offload::supervisor::{Event, State};
+
+struct Mirror {
+    routes: Vec<IpPrefix>,
+}
+
+impl RouteSource for Mirror {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for p in &self.routes {
+            visit(*p, &[fake_vpp::nh()]);
+        }
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        visit(fake_vpp::nh(), "eth4", MAC);
+    }
+}
+
+fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: "eth4".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec!["eth4".into()],
+        1_000_000,
+        FamilyPolicy::V4Only,
+    );
+    let mirror = Mirror {
+        routes: (0..n_routes).map(|i| fake_vpp::v4(0, i)).collect(),
+    };
+    Runtime::new(
+        engine,
+        Box::new(mirror),
+        Box::new(SteeringUnavailable),
+        Box::new(NullStore),
+        "/usr/bin/vpp",
+        "/tmp/startup.conf",
+    )
+}
+
+/// The production loop shape: tick, inject completed work, honour the
+/// sleep by advancing the clock. Bounded so a loop that cannot settle
+/// fails instead of hanging CI.
+fn run_until(
+    d: &mut Driver,
+    rt: &Runtime,
+    mut now: Instant,
+    stop: impl Fn(&Driver) -> bool,
+) -> (Instant, Vec<Event>) {
+    let (mut obs, mut fx) = rt.views();
+    let mut seen = Vec::new();
+    for _ in 0..256 {
+        if stop(d) {
+            return (now, seen);
+        }
+        let t = d.tick(now, &mut obs, &mut fx);
+        seen.extend(t.events.clone());
+        for e in rt.take_pending() {
+            // inject() reports the event back in its own Tick.events,
+            // so extending with those alone counts each exactly once.
+            let it = d.inject(now, e, &mut fx);
+            seen.extend(it.events);
+        }
+        rt.set_steered(d.supervisor().is_steered());
+        // Advance by the permitted sleep, floored so time always moves.
+        now += t
+            .sleep
+            .unwrap_or(Duration::from_millis(100))
+            .max(Duration::from_millis(1));
+    }
+    panic!("loop did not reach the stop condition; events: {seen:?}");
+}
+
+/// Adoption → attach → resync → verify → Ready, end to end, with the
+/// verdict travelling through `take_pending` exactly as the real loop
+/// will carry it.
+#[test]
+fn the_full_loop_converges_an_adopted_vpp_to_ready() {
+    let fake = Fake::start("loop");
+    let rt = runtime_for(&fake, 5);
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    // The attach wiring connects and confirms the API answers before it
+    // injects the adoption — an adopted VPP whose socket is dead is not
+    // one to adopt. Mirror that here.
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    assert_eq!(d.state(), State::Syncing);
+
+    let (_, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+
+    // The verdict must have arrived through the pending seam.
+    assert!(
+        events.contains(&Event::SyncComplete),
+        "the drain reported completion: {events:?}"
+    );
+    assert!(
+        events.contains(&Event::VerifyPassed),
+        "the verdict was injected: {events:?}"
+    );
+    assert!(
+        !d.supervisor().is_steered(),
+        "an unsteered adoption waits for the operator's canary"
+    );
+
+    // And the table is really in the fake, on the index VPP assigned.
+    let status = rt.status();
+    assert_eq!(status.counts.installed, 5);
+    assert!(!status.counts.blocks_first_steer());
+    let routes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(routes.len(), 5);
+    assert!(routes
+        .iter()
+        .all(|r| r.path_indices == vec![ASSIGNED_INDEX]));
+}
+
+/// A drain that dies mid-resync must fail convergence, deliver the
+/// abort acknowledgement, and reach a retryable state — not spin, not
+/// hang, not absorb the error.
+///
+/// The retry itself goes through `Spawn`, which host CI cannot perform
+/// (there is no VPP binary, and on non-Linux the process handle is an
+/// ENOSYS stub) — so this asserts the failure path up to and including
+/// the retry *attempt*, and full crash-recovery with a respawn stays
+/// hardware territory alongside the failover drills.
+#[test]
+fn a_broken_socket_mid_resync_fails_convergence_and_retries() {
+    // Hang up after 2 route ops, once; later connections behave.
+    let fake = Fake::start_with("loop-hangup", 2);
+    let rt = runtime_for(&fake, 8);
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+
+    let (_, events) = run_until(&mut d, &rt, t0, |d| {
+        d.supervisor().failures() > 0 && d.state() != State::Syncing
+    });
+
+    assert!(
+        events.contains(&Event::ConvergenceFailed),
+        "the hangup must be reported, not absorbed: {events:?}"
+    );
+    assert!(
+        events.contains(&Event::ConvergenceStopped),
+        "the abort must be acknowledged, or may_restart never clears: {events:?}"
+    );
+
+    let first_failures = d.supervisor().failures();
+    assert!(first_failures > 0);
+    // Drive on from a clock past the backoff deadline until the retry
+    // is attempted and itself fails (a second recorded failure). The
+    // state is already `Backoff` at entry, so stopping on state would
+    // stop before a single tick.
+    let (_, more) = run_until(&mut d, &rt, t0 + Duration::from_secs(60), |d| {
+        d.supervisor().failures() > first_failures
+    });
+    let all: Vec<_> = events.iter().chain(more.iter()).cloned().collect();
+    assert!(
+        more.contains(&Event::BackoffElapsed),
+        "the backoff must fire a retry: {all:?}"
+    );
+    assert!(
+        all.contains(&Event::SpawnFailed),
+        "host CI has no VPP to spawn, and that must be reported as \
+         SpawnFailed — not sat on: {all:?}"
+    );
+
+    // Nothing was silently lost: the routes the hangup interrupted are
+    // still owed, so a real respawn would converge them.
+    let status = rt.status();
+    assert!(
+        status.pending_ops > 0,
+        "unacknowledged work must still be pending after the failure"
+    );
+    assert!(
+        status.counts.installed <= 2,
+        "only routes the fake acknowledged before hanging up may count"
+    );
+}


### PR DESCRIPTION
The last layer of pure wiring before `Module::attach()`: `Observe` and `Effects` implemented by delegation to the real machinery — `VppProcess`, `ConvergenceEngine`, and a `Steering` seam for slice 5.

## The structural problem

`Driver::tick` takes the two traits as separate `&mut` receivers — right for tests, right conceptually. But in the real system both terminate in the same state: the engine owns the socket that `ping` (observe) and `start_resync` (effect) both use. `Runtime::views()` yields two views over a `RefCell` core; sound because the driver's call pattern is strictly sequential, and a re-entrant borrow panic would mean the driver broke that contract — a loud panic being the correct report.

## Decisions, each from the failure it prevents

- **Persist-or-kill at spawn.** Identity is recorded the moment the child exists; if recording fails the child is killed and the spawn reported failed. A VPP whose identity is not on disk cannot be adopted after a daemon restart — it survives as an orphan holding the VF.
- **The steering placeholder refuses both directions.** Refusing `unsteer` is the load-bearing half: `Ok` becomes `Unsteered`, which clears `steered` and unblocks resource release — faking it would free a VF that rules from a previous run may still target.
- **Verdicts travel through `take_pending` → `Driver::inject`**, never applied from inside an Effects call. `abort_convergence` delivers `ConvergenceStopped` the same way — nothing else ever emits it, and without it `may_restart` is false forever.
- **`MustLeak` keeps the process handle** — the pidfd is the only observer that will ever report the late exit.
- **`release_resources` refuses** rather than no-ops: acquisition is owned by the attach wiring, which does not exist yet, and "freed" without an owner is the requested-vs-observed bug in its purest form.

## The payoff test

[tests/vpp_runtime.rs](crates/modules/vpp-offload/tests/vpp_runtime.rs): **the first composition of every merged layer** — driver tick loop, runtime delegation, engine transport, drainer pipeline — with the only fake being VPP itself, on a real unix socket, host CI:

- an adopted VPP converges to `Ready` end to end, routes landing on the index VPP assigned, verdict travelling the pending seam
- a socket hangup mid-resync fails convergence, delivers the abort ack, backs off and retries, with the interrupted work still owed

The fake moved to `tests/common/fake_vpp.rs` so this did not become a fourth divergent copy (migrating the older two harnesses onto it is recorded follow-up).

**Honestly scoped:** recovery-with-respawn is not asserted on host — the retry goes through `Spawn`, host CI has no VPP binary, and non-Linux process handles are ENOSYS stubs. That stays hardware territory with the failover drills. Two Linux-gated tests (spawn `/bin/true`, pidfd exit observation, persist-or-kill) run in the qemu matrix.

## Still not wired

`Module::attach()` — resource acquisition, the state file behind `IdentityStore`, the route feed. Next PR.

505 workspace tests pass; fmt + clippy clean on host and all four cross targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)