### PR TITLE
feat(vpp-offload): the supervision service — the loop on a thread, honestly stoppable

### DIFF
--- a/crates/common/src/module.rs
+++ b/crates/common/src/module.rs
@@ -184,6 +184,27 @@ impl<'a> MetricsWriter<'a> {
 /// modules so the loader can drive them polymorphically; see SPEC.md §3.2 for
 /// the per-method contract (notably: `detach` must complete in under 1s, and
 /// `reconfigure` must not reload programs, only mutate maps).
+///
+/// ## What the `detach` deadline requires
+///
+/// It bounds **returning**, not finishing. A module whose teardown cannot
+/// complete in time must return inside the deadline and report what is
+/// still held — never block the loader past it.
+///
+/// The distinction became load-bearing with vpp-offload, whose teardown
+/// legitimately cannot fit: it supervises a process on VFIO/DMA, where
+/// SIGKILL may not bite at all, and its kill path alone budgets 500 ms of
+/// SIGTERM grace plus a bounded SIGKILL wait. Reading the deadline as
+/// "finish within 1 s" leaves only two options for such a module, and both
+/// are worse than reporting: block the loader for tens of seconds, or
+/// release a VF while a live process may still be DMAing into it. Reading
+/// it as "return within 1 s" keeps the loader responsive and puts the
+/// incomplete teardown on the record where an operator and the next
+/// `detach --all` can act on it.
+///
+/// This is a clarification of an existing requirement rather than a change
+/// to it: no method signature moves, and a module that genuinely finishes
+/// in time is unaffected.
 pub trait Module: Send + Sync {
     fn name(&self) -> &'static str;
 

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -139,6 +139,20 @@ impl Driver {
         &self.sup
     }
 
+    /// The API's liveness as the health surface classifies it, from
+    /// the driver's own detector and budget selection.
+    ///
+    /// Lives here because the detector is deliberately private: it must
+    /// not exist before the first pong, and exposing it raw invites a
+    /// caller to consult it in exactly that window. The budget comes
+    /// from the same `budget_for` the wedge decision uses, so status
+    /// can never disagree with the detector about what "too silent"
+    /// means.
+    pub fn api_health(&self, now: Instant) -> crate::status::ApiHealth {
+        let budget = budget_for(self.sup.is_steered(), self.sup.is_converging());
+        crate::status::ApiHealth::observe(self.sup.state(), self.detector.as_ref(), now, budget)
+    }
+
     /// Feed an externally-sourced event (an operator's start/stop, an
     /// adoption) and run its actions.
     pub fn inject(&mut self, now: Instant, event: Event, fx: &mut dyn Effects) -> Tick {

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -1054,6 +1054,43 @@ mod tests {
         );
     }
 
+    /// `on_process_gone` clears the last verify verdict, and it must —
+    /// the verdict describes a FIB that died with the instance.
+    ///
+    /// Pinned because the supervision loop depends on it in the awkward
+    /// direction: `VerifyFailed`'s own teardown kills the process, so the
+    /// engine erases the verdict as a side effect of acting on it. The
+    /// loop therefore keeps its own copy, captured before the injection
+    /// (see `service::run_loop`), and without that a completed, failed
+    /// verification was reported as "never verified" — a concrete failure
+    /// summary replaced by something indistinguishable from a VPP still
+    /// converging. If this clearing is ever removed, the retention in the
+    /// loop becomes redundant rather than load-bearing; this test is where
+    /// that shows up.
+    #[test]
+    fn a_dead_process_takes_its_verify_verdict_with_it() {
+        let mut e = ConvergenceEngine::new(
+            "/nonexistent/api.sock",
+            Vec::new(),
+            vec!["eth4".into()],
+            1_000,
+            FamilyPolicy::V4Only,
+        );
+        e.last_verify = Some(crate::verify::VerifyOutcome {
+            sampled: 4,
+            mismatches: vec![],
+            unresolvable: 0,
+            withheld: 0,
+            dead_interfaces: vec![],
+        });
+        assert!(e.last_verify().is_some());
+        e.on_process_gone();
+        assert!(
+            e.last_verify().is_none(),
+            "the verdict outlived the instance it describes"
+        );
+    }
+
     /// Every operation must refuse rather than pretend when there is no
     /// socket. An engine that silently no-ops would report a converged
     /// FIB it never sent.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -44,6 +44,7 @@ pub mod process;
 pub mod resources;
 pub mod runtime;
 pub mod schedule;
+pub mod service;
 pub mod sink;
 pub mod startup_conf;
 pub mod status;

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -351,7 +351,7 @@ impl Core {
         // The exit is a fact whether or not it can be recorded; surface
         // the failure, do not block on it.
         let r = self.store.process_changed(None);
-        self.note_persist(r);
+        let _ = self.note_persist(r);
     }
 
     /// The single place a persist outcome is recorded — and the only
@@ -369,11 +369,19 @@ impl Core {
     /// write that lands makes the file current — hugepages, VFs,
     /// interface indices and process identity together. That is what
     /// makes "adoption is safe again" a fact rather than a hope.
-    fn note_persist(&mut self, r: Result<(), String>) {
-        match r {
+    /// Returns the outcome so callers that must ACT on a failure — spawn's
+    /// persist-or-kill — can still branch on it without bypassing the
+    /// recorder. The first version returned `()`, which is precisely why
+    /// `spawn` kept its own direct `store.process_changed` call and a
+    /// successful spawn-persist never cleared an earlier failure: the
+    /// helper's own doc claimed to be the single recorder while one writer
+    /// in the same file went around it.
+    fn note_persist(&mut self, r: Result<(), String>) -> Result<(), String> {
+        match &r {
             Ok(()) => self.last_store_error = None,
-            Err(e) => self.last_store_error = Some(e),
+            Err(e) => self.last_store_error = Some(e.clone()),
         }
+        r
     }
 }
 
@@ -453,9 +461,12 @@ impl Effects for EffectsView {
             start_ticks: p.start_ticks(),
             boot_id: Some(boot_id),
         };
-        if let Err(e) = c.store.process_changed(Some(identity)) {
-            // Persist-or-kill: a VPP whose identity is not on disk
-            // cannot be adopted after a daemon restart.
+        // Through `note_persist`, not around it: a spawn that persists
+        // successfully must also CLEAR any earlier failure, since the save
+        // is whole-record. Persist-or-kill still applies — a VPP whose
+        // identity is not on disk cannot be adopted after a daemon restart.
+        let recorded = c.store.process_changed(Some(identity));
+        if let Err(e) = c.note_persist(recorded) {
             return Err(c.abandon_spawn(p, format!("could not record it: {e}")));
         }
         c.process = Some(p);
@@ -505,7 +516,7 @@ impl Effects for EffectsView {
         // a success here CLEARS an earlier failure, since the save is
         // whole-record (see `note_persist`).
         let r = c.store.interfaces_attached(&indices);
-        c.note_persist(r);
+        let _ = c.note_persist(r);
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -348,10 +348,31 @@ impl Core {
         self.process = None;
         self.attach_mode = crate::attach::AttachMode::Fresh;
         self.engine.on_process_gone();
-        if let Err(e) = self.store.process_changed(None) {
-            // The exit is a fact whether or not it can be recorded;
-            // surface the failure, do not block on it.
-            self.last_store_error = Some(e);
+        // The exit is a fact whether or not it can be recorded; surface
+        // the failure, do not block on it.
+        let r = self.store.process_changed(None);
+        self.note_persist(r);
+    }
+
+    /// The single place a persist outcome is recorded — and the only
+    /// place it is cleared.
+    ///
+    /// Clearing on success matters because the degradation is otherwise
+    /// permanent: `last_store_error` was set on every failure and never
+    /// reset, so one transient failure (a briefly read-only state dir, a
+    /// full filesystem) kept the module out of `nominal()` for the life of
+    /// the service even after the record became durable again.
+    ///
+    /// And a single successful write really does restore the whole
+    /// record: [`crate::acquire::FileStore`] saves the entire
+    /// `ResourceState` on every observation rather than a delta, so any
+    /// write that lands makes the file current — hugepages, VFs,
+    /// interface indices and process identity together. That is what
+    /// makes "adoption is safe again" a fact rather than a hope.
+    fn note_persist(&mut self, r: Result<(), String>) {
+        match r {
+            Ok(()) => self.last_store_error = None,
+            Err(e) => self.last_store_error = Some(e),
         }
     }
 }
@@ -477,14 +498,14 @@ impl Effects for EffectsView {
         let mode = c.attach_mode;
         c.engine.attach_devices(mode).map_err(|e| e.to_string())?;
         let indices = c.engine.attached_indices();
-        if let Err(e) = c.store.interfaces_attached(&indices) {
-            // Unlike spawn, do not tear anything down: the interfaces
-            // exist and work. The cost of a lost record is one refused
-            // adoption after a daemon restart (UnknownIndexOnAdopt →
-            // clean restart), which is the designed safe fallback.
-            // Surfaced, not fatal.
-            c.last_store_error = Some(e);
-        }
+        // Unlike spawn, do not tear anything down: the interfaces exist
+        // and work. The cost of a lost record is one refused adoption
+        // after a daemon restart (UnknownIndexOnAdopt → clean restart),
+        // which is the designed safe fallback. Surfaced, not fatal — and
+        // a success here CLEARS an earlier failure, since the save is
+        // whole-record (see `note_persist`).
+        let r = c.store.interfaces_attached(&indices);
+        c.note_persist(r);
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -88,6 +88,17 @@ pub struct Published {
     /// The teardown declined to release resources (unsteer failed or
     /// the process survived); they are deliberately still held.
     pub resources_leaked: bool,
+    /// Failures from the most recent ORDINARY tick — a missing VPP
+    /// binary, a refused device attach, a broken resync. The supervisor
+    /// only counts these ("restarting after N failures"); the actionable
+    /// reason lives here and nowhere else, so dropping it left an
+    /// operator watching a retry loop with no way to learn why.
+    pub last_failures: Vec<String>,
+    /// The runtime could not persist something it observed. Not fatal
+    /// to convergence by design — but it means the next daemon restart
+    /// will refuse adoption, so it degrades health rather than passing
+    /// silently.
+    pub store_error: Option<String>,
 }
 
 /// Shared between the loop and the module.
@@ -226,7 +237,8 @@ fn run_loop(
                    last_verify_at: &Option<Instant>,
                    terminal: &Option<String>,
                    teardown_failures: &[String],
-                   resources_leaked: bool| {
+                   resources_leaked: bool,
+                   last_failures: &[String]| {
         let now = Instant::now();
         let rs = runtime.status();
         let fib = match (&rs.last_verify, last_verify_at) {
@@ -242,14 +254,41 @@ fn run_loop(
             fib,
             rs.port_links,
         );
+        // A store failure is a real degradation: convergence continues
+        // (correctly — the interfaces work), but the next daemon
+        // restart will refuse adoption because the index it needs was
+        // never persisted. Reporting Healthy over that would hide a
+        // problem whose consequence only appears at the worst moment.
+        let mut report = snap.report();
+        if let Some(e) = &rs.store_error {
+            report.overall = match report.overall {
+                packetframe_common::module::HealthState::Healthy => {
+                    packetframe_common::module::HealthState::Degraded
+                }
+                other => other,
+            };
+            report
+                .subsystems
+                .push(packetframe_common::module::SubsystemHealth {
+                    name: "state-file".into(),
+                    state: packetframe_common::module::HealthState::Degraded,
+                    message: Some(format!(
+                        "could not persist observed state ({e}); a daemon restart will \
+                     refuse adoption and cycle VPP instead"
+                    )),
+                    last_success_age_seconds: None,
+                });
+        }
         let published = Published {
-            report: snap.report(),
+            report,
             metrics: crate::status::render_metrics(&snap, module),
             state: driver.state(),
             api_error: rs.api_error,
             terminal: terminal.clone(),
             teardown_failures: teardown_failures.to_vec(),
             resources_leaked,
+            last_failures: last_failures.to_vec(),
+            store_error: rs.store_error,
         };
         *shared.latest.lock().expect("status lock") = Some(published);
     };
@@ -257,7 +296,7 @@ fn run_loop(
     // First snapshot before the first tick; the handshake below is
     // what makes `start()`'s "status() is Some on return" guarantee
     // actually true rather than a race the test suite happens to win.
-    publish(&driver, &runtime, &last_verify_at, &None, &[], false);
+    publish(&driver, &runtime, &last_verify_at, &None, &[], false, &[]);
     let _ = ready.send(Ok(()));
 
     while !shared.stop.load(Ordering::SeqCst) {
@@ -298,7 +337,24 @@ fn run_loop(
             ));
             break;
         }
-        publish(&driver, &runtime, &last_verify_at, &terminal, &[], false);
+        // The supervisor counts failures; only the outcome carries WHY.
+        // Republished every pass so a retry loop is diagnosable from
+        // status alone, which is all an operator on the box has.
+        let failures: Vec<String> = tick
+            .outcome
+            .failures
+            .iter()
+            .map(|(action, why)| format!("{action:?}: {why}"))
+            .collect();
+        publish(
+            &driver,
+            &runtime,
+            &last_verify_at,
+            &terminal,
+            &[],
+            false,
+            &failures,
+        );
 
         match tick.sleep {
             Some(d) if d.is_zero() => {} // more work queued; go again
@@ -354,6 +410,7 @@ fn run_loop(
         &terminal,
         &teardown_failures,
         resources_leaked,
+        &[],
     );
 }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -54,6 +54,12 @@ const STOP_POLL_CAP: Duration = Duration::from_millis(50);
 /// the final published status says which.
 const STOP_PATIENCE: Duration = Duration::from_secs(10);
 
+/// Cap on distinct reasons retained for one unhealthy episode.
+///
+/// Enough for a cause plus a few symptoms, small enough that a backoff loop
+/// cannot grow a `Vec` that is cloned into every published snapshot.
+const MAX_EPISODE_REASONS: usize = 8;
+
 /// How long `stop()` waits for the loop before returning with an
 /// unfinished teardown on the record.
 ///
@@ -410,13 +416,40 @@ fn expire_verdict(
     }
     if let Some(v) = last_verify.take() {
         if !v.passed() {
-            let summary = format!("Verify: {}", v.summary());
-            if !last_failures.contains(&summary) {
-                last_failures.push(summary);
-            }
+            // Through `remember_failures` like every other writer. This
+            // one used to append directly while the tick paths assigned,
+            // so whether the verify reason survived depended on ordering.
+            remember_failures(last_failures, vec![format!("Verify: {}", v.summary())]);
         }
     }
     *last_verify_at = None;
+}
+
+/// Add reasons for the CURRENT unhealthy episode, keeping the earliest as
+/// well as the latest.
+///
+/// One operation, because there were three writers with two different
+/// semantics: `expire_verdict` appended a failed verify's summary while the
+/// tick paths assigned, so whether the root cause survived depended on
+/// which happened last. A failed verify followed by a failed respawn would
+/// report only "cannot spawn" — losing the reason the restart was happening
+/// at all.
+///
+/// Accumulating rather than replacing is the right default here because an
+/// episode has a cause and a symptom and an operator needs both, but it is
+/// bounded: `MAX_EPISODE_REASONS` distinct entries, deduplicated, because a
+/// long backoff loop would otherwise append the same spawn failure forever
+/// into a `Vec` published on every tick. The episode ends — and the list is
+/// cleared — when health returns to `Healthy`.
+fn remember_failures(into: &mut Vec<String>, new: Vec<String>) {
+    for reason in new {
+        if into.len() >= MAX_EPISODE_REASONS {
+            return;
+        }
+        if !into.contains(&reason) {
+            into.push(reason);
+        }
+    }
 }
 
 fn fmt_failures(outcome: &crate::executor::Outcome) -> Vec<String> {
@@ -475,10 +508,7 @@ fn run_loop(
     for e in initial {
         let now = Instant::now();
         let injected = driver.inject(now, e, &mut fx);
-        let f = fmt_failures(&injected.outcome);
-        if !f.is_empty() {
-            last_failures = f;
-        }
+        remember_failures(&mut last_failures, fmt_failures(&injected.outcome));
     }
 
     // Returns the overall health it published, which is what decides
@@ -622,9 +652,7 @@ fn run_loop(
         // reason on the very next tick. `Healthy` is the condition that
         // actually covers every way this module can be unwell, because it
         // is the same whitelist `nominal()` applies.
-        if !failures.is_empty() {
-            last_failures = failures;
-        }
+        remember_failures(&mut last_failures, failures);
 
         // One call, one rule. See `expire_verdict`.
         expire_verdict(

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -339,13 +339,36 @@ impl SupervisionService {
 }
 
 impl Drop for SupervisionService {
+    /// **Deliberately does not tear anything down.**
+    ///
+    /// The loader's SIGTERM/SIGINT path is `drop(modules)`, and it means
+    /// that literally: SPEC.md §7.3/§8.5 exit *without* detaching, so the
+    /// dataplane survives a daemon restart. For the eBPF modules that works
+    /// because bpffs pins hold the kernel references. For this one it works
+    /// because VPP is a separate process that a later daemon adopts —
+    /// which is drill (d) in the plan: restart packetframe with VPP alive,
+    /// adopt, dirty-resync, WITHOUT unsteering, zero loss.
+    ///
+    /// This used to set the stop flag, which raced that: if the supervision
+    /// thread got scheduled before the process exited it would unsteer and
+    /// kill the very VPP the loader was preserving, and if it did not the
+    /// attachment survived. Same signal, two different outcomes, decided by
+    /// the scheduler — and the losing case is a blackhole plus a full
+    /// reconvergence on the next start.
+    ///
+    /// So teardown has exactly one entrance: [`SupervisionService::stop`],
+    /// which `Module::detach` calls. A drop that still holds the thread
+    /// handle is by definition NOT that path, and is either a preserving
+    /// exit (the thread dies with the process — correct) or a caller that
+    /// dropped without detaching, which leaks one thread and is logged
+    /// rather than silently converted into a teardown.
     fn drop(&mut self) {
-        // A dropped-without-stop service still signals the loop; the
-        // thread is detached rather than joined, because blocking an
-        // arbitrary drop site for the teardown's duration is worse
-        // than letting shutdown proceed in the background. `stop()` is
-        // the orderly path and the module's detach uses it.
-        self.shared.stop.store(true, Ordering::SeqCst);
+        if self.thread.is_some() {
+            tracing::info!(
+                "vpp-offload supervision dropped without stop(); VPP is left running and \
+                 adoptable (§8.5 preserve-on-exit). `packetframe detach` is what tears it down."
+            );
+        }
     }
 }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -54,16 +54,35 @@ const STOP_POLL_CAP: Duration = Duration::from_millis(50);
 /// the final published status says which.
 const STOP_PATIENCE: Duration = Duration::from_secs(10);
 
-/// Marker prefixed to the error from a pre-publish panic.
+/// Marker prefixed to any error meaning **a VPP may still be running and
+/// holding its VF and hugepages**.
 ///
 /// Exists so a caller can distinguish "attach failed and left nothing
 /// behind" from "attach failed and may have left a live VPP holding a VF".
 /// The two demand opposite handling: the first should roll back, the second
 /// must NOT, because releasing a VF under a process that can still DMA
-/// through it is worse than leaking it. Matching on a string is crude, and
-/// preferable to the alternative that was there — a generic message that
-/// made the distinction invisible.
-pub const PANIC_MAY_HOLD_RESOURCES: &str = "SUPERVISION PANIC (resources may be held)";
+/// through it is worse than leaking it.
+///
+/// Two producers, and it started with only one. The pre-publish panic path
+/// sets it here. But a **factory** must set it too, on any error it returns
+/// after it has adopted or spawned a VPP — an adoption that fails partway
+/// (an unreadable boot id, a pidfd that will not open) leaves the recorded
+/// process running exactly as a panic does, and forwarding that as an
+/// ordinary error let the caller roll back and unbind the VF underneath it.
+/// [`may_hold_resources`] is the check; use it rather than re-spelling the
+/// prefix.
+pub const MAY_HOLD_RESOURCES: &str = "RESOURCES MAY BE HELD";
+
+/// Whether an error from [`SupervisionService::start`] means resources may
+/// still be held.
+///
+/// A function rather than leaving callers to `starts_with` by hand: the one
+/// caller that must branch on this is deciding whether to unbind a VF, and
+/// a check spelled slightly differently at a second call site fails open
+/// into memory corruption.
+pub fn may_hold_resources(e: &str) -> bool {
+    e.starts_with(MAY_HOLD_RESOURCES)
+}
 
 /// Cap on distinct reasons retained for one unhealthy episode.
 ///
@@ -353,13 +372,13 @@ impl SupervisionService {
                 // reach it. The only remedy is telling the operator, in
                 // words that say what to do.
                 //
-                // `PANIC_MAY_HOLD_RESOURCES` is a marker the caller can
+                // `MAY_HOLD_RESOURCES` is a marker the caller can
                 // match on: `bring_up`'s rollback must NOT release VFs and
                 // hugepages after this, because releasing them under a live
                 // VPP is the DMA hazard the whole `MustLeak` path exists to
                 // avoid.
                 Err(format!(
-                    "{PANIC_MAY_HOLD_RESOURCES}: the supervision loop panicked before \
+                    "{MAY_HOLD_RESOURCES}: the supervision loop panicked before \
                      publishing its first status (see the log). If it had already adopted \
                      or started VPP, that process is STILL RUNNING and still holds its VF \
                      and hugepages — nothing here can reach it any more. Run `packetframe \
@@ -989,6 +1008,47 @@ mod tests {
         assert!(err.contains("API mismatch"), "{err}");
     }
 
+    /// A factory error carrying the marker survives to the caller, so a
+    /// rollback can be suppressed.
+    ///
+    /// The pre-publish panic is not the only way a failed attach can leave a
+    /// live VPP: a factory that adopted a recorded process and THEN failed —
+    /// an unreadable boot id, a pidfd that will not open — leaves it running
+    /// just the same. `start` forwards factory errors verbatim, so the
+    /// marker has to survive that forwarding for the distinction to reach
+    /// the caller who decides whether to unbind a VF.
+    #[test]
+    fn a_marked_factory_error_reaches_the_caller_intact() {
+        let err = SupervisionService::start(
+            "vpp-offload",
+            Box::new(|| {
+                Err(format!(
+                    "{MAY_HOLD_RESOURCES}: adopted pid 4242, then failed"
+                ))
+            }),
+        )
+        .err()
+        .expect("start must fail");
+        assert!(
+            may_hold_resources(&err),
+            "the caller cannot tell this from a clean failure and will roll back: {err}"
+        );
+        assert!(err.contains("adopted pid 4242"), "{err}");
+    }
+
+    /// An ordinary factory error must NOT be marked, or every failed attach
+    /// would leak its VF rather than rolling back.
+    #[test]
+    fn an_ordinary_factory_error_is_not_marked() {
+        let err = SupervisionService::start(
+            "vpp-offload",
+            Box::new(|| Err("API mismatch for `ip_route_add_del`".into())),
+        )
+        .err()
+        .expect("start must fail");
+        assert!(!may_hold_resources(&err), "{err}");
+    }
+
     /// A pre-publish panic must SAY that resources may be held.
     ///
     /// The twin of the post-publish panic path, and it was left uncovered
@@ -1007,7 +1067,7 @@ mod tests {
         .err()
         .expect("start must fail");
         assert!(
-            err.starts_with(PANIC_MAY_HOLD_RESOURCES),
+            err.starts_with(MAY_HOLD_RESOURCES),
             "the caller cannot distinguish this from a clean failure: {err}"
         );
         assert!(err.contains("STILL RUNNING"), "{err}");

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1,0 +1,276 @@
+//! The supervision service: the loop, on its own thread, with a stop
+//! switch and a status window.
+//!
+//! `Module::attach()` cannot run the tick loop inline — `attach` must
+//! return while supervision continues for the life of the attachment —
+//! so this owns the thread. Everything inside is machinery that already
+//! exists ([`Driver`], [`Runtime`]); the service adds exactly three
+//! things: the real clock, the stop protocol, and a continuously
+//! published [`HealthReport`] + metrics snapshot for
+//! `health_check`/`sample_metrics` to read without touching the loop.
+//!
+//! ## Construction happens ON the loop thread
+//!
+//! [`Runtime`] is deliberately `!Send` (its two trait views share an
+//! `Rc<RefCell>` core), so the service takes a **factory** and calls it
+//! from inside the spawned thread. That is not a workaround; it is the
+//! ownership story stated in types: the loop thread is the only thing
+//! that may ever drive the runtime, and handing a built one across
+//! threads would be the lie the `Rc` exists to prevent.
+//!
+//! ## The stop protocol
+//!
+//! `stop()` flips the flag; the loop then injects `StopRequested` —
+//! which the supervisor turns into the full teardown ordering
+//! (unsteer-if-steered → abort convergence → kill → release) — and
+//! keeps ticking until the machine settles in `Stopped` or the bounded
+//! patience runs out (an undead VPP can legitimately refuse to die,
+//! and a detach that hangs forever on it would be worse than one that
+//! reports it). The final status is published either way, so the
+//! caller can see exactly what the shutdown left behind.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
+
+use packetframe_common::module::HealthReport;
+
+use crate::driver::Driver;
+use crate::runtime::Runtime;
+use crate::status::{FibSync, StatusSnapshot};
+use crate::supervisor::{Event, State};
+
+/// Ceiling on any single sleep, so the stop flag is honoured promptly
+/// even when the schedule would otherwise permit a long doze. This is
+/// a bounded sleep, not a busy loop: at worst ~20 wakeups/second while
+/// completely idle, each a flag check and nothing more.
+const STOP_POLL_CAP: Duration = Duration::from_millis(50);
+
+/// How long `stop()` waits for the teardown to settle before giving up
+/// on the loop. Covers the kill path's worst honest case (SIGTERM
+/// grace + bounded SIGKILL wait) with margin; past it, either the
+/// machine is `Stopped` or something (an undead VPP) is refusing, and
+/// the final published status says which.
+const STOP_PATIENCE: Duration = Duration::from_secs(10);
+
+/// What the loop publishes after every pass.
+#[derive(Debug, Clone)]
+pub struct Published {
+    pub report: HealthReport,
+    /// Rendered `packetframe_vpp_*` gauges, ready for the textfile
+    /// exporter.
+    pub metrics: String,
+    /// The supervision state at publish time, for `packetframe status`.
+    pub state: State,
+}
+
+/// Shared between the loop and the module.
+struct Shared {
+    stop: AtomicBool,
+    latest: Mutex<Option<Published>>,
+}
+
+/// Handle to a running supervision loop.
+pub struct SupervisionService {
+    shared: Arc<Shared>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl SupervisionService {
+    /// Spawn the loop. `factory` runs on the new thread and builds the
+    /// non-`Send` pieces there; `initial` is injected before the first
+    /// tick (a `StartRequested`, or `Adopted { steered }` when the
+    /// attach wiring adopted a process — in which case it MUST also
+    /// have called `Runtime::adopt_process` inside the factory).
+    ///
+    /// `module` labels the published metrics.
+    /// Blocks until the loop has published its first snapshot, so a
+    /// successful return GUARANTEES `status()` is `Some` — and a
+    /// factory that dies (bad socket, failed adoption) surfaces here,
+    /// synchronously, as the attach failure it is, rather than as a
+    /// mysteriously dead thread discovered on the first health check.
+    pub fn start(
+        module: &'static str,
+        factory: Box<dyn FnOnce() -> (Driver, Runtime, Vec<Event>) + Send>,
+    ) -> Result<Self, String> {
+        let shared = Arc::new(Shared {
+            stop: AtomicBool::new(false),
+            latest: Mutex::new(None),
+        });
+        let looped = Arc::clone(&shared);
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+        let thread = std::thread::Builder::new()
+            .name("vpp-supervision".into())
+            .spawn(move || run_loop(module, factory, &looped, ready_tx))
+            .map_err(|e| format!("spawning the supervision thread: {e}"))?;
+        // A dropped sender (the factory panicked before the first
+        // publish) turns this into RecvError — the failure is reaped
+        // and reported here instead of leaking a dead thread.
+        if ready_rx.recv().is_err() {
+            let _ = thread.join();
+            return Err(
+                "the supervision loop died before publishing its first status — the \
+                 factory failed (see the panic in the log)"
+                    .into(),
+            );
+        }
+        Ok(Self {
+            shared,
+            thread: Some(thread),
+        })
+    }
+
+    /// The most recent snapshot, if the loop has completed a pass.
+    pub fn status(&self) -> Option<Published> {
+        self.shared.latest.lock().expect("status lock").clone()
+    }
+
+    /// Request shutdown and wait for the loop to finish its teardown.
+    ///
+    /// Consumes the handle: there is nothing meaningful to do with a
+    /// service after stopping it except read the final status, which
+    /// is returned.
+    pub fn stop(mut self) -> Option<Published> {
+        self.shared.stop.store(true, Ordering::SeqCst);
+        if let Some(t) = self.thread.take() {
+            // A panicked loop already published nothing further; the
+            // join error carries no more than the panic message the
+            // thread printed, so it is not propagated as a second
+            // panic here.
+            let _ = t.join();
+        }
+        self.status()
+    }
+
+    /// Whether the loop thread is still running. `false` after `stop`,
+    /// and — importantly — after a panic: a dead loop means nothing is
+    /// supervising VPP, which the caller must surface rather than keep
+    /// reporting the last published (now frozen) status as current.
+    pub fn is_alive(&self) -> bool {
+        self.thread.as_ref().is_some_and(|t| !t.is_finished())
+    }
+}
+
+impl Drop for SupervisionService {
+    fn drop(&mut self) {
+        // A dropped-without-stop service still signals the loop; the
+        // thread is detached rather than joined, because blocking an
+        // arbitrary drop site for the teardown's duration is worse
+        // than letting shutdown proceed in the background. `stop()` is
+        // the orderly path and the module's detach uses it.
+        self.shared.stop.store(true, Ordering::SeqCst);
+    }
+}
+
+fn run_loop(
+    module: &'static str,
+    factory: Box<dyn FnOnce() -> (Driver, Runtime, Vec<Event>) + Send>,
+    shared: &Shared,
+    ready: std::sync::mpsc::Sender<()>,
+) {
+    let (mut driver, runtime, initial) = factory();
+    let (mut obs, mut fx) = runtime.views();
+    // When the last passing verify was observed, for the freshness the
+    // health surface reports. Tracked here because `VerifyOutcome`
+    // deliberately carries no clock.
+    let mut last_verify_at: Option<Instant> = None;
+
+    for e in initial {
+        let now = Instant::now();
+        let _ = driver.inject(now, e, &mut fx);
+    }
+
+    let publish = |driver: &Driver, runtime: &Runtime, last_verify_at: &Option<Instant>| {
+        let now = Instant::now();
+        let rs = runtime.status();
+        let fib = match (&rs.last_verify, last_verify_at) {
+            (Some(outcome), Some(at)) => FibSync::from_outcome(outcome, now - *at),
+            _ => FibSync::NeverVerified,
+        };
+        let snap = StatusSnapshot::observe_parts(
+            driver.supervisor(),
+            rs.counts,
+            rs.pending_ops,
+            rs.parked_ops,
+            driver.api_health(now),
+            fib,
+            rs.port_links,
+        );
+        let published = Published {
+            report: snap.report(),
+            metrics: crate::status::render_metrics(&snap, module),
+            state: driver.state(),
+        };
+        *shared.latest.lock().expect("status lock") = Some(published);
+    };
+
+    // First snapshot before the first tick; the handshake below is
+    // what makes `start()`'s "status() is Some on return" guarantee
+    // actually true rather than a race the test suite happens to win.
+    publish(&driver, &runtime, &last_verify_at);
+    let _ = ready.send(());
+
+    while !shared.stop.load(Ordering::SeqCst) {
+        let now = Instant::now();
+        let tick = driver.tick(now, &mut obs, &mut fx);
+        for e in runtime.take_pending() {
+            if matches!(e, Event::VerifyPassed) {
+                last_verify_at = Some(Instant::now());
+            }
+            let _ = driver.inject(Instant::now(), e, &mut fx);
+        }
+        runtime.set_steered(driver.supervisor().is_steered());
+        publish(&driver, &runtime, &last_verify_at);
+
+        match tick.sleep {
+            Some(d) if d.is_zero() => {} // more work queued; go again
+            Some(d) => std::thread::sleep(d.min(STOP_POLL_CAP)),
+            // "Block on the fds" — this loop has no reactor, so the
+            // bounded poll interval stands in for one. The cost is one
+            // flag-check wakeup per interval while fully idle.
+            None => std::thread::sleep(STOP_POLL_CAP),
+        }
+    }
+
+    // Orderly teardown: hand the machine the stop and tick it until it
+    // settles or the bounded patience expires. `StopRequested` on an
+    // already-Stopped machine is a no-op, so the redundant case is
+    // harmless.
+    let deadline = Instant::now() + STOP_PATIENCE;
+    let _ = driver.inject(Instant::now(), Event::StopRequested, &mut fx);
+    while driver.state() != State::Stopped && Instant::now() < deadline {
+        let now = Instant::now();
+        let tick = driver.tick(now, &mut obs, &mut fx);
+        for e in runtime.take_pending() {
+            let _ = driver.inject(Instant::now(), e, &mut fx);
+        }
+        match tick.sleep {
+            Some(d) if d.is_zero() => {}
+            _ => std::thread::sleep(Duration::from_millis(10)),
+        }
+    }
+    // The final word: whatever the teardown left behind — including an
+    // undead VPP that refused to die — is on the record for the caller.
+    publish(&driver, &runtime, &last_verify_at);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A factory that dies is an ATTACH failure, reported synchronously
+    /// from `start()` — not a mysteriously dead thread discovered later
+    /// by a health check reading frozen status.
+    #[test]
+    fn a_failed_factory_fails_start_synchronously() {
+        let result = SupervisionService::start(
+            "vpp-offload",
+            Box::new(|| panic!("factory failed on purpose")),
+        );
+        let err = result
+            .err()
+            .expect("start must fail, not hand back a dead loop");
+        assert!(err.contains("died before publishing"), "{err}");
+    }
+}

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -147,6 +147,68 @@ struct Shared {
     latest: Mutex<Option<Published>>,
 }
 
+/// The one place a shutdown that did not complete is turned into a snapshot.
+///
+/// Three callers now — the detach-budget timeout, a panicked loop, and a
+/// background teardown that panics after `stop()` has already returned — and
+/// they had started to diverge at two. All three need the same three things:
+/// the reason on `teardown_failures`, `resources_leaked` set because nothing
+/// confirmed a release, and the health snapshot corrected.
+///
+/// The correction matters as much as the reason. The rest of the snapshot
+/// comes from the last ORDINARY publish, which may well say `Ready`/Healthy —
+/// true when it was published, not true now — so returning it unchanged
+/// advertised a healthy dataplane alongside "teardown unfinished, resources
+/// may be held", in one object. Metrics are CLEARED rather than adjusted:
+/// they were rendered from a snapshot that no longer describes anything, and
+/// rewriting gauge lines by string surgery would be a second, divergent
+/// renderer. No data beats stale data that reads as healthy.
+///
+/// A free function because `PendingTeardown` needs it too and does not own a
+/// `SupervisionService`; making it a method is what made the pending path
+/// grow its own, absent, version of this correction.
+fn incomplete_teardown(last: Option<Published>, why: String) -> Published {
+    // `status()` is `Some` for any started service — `start` blocks on
+    // the first publish — so the fallback is unreachable in practice
+    // and is written as a real snapshot rather than a `?` that would
+    // silently discard the reason.
+    let mut last = last.unwrap_or_else(|| Published {
+        report: HealthReport::healthy(),
+        metrics: String::new(),
+        state: State::Stopped,
+        api_error: None,
+        terminal: None,
+        teardown_failures: Vec::new(),
+        resources_leaked: false,
+        last_failures: Vec::new(),
+        store_error: None,
+    });
+    last.report.overall = packetframe_common::module::HealthState::Unhealthy;
+    last.report
+        .subsystems
+        .push(packetframe_common::module::SubsystemHealth {
+            name: "supervision".into(),
+            state: packetframe_common::module::HealthState::Unhealthy,
+            message: Some(why.clone()),
+            last_success_age_seconds: None,
+        });
+    last.teardown_failures.push(why);
+    last.resources_leaked = true;
+    last.metrics.clear();
+    // `state` is deliberately LEFT as the last observed one, and this
+    // note exists because leaving it unremarked is what made the
+    // metrics case a review finding.
+    //
+    // It cannot be corrected truthfully: the machine may be anywhere,
+    // `Stopped` would claim a completed teardown that did not happen,
+    // and there is no `Unknown` variant to reach for. So it stays a
+    // factual record of the last publish — with `report.overall` now
+    // `Unhealthy` and a named subsystem saying why, which is what a
+    // reader consults. If a consumer is ever added that keys on `state`
+    // rather than on the report, this is the line it will need.
+    last
+}
+
 /// A teardown that outlived the detach budget, and the way to watch it.
 ///
 /// `stop()` returns one of these instead of simply dropping the thread
@@ -170,10 +232,44 @@ impl PendingTeardown {
         self.shared.latest.lock().expect("status lock").clone()
     }
 
-    /// Whether the loop has finished. Once true, [`Self::status`] is the
-    /// FINAL word on the teardown — what was released and what was not.
+    /// Whether the loop has stopped running. **Not** the same as "the
+    /// result is trustworthy": a thread that panicked is also finished, and
+    /// published nothing after it. [`Self::settle`] is the authoritative
+    /// end.
     pub fn is_finished(&self) -> bool {
         self.thread.is_finished()
+    }
+
+    /// Join the background teardown and return its FINAL snapshot.
+    ///
+    /// The panic case is why this exists. `is_finished()` goes true for a
+    /// panicked thread just as it does for a clean one, and a panicked
+    /// thread publishes nothing further — so a caller polling `status()`
+    /// would take the last ordinary snapshot as the promised final result,
+    /// which is the same "a panic reads as a clean stop" defect `stop()`
+    /// already fixes on its own path. Same reason, same report: this routes
+    /// through the one `incomplete_teardown`.
+    ///
+    /// Blocks until the loop exits. It is already bounded by
+    /// `STOP_PATIENCE` on its own side, so this cannot wait indefinitely on
+    /// anything the loop can control.
+    pub fn settle(self) -> Published {
+        let last = self.status();
+        match self.thread.join() {
+            Ok(()) => last.unwrap_or_else(|| {
+                incomplete_teardown(
+                    None,
+                    "the supervision loop finished without publishing a final status".into(),
+                )
+            }),
+            Err(_) => incomplete_teardown(
+                last,
+                "the background teardown PANICKED after detach returned; VPP may still be \
+                 running and holding its VF and hugepages — check `ip link show`, the state \
+                 file and the log, and run `packetframe detach --all` before re-attaching"
+                    .to_string(),
+            ),
+        }
     }
 }
 
@@ -321,18 +417,27 @@ impl SupervisionService {
             // in flight is exactly the lie `teardown_failures` exists to
             // prevent.
             //
-            let published = Some(self.incomplete_teardown(format!(
-                "the supervision loop was still working after {} ms and was not waited on \
+            let corrected = incomplete_teardown(
+                self.status(),
+                format!(
+                    "the supervision loop was still working after {} ms and was not waited on \
                  further; VPP and its resources may still be held — it continues tearing \
                  down in the background, but check `packetframe status` and the state file \
                  before re-attaching",
-                DETACH_BUDGET.as_millis()
-            )));
+                    DETACH_BUDGET.as_millis()
+                ),
+            );
+            // Written INTO the shared window, not just returned. The
+            // correction existed only in the returned value, so a caller
+            // polling `PendingTeardown::status()` — which is what the
+            // message tells the operator to do — kept reading the stale
+            // `Ready`/Healthy snapshot for the rest of `STOP_PATIENCE`. One
+            // window, one truth.
+            *self.shared.latest.lock().expect("status lock") = Some(corrected.clone());
             // The thread keeps its own `Arc<Shared>`, so handing the caller
-            // one keeps the eventual final publish reachable — which is
-            // exactly what the message above sends the operator to read.
+            // one keeps the eventual final publish reachable.
             return StopReport {
-                published,
+                published: Some(corrected),
                 pending: Some(PendingTeardown {
                     shared: Arc::clone(&self.shared),
                     thread: t,
@@ -352,81 +457,20 @@ impl SupervisionService {
         // status, not an unwind.
         let published = match t.join() {
             Ok(()) => self.status(),
-            Err(_) => Some(
-                self.incomplete_teardown(
-                    "the supervision loop PANICKED; the stop transition never ran, so VPP may \
+            Err(_) => Some(incomplete_teardown(
+                self.status(),
+                "the supervision loop PANICKED; the stop transition never ran, so VPP may \
                  still be running and holding its VF and hugepages — check `ip link show`, \
                  the state file and the log, and run `packetframe detach --all` before \
                  re-attaching"
-                        .to_string(),
-                ),
-            ),
+                    .to_string(),
+            )),
         };
         // Settled — the loop is gone, so there is nothing left to watch.
         StopReport {
             published,
             pending: None,
         }
-    }
-
-    /// The one place a shutdown that did not complete is turned into a
-    /// snapshot.
-    ///
-    /// Two callers — the detach-budget timeout and a panicked loop — and
-    /// they had started to diverge, which is the shape that has cost this
-    /// file seven review rounds. Both need exactly the same three things:
-    /// the reason on `teardown_failures`, `resources_leaked` set because
-    /// nothing confirmed a release, and the health snapshot corrected.
-    ///
-    /// The correction matters as much as the reason. The rest of the
-    /// snapshot comes from the last ORDINARY publish, which may well say
-    /// `Ready`/Healthy — true when it was published, not true now — so
-    /// returning it unchanged advertised a healthy dataplane alongside
-    /// "teardown unfinished, resources may be held", in one object.
-    /// Metrics are CLEARED rather than adjusted: they were rendered from a
-    /// snapshot that no longer describes anything, and rewriting gauge
-    /// lines by string surgery would be a second, divergent renderer. No
-    /// data beats stale data that reads as healthy.
-    fn incomplete_teardown(&self, why: String) -> Published {
-        // `status()` is `Some` for any started service — `start` blocks on
-        // the first publish — so the fallback is unreachable in practice
-        // and is written as a real snapshot rather than a `?` that would
-        // silently discard the reason.
-        let mut last = self.status().unwrap_or_else(|| Published {
-            report: HealthReport::healthy(),
-            metrics: String::new(),
-            state: State::Stopped,
-            api_error: None,
-            terminal: None,
-            teardown_failures: Vec::new(),
-            resources_leaked: false,
-            last_failures: Vec::new(),
-            store_error: None,
-        });
-        last.report.overall = packetframe_common::module::HealthState::Unhealthy;
-        last.report
-            .subsystems
-            .push(packetframe_common::module::SubsystemHealth {
-                name: "supervision".into(),
-                state: packetframe_common::module::HealthState::Unhealthy,
-                message: Some(why.clone()),
-                last_success_age_seconds: None,
-            });
-        last.teardown_failures.push(why);
-        last.resources_leaked = true;
-        last.metrics.clear();
-        // `state` is deliberately LEFT as the last observed one, and this
-        // note exists because leaving it unremarked is what made the
-        // metrics case a review finding.
-        //
-        // It cannot be corrected truthfully: the machine may be anywhere,
-        // `Stopped` would claim a completed teardown that did not happen,
-        // and there is no `Unknown` variant to reach for. So it stays a
-        // factual record of the last publish — with `report.overall` now
-        // `Unhealthy` and a named subsystem saying why, which is what a
-        // reader consults. If a consumer is ever added that keys on `state`
-        // rather than on the report, this is the line it will need.
-        last
     }
 
     /// Whether the loop thread is still running. `false` after `stop`,

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -248,20 +248,43 @@ fn run_loop(
     // The most recent nonempty failure set, retained across the empty
     // backoff ticks that follow it. See the publish site for why.
     let mut last_failures: Vec<String> = Vec::new();
-    // When the last passing verify was observed, for the freshness the
-    // health surface reports. Tracked here because `VerifyOutcome`
-    // deliberately carries no clock.
+    // The last COMPLETED verify verdict and when it completed.
+    //
+    // Held here rather than read from the engine at publish time,
+    // because the engine's copy is per-process state and the verdict's
+    // own teardown destroys it: `VerifyFailed` injects `Kill`, `kill`
+    // calls `process_gone`, and `on_process_gone` sets
+    // `last_verify = None`. The publish that followed therefore paired a
+    // fresh timestamp with no outcome and reported `NeverVerified` —
+    // hiding a concrete failure summary behind "not yet verified",
+    // which is the same disappearance an earlier round fixed for the
+    // timestamp alone, arriving through the engine's state reset instead.
+    //
+    // `VerifyOutcome` deliberately carries no clock, hence the pair.
+    let mut last_verify: Option<crate::verify::VerifyOutcome> = None;
     let mut last_verify_at: Option<Instant> = None;
 
+    // The initial injection is a real attach step, and its failures are
+    // no less actionable than an ordinary tick's — a `StartRequested`
+    // whose `Spawn` fails, or an `Adopted` whose `AttachDevices` is
+    // refused, has its only detailed reason in this Tick. Discarding it
+    // published a first snapshot with an empty `last_failures`, and if
+    // the failure left an undead process blocking retries, no later tick
+    // could ever reconstruct the reason.
     for e in initial {
         let now = Instant::now();
-        let _ = driver.inject(now, e, &mut fx);
+        let injected = driver.inject(now, e, &mut fx);
+        let f = fmt_failures(&injected.outcome);
+        if !f.is_empty() {
+            last_failures = f;
+        }
     }
 
     // Returns the overall health it published, which is what decides
     // whether a retained failure reason may finally be dropped.
     let publish = |driver: &Driver,
                    runtime: &Runtime,
+                   last_verify: &Option<crate::verify::VerifyOutcome>,
                    last_verify_at: &Option<Instant>,
                    terminal: &Option<String>,
                    teardown_failures: &[String],
@@ -270,7 +293,7 @@ fn run_loop(
      -> packetframe_common::module::HealthState {
         let now = Instant::now();
         let rs = runtime.status();
-        let fib = match (&rs.last_verify, last_verify_at) {
+        let fib = match (last_verify, last_verify_at) {
             (Some(outcome), Some(at)) => FibSync::from_outcome(outcome, now - *at),
             _ => FibSync::NeverVerified,
         };
@@ -313,7 +336,16 @@ fn run_loop(
     // First snapshot before the first tick; the handshake below is
     // what makes `start()`'s "status() is Some on return" guarantee
     // actually true rather than a race the test suite happens to win.
-    publish(&driver, &runtime, &last_verify_at, &None, &[], false, &[]);
+    publish(
+        &driver,
+        &runtime,
+        &last_verify,
+        &last_verify_at,
+        &None,
+        &[],
+        false,
+        &last_failures,
+    );
     let _ = ready.send(Ok(()));
 
     while !shared.stop.load(Ordering::SeqCst) {
@@ -330,6 +362,13 @@ fn run_loop(
                 e,
                 Event::VerifyPassed | Event::VerifyFailed | Event::VerifyIncomplete
             ) {
+                // BEFORE the injection, because the injection may destroy
+                // it: `VerifyFailed`'s teardown runs `Kill` →
+                // `process_gone` → `on_process_gone`, which clears the
+                // engine's `last_verify`. Reading it afterwards yields
+                // `None` and reports `NeverVerified` over a verify that
+                // definitely completed and definitely failed.
+                last_verify = runtime.status().last_verify;
                 last_verify_at = Some(Instant::now());
             }
             // The injected event's actions run synchronously HERE, and
@@ -343,6 +382,15 @@ fn run_loop(
             failures.extend(fmt_failures(&injected.outcome));
         }
         runtime.set_steered(driver.supervisor().is_steered());
+        // The retained verdict describes ONE process instance. Once a
+        // replacement is being started it describes nothing live, and
+        // reporting it would claim a verified FIB for a VPP that has not
+        // built one yet. `Backoff` deliberately still reports it — the
+        // failed verify is precisely why we are backing off.
+        if driver.state() == State::Starting {
+            last_verify = None;
+            last_verify_at = None;
+        }
 
         // The check `api_incompatible` exists FOR, in the loop it was
         // built for. A CRC mismatch or handshake refusal fails
@@ -393,6 +441,7 @@ fn run_loop(
         let overall = publish(
             &driver,
             &runtime,
+            &last_verify,
             &last_verify_at,
             &terminal,
             &[],
@@ -451,11 +500,12 @@ fn run_loop(
     publish(
         &driver,
         &runtime,
+        &last_verify,
         &last_verify_at,
         &terminal,
         &teardown_failures,
         resources_leaked,
-        &[],
+        &last_failures,
     );
 }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -254,8 +254,16 @@ impl PendingTeardown {
     /// `STOP_PATIENCE` on its own side, so this cannot wait indefinitely on
     /// anything the loop can control.
     pub fn settle(self) -> Published {
-        let last = self.status();
-        match self.thread.join() {
+        // Read AFTER the join, not before. The loop is still running when
+        // `settle` is called in the case that matters — that is the whole
+        // point of the handle — and it publishes its real final status
+        // during the join: whether the release finally succeeded, which VF
+        // refused to unbind. A pre-join read returned the timeout snapshot
+        // instead and threw that away, which is the same "promise the final
+        // word, deliver a stale one" defect this handle was added to fix.
+        let joined = self.thread.join();
+        let last = self.shared.latest.lock().expect("status lock").clone();
+        match joined {
             Ok(()) => last.unwrap_or_else(|| {
                 incomplete_teardown(
                     None,
@@ -817,6 +825,19 @@ fn run_loop(
                     .as_deref()
                     .unwrap_or("(no detail recorded)")
             ));
+            break;
+        }
+        // The stop flag is rechecked HERE, not only at the top of the loop.
+        //
+        // `stop()` can set it — and write its corrected, unhealthy snapshot
+        // into the shared window — while this iteration is blocked inside a
+        // tick. Publishing an ordinary snapshot afterwards overwrote that
+        // correction with one carrying no timeout failure and
+        // `resources_leaked = false`, so a caller polling
+        // `PendingTeardown::status()` lost the warning again until teardown
+        // finished. The teardown below publishes the real final word; this
+        // iteration has nothing left to say.
+        if shared.stop.load(Ordering::SeqCst) {
             break;
         }
         let overall = publish(

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -236,61 +236,86 @@ impl SupervisionService {
             // in flight is exactly the lie `teardown_failures` exists to
             // prevent.
             //
-            // `status()` is `Some` for any started service —
-            // `SupervisionService::start` blocks on the first publish — so
-            // the fallback below is unreachable in practice and is written
-            // as a real snapshot rather than a `?` that would silently
-            // discard the timeout.
-            let mut last = self.status().unwrap_or_else(|| Published {
-                report: HealthReport::healthy(),
-                metrics: String::new(),
-                state: State::Stopped,
-                api_error: None,
-                terminal: None,
-                teardown_failures: Vec::new(),
-                resources_leaked: false,
-                last_failures: Vec::new(),
-                store_error: None,
-            });
-            last.teardown_failures.push(format!(
+            return Some(self.incomplete_teardown(format!(
                 "the supervision loop was still working after {} ms and was not waited on \
                  further; VPP and its resources may still be held — it continues tearing \
                  down in the background, but check `packetframe status` and the state file \
                  before re-attaching",
                 DETACH_BUDGET.as_millis()
-            ));
-            last.resources_leaked = true;
-            // The rest of the snapshot is from the last ORDINARY publish,
-            // which may well say `Ready`/Healthy — it was true when the
-            // loop published it and is not true now. Returning it unchanged
-            // advertised healthy-and-ready alongside "teardown unfinished,
-            // resources may be held", in one object.
-            last.report.overall = packetframe_common::module::HealthState::Unhealthy;
-            last.report
-                .subsystems
-                .push(packetframe_common::module::SubsystemHealth {
-                    name: "supervision".into(),
-                    state: packetframe_common::module::HealthState::Unhealthy,
-                    message: Some(
-                        "shutdown did not complete within the detach budget; the loop is \
-                         still running"
-                            .into(),
-                    ),
-                    last_success_age_seconds: None,
-                });
-            // Metrics are emptied rather than adjusted. They were rendered
-            // from a snapshot that no longer describes anything, and
-            // rewriting individual gauge lines by string surgery would be a
-            // second, divergent renderer. No data beats stale data that
-            // reads as healthy.
-            last.metrics.clear();
-            return Some(last);
+            )));
         }
-        // A panicked loop already published nothing further; the join
-        // error carries no more than the panic message the thread
-        // printed, so it is not propagated as a second panic here.
-        let _ = t.join();
-        self.status()
+        // A panic is NOT a clean stop, and discarding the join error made
+        // it look like one. `is_finished()` is true for a panicked thread,
+        // so this path was reached with the last snapshot possibly saying
+        // `Ready`/Healthy — while the stop transition never ran at all.
+        // Dropping `Runtime` drops the process handle; it does not
+        // terminate VPP. So the process and its VF can still be live while
+        // `stop()` reports success.
+        //
+        // The panic payload itself is not propagated as a second panic
+        // here: the thread already printed it, and the caller needs a
+        // status, not an unwind.
+        match t.join() {
+            Ok(()) => self.status(),
+            Err(_) => Some(
+                self.incomplete_teardown(
+                    "the supervision loop PANICKED; the stop transition never ran, so VPP may \
+                 still be running and holding its VF and hugepages — check `ip link show`, \
+                 the state file and the log, and run `packetframe detach --all` before \
+                 re-attaching"
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+
+    /// The one place a shutdown that did not complete is turned into a
+    /// snapshot.
+    ///
+    /// Two callers — the detach-budget timeout and a panicked loop — and
+    /// they had started to diverge, which is the shape that has cost this
+    /// file seven review rounds. Both need exactly the same three things:
+    /// the reason on `teardown_failures`, `resources_leaked` set because
+    /// nothing confirmed a release, and the health snapshot corrected.
+    ///
+    /// The correction matters as much as the reason. The rest of the
+    /// snapshot comes from the last ORDINARY publish, which may well say
+    /// `Ready`/Healthy — true when it was published, not true now — so
+    /// returning it unchanged advertised a healthy dataplane alongside
+    /// "teardown unfinished, resources may be held", in one object.
+    /// Metrics are CLEARED rather than adjusted: they were rendered from a
+    /// snapshot that no longer describes anything, and rewriting gauge
+    /// lines by string surgery would be a second, divergent renderer. No
+    /// data beats stale data that reads as healthy.
+    fn incomplete_teardown(&self, why: String) -> Published {
+        // `status()` is `Some` for any started service — `start` blocks on
+        // the first publish — so the fallback is unreachable in practice
+        // and is written as a real snapshot rather than a `?` that would
+        // silently discard the reason.
+        let mut last = self.status().unwrap_or_else(|| Published {
+            report: HealthReport::healthy(),
+            metrics: String::new(),
+            state: State::Stopped,
+            api_error: None,
+            terminal: None,
+            teardown_failures: Vec::new(),
+            resources_leaked: false,
+            last_failures: Vec::new(),
+            store_error: None,
+        });
+        last.report.overall = packetframe_common::module::HealthState::Unhealthy;
+        last.report
+            .subsystems
+            .push(packetframe_common::module::SubsystemHealth {
+                name: "supervision".into(),
+                state: packetframe_common::module::HealthState::Unhealthy,
+                message: Some(why.clone()),
+                last_success_age_seconds: None,
+            });
+        last.teardown_failures.push(why);
+        last.resources_leaked = true;
+        last.metrics.clear();
+        last
     }
 
     /// Whether the loop thread is still running. `false` after `stop`,

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -422,6 +422,49 @@ fn run_loop(
             failures.extend(fmt_failures(&injected.outcome));
         }
         runtime.set_steered(driver.supervisor().is_steered());
+        // Retained BEFORE the terminal check below, which `break`s.
+        //
+        // With the assignment after it, a tick whose failures coincided
+        // with detecting a permanently-incompatible API had those failures
+        // discarded — on the one path where supervision ends for good and
+        // the final snapshot is all an operator has. `terminal` carries
+        // the API error itself, but not the refused attach or steer beside
+        // it.
+        //
+        // Found by re-reading rather than by review, and deliberately NOT
+        // accompanied by a test: the window is a single tick's
+        // coincidence, and every test I could construct for it reached the
+        // assertion without ever setting `terminal`, which is coverage
+        // theatre. The ordering is defensive and free; the honest note is
+        // that it is unproven.
+        // The supervisor counts failures; only the outcome carries WHY —
+        // and the reason has to OUTLIVE the tick that produced it.
+        //
+        // A failing tick is followed immediately by backoff ticks whose
+        // outcomes are empty, and republishing those verbatim overwrote
+        // `last_failures` with nothing within one 50 ms poll while the
+        // service sat in the same failed retry state for seconds. An
+        // operator running `packetframe status` would essentially always
+        // land in the empty window and see a bare failure count.
+        //
+        // So it is sticky, and the release condition is an *observation*
+        // of recovery: the reason is dropped only once the published
+        // health returns to `Healthy`. A newer failure supersedes an
+        // older one.
+        //
+        // The obvious release condition — the supervisor's own
+        // consecutive-failure count reaching zero — is WRONG, and
+        // instructively so. A refused `Steer` deliberately does not count
+        // as a supervisor failure (a failed canary must not cycle a VPP
+        // that is forwarding fine), so `failures()` is already zero at
+        // the moment the steer is refused, and keying on it wiped the
+        // reason on the very next tick. `Healthy` is the condition that
+        // actually covers every way this module can be unwell, because it
+        // is the same whitelist `nominal()` applies.
+        if !failures.is_empty() {
+            last_failures = failures;
+        }
+
         // The retained verdict describes ONE process instance, so process
         // loss has to invalidate it — but asymmetrically, and the
         // asymmetry is the whole point:
@@ -462,33 +505,6 @@ fn run_loop(
                     .unwrap_or("(no detail recorded)")
             ));
             break;
-        }
-        // The supervisor counts failures; only the outcome carries WHY —
-        // and the reason has to OUTLIVE the tick that produced it.
-        //
-        // A failing tick is followed immediately by backoff ticks whose
-        // outcomes are empty, and republishing those verbatim overwrote
-        // `last_failures` with nothing within one 50 ms poll while the
-        // service sat in the same failed retry state for seconds. An
-        // operator running `packetframe status` would essentially always
-        // land in the empty window and see a bare failure count.
-        //
-        // So it is sticky, and the release condition is an *observation*
-        // of recovery: the reason is dropped only once the published
-        // health returns to `Healthy`. A newer failure supersedes an
-        // older one.
-        //
-        // The obvious release condition — the supervisor's own
-        // consecutive-failure count reaching zero — is WRONG, and
-        // instructively so. A refused `Steer` deliberately does not count
-        // as a supervisor failure (a failed canary must not cycle a VPP
-        // that is forwarding fine), so `failures()` is already zero at
-        // the moment the steer is refused, and keying on it wiped the
-        // reason on the very next tick. `Healthy` is the condition that
-        // actually covers every way this module can be unwell, because it
-        // is the same whitelist `nominal()` applies.
-        if !failures.is_empty() {
-            last_failures = failures;
         }
         let overall = publish(
             &driver,

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -316,13 +316,48 @@ impl Drop for SupervisionService {
 /// One action failure per line, `Action: reason`, for the published
 /// diagnostics. Shared so an ordinary tick, an injected event and the
 /// teardown all render identically.
-/// Whether a supervised process exists right now.
+/// Drop a verify verdict that no longer describes a live process, keeping
+/// the REASON if it was a failure.
 ///
-/// `Backoff` and `Stopped` are deliberately "no process": the previous one
-/// is already gone. Anything learned FROM that process — notably a verify
-/// verdict — stops describing reality here.
-fn has_process_now(driver: &Driver) -> bool {
-    driver.state().has_process()
+/// A free function with exactly two callers — the main loop and the final
+/// publish after teardown — because that is the shape the alternative kept
+/// getting wrong. The rule first lived inline in the loop, which meant the
+/// stopped snapshot published after `StopRequested` killed the process still
+/// carried the passing verdict: `packetframe_vpp_fib_verified 1` for a VPP
+/// that had just been killed. Teardown is a second exit path, and a rule
+/// written at one exit is not a rule.
+///
+/// The verdict's lifetime is the process's, in BOTH polarities. A passing
+/// one kept past the process claims a verified FIB that no longer exists; a
+/// failing one kept past it survived into the *replacement* and described a
+/// process it had never seen. What keeps the second case from losing
+/// information is that the summary moves to `last_failures`, the field that
+/// exists to retain reasons across ticks — the FIB subsystem reports on the
+/// current instance, "why are we in backoff" does not.
+///
+/// Not keyed on any state name: `Starting` never fires (a lost process lands
+/// in `Backoff`), and the false→true edge of a replacement cannot be
+/// sampled at all, since `BackoffElapsed` enters `Starting` and a failed
+/// spawn returns to `Backoff` inside one tick. `has_process()` is stable for
+/// as long as it matters.
+fn expire_verdict(
+    driver: &Driver,
+    last_verify: &mut Option<crate::verify::VerifyOutcome>,
+    last_verify_at: &mut Option<Instant>,
+    last_failures: &mut Vec<String>,
+) {
+    if driver.state().has_process() {
+        return;
+    }
+    if let Some(v) = last_verify.take() {
+        if !v.passed() {
+            let summary = format!("Verify: {}", v.summary());
+            if !last_failures.contains(&summary) {
+                last_failures.push(summary);
+            }
+        }
+    }
+    *last_verify_at = None;
 }
 
 fn fmt_failures(outcome: &crate::executor::Outcome) -> Vec<String> {
@@ -532,40 +567,13 @@ fn run_loop(
             last_failures = failures;
         }
 
-        // The retained verdict describes ONE process instance, and it dies
-        // with it — in BOTH polarities.
-        //
-        // Three attempts got this wrong before the reason became clear, so
-        // the reasoning is worth keeping. Keying on `Starting` never fired
-        // (a lost process lands in `Backoff`, never passing through
-        // `Starting`). Keying on `!has_process()` fired on loss but not on
-        // replacement. Trying to detect the replacement as a false→true
-        // edge failed too, and instructively: `BackoffElapsed` enters
-        // `Starting` and a failed spawn returns to `Backoff` inside ONE
-        // tick, so a once-per-pass sample never observes it — a transient
-        // state cannot be detected by polling.
-        //
-        // The asymmetry was the real mistake. It existed to keep a failed
-        // verdict visible as the explanation for backoff, which conflated
-        // two jobs: the FIB subsystem reports on the CURRENT instance,
-        // while "why are we in backoff" belongs to `last_failures`, the
-        // field that already retains reasons across the empty ticks. Split
-        // them and the transient-state problem disappears — the condition
-        // becomes `!has_process()`, which is stable for as long as it
-        // matters.
-        if !has_process_now(&driver) {
-            if let Some(v) = last_verify.take() {
-                if !v.passed() {
-                    // Retain the WHY where reasons live, before dropping
-                    // the verdict that can no longer describe anything.
-                    let summary = format!("Verify: {}", v.summary());
-                    if !last_failures.contains(&summary) {
-                        last_failures.push(summary);
-                    }
-                }
-            }
-            last_verify_at = None;
-        }
+        // One call, one rule. See `expire_verdict`.
+        expire_verdict(
+            &driver,
+            &mut last_verify,
+            &mut last_verify_at,
+            &mut last_failures,
+        );
 
         // The check `api_incompatible` exists FOR, in the loop it was
         // built for. A CRC mismatch or handshake refusal fails
@@ -693,6 +701,16 @@ fn run_loop(
             &mut resources_leaked,
         );
     }
+    // The teardown just killed the process, so the verdict it produced no
+    // longer describes anything. Same rule, same function — this is the
+    // second exit path the inline version missed.
+    expire_verdict(
+        &driver,
+        &mut last_verify,
+        &mut last_verify_at,
+        &mut last_failures,
+    );
+
     // The final word: whatever the teardown left behind — an undead VPP
     // that refused to die, a release that failed after `Stopped`, the
     // incompatibility that ended supervision — is on the record.

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -54,6 +54,17 @@ const STOP_POLL_CAP: Duration = Duration::from_millis(50);
 /// the final published status says which.
 const STOP_PATIENCE: Duration = Duration::from_secs(10);
 
+/// Marker prefixed to the error from a pre-publish panic.
+///
+/// Exists so a caller can distinguish "attach failed and left nothing
+/// behind" from "attach failed and may have left a live VPP holding a VF".
+/// The two demand opposite handling: the first should roll back, the second
+/// must NOT, because releasing a VF under a process that can still DMA
+/// through it is worse than leaking it. Matching on a string is crude, and
+/// preferable to the alternative that was there — a generic message that
+/// made the distinction invisible.
+pub const PANIC_MAY_HOLD_RESOURCES: &str = "SUPERVISION PANIC (resources may be held)";
+
 /// Cap on distinct reasons retained for one unhealthy episode.
 ///
 /// Enough for a cause plus a few symptoms, small enough that a backoff loop
@@ -181,11 +192,33 @@ impl SupervisionService {
             }
             Err(_) => {
                 let _ = thread.join();
-                Err(
-                    "the supervision loop died before publishing its first status — the \
-                     factory panicked (see the log)"
-                        .into(),
-                )
+                // A panic BEFORE the first publish, which is the twin of
+                // the post-publish one `stop()` handles — and it was left
+                // uncovered when that one was fixed.
+                //
+                // There is nothing to tear down from here and no snapshot
+                // to correct: the thread unwound, and unwinding dropped
+                // `Runtime`, which drops the VPP process handle WITHOUT
+                // terminating the process. So if the factory had already
+                // adopted (or the initial injection had already spawned) a
+                // VPP, it is still running, still holding its VF and
+                // hugepages, and nothing left in this address space can
+                // reach it. The only remedy is telling the operator, in
+                // words that say what to do.
+                //
+                // `PANIC_MAY_HOLD_RESOURCES` is a marker the caller can
+                // match on: `bring_up`'s rollback must NOT release VFs and
+                // hugepages after this, because releasing them under a live
+                // VPP is the DMA hazard the whole `MustLeak` path exists to
+                // avoid.
+                Err(format!(
+                    "{PANIC_MAY_HOLD_RESOURCES}: the supervision loop panicked before \
+                     publishing its first status (see the log). If it had already adopted \
+                     or started VPP, that process is STILL RUNNING and still holds its VF \
+                     and hugepages — nothing here can reach it any more. Run `packetframe \
+                     detach --all` and check `ip link show` and the state file before \
+                     re-attaching."
+                ))
             }
         }
     }
@@ -828,6 +861,34 @@ mod tests {
         );
         let err = result.err().expect("start must fail");
         assert!(err.contains("API mismatch"), "{err}");
+    }
+
+    /// A pre-publish panic must SAY that resources may be held.
+    ///
+    /// The twin of the post-publish panic path, and it was left uncovered
+    /// when that one was fixed. Nothing here can tear down: the thread
+    /// unwound, and unwinding dropped `Runtime`, which drops the VPP
+    /// process handle without terminating the process. So the only remedy
+    /// is an error an operator can act on — and a marker `bring_up` can
+    /// match on, because its rollback must NOT release a VF that a live VPP
+    /// may still be DMAing through.
+    #[test]
+    fn a_pre_publish_panic_says_resources_may_be_held() {
+        let err = SupervisionService::start(
+            "vpp-offload",
+            Box::new(|| panic!("initial injection panicked on purpose")),
+        )
+        .err()
+        .expect("start must fail");
+        assert!(
+            err.starts_with(PANIC_MAY_HOLD_RESOURCES),
+            "the caller cannot distinguish this from a clean failure: {err}"
+        );
+        assert!(err.contains("STILL RUNNING"), "{err}");
+        assert!(
+            err.contains("detach --all"),
+            "the remedy must be named: {err}"
+        );
     }
 
     /// A factory that PANICS must not leave a dead thread behind a

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -54,6 +54,15 @@ const STOP_POLL_CAP: Duration = Duration::from_millis(50);
 /// the final published status says which.
 const STOP_PATIENCE: Duration = Duration::from_secs(10);
 
+/// Builds the loop's non-`Send` pieces on the loop thread, and returns
+/// the events to inject before the first tick.
+///
+/// `Err` is an **attach failure** — a dead API socket, a version-skewed
+/// VPP, a refused adoption — surfaced synchronously by
+/// [`SupervisionService::start`] rather than becoming a dead thread the
+/// first health check discovers.
+pub type LoopFactory = Box<dyn FnOnce() -> Result<(Driver, Runtime, Vec<Event>), String> + Send>;
+
 /// What the loop publishes after every pass.
 #[derive(Debug, Clone)]
 pub struct Published {
@@ -63,6 +72,22 @@ pub struct Published {
     pub metrics: String,
     /// The supervision state at publish time, for `packetframe status`.
     pub state: State,
+    /// The engine's last API error, verbatim. Carried so a CRC
+    /// mismatch reads as "our definitions say X, this VPP says Y"
+    /// instead of a generic startup failure.
+    pub api_error: Option<String>,
+    /// Set when the loop ended itself: the reason supervision is over
+    /// and will not resume (today: a permanently incompatible API).
+    pub terminal: Option<String>,
+    /// Failures collected while executing the stop transition —
+    /// including a refused resource release, which produces NO event
+    /// (the supervisor is already `Stopped`) and would otherwise
+    /// vanish with the discarded Tick, leaving detach reporting a
+    /// clean stop over still-held VFs.
+    pub teardown_failures: Vec<String>,
+    /// The teardown declined to release resources (unsteer failed or
+    /// the process survived); they are deliberately still held.
+    pub resources_leaked: bool,
 }
 
 /// Shared between the loop and the module.
@@ -90,35 +115,39 @@ impl SupervisionService {
     /// factory that dies (bad socket, failed adoption) surfaces here,
     /// synchronously, as the attach failure it is, rather than as a
     /// mysteriously dead thread discovered on the first health check.
-    pub fn start(
-        module: &'static str,
-        factory: Box<dyn FnOnce() -> (Driver, Runtime, Vec<Event>) + Send>,
-    ) -> Result<Self, String> {
+    pub fn start(module: &'static str, factory: LoopFactory) -> Result<Self, String> {
         let shared = Arc::new(Shared {
             stop: AtomicBool::new(false),
             latest: Mutex::new(None),
         });
         let looped = Arc::clone(&shared);
-        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<()>();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
         let thread = std::thread::Builder::new()
             .name("vpp-supervision".into())
             .spawn(move || run_loop(module, factory, &looped, ready_tx))
             .map_err(|e| format!("spawning the supervision thread: {e}"))?;
-        // A dropped sender (the factory panicked before the first
-        // publish) turns this into RecvError — the failure is reaped
-        // and reported here instead of leaking a dead thread.
-        if ready_rx.recv().is_err() {
-            let _ = thread.join();
-            return Err(
-                "the supervision loop died before publishing its first status — the \
-                 factory failed (see the panic in the log)"
-                    .into(),
-            );
+        // Three outcomes, all reported synchronously as the attach
+        // failures they are: the factory returned an error (a dead API
+        // socket, a version-skewed VPP), the factory panicked (dropped
+        // sender → RecvError), or it succeeded and published.
+        match ready_rx.recv() {
+            Ok(Ok(())) => Ok(Self {
+                shared,
+                thread: Some(thread),
+            }),
+            Ok(Err(e)) => {
+                let _ = thread.join();
+                Err(e)
+            }
+            Err(_) => {
+                let _ = thread.join();
+                Err(
+                    "the supervision loop died before publishing its first status — the \
+                     factory panicked (see the log)"
+                        .into(),
+                )
+            }
         }
-        Ok(Self {
-            shared,
-            thread: Some(thread),
-        })
     }
 
     /// The most recent snapshot, if the loop has completed a pass.
@@ -165,12 +194,23 @@ impl Drop for SupervisionService {
 
 fn run_loop(
     module: &'static str,
-    factory: Box<dyn FnOnce() -> (Driver, Runtime, Vec<Event>) + Send>,
+    factory: LoopFactory,
     shared: &Shared,
-    ready: std::sync::mpsc::Sender<()>,
+    ready: std::sync::mpsc::Sender<Result<(), String>>,
 ) {
-    let (mut driver, runtime, initial) = factory();
+    let (mut driver, runtime, initial) = match factory() {
+        Ok(parts) => parts,
+        Err(e) => {
+            // Nothing was built, so there is nothing to publish or tear
+            // down; `start()` turns this into its return value.
+            let _ = ready.send(Err(e));
+            return;
+        }
+    };
     let (mut obs, mut fx) = runtime.views();
+    let mut terminal: Option<String> = None;
+    let mut teardown_failures: Vec<String> = Vec::new();
+    let mut resources_leaked = false;
     // When the last passing verify was observed, for the freshness the
     // health surface reports. Tracked here because `VerifyOutcome`
     // deliberately carries no clock.
@@ -181,7 +221,12 @@ fn run_loop(
         let _ = driver.inject(now, e, &mut fx);
     }
 
-    let publish = |driver: &Driver, runtime: &Runtime, last_verify_at: &Option<Instant>| {
+    let publish = |driver: &Driver,
+                   runtime: &Runtime,
+                   last_verify_at: &Option<Instant>,
+                   terminal: &Option<String>,
+                   teardown_failures: &[String],
+                   resources_leaked: bool| {
         let now = Instant::now();
         let rs = runtime.status();
         let fib = match (&rs.last_verify, last_verify_at) {
@@ -201,6 +246,10 @@ fn run_loop(
             report: snap.report(),
             metrics: crate::status::render_metrics(&snap, module),
             state: driver.state(),
+            api_error: rs.api_error,
+            terminal: terminal.clone(),
+            teardown_failures: teardown_failures.to_vec(),
+            resources_leaked,
         };
         *shared.latest.lock().expect("status lock") = Some(published);
     };
@@ -208,20 +257,48 @@ fn run_loop(
     // First snapshot before the first tick; the handshake below is
     // what makes `start()`'s "status() is Some on return" guarantee
     // actually true rather than a race the test suite happens to win.
-    publish(&driver, &runtime, &last_verify_at);
-    let _ = ready.send(());
+    publish(&driver, &runtime, &last_verify_at, &None, &[], false);
+    let _ = ready.send(Ok(()));
 
     while !shared.stop.load(Ordering::SeqCst) {
         let now = Instant::now();
         let tick = driver.tick(now, &mut obs, &mut fx);
         for e in runtime.take_pending() {
-            if matches!(e, Event::VerifyPassed) {
+            // Every COMPLETED verify gets the timestamp, not only a
+            // pass. Stamping only `VerifyPassed` converted a first
+            // failed verify into `NeverVerified` — hiding a concrete
+            // failure summary behind "not yet verified" — and gave a
+            // later failure the stale timestamp of the last pass.
+            if matches!(
+                e,
+                Event::VerifyPassed | Event::VerifyFailed | Event::VerifyIncomplete
+            ) {
                 last_verify_at = Some(Instant::now());
             }
             let _ = driver.inject(Instant::now(), e, &mut fx);
         }
         runtime.set_steered(driver.supervisor().is_steered());
-        publish(&driver, &runtime, &last_verify_at);
+
+        // The check `api_incompatible` exists FOR, in the loop it was
+        // built for. A CRC mismatch or handshake refusal fails
+        // identically on every attempt: without this, the loop polls
+        // out the 60 s startup budget, kills a VPP that answered its
+        // socket perfectly well, restarts it, and repeats forever —
+        // while the version skew that explains everything sits
+        // unread in the engine. Terminal means terminal: tear down and
+        // end supervision with the reason on the record.
+        if runtime.api_incompatible() {
+            terminal = Some(format!(
+                "VPP's API is permanently incompatible: {}",
+                runtime
+                    .status()
+                    .api_error
+                    .as_deref()
+                    .unwrap_or("(no detail recorded)")
+            ));
+            break;
+        }
+        publish(&driver, &runtime, &last_verify_at, &terminal, &[], false);
 
         match tick.sleep {
             Some(d) if d.is_zero() => {} // more work queued; go again
@@ -237,33 +314,70 @@ fn run_loop(
     // settles or the bounded patience expires. `StopRequested` on an
     // already-Stopped machine is a no-op, so the redundant case is
     // harmless.
+    //
+    // Outcomes are ACCUMULATED here, not dropped. The stop transition's
+    // `ReleaseResources` can fail after the supervisor is already
+    // `Stopped`, so no event will ever carry that failure — the
+    // discarded Tick was the only witness, and discarding it made
+    // `stop()` return a clean-looking snapshot over still-held VFs.
+    let mut absorb = |outcome: crate::executor::Outcome| {
+        for (action, why) in outcome.failures {
+            teardown_failures.push(format!("{action:?}: {why}"));
+        }
+        resources_leaked |= outcome.resources_leaked;
+    };
     let deadline = Instant::now() + STOP_PATIENCE;
-    let _ = driver.inject(Instant::now(), Event::StopRequested, &mut fx);
+    absorb(
+        driver
+            .inject(Instant::now(), Event::StopRequested, &mut fx)
+            .outcome,
+    );
     while driver.state() != State::Stopped && Instant::now() < deadline {
         let now = Instant::now();
         let tick = driver.tick(now, &mut obs, &mut fx);
+        absorb(tick.outcome.clone());
         for e in runtime.take_pending() {
-            let _ = driver.inject(Instant::now(), e, &mut fx);
+            absorb(driver.inject(Instant::now(), e, &mut fx).outcome);
         }
         match tick.sleep {
             Some(d) if d.is_zero() => {}
             _ => std::thread::sleep(Duration::from_millis(10)),
         }
     }
-    // The final word: whatever the teardown left behind — including an
-    // undead VPP that refused to die — is on the record for the caller.
-    publish(&driver, &runtime, &last_verify_at);
+    // The final word: whatever the teardown left behind — an undead VPP
+    // that refused to die, a release that failed after `Stopped`, the
+    // incompatibility that ended supervision — is on the record.
+    publish(
+        &driver,
+        &runtime,
+        &last_verify_at,
+        &terminal,
+        &teardown_failures,
+        resources_leaked,
+    );
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A factory that dies is an ATTACH failure, reported synchronously
-    /// from `start()` — not a mysteriously dead thread discovered later
-    /// by a health check reading frozen status.
+    /// A factory that FAILS is an attach failure carrying its own
+    /// reason — this is the path a version-skewed VPP takes, since the
+    /// attach wiring verifies the API before it commits to adopting.
     #[test]
-    fn a_failed_factory_fails_start_synchronously() {
+    fn a_factory_error_fails_start_with_its_own_reason() {
+        let result = SupervisionService::start(
+            "vpp-offload",
+            Box::new(|| Err("API mismatch for `ip_route_add_del`".into())),
+        );
+        let err = result.err().expect("start must fail");
+        assert!(err.contains("API mismatch"), "{err}");
+    }
+
+    /// A factory that PANICS must not leave a dead thread behind a
+    /// health check that would go on reading frozen status as current.
+    #[test]
+    fn a_panicking_factory_fails_start_synchronously() {
         let result = SupervisionService::start(
             "vpp-offload",
             Box::new(|| panic!("factory failed on purpose")),
@@ -271,6 +385,6 @@ mod tests {
         let err = result
             .err()
             .expect("start must fail, not hand back a dead loop");
-        assert!(err.contains("died before publishing"), "{err}");
+        assert!(err.contains("panicked"), "{err}");
     }
 }

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -54,6 +54,17 @@ const STOP_POLL_CAP: Duration = Duration::from_millis(50);
 /// the final published status says which.
 const STOP_PATIENCE: Duration = Duration::from_secs(10);
 
+/// How long `stop()` waits for the loop before returning with an
+/// unfinished teardown on the record.
+///
+/// Sized to the `Module::detach` contract (under 1 s, SPEC.md §3.2) with
+/// room for the poll granularity, NOT to the loop's internal teardown
+/// budget. The distinction is the point: the loop may legitimately need
+/// `STOP_PATIENCE` to outlast an undead VPP, and the caller must not be
+/// blocked for it. What the caller gets instead is a snapshot that says
+/// the teardown is unfinished.
+const DETACH_BUDGET: Duration = Duration::from_millis(900);
+
 /// Builds the loop's non-`Send` pieces on the loop thread, and returns
 /// the events to inject before the first tick.
 ///
@@ -188,44 +199,91 @@ impl SupervisionService {
         let Some(t) = self.thread.take() else {
             return self.status();
         };
-        // Bounded and interruptible, NOT `join()`.
+        // Bounded and interruptible, NOT `join()`, and bounded by the
+        // CONTRACT rather than by this module's convenience.
         //
-        // An unconditional join cannot observe `STOP_PATIENCE` or the
-        // stop flag until the tick in progress returns — and a tick can
-        // legitimately sit in a synchronous API call for a full
-        // `SYNC_PING_BUDGET` (10 s unsteered), with verification issuing
-        // several such calls in a row. The teardown deadline only starts
-        // counting after that, so the honest worst case was ~20 s with no
-        // ceiling anywhere, against a `Module::detach` contract of under
-        // one second (SPEC.md §3.2).
+        // An unconditional join cannot observe any deadline until the tick
+        // in progress returns — and a tick can legitimately sit in a
+        // synchronous API call for a full `SYNC_PING_BUDGET` (10 s
+        // unsteered), with verification issuing several in a row. So the
+        // honest worst case was ~20 s with no ceiling.
         //
-        // Under one second is not achievable on this platform and the plan
-        // says so: VPP sits on VFIO/DMA, SIGKILL cannot interrupt an
-        // uninterruptible sleep, and the kill path alone budgets 500 ms of
-        // SIGTERM grace plus a bounded SIGKILL wait. So the contract is
-        // relaxed to a documented best-effort bound, and this is where
-        // that bound is enforced: `STOP_PATIENCE`, the same budget the
-        // loop gives its own teardown, so a teardown that completes
-        // normally always completes inside it.
-        let deadline = Instant::now() + STOP_PATIENCE;
+        // The first fix bounded it at `STOP_PATIENCE` (10 s), which was
+        // still wrong for a reason worth naming: `Module::detach` is
+        // documented to complete in under a second, and 10 s is an order of
+        // magnitude past it. Choosing the loop's internal budget as the
+        // caller's bound was picking whichever of two contradicting
+        // documents suited the code.
+        //
+        // Waiting for the whole teardown inside a second is genuinely
+        // impossible here — the kill path alone budgets 500 ms of SIGTERM
+        // grace plus a bounded SIGKILL wait, and VFIO/DMA can defeat
+        // SIGKILL entirely. But *returning* inside a second is not: the
+        // loop keeps its own `STOP_PATIENCE` and finishes the teardown in
+        // the background, and the state file is what lets a later
+        // `detach --all` complete anything left. So this waits only for the
+        // fast path — the overwhelmingly common case, where nothing is
+        // wedged and the loop settles in milliseconds — and past that
+        // reports an unfinished teardown rather than blocking the loader.
+        let deadline = Instant::now() + DETACH_BUDGET;
         while !t.is_finished() && Instant::now() < deadline {
             std::thread::sleep(STOP_POLL_CAP);
         }
         if !t.is_finished() {
-            // Deliberately NOT joined: blocking past the stated bound is
-            // the thing being fixed. The thread is left to finish its own
-            // teardown — it has the same deadline and will release what it
-            // can — but the caller is told, because a detach that reports
-            // success over a teardown still in flight is exactly the lie
-            // `teardown_failures` exists to prevent.
-            let mut last = self.status()?;
+            // Deliberately NOT joined. The thread is left to finish its own
+            // teardown under `STOP_PATIENCE`, but the caller is told,
+            // because a detach that reports success over a teardown still
+            // in flight is exactly the lie `teardown_failures` exists to
+            // prevent.
+            //
+            // `status()` is `Some` for any started service —
+            // `SupervisionService::start` blocks on the first publish — so
+            // the fallback below is unreachable in practice and is written
+            // as a real snapshot rather than a `?` that would silently
+            // discard the timeout.
+            let mut last = self.status().unwrap_or_else(|| Published {
+                report: HealthReport::healthy(),
+                metrics: String::new(),
+                state: State::Stopped,
+                api_error: None,
+                terminal: None,
+                teardown_failures: Vec::new(),
+                resources_leaked: false,
+                last_failures: Vec::new(),
+                store_error: None,
+            });
             last.teardown_failures.push(format!(
-                "the supervision loop was still working after {}s and was not waited on \
-                 further; VPP and its resources may still be held — check `packetframe \
-                 status` and the state file before re-attaching",
-                STOP_PATIENCE.as_secs()
+                "the supervision loop was still working after {} ms and was not waited on \
+                 further; VPP and its resources may still be held — it continues tearing \
+                 down in the background, but check `packetframe status` and the state file \
+                 before re-attaching",
+                DETACH_BUDGET.as_millis()
             ));
             last.resources_leaked = true;
+            // The rest of the snapshot is from the last ORDINARY publish,
+            // which may well say `Ready`/Healthy — it was true when the
+            // loop published it and is not true now. Returning it unchanged
+            // advertised healthy-and-ready alongside "teardown unfinished,
+            // resources may be held", in one object.
+            last.report.overall = packetframe_common::module::HealthState::Unhealthy;
+            last.report
+                .subsystems
+                .push(packetframe_common::module::SubsystemHealth {
+                    name: "supervision".into(),
+                    state: packetframe_common::module::HealthState::Unhealthy,
+                    message: Some(
+                        "shutdown did not complete within the detach budget; the loop is \
+                         still running"
+                            .into(),
+                    ),
+                    last_success_age_seconds: None,
+                });
+            // Metrics are emptied rather than adjusted. They were rendered
+            // from a snapshot that no longer describes anything, and
+            // rewriting individual gauge lines by string surgery would be a
+            // second, divergent renderer. No data beats stale data that
+            // reads as healthy.
+            last.metrics.clear();
             return Some(last);
         }
         // A panicked loop already published nothing further; the join
@@ -258,6 +316,15 @@ impl Drop for SupervisionService {
 /// One action failure per line, `Action: reason`, for the published
 /// diagnostics. Shared so an ordinary tick, an injected event and the
 /// teardown all render identically.
+/// Whether a supervised process exists right now.
+///
+/// `Backoff` and `Stopped` are deliberately "no process": the previous one
+/// is already gone. Anything learned FROM that process — notably a verify
+/// verdict — stops describing reality here.
+fn has_process_now(driver: &Driver) -> bool {
+    driver.state().has_process()
+}
+
 fn fmt_failures(outcome: &crate::executor::Outcome) -> Vec<String> {
     outcome
         .failures
@@ -465,25 +532,38 @@ fn run_loop(
             last_failures = failures;
         }
 
-        // The retained verdict describes ONE process instance, so process
-        // loss has to invalidate it — but asymmetrically, and the
-        // asymmetry is the whole point:
+        // The retained verdict describes ONE process instance, and it dies
+        // with it — in BOTH polarities.
         //
-        // - a **passing** verdict must go. Keeping it reported a verified
-        //   FIB, and `packetframe_vpp_fib_verified 1`, for a process that
-        //   no longer exists — through the entire backoff interval and in
-        //   the final stopped snapshot.
-        // - a **failing** verdict must stay. It is the reason we are in
-        //   backoff at all, and dropping it puts "not yet verified" where
-        //   the explanation should be.
+        // Three attempts got this wrong before the reason became clear, so
+        // the reasoning is worth keeping. Keying on `Starting` never fired
+        // (a lost process lands in `Backoff`, never passing through
+        // `Starting`). Keying on `!has_process()` fired on loss but not on
+        // replacement. Trying to detect the replacement as a false→true
+        // edge failed too, and instructively: `BackoffElapsed` enters
+        // `Starting` and a failed spawn returns to `Backoff` inside ONE
+        // tick, so a once-per-pass sample never observes it — a transient
+        // state cannot be detected by polling.
         //
-        // Keyed on `has_process()`, not on a state guess. The first
-        // version keyed on `Starting`, which a lost process does not pass
-        // through: a crash, a wedge or a stop lands in `Backoff` or
-        // `Stopped`, so the invalidation never fired for any of the cases
-        // it existed to cover.
-        if !driver.state().has_process() && last_verify.as_ref().is_some_and(|v| v.passed()) {
-            last_verify = None;
+        // The asymmetry was the real mistake. It existed to keep a failed
+        // verdict visible as the explanation for backoff, which conflated
+        // two jobs: the FIB subsystem reports on the CURRENT instance,
+        // while "why are we in backoff" belongs to `last_failures`, the
+        // field that already retains reasons across the empty ticks. Split
+        // them and the transient-state problem disappears — the condition
+        // becomes `!has_process()`, which is stable for as long as it
+        // matters.
+        if !has_process_now(&driver) {
+            if let Some(v) = last_verify.take() {
+                if !v.passed() {
+                    // Retain the WHY where reasons live, before dropping
+                    // the verdict that can no longer describe anything.
+                    let summary = format!("Verify: {}", v.summary());
+                    if !last_failures.contains(&summary) {
+                        last_failures.push(summary);
+                    }
+                }
+            }
             last_verify_at = None;
         }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -147,6 +147,49 @@ struct Shared {
     latest: Mutex<Option<Published>>,
 }
 
+/// A teardown that outlived the detach budget, and the way to watch it.
+///
+/// `stop()` returns one of these instead of simply dropping the thread
+/// handle. It has to: the timeout message tells the operator to check
+/// `packetframe status`, and without this the background thread became the
+/// only owner of the shared status window — so its eventual final publish,
+/// including whether `ReleaseResources` finally succeeded or exactly which
+/// VF refused to unbind, went somewhere nobody could read and was destroyed
+/// when the thread exited. A promise of information with no channel behind
+/// it is the defect this file has produced repeatedly; this one promised it
+/// to an operator rather than to a caller.
+pub struct PendingTeardown {
+    shared: Arc<Shared>,
+    thread: JoinHandle<()>,
+}
+
+impl PendingTeardown {
+    /// The most recent snapshot the loop published, including the final one
+    /// once it settles. Poll while [`Self::is_finished`] is false.
+    pub fn status(&self) -> Option<Published> {
+        self.shared.latest.lock().expect("status lock").clone()
+    }
+
+    /// Whether the loop has finished. Once true, [`Self::status`] is the
+    /// FINAL word on the teardown — what was released and what was not.
+    pub fn is_finished(&self) -> bool {
+        self.thread.is_finished()
+    }
+}
+
+/// What `stop()` observed.
+///
+/// A struct rather than an enum because most callers only want
+/// `published`; `pending` is `Some` exactly when the loop was still working
+/// when the detach budget expired, and making it a field is what turns
+/// dropping it into a deliberate act rather than an accident.
+pub struct StopReport {
+    /// What to report now.
+    pub published: Option<Published>,
+    /// `Some` when the teardown is still running in the background.
+    pub pending: Option<PendingTeardown>,
+}
+
 /// Handle to a running supervision loop.
 pub struct SupervisionService {
     shared: Arc<Shared>,
@@ -233,10 +276,13 @@ impl SupervisionService {
     /// Consumes the handle: there is nothing meaningful to do with a
     /// service after stopping it except read the final status, which
     /// is returned.
-    pub fn stop(mut self) -> Option<Published> {
+    pub fn stop(mut self) -> StopReport {
         self.shared.stop.store(true, Ordering::SeqCst);
         let Some(t) = self.thread.take() else {
-            return self.status();
+            return StopReport {
+                published: self.status(),
+                pending: None,
+            };
         };
         // Bounded and interruptible, NOT `join()`, and bounded by the
         // CONTRACT rather than by this module's convenience.
@@ -275,13 +321,23 @@ impl SupervisionService {
             // in flight is exactly the lie `teardown_failures` exists to
             // prevent.
             //
-            return Some(self.incomplete_teardown(format!(
+            let published = Some(self.incomplete_teardown(format!(
                 "the supervision loop was still working after {} ms and was not waited on \
                  further; VPP and its resources may still be held — it continues tearing \
                  down in the background, but check `packetframe status` and the state file \
                  before re-attaching",
                 DETACH_BUDGET.as_millis()
             )));
+            // The thread keeps its own `Arc<Shared>`, so handing the caller
+            // one keeps the eventual final publish reachable — which is
+            // exactly what the message above sends the operator to read.
+            return StopReport {
+                published,
+                pending: Some(PendingTeardown {
+                    shared: Arc::clone(&self.shared),
+                    thread: t,
+                }),
+            };
         }
         // A panic is NOT a clean stop, and discarding the join error made
         // it look like one. `is_finished()` is true for a panicked thread,
@@ -294,7 +350,7 @@ impl SupervisionService {
         // The panic payload itself is not propagated as a second panic
         // here: the thread already printed it, and the caller needs a
         // status, not an unwind.
-        match t.join() {
+        let published = match t.join() {
             Ok(()) => self.status(),
             Err(_) => Some(
                 self.incomplete_teardown(
@@ -305,6 +361,11 @@ impl SupervisionService {
                         .to_string(),
                 ),
             ),
+        };
+        // Settled — the loop is gone, so there is nothing left to watch.
+        StopReport {
+            published,
+            pending: None,
         }
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -315,6 +315,17 @@ impl SupervisionService {
         last.teardown_failures.push(why);
         last.resources_leaked = true;
         last.metrics.clear();
+        // `state` is deliberately LEFT as the last observed one, and this
+        // note exists because leaving it unremarked is what made the
+        // metrics case a review finding.
+        //
+        // It cannot be corrected truthfully: the machine may be anywhere,
+        // `Stopped` would claim a completed teardown that did not happen,
+        // and there is no `Unknown` variant to reach for. So it stays a
+        // factual record of the last publish — with `report.overall` now
+        // `Unhealthy` and a named subsystem saying why, which is what a
+        // reader consults. If a consumer is ever added that keys on `state`
+        // rather than on the report, this is the line it will need.
         last
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -88,11 +88,23 @@ pub struct Published {
     /// The teardown declined to release resources (unsteer failed or
     /// the process survived); they are deliberately still held.
     pub resources_leaked: bool,
-    /// Failures from the most recent ORDINARY tick — a missing VPP
-    /// binary, a refused device attach, a broken resync. The supervisor
+    /// Why the last failure happened — a missing VPP binary, a refused
+    /// device attach, a broken resync, a refused steer. The supervisor
     /// only counts these ("restarting after N failures"); the actionable
-    /// reason lives here and nowhere else, so dropping it left an
-    /// operator watching a retry loop with no way to learn why.
+    /// reason lives here and nowhere else.
+    ///
+    /// **Retained until recovery**, not just for the tick that produced
+    /// it. Failures are followed by backoff ticks with empty outcomes, so
+    /// republishing each tick verbatim cleared this within ~50 ms while
+    /// the service stayed in the same failed state for seconds — an
+    /// operator polling status would essentially always miss it. Cleared
+    /// when the supervisor's consecutive-failure count returns to zero,
+    /// which it does only on a verified-healthy cycle.
+    ///
+    /// Covers failures from injected events too (a `VerifyPassed` whose
+    /// `Steer` was refused, a `VerifyFailed` whose teardown failed);
+    /// those run synchronously inside the injection and can never appear
+    /// in an ordinary tick's outcome.
     pub last_failures: Vec<String>,
     /// The runtime could not persist something it observed. Not fatal
     /// to convergence by design — but it means the next daemon restart
@@ -203,6 +215,17 @@ impl Drop for SupervisionService {
     }
 }
 
+/// One action failure per line, `Action: reason`, for the published
+/// diagnostics. Shared so an ordinary tick, an injected event and the
+/// teardown all render identically.
+fn fmt_failures(outcome: &crate::executor::Outcome) -> Vec<String> {
+    outcome
+        .failures
+        .iter()
+        .map(|(action, why)| format!("{action:?}: {why}"))
+        .collect()
+}
+
 fn run_loop(
     module: &'static str,
     factory: LoopFactory,
@@ -222,6 +245,9 @@ fn run_loop(
     let mut terminal: Option<String> = None;
     let mut teardown_failures: Vec<String> = Vec::new();
     let mut resources_leaked = false;
+    // The most recent nonempty failure set, retained across the empty
+    // backoff ticks that follow it. See the publish site for why.
+    let mut last_failures: Vec<String> = Vec::new();
     // When the last passing verify was observed, for the freshness the
     // health surface reports. Tracked here because `VerifyOutcome`
     // deliberately carries no clock.
@@ -232,19 +258,31 @@ fn run_loop(
         let _ = driver.inject(now, e, &mut fx);
     }
 
+    // Returns the overall health it published, which is what decides
+    // whether a retained failure reason may finally be dropped.
     let publish = |driver: &Driver,
                    runtime: &Runtime,
                    last_verify_at: &Option<Instant>,
                    terminal: &Option<String>,
                    teardown_failures: &[String],
                    resources_leaked: bool,
-                   last_failures: &[String]| {
+                   last_failures: &[String]|
+     -> packetframe_common::module::HealthState {
         let now = Instant::now();
         let rs = runtime.status();
         let fib = match (&rs.last_verify, last_verify_at) {
             (Some(outcome), Some(at)) => FibSync::from_outcome(outcome, now - *at),
             _ => FibSync::NeverVerified,
         };
+        // The store failure goes INTO the snapshot, not onto the report
+        // afterwards. A store failure is a real degradation — convergence
+        // continues correctly, but the next daemon restart will refuse
+        // adoption because the index it needs was never persisted — and
+        // patching `report()` here left `render_metrics` rendering
+        // `packetframe_vpp_health` from the unpatched snapshot. The health
+        // check said Degraded and Prometheus said Healthy, about the same
+        // instant, during exactly the failure the patch existed to
+        // surface. One condition, one place: `StatusSnapshot`.
         let snap = StatusSnapshot::observe_parts(
             driver.supervisor(),
             rs.counts,
@@ -253,32 +291,10 @@ fn run_loop(
             driver.api_health(now),
             fib,
             rs.port_links,
+            rs.store_error.clone(),
         );
-        // A store failure is a real degradation: convergence continues
-        // (correctly — the interfaces work), but the next daemon
-        // restart will refuse adoption because the index it needs was
-        // never persisted. Reporting Healthy over that would hide a
-        // problem whose consequence only appears at the worst moment.
-        let mut report = snap.report();
-        if let Some(e) = &rs.store_error {
-            report.overall = match report.overall {
-                packetframe_common::module::HealthState::Healthy => {
-                    packetframe_common::module::HealthState::Degraded
-                }
-                other => other,
-            };
-            report
-                .subsystems
-                .push(packetframe_common::module::SubsystemHealth {
-                    name: "state-file".into(),
-                    state: packetframe_common::module::HealthState::Degraded,
-                    message: Some(format!(
-                        "could not persist observed state ({e}); a daemon restart will \
-                     refuse adoption and cycle VPP instead"
-                    )),
-                    last_success_age_seconds: None,
-                });
-        }
+        let report = snap.report();
+        let overall = report.overall;
         let published = Published {
             report,
             metrics: crate::status::render_metrics(&snap, module),
@@ -291,6 +307,7 @@ fn run_loop(
             store_error: rs.store_error,
         };
         *shared.latest.lock().expect("status lock") = Some(published);
+        overall
     };
 
     // First snapshot before the first tick; the handshake below is
@@ -302,6 +319,7 @@ fn run_loop(
     while !shared.stop.load(Ordering::SeqCst) {
         let now = Instant::now();
         let tick = driver.tick(now, &mut obs, &mut fx);
+        let mut failures: Vec<String> = fmt_failures(&tick.outcome);
         for e in runtime.take_pending() {
             // Every COMPLETED verify gets the timestamp, not only a
             // pass. Stamping only `VerifyPassed` converted a first
@@ -314,7 +332,15 @@ fn run_loop(
             ) {
                 last_verify_at = Some(Instant::now());
             }
-            let _ = driver.inject(Instant::now(), e, &mut fx);
+            // The injected event's actions run synchronously HERE, and
+            // its failures exist only in this Tick. Discarding it lost a
+            // whole class of diagnostic: `VerifyPassed` triggers `Steer`,
+            // so a refused steer — the canary failing — never appeared
+            // anywhere, and `VerifyFailed`'s teardown failures went the
+            // same way. Neither can ever show up in the ordinary tick's
+            // outcome, because neither is produced by one.
+            let injected = driver.inject(Instant::now(), e, &mut fx);
+            failures.extend(fmt_failures(&injected.outcome));
         }
         runtime.set_steered(driver.supervisor().is_steered());
 
@@ -337,24 +363,45 @@ fn run_loop(
             ));
             break;
         }
-        // The supervisor counts failures; only the outcome carries WHY.
-        // Republished every pass so a retry loop is diagnosable from
-        // status alone, which is all an operator on the box has.
-        let failures: Vec<String> = tick
-            .outcome
-            .failures
-            .iter()
-            .map(|(action, why)| format!("{action:?}: {why}"))
-            .collect();
-        publish(
+        // The supervisor counts failures; only the outcome carries WHY —
+        // and the reason has to OUTLIVE the tick that produced it.
+        //
+        // A failing tick is followed immediately by backoff ticks whose
+        // outcomes are empty, and republishing those verbatim overwrote
+        // `last_failures` with nothing within one 50 ms poll while the
+        // service sat in the same failed retry state for seconds. An
+        // operator running `packetframe status` would essentially always
+        // land in the empty window and see a bare failure count.
+        //
+        // So it is sticky, and the release condition is an *observation*
+        // of recovery: the reason is dropped only once the published
+        // health returns to `Healthy`. A newer failure supersedes an
+        // older one.
+        //
+        // The obvious release condition — the supervisor's own
+        // consecutive-failure count reaching zero — is WRONG, and
+        // instructively so. A refused `Steer` deliberately does not count
+        // as a supervisor failure (a failed canary must not cycle a VPP
+        // that is forwarding fine), so `failures()` is already zero at
+        // the moment the steer is refused, and keying on it wiped the
+        // reason on the very next tick. `Healthy` is the condition that
+        // actually covers every way this module can be unwell, because it
+        // is the same whitelist `nominal()` applies.
+        if !failures.is_empty() {
+            last_failures = failures;
+        }
+        let overall = publish(
             &driver,
             &runtime,
             &last_verify_at,
             &terminal,
             &[],
             false,
-            &failures,
+            &last_failures,
         );
+        if overall == packetframe_common::module::HealthState::Healthy {
+            last_failures.clear();
+        }
 
         match tick.sleep {
             Some(d) if d.is_zero() => {} // more work queued; go again
@@ -377,9 +424,7 @@ fn run_loop(
     // discarded Tick was the only witness, and discarding it made
     // `stop()` return a clean-looking snapshot over still-held VFs.
     let mut absorb = |outcome: crate::executor::Outcome| {
-        for (action, why) in outcome.failures {
-            teardown_failures.push(format!("{action:?}: {why}"));
-        }
+        teardown_failures.extend(fmt_failures(&outcome));
         resources_leaked |= outcome.resources_leaked;
     };
     let deadline = Instant::now() + STOP_PATIENCE;

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -185,13 +185,53 @@ impl SupervisionService {
     /// is returned.
     pub fn stop(mut self) -> Option<Published> {
         self.shared.stop.store(true, Ordering::SeqCst);
-        if let Some(t) = self.thread.take() {
-            // A panicked loop already published nothing further; the
-            // join error carries no more than the panic message the
-            // thread printed, so it is not propagated as a second
-            // panic here.
-            let _ = t.join();
+        let Some(t) = self.thread.take() else {
+            return self.status();
+        };
+        // Bounded and interruptible, NOT `join()`.
+        //
+        // An unconditional join cannot observe `STOP_PATIENCE` or the
+        // stop flag until the tick in progress returns — and a tick can
+        // legitimately sit in a synchronous API call for a full
+        // `SYNC_PING_BUDGET` (10 s unsteered), with verification issuing
+        // several such calls in a row. The teardown deadline only starts
+        // counting after that, so the honest worst case was ~20 s with no
+        // ceiling anywhere, against a `Module::detach` contract of under
+        // one second (SPEC.md §3.2).
+        //
+        // Under one second is not achievable on this platform and the plan
+        // says so: VPP sits on VFIO/DMA, SIGKILL cannot interrupt an
+        // uninterruptible sleep, and the kill path alone budgets 500 ms of
+        // SIGTERM grace plus a bounded SIGKILL wait. So the contract is
+        // relaxed to a documented best-effort bound, and this is where
+        // that bound is enforced: `STOP_PATIENCE`, the same budget the
+        // loop gives its own teardown, so a teardown that completes
+        // normally always completes inside it.
+        let deadline = Instant::now() + STOP_PATIENCE;
+        while !t.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(STOP_POLL_CAP);
         }
+        if !t.is_finished() {
+            // Deliberately NOT joined: blocking past the stated bound is
+            // the thing being fixed. The thread is left to finish its own
+            // teardown — it has the same deadline and will release what it
+            // can — but the caller is told, because a detach that reports
+            // success over a teardown still in flight is exactly the lie
+            // `teardown_failures` exists to prevent.
+            let mut last = self.status()?;
+            last.teardown_failures.push(format!(
+                "the supervision loop was still working after {}s and was not waited on \
+                 further; VPP and its resources may still be held — check `packetframe \
+                 status` and the state file before re-attaching",
+                STOP_PATIENCE.as_secs()
+            ));
+            last.resources_leaked = true;
+            return Some(last);
+        }
+        // A panicked loop already published nothing further; the join
+        // error carries no more than the panic message the thread
+        // printed, so it is not propagated as a second panic here.
+        let _ = t.join();
         self.status()
     }
 
@@ -382,12 +422,24 @@ fn run_loop(
             failures.extend(fmt_failures(&injected.outcome));
         }
         runtime.set_steered(driver.supervisor().is_steered());
-        // The retained verdict describes ONE process instance. Once a
-        // replacement is being started it describes nothing live, and
-        // reporting it would claim a verified FIB for a VPP that has not
-        // built one yet. `Backoff` deliberately still reports it — the
-        // failed verify is precisely why we are backing off.
-        if driver.state() == State::Starting {
+        // The retained verdict describes ONE process instance, so process
+        // loss has to invalidate it — but asymmetrically, and the
+        // asymmetry is the whole point:
+        //
+        // - a **passing** verdict must go. Keeping it reported a verified
+        //   FIB, and `packetframe_vpp_fib_verified 1`, for a process that
+        //   no longer exists — through the entire backoff interval and in
+        //   the final stopped snapshot.
+        // - a **failing** verdict must stay. It is the reason we are in
+        //   backoff at all, and dropping it puts "not yet verified" where
+        //   the explanation should be.
+        //
+        // Keyed on `has_process()`, not on a state guess. The first
+        // version keyed on `Starting`, which a lost process does not pass
+        // through: a crash, a wedge or a stop lands in `Backoff` or
+        // `Stopped`, so the invalidation never fired for any of the cases
+        // it existed to cover.
+        if !driver.state().has_process() && last_verify.as_ref().is_some_and(|v| v.passed()) {
             last_verify = None;
             last_verify_at = None;
         }
@@ -462,37 +514,88 @@ fn run_loop(
         }
     }
 
-    // Orderly teardown: hand the machine the stop and tick it until it
-    // settles or the bounded patience expires. `StopRequested` on an
-    // already-Stopped machine is a no-op, so the redundant case is
-    // harmless.
+    // Orderly teardown: hand the machine the stop, then keep working until
+    // the resources are actually released or the bounded patience expires.
     //
     // Outcomes are ACCUMULATED here, not dropped. The stop transition's
     // `ReleaseResources` can fail after the supervisor is already
     // `Stopped`, so no event will ever carry that failure — the
     // discarded Tick was the only witness, and discarding it made
     // `stop()` return a clean-looking snapshot over still-held VFs.
-    let mut absorb = |outcome: crate::executor::Outcome| {
-        teardown_failures.extend(fmt_failures(&outcome));
-        resources_leaked |= outcome.resources_leaked;
-    };
+    // A free function rather than a closure: the retry below has to read
+    // and reset `resources_leaked`, which a closure capturing it mutably
+    // would forbid.
+    fn absorb(outcome: crate::executor::Outcome, failures: &mut Vec<String>, leaked: &mut bool) {
+        failures.extend(fmt_failures(&outcome));
+        *leaked |= outcome.resources_leaked;
+    }
     let deadline = Instant::now() + STOP_PATIENCE;
     absorb(
         driver
             .inject(Instant::now(), Event::StopRequested, &mut fx)
             .outcome,
+        &mut teardown_failures,
+        &mut resources_leaked,
     );
-    while driver.state() != State::Stopped && Instant::now() < deadline {
+    // The loop waits on the ONE condition that waiting can resolve: an
+    // undead process.
+    //
+    // Two bugs met here. `(_, StopRequested)` assigns `Stopped`
+    // unconditionally — before knowing whether `Unsteer` succeeded or
+    // `Kill` reported `MustLeak` — so the old `while state != Stopped`
+    // condition was false on its first evaluation and the whole patience
+    // window was dead code: a VPP that exits a moment after SIGKILL, whose
+    // VF could then have been released well inside the budget, produced an
+    // immediate leaked-resources snapshot instead.
+    //
+    // But the fix must not be "retry while anything is still held". On a
+    // structural refusal — `SteeringUnavailable` declining to unsteer, a VF
+    // that will not unbind — nothing changes by waiting, and looping to the
+    // deadline would add ten seconds to every such detach. `undead` is
+    // different in kind: it means SIGKILL could not bite (VFIO/DMA), and
+    // the pidfd will report the exit whenever it comes. Ticking is what
+    // observes it.
+    //
+    // Retrying is possible because `StopRequested` is NOT a no-op on an
+    // already-`Stopped` machine (the comment here used to claim it was):
+    // it matches any state and re-emits Unsteer/Kill/ReleaseResources
+    // against a world that has since changed.
+    let was_undead = driver.supervisor().is_undead();
+    while driver.supervisor().is_undead() && Instant::now() < deadline {
         let now = Instant::now();
         let tick = driver.tick(now, &mut obs, &mut fx);
-        absorb(tick.outcome.clone());
+        absorb(
+            tick.outcome.clone(),
+            &mut teardown_failures,
+            &mut resources_leaked,
+        );
         for e in runtime.take_pending() {
-            absorb(driver.inject(Instant::now(), e, &mut fx).outcome);
+            absorb(
+                driver.inject(Instant::now(), e, &mut fx).outcome,
+                &mut teardown_failures,
+                &mut resources_leaked,
+            );
         }
         match tick.sleep {
             Some(d) if d.is_zero() => {}
             _ => std::thread::sleep(Duration::from_millis(10)),
         }
+    }
+    if was_undead && !driver.supervisor().is_undead() {
+        // The process that survived SIGKILL has since exited, so its VF and
+        // hugepages are releasable now. Clear the verdict from the attempt
+        // that could not proceed before re-running the teardown, or the
+        // stale `true` would outlive the condition that produced it.
+        resources_leaked = false;
+        teardown_failures
+            .push("the process survived SIGKILL and then exited; teardown re-run".into());
+        absorb(
+            driver
+                .inject(Instant::now(), Event::StopRequested, &mut fx)
+                .outcome,
+            &mut teardown_failures,
+            &mut resources_leaked,
+        );
     }
     // The final word: whatever the teardown left behind — an undead VPP
     // that refused to die, a release that failed after `Stopped`, the

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -252,6 +252,31 @@ impl StatusSnapshot {
         fib: FibSync,
         ports: Vec<PortLink>,
     ) -> Self {
+        Self::observe_parts(
+            sup,
+            counts,
+            pending.len() as u64,
+            pending.withheld_len() as u64,
+            api,
+            fib,
+            ports,
+        )
+    }
+
+    /// Same observation, from already-extracted pending counts — for
+    /// the supervision service, which reads them out of the runtime's
+    /// [`crate::runtime::RuntimeStatus`] rather than holding the
+    /// `PendingMap` itself. Every supervisor-derived field still comes
+    /// from `sup`, never from a caller's belief.
+    pub fn observe_parts(
+        sup: &Supervisor,
+        counts: SinkCounts,
+        pending_ops: u64,
+        parked_ops: u64,
+        api: ApiHealth,
+        fib: FibSync,
+        ports: Vec<PortLink>,
+    ) -> Self {
         Self {
             state: sup.state(),
             steered: sup.is_steered(),
@@ -259,8 +284,8 @@ impl StatusSnapshot {
             undead: sup.is_undead(),
             failures: sup.failures(),
             counts,
-            pending_ops: pending.len() as u64,
-            parked_ops: pending.withheld_len() as u64,
+            pending_ops,
+            parked_ops,
             api,
             fib,
             ports,

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -57,6 +57,9 @@ pub const SUBSYS_API: &str = "api-ping";
 pub const SUBSYS_FIB: &str = "fib-synced";
 pub const SUBSYS_STEERING: &str = "steering";
 pub const SUBSYS_PORTS: &str = "ports";
+/// Reported only when a persist failed; see
+/// [`StatusSnapshot::store_error`].
+pub const SUBSYS_STATE_FILE: &str = "state-file";
 
 /// Liveness of the binary API, as observed from ping/pong timestamps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -236,6 +239,17 @@ pub struct StatusSnapshot {
     pub api: ApiHealth,
     pub fib: FibSync,
     pub ports: Vec<PortLink>,
+    /// The runtime could not persist something it observed.
+    ///
+    /// Part of the **snapshot**, not something a caller layers on top of
+    /// the report afterwards. It was that at first, in the supervision
+    /// service — and the consequence was precise: `report()` was patched
+    /// to `Degraded` while [`render_metrics`] rendered its health gauge
+    /// from the unpatched snapshot, so `packetframe_vpp_health` went on
+    /// reporting `healthy` during exactly the persistence failure the
+    /// patch existed to surface. Two surfaces, one condition, one place
+    /// to encode it.
+    pub store_error: Option<String>,
 }
 
 impl StatusSnapshot {
@@ -260,6 +274,7 @@ impl StatusSnapshot {
             api,
             fib,
             ports,
+            None,
         )
     }
 
@@ -268,6 +283,7 @@ impl StatusSnapshot {
     /// [`crate::runtime::RuntimeStatus`] rather than holding the
     /// `PendingMap` itself. Every supervisor-derived field still comes
     /// from `sup`, never from a caller's belief.
+    #[allow(clippy::too_many_arguments)]
     pub fn observe_parts(
         sup: &Supervisor,
         counts: SinkCounts,
@@ -276,6 +292,7 @@ impl StatusSnapshot {
         api: ApiHealth,
         fib: FibSync,
         ports: Vec<PortLink>,
+        store_error: Option<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -289,6 +306,7 @@ impl StatusSnapshot {
             api,
             fib,
             ports,
+            store_error,
         }
     }
 
@@ -315,13 +333,27 @@ impl StatusSnapshot {
     /// Structured report for `packetframe status`, circuit breakers and
     /// the Prometheus surface.
     pub fn report(&self) -> HealthReport {
-        let subsystems = vec![
+        let mut subsystems = vec![
             self.process_health(),
             self.api_health(),
             self.fib_health(),
             self.steering_health(),
             self.ports_health(),
         ];
+        // Only present when the runtime actually failed to persist
+        // something, so the subsystem list does not carry a permanent
+        // "state-file: fine" row nobody reads.
+        if let Some(e) = &self.store_error {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_STATE_FILE.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "could not persist observed state ({e}); a daemon restart will refuse \
+                     adoption and cycle VPP instead"
+                )),
+                last_success_age_seconds: None,
+            });
+        }
         HealthReport {
             overall: self.overall(),
             subsystems,
@@ -393,6 +425,12 @@ impl StatusSnapshot {
             && self.dead_ports().is_empty()
             // Steering wanted but absent: a broken rollout, not staging.
             && (self.steered || !self.steer_intended)
+            // Convergence is fine and the interfaces work, but the next
+            // daemon restart will refuse adoption and cycle a VPP that
+            // was forwarding. Nominal has to mean "and it will survive a
+            // restart", or the whitelist quietly stops covering the one
+            // failure whose consequence is deferred.
+            && self.store_error.is_none()
     }
 
     fn process_health(&self) -> SubsystemHealth {
@@ -1286,6 +1324,68 @@ mod tests {
         // The gauge and the structured report must never disagree.
         assert_eq!(s.report().overall, HealthState::Degraded);
         assert!(m.contains("packetframe_vpp_health{module=\"vpp-offload\",state=\"degraded\"} 1"));
+    }
+
+    /// The agreement above must hold for **every** condition, including
+    /// the ones added last. A store failure used to be layered onto the
+    /// report by the supervision service *after* the snapshot, so
+    /// `health_check` said Degraded while `packetframe_vpp_health` — which
+    /// renders from `report()` on the unmodified snapshot — went on saying
+    /// healthy, during exactly the failure the layering existed to
+    /// surface. Asserted here rather than at the service, because this is
+    /// where the two surfaces have to come from one input.
+    #[test]
+    fn a_store_failure_degrades_the_report_and_the_gauge_together() {
+        let clean = snap_of(
+            &steered_supervisor(),
+            &ledger_with(10, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::ZERO,
+            },
+            verified(1),
+            ports_up(),
+        );
+        assert_eq!(
+            clean.report().overall,
+            HealthState::Healthy,
+            "the control must be healthy or this proves nothing"
+        );
+
+        let mut degraded = clean.clone();
+        degraded.store_error = Some("state dir is read-only".into());
+        assert_eq!(degraded.report().overall, HealthState::Degraded);
+        let m = render_metrics(&degraded, "vpp-offload");
+        assert!(
+            m.contains("packetframe_vpp_health{module=\"vpp-offload\",state=\"degraded\"} 1"),
+            "the gauge disagrees with the report: {m}"
+        );
+        assert!(
+            m.contains("packetframe_vpp_health{module=\"vpp-offload\",state=\"healthy\"} 0"),
+            "{m}"
+        );
+        // And it is NAMED, with the consequence spelled out — the
+        // degradation is invisible until a restart, so the message has to
+        // say what that restart will do.
+        let sub = degraded
+            .report()
+            .subsystems
+            .into_iter()
+            .find(|s| s.name == SUBSYS_STATE_FILE)
+            .expect("the state-file subsystem must be present");
+        let msg = sub.message.unwrap_or_default();
+        assert!(msg.contains("read-only"), "{msg}");
+        assert!(msg.contains("refuse adoption"), "{msg}");
+
+        // No row at all when nothing failed, rather than a permanent
+        // "state-file: fine" nobody reads.
+        assert!(
+            !clean
+                .report()
+                .subsystems
+                .iter()
+                .any(|s| s.name == SUBSYS_STATE_FILE),
+            "a healthy snapshot grew a state-file row"
+        );
     }
 
     #[test]

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -148,6 +148,9 @@ pub struct Behaviour {
     /// Reject this many *deletes* with a non-zero retval before
     /// accepting them.
     pub reject_deletes: usize,
+    /// Advertise garbage CRCs in the handshake's message table — the
+    /// version-skew shape the transport must refuse loudly.
+    pub garbage_crcs: bool,
 }
 
 impl Fake {
@@ -215,9 +218,14 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
         message_table: Vec::new(),
     };
     for (i, m) in MESSAGE_META.iter().enumerate() {
+        let crc = if behaviour.garbage_crcs {
+            "deadbeef".to_string()
+        } else {
+            m.crc.trim_start_matches("0x").to_string()
+        };
         reply.message_table.push(MessageTableEntry {
             index: 100 + i as u16,
-            name: format!("{}_{}", m.name, m.crc.trim_start_matches("0x")),
+            name: format!("{}_{crc}", m.name),
         });
     }
     let mut payload = Vec::new();

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -151,6 +151,15 @@ pub struct Behaviour {
     /// Advertise garbage CRCs in the handshake's message table — the
     /// version-skew shape the transport must refuse loudly.
     pub garbage_crcs: bool,
+    /// Answer `ip_route_lookup` with a path on an interface the module
+    /// does not own, so readback verification FAILS.
+    ///
+    /// The shape that matters: routes install cleanly, the drain
+    /// completes, and only the verify catches that VPP's FIB is not what
+    /// we asked for. It is also the only way to reach the supervisor's
+    /// `VerifyFailed` teardown from a test, because the verdict arrives
+    /// as an INJECTED event rather than from an ordinary tick.
+    pub verify_mismatch: bool,
 }
 
 impl Fake {
@@ -326,6 +335,13 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
             }
             "ip_route_lookup" => {
                 out = reply_head("ip_route_lookup_reply");
+                // A path on an index we never attached: present, ack'd,
+                // and forwarding nowhere we control.
+                let idx = if behaviour.verify_mismatch {
+                    ASSIGNED_INDEX + 100
+                } else {
+                    ASSIGNED_INDEX
+                };
                 IpRouteLookupReply {
                     context: ctx,
                     retval: 0,
@@ -334,7 +350,7 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                         stats_index: 0,
                         prefix: prefix_of(v4(10, 0)),
                         n_paths: 1,
-                        paths: vec![path_on(ASSIGNED_INDEX)],
+                        paths: vec![path_on(idx)],
                     },
                 }
                 .encode(&mut out);

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -151,6 +151,15 @@ pub struct Behaviour {
     /// Advertise garbage CRCs in the handshake's message table — the
     /// version-skew shape the transport must refuse loudly.
     pub garbage_crcs: bool,
+    /// Stop answering `control_ping` after this many of them, WITHOUT
+    /// closing the connection.
+    ///
+    /// Models a VPP whose main thread is busy: the client blocks in its
+    /// synchronous socket read until the timeout in force. That is the
+    /// shape that made `stop()` unbounded — a tick sitting inside an API
+    /// call cannot observe the stop flag — and a hangup cannot model it,
+    /// because a closed socket returns immediately.
+    pub stall_pings_after: Option<usize>,
     /// Answer `ip_route_lookup` with a path on an interface the module
     /// does not own, so readback verification FAILS.
     ///
@@ -363,7 +372,15 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                 write_frame(sock, &d);
                 continue;
             }
+            "control_ping" if behaviour.stall_pings_after == Some(0) => {
+                // Silence, connection held open: the client blocks until
+                // its read timeout.
+                continue;
+            }
             "control_ping" => {
+                if let Some(n) = behaviour.stall_pings_after.as_mut() {
+                    *n -= 1;
+                }
                 out = reply_head("control_ping_reply");
                 ControlPingReply {
                     context: ctx,

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -329,6 +329,7 @@ fn a_refused_derived_delete_is_retried() {
             hangup_after: None,
             reject_deletes: 1,
             garbage_crcs: false,
+            verify_mismatch: false,
         },
     );
     let mut e = engine_for(&fake);
@@ -474,6 +475,7 @@ fn a_crc_mismatch_is_recorded_as_permanent() {
             hangup_after: None,
             reject_deletes: 0,
             garbage_crcs: true,
+            verify_mismatch: false,
         },
     );
     let mut e = engine_for(&fake);

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -17,415 +17,17 @@
 //! actually moves packets is gate 0b's job on hardware, and nothing here
 //! should be read as evidence about that.
 
-use std::io::{Read, Write};
+#[path = "common/fake_vpp.rs"]
+mod fake_vpp;
+
 use std::net::{IpAddr, Ipv4Addr};
-use std::os::unix::net::{UnixListener, UnixStream};
-use std::path::PathBuf;
-use std::sync::mpsc::{channel, Receiver, Sender};
-use std::thread;
 
 use packetframe_common::fib::IpPrefix;
 use packetframe_vpp_offload::attach::{AttachMode, PortAttach};
 use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
 use packetframe_vpp_offload::fib_sync::FamilyPolicy;
-use packetframe_vpp_offload::vpp_api::codec::{
-    parse_frame_header, peek_msg_id, write_frame_header, Decode, Decoder, Encode, MSG_HEADER_LEN,
-    SOCKCLNT_CREATE_MSG_ID,
-};
-use packetframe_vpp_offload::vpp_api::generated::{
-    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpNeighborAddDel,
-    IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteLookupReply,
-    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
-    MESSAGE_META,
-};
 
-/// The index the fake's `dev_create_port_if` hands out. Routes must
-/// install onto *this*, learned from VPP, never onto a guess.
-const ASSIGNED_INDEX: u32 = 3;
-
-/// Link-layer address the fake mirror hands out for its one neighbour.
-const MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-
-fn id_for(name: &str) -> u16 {
-    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
-}
-
-fn name_for(id: u16) -> &'static str {
-    MESSAGE_META[(id - 100) as usize].name
-}
-
-fn reply_head(name: &str) -> Vec<u8> {
-    let meta = MESSAGE_META
-        .iter()
-        .find(|m| m.name == name)
-        .expect("known reply");
-    let mut out = Vec::new();
-    out.extend_from_slice(&id_for(name).to_be_bytes());
-    if meta.client_index_prefix {
-        out.extend_from_slice(&7u32.to_be_bytes());
-    }
-    out
-}
-
-fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
-    let mut hdr = [0u8; MSG_HEADER_LEN];
-    s.read_exact(&mut hdr).ok()?;
-    let len = parse_frame_header(&hdr) as usize;
-    let mut payload = vec![0u8; len];
-    s.read_exact(&mut payload).ok()?;
-    Some(payload)
-}
-
-fn write_frame(s: &mut UnixStream, payload: &[u8]) {
-    let mut framed = Vec::new();
-    write_frame_header(&mut framed, payload.len());
-    framed.extend_from_slice(payload);
-    let _ = s.write_all(&framed);
-    let _ = s.flush();
-}
-
-fn request_context(payload: &[u8]) -> u32 {
-    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
-}
-
-mod tempdir {
-    use std::path::{Path, PathBuf};
-    pub struct TempDir(PathBuf);
-    impl TempDir {
-        pub fn new(tag: &str) -> std::io::Result<Self> {
-            let mut p = std::env::temp_dir();
-            // Short by construction: a unix socket path is capped at
-            // SUN_LEN (~104 bytes) and macOS $TMPDIR is already ~50 of
-            // them, so a full nanosecond stamp overflows it and the
-            // failure surfaces as an unrelated-looking bind error.
-            p.push(format!(
-                "pf-e{tag}-{}-{:x}",
-                std::process::id(),
-                std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos()
-                    % 0x100_000
-            ));
-            std::fs::create_dir_all(&p)?;
-            Ok(Self(p))
-        }
-        pub fn path(&self) -> &Path {
-            &self.0
-        }
-    }
-    impl Drop for TempDir {
-        fn drop(&mut self) {
-            let _ = std::fs::remove_dir_all(&self.0);
-        }
-    }
-}
-
-/// One route operation as the fake decoded it off the wire.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct WireRoute {
-    is_add: bool,
-    /// First four address bytes + prefix length, enough to identify the
-    /// v4 prefixes these tests use.
-    addr: [u8; 4],
-    len: u8,
-    /// Interface indices the paths reference.
-    path_indices: Vec<u32>,
-}
-
-#[derive(Debug, Clone)]
-enum Event {
-    Msg(String),
-    Route(WireRoute),
-    Neighbour {
-        sw_if_index: u32,
-        mac: [u8; 6],
-        flags: u8,
-    },
-}
-
-struct Fake {
-    path: PathBuf,
-    _dir: tempdir::TempDir,
-    events: Receiver<Event>,
-}
-
-/// How the fake misbehaves.
-#[derive(Clone, Copy, Default)]
-struct Behaviour {
-    /// Drop the connection after this many route ops.
-    hangup_after: Option<usize>,
-    /// Reject this many *deletes* with a non-zero retval before
-    /// accepting them.
-    reject_deletes: usize,
-}
-
-impl Fake {
-    fn start(tag: &str) -> Self {
-        Self::start_behaving(tag, Behaviour::default())
-    }
-
-    /// Drop the connection after `hangup_after` route ops — the
-    /// mid-drain failure the unwind path exists for.
-    ///
-    /// **One-shot, deliberately.** The point of the test is that a fresh
-    /// connection can finish the job, so a fake that hung up on every
-    /// connection would make recovery untestable rather than testing it.
-    fn start_with(tag: &str, hangup_after: usize) -> Self {
-        Self::start_behaving(
-            tag,
-            Behaviour {
-                hangup_after: Some(hangup_after),
-                ..Default::default()
-            },
-        )
-    }
-
-    fn start_behaving(tag: &str, behaviour: Behaviour) -> Self {
-        let dir = tempdir::TempDir::new(tag).unwrap();
-        let path = dir.path().join("api.sock");
-        let listener = UnixListener::bind(&path).unwrap();
-        let (tx, rx): (Sender<Event>, Receiver<Event>) = channel();
-
-        thread::spawn(move || {
-            let mut b = behaviour;
-            // Accept repeatedly: a disconnect-and-reconnect is part of
-            // what these tests exercise.
-            while let Ok((mut sock, _)) = listener.accept() {
-                serve(&mut sock, &tx, b);
-                // One-shot hangup: the point of that test is that a fresh
-                // connection can finish the job.
-                b.hangup_after = None;
-            }
-        });
-
-        Self {
-            path,
-            _dir: dir,
-            events: rx,
-        }
-    }
-
-    fn drain_events(&self) -> Vec<Event> {
-        let mut v = Vec::new();
-        while let Ok(e) = self.events.try_recv() {
-            v.push(e);
-        }
-        v
-    }
-}
-
-fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) -> Option<()> {
-    read_frame(sock)?;
-    let mut reply = SockclntCreateReply {
-        context: 1,
-        response: 0,
-        index: 7,
-        count: MESSAGE_META.len() as u16,
-        message_table: Vec::new(),
-    };
-    for (i, m) in MESSAGE_META.iter().enumerate() {
-        reply.message_table.push(MessageTableEntry {
-            index: 100 + i as u16,
-            name: format!("{}_{}", m.name, m.crc.trim_start_matches("0x")),
-        });
-    }
-    let mut payload = Vec::new();
-    payload.extend_from_slice(&SOCKCLNT_CREATE_MSG_ID.to_be_bytes());
-    payload.extend_from_slice(&7u32.to_be_bytes());
-    reply.encode(&mut payload);
-    write_frame(sock, &payload);
-
-    let mut routes_seen = 0usize;
-
-    loop {
-        let req = read_frame(sock)?;
-        let id = peek_msg_id(&req).expect("msg id");
-        let ctx = request_context(&req);
-        let which = name_for(id);
-        let _ = tx.send(Event::Msg(which.to_string()));
-
-        let mut out;
-        match which {
-            "dev_attach" => {
-                out = reply_head("dev_attach_reply");
-                DevAttachReply {
-                    context: ctx,
-                    dev_index: 0,
-                    retval: 0,
-                    error_string: String::new(),
-                }
-                .encode(&mut out);
-            }
-            "dev_create_port_if" => {
-                out = reply_head("dev_create_port_if_reply");
-                DevCreatePortIfReply {
-                    context: ctx,
-                    sw_if_index: ASSIGNED_INDEX,
-                    retval: 0,
-                    error_string: String::new(),
-                }
-                .encode(&mut out);
-            }
-            "sw_interface_set_flags" => {
-                out = reply_head("sw_interface_set_flags_reply");
-                SwInterfaceSetFlagsReply {
-                    context: ctx,
-                    retval: 0,
-                }
-                .encode(&mut out);
-            }
-            "ip_route_add_del" => {
-                // Decoded with the same generated impl the client
-                // encodes with, so this asserts on the real wire.
-                let mut d = Decoder::new(&req);
-                let r = IpRouteAddDel::decode(&mut d).expect("decodes as a route op");
-                let mut addr = [0u8; 4];
-                addr.copy_from_slice(&r.route.prefix.address.un.0[..4]);
-                let _ = tx.send(Event::Route(WireRoute {
-                    is_add: r.is_add,
-                    addr,
-                    len: r.route.prefix.len,
-                    path_indices: r.route.paths.iter().map(|p| p.sw_if_index).collect(),
-                }));
-
-                routes_seen += 1;
-                if behaviour.hangup_after.is_some_and(|n| routes_seen > n) {
-                    return None;
-                }
-                // Reject deletes for a while, so the retry path is
-                // exercised against a per-route refusal rather than a
-                // connection fault.
-                let retval = if !r.is_add && behaviour.reject_deletes > 0 {
-                    behaviour.reject_deletes -= 1;
-                    -1
-                } else {
-                    0
-                };
-                out = reply_head("ip_route_add_del_reply");
-                IpRouteAddDelReply {
-                    context: ctx,
-                    retval,
-                    stats_index: 0,
-                }
-                .encode(&mut out);
-            }
-            "ip_neighbor_add_del" => {
-                let mut d = Decoder::new(&req);
-                let n = IpNeighborAddDel::decode(&mut d).expect("decodes as a neighbour op");
-                let _ = tx.send(Event::Neighbour {
-                    sw_if_index: n.neighbor.sw_if_index,
-                    mac: n.neighbor.mac_address,
-                    flags: n.neighbor.flags,
-                });
-                out = reply_head("ip_neighbor_add_del_reply");
-                IpNeighborAddDelReply {
-                    context: ctx,
-                    retval: 0,
-                    stats_index: 0,
-                }
-                .encode(&mut out);
-            }
-            "ip_route_lookup" => {
-                out = reply_head("ip_route_lookup_reply");
-                IpRouteLookupReply {
-                    context: ctx,
-                    retval: 0,
-                    route: IpRoute {
-                        table_id: 0,
-                        stats_index: 0,
-                        prefix: prefix_of(v4(10, 0)),
-                        n_paths: 1,
-                        paths: vec![path_on(ASSIGNED_INDEX)],
-                    },
-                }
-                .encode(&mut out);
-            }
-            // DUMP: one details frame per interface, no terminator — the
-            // trailing control_ping's reply ends the stream, as VPP does.
-            "sw_interface_dump" => {
-                let mut d = reply_head("sw_interface_details");
-                details(ASSIGNED_INDEX, "octeon0/0", 3, ctx).encode(&mut d);
-                write_frame(sock, &d);
-                continue;
-            }
-            "control_ping" => {
-                out = reply_head("control_ping_reply");
-                ControlPingReply {
-                    context: ctx,
-                    retval: 0,
-                    vpe_pid: 4242,
-                }
-                .encode(&mut out);
-            }
-            other => panic!("fake got unexpected message {other}"),
-        }
-        write_frame(sock, &out);
-    }
-}
-
-fn details(sw_if_index: u32, name: &str, flags: u32, context: u32) -> SwInterfaceDetails {
-    SwInterfaceDetails {
-        context,
-        sw_if_index,
-        sup_sw_if_index: sw_if_index,
-        l2_address: [0u8; 6],
-        flags,
-        r#type: 0,
-        link_duplex: 0,
-        link_speed: 2_500_000,
-        link_mtu: 9000,
-        mtu: [9000, 0, 0, 0],
-        sub_id: 0,
-        sub_number_of_tags: 0,
-        sub_outer_vlan_id: 0,
-        sub_inner_vlan_id: 0,
-        sub_if_flags: 0,
-        vtr_op: 0,
-        vtr_push_dot1q: 0,
-        vtr_tag1: 0,
-        vtr_tag2: 0,
-        outer_tag: 0,
-        b_dmac: [0u8; 6],
-        b_smac: [0u8; 6],
-        b_vlanid: 0,
-        i_sid: 0,
-        interface_name: name.to_string(),
-        interface_dev_type: "octeon".into(),
-        tag: String::new(),
-    }
-}
-
-fn path_on(sw_if_index: u32) -> FibPath {
-    FibPath {
-        sw_if_index,
-        table_id: 0,
-        rpf_id: 0,
-        weight: 1,
-        preference: 0,
-        r#type: 0,
-        flags: 0,
-        proto: 0,
-        nh: Default::default(),
-        n_labels: 0,
-        label_stack: Default::default(),
-    }
-}
-
-fn prefix_of(p: IpPrefix) -> packetframe_vpp_offload::vpp_api::generated::Prefix {
-    packetframe_vpp_offload::fib_sync::to_prefix(p)
-}
-
-fn v4(a: u8, b: u8) -> IpPrefix {
-    IpPrefix::V4 {
-        addr: [10, a, b, 0],
-        prefix_len: 24,
-    }
-}
-
-fn nh() -> IpAddr {
-    IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))
-}
+use fake_vpp::{nh, v4, Behaviour, Event, Fake, WireRoute, ASSIGNED_INDEX, MAC};
 
 struct Mirror {
     routes: Vec<IpPrefix>,
@@ -726,6 +328,7 @@ fn a_refused_derived_delete_is_retried() {
         Behaviour {
             hangup_after: None,
             reject_deletes: 1,
+            garbage_crcs: false,
         },
     );
     let mut e = engine_for(&fake);
@@ -857,5 +460,28 @@ fn neighbours_on_foreign_devices_are_skipped() {
         e.program_neighbours(&MixedMirror).unwrap(),
         1,
         "only the member-port neighbour"
+    );
+}
+
+/// A VPP advertising different CRCs must be refused as *permanently*
+/// incompatible, not as a transient not-ready-yet: the difference is
+/// whether the supervisor retries forever or stops and reports.
+#[test]
+fn a_crc_mismatch_is_recorded_as_permanent() {
+    let fake = Fake::start_behaving(
+        "crc",
+        Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: true,
+        },
+    );
+    let mut e = engine_for(&fake);
+    assert!(!e.api_ready(), "a CRC mismatch must not read as ready");
+    let err = e.last_api_error().expect("the reason is recorded");
+    assert!(err.contains("API mismatch"), "{err}");
+    assert!(
+        e.api_incompatible(),
+        "retrying cannot fix a version skew: {err}"
     );
 }

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -329,6 +329,7 @@ fn a_refused_derived_delete_is_retried() {
             hangup_after: None,
             reject_deletes: 1,
             garbage_crcs: false,
+            stall_pings_after: None,
             verify_mismatch: false,
         },
     );
@@ -475,6 +476,7 @@ fn a_crc_mismatch_is_recorded_as_permanent() {
             hangup_after: None,
             reject_deletes: 0,
             garbage_crcs: true,
+            stall_pings_after: None,
             verify_mismatch: false,
         },
     );

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -317,3 +317,77 @@ fn a_persist_that_recovers_clears_the_recorded_failure() {
         rt.status().store_error
     );
 }
+
+/// A successful SPAWN persist clears an earlier store failure too.
+///
+/// `spawn` kept its own direct `store.process_changed` call while
+/// `note_persist`'s doc claimed to be the single recorder — so a store that
+/// failed on an exit and recovered before the retry spawn went on reporting
+/// "observed state is not durable" until a later device attach happened to
+/// succeed, potentially for the whole API startup interval. The class is
+/// exactly the one this module keeps producing: prose asserting a single
+/// owner, with a writer in the same file going around it.
+///
+/// Linux-only because it needs a real spawn; `/bin/true` is enough — the
+/// child's behaviour is irrelevant, only that a pid was recorded.
+#[cfg(target_os = "linux")]
+#[test]
+fn a_successful_spawn_persist_clears_an_earlier_store_failure() {
+    use packetframe_vpp_offload::executor::Effects as _;
+    use packetframe_vpp_offload::runtime::{IdentityStore, ProcessIdentity};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct Flaky(Arc<AtomicBool>);
+    impl IdentityStore for Flaky {
+        fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+            if self.0.load(Ordering::SeqCst) {
+                Err("state dir is read-only".into())
+            } else {
+                Ok(())
+            }
+        }
+        fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    let fake = Fake::start("spawn-clears");
+    let failing = Arc::new(AtomicBool::new(true));
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        Vec::new(),
+        vec!["eth4".into()],
+        1_000,
+        FamilyPolicy::V4Only,
+    );
+    let rt = Runtime::new(
+        engine,
+        Box::new(Mirror { routes: vec![] }),
+        Box::new(SteeringUnavailable),
+        Box::new(Flaky(Arc::clone(&failing))),
+        // `spawn(binary, conf)` execs `binary -c conf`; /bin/true exits
+        // immediately regardless, which is all this needs.
+        "/bin/true",
+        "/dev/null",
+    );
+
+    // First spawn: the child starts, the record fails, and persist-or-kill
+    // abandons it — with the failure recorded.
+    let (_, mut fx) = rt.views();
+    assert!(fx.spawn().is_err(), "persist-or-kill must refuse");
+    assert!(
+        rt.status().store_error.is_some(),
+        "the failed persist must be surfaced"
+    );
+
+    // The store recovers, and the retry spawn persists. That success makes
+    // the whole record durable again, so the degradation must end with it.
+    failing.store(false, Ordering::SeqCst);
+    fx.spawn().expect("the retry spawn records cleanly");
+    assert!(
+        rt.status().store_error.is_none(),
+        "a successful spawn persist left the earlier failure reported: {:?}",
+        rt.status().store_error
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -232,3 +232,88 @@ fn a_broken_socket_mid_resync_fails_convergence_and_retries() {
         "only routes the fake acknowledged before hanging up may count"
     );
 }
+
+/// A persist that fails and later succeeds must stop being reported.
+///
+/// `last_store_error` was set on every failure and never cleared, so one
+/// transient failure — a briefly read-only state dir, a full filesystem —
+/// kept the module out of `nominal()` for the life of the service even
+/// once the record was durable again. Clearing is safe precisely because
+/// the save is whole-record: `FileStore` writes the entire
+/// `ResourceState` on every observation, so any write that lands makes
+/// hugepages, VFs, indices and process identity current together.
+///
+/// Driven through the real seam (`Effects::attach_devices` against the
+/// fake VPP) rather than at the loop level: the loop only re-persists
+/// during a fresh convergence, which needs a restart and therefore a real
+/// process. Two calls here is the same event the loop would produce.
+#[test]
+fn a_persist_that_recovers_clears_the_recorded_failure() {
+    use packetframe_vpp_offload::executor::Effects as _;
+    use packetframe_vpp_offload::runtime::{IdentityStore, ProcessIdentity};
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    struct Flaky(Arc<AtomicBool>);
+    impl IdentityStore for Flaky {
+        fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+            Ok(())
+        }
+        fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+            if self.0.load(Ordering::SeqCst) {
+                Err("state dir is read-only".into())
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    let fake = Fake::start("store-recover");
+    let failing = Arc::new(AtomicBool::new(true));
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: "eth4".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec!["eth4".into()],
+        1_000_000,
+        FamilyPolicy::V4Only,
+    );
+    let rt = Runtime::new(
+        engine,
+        Box::new(Mirror {
+            routes: vec![fake_vpp::v4(0, 0)],
+        }),
+        Box::new(SteeringUnavailable),
+        Box::new(Flaky(Arc::clone(&failing))),
+        "/usr/bin/vpp",
+        "/dev/null",
+    );
+    {
+        use packetframe_vpp_offload::driver::Observe as _;
+        let (mut obs, _) = rt.views();
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+
+    let (_, mut fx) = rt.views();
+    fx.attach_devices()
+        .expect("attach succeeds; only the RECORD fails");
+    assert!(
+        rt.status().store_error.is_some(),
+        "the failed persist must be surfaced"
+    );
+
+    // The underlying problem goes away; the next successful persist makes
+    // the whole record durable, so the degradation must end with it.
+    failing.store(false, Ordering::SeqCst);
+    fx.attach_devices().expect("attach still succeeds");
+    assert!(
+        rt.status().store_error.is_none(),
+        "a successful persist left the earlier failure reported; health would stay \
+         Degraded for the life of the service: {:?}",
+        rt.status().store_error
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -132,7 +132,7 @@ fn the_service_converges_publishes_health_and_stops_clean() {
     // The runtime's release_resources refuses by design until the
     // attach wiring exists, and that refusal must reach the caller
     // rather than vanish with a discarded Tick.
-    let last = svc.stop().expect("final status");
+    let last = svc.stop().published.expect("final status");
     assert_eq!(last.state, State::Stopped, "{:?}", last.report);
     assert!(
         last.metrics.contains("state=\"stopped\"} 1"),
@@ -729,7 +729,7 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
     }
     assert!(!svc.is_alive(), "the loop was expected to panic");
 
-    let last = svc.stop().expect("a status, even after a panic");
+    let last = svc.stop().published.expect("a status, even after a panic");
     assert!(
         last.resources_leaked,
         "nothing confirmed a release, so resources must be reported as possibly held: {:?}",
@@ -848,4 +848,106 @@ fn an_episode_keeps_its_root_cause_alongside_the_latest_symptom() {
     }
 
     let _ = svc.stop();
+}
+
+/// A teardown that outlives the detach budget stays OBSERVABLE.
+///
+/// `stop()`'s timeout message tells the operator to check `packetframe
+/// status`. That promise was unkeepable: `stop()` consumes the service and
+/// dropped the thread handle, leaving the background loop as the only owner
+/// of the shared status window — so its eventual final publish, including
+/// whether the release finally succeeded, went somewhere nobody could read.
+///
+/// The loop is held up by a fake that stops answering `control_ping` while
+/// keeping the connection open, so a tick sits in its synchronous socket
+/// read past the 900 ms budget.
+#[test]
+fn a_teardown_that_outlives_the_budget_is_still_observable() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-pending",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: false,
+            stall_pings_after: Some(1),
+            verify_mismatch: false,
+        },
+    );
+    let sock = fake.path.clone();
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let report = svc.stop();
+    assert!(
+        report.published.is_some(),
+        "a snapshot must come back either way"
+    );
+
+    // Whether the budget expires is a race against the stalled ping, so
+    // BOTH outcomes assert something — a conditional assertion that can
+    // silently do nothing is the shape this PR has produced five times.
+    // Locally this takes the pending branch; the settled branch is asserted
+    // in case a slower runner beats the stall.
+    let Some(pending) = report.pending else {
+        assert_eq!(
+            report.published.as_ref().map(|p| p.state),
+            Some(State::Stopped),
+            "no pending handle, so the teardown must have actually completed"
+        );
+        return;
+    };
+    {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !pending.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(
+            pending.is_finished(),
+            "the background teardown never settled"
+        );
+        let final_status = pending
+            .status()
+            .expect("the final publish must be reachable through the handle");
+        assert_eq!(
+            final_status.state,
+            State::Stopped,
+            "the FINAL word on the teardown, which used to be destroyed with the thread: \
+             {:?}",
+            final_status.teardown_failures
+        );
+    }
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1,0 +1,136 @@
+//! The supervision service against the fake VPP: real thread, real
+//! clock, the exact shape `Module::attach()` will own.
+//!
+//! `vpp_runtime.rs` proved the loop body composes under a synthetic
+//! clock; this proves the SERVICE does — thread lifecycle, stop
+//! protocol, and the published status window — with wall-clock sleeps
+//! and the factory building the non-`Send` pieces on the loop thread.
+
+#[path = "common/fake_vpp.rs"]
+mod fake_vpp;
+
+use std::net::IpAddr;
+use std::time::{Duration, Instant};
+
+use fake_vpp::{Fake, MAC};
+use packetframe_common::fib::IpPrefix;
+use packetframe_common::module::HealthState;
+use packetframe_vpp_offload::attach::PortAttach;
+use packetframe_vpp_offload::driver::Driver;
+use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
+use packetframe_vpp_offload::fib_sync::FamilyPolicy;
+use packetframe_vpp_offload::runtime::{NullStore, Runtime, SteeringUnavailable};
+use packetframe_vpp_offload::service::SupervisionService;
+use packetframe_vpp_offload::supervisor::{Event, State};
+
+struct Mirror(Vec<IpPrefix>);
+impl RouteSource for Mirror {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for p in &self.0 {
+            visit(*p, &[fake_vpp::nh()]);
+        }
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        visit(fake_vpp::nh(), "eth4", MAC);
+    }
+}
+
+#[test]
+fn the_service_converges_publishes_health_and_stops_clean() {
+    let fake = Fake::start("svc");
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            // The attach wiring verifies the API answers before it
+            // injects an adoption; the factory mirrors that.
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready(), "fake must answer the handshake");
+            }
+            (
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            )
+        }),
+    )
+    .expect("service starts");
+
+    // start() blocked on the first publish, so this is a guarantee,
+    // not a race the test happens to win.
+    assert!(svc.status().is_some(), "initial snapshot published");
+
+    // Converge on the wall clock, bounded.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let ready = loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Ready {
+            break s;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Ready; last state {:?}, report {:?}",
+            s.state,
+            s.report.overall
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    // The staging state is the designed resting place: Healthy, with
+    // the FIB subsystem verified and the metrics carrying the state
+    // one-hot.
+    assert_eq!(
+        ready.report.overall,
+        HealthState::Healthy,
+        "{:?}",
+        ready.report
+    );
+    assert!(
+        ready
+            .metrics
+            .contains("packetframe_vpp_state{module=\"vpp-offload\",state=\"ready\"} 1"),
+        "{}",
+        ready.metrics
+    );
+    assert!(
+        ready
+            .metrics
+            .contains("packetframe_vpp_fib_verified{module=\"vpp-offload\"} 1"),
+        "{}",
+        ready.metrics
+    );
+    assert!(svc.is_alive());
+
+    // Stop: the machine is handed StopRequested, settles in Stopped,
+    // and the final snapshot says so.
+    let last = svc.stop().expect("final status");
+    assert_eq!(last.state, State::Stopped, "{:?}", last.report);
+    assert!(
+        last.metrics.contains("state=\"stopped\"} 1"),
+        "{}",
+        last.metrics
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -169,6 +169,7 @@ fn an_incompatible_api_fails_attach_with_the_reason() {
             hangup_after: None,
             reject_deletes: 0,
             garbage_crcs: true,
+            verify_mismatch: false,
         },
     );
     let sock = fake.path.clone();
@@ -310,6 +311,138 @@ fn an_unpersisted_identity_degrades_health_and_is_named() {
         "and it must name the consequence: {:?}",
         ready.report.subsystems
     );
+    // The gauge has to agree with the report. It did not, once: the
+    // service patched `report` after building the snapshot, while
+    // `render_metrics` rendered from the snapshot — so Prometheus kept
+    // reporting healthy through the whole degradation.
+    assert!(
+        ready
+            .metrics
+            .contains("packetframe_vpp_health{module=\"vpp-offload\",state=\"degraded\"} 1"),
+        "metrics and health_check disagree: {}",
+        ready.metrics
+    );
+
+    let _ = svc.stop();
+}
+
+/// A failing verify's teardown failures must reach the published
+/// diagnostics — and stay there until recovery.
+///
+/// This is the only path in the module where an action's failure exists
+/// **solely** inside an injected event. Verify verdicts arrive through
+/// `runtime.take_pending()`, and `driver.inject(VerifyFailed)` runs the
+/// resulting teardown (`Unsteer` → `Kill` → backoff) synchronously; the
+/// loop used to discard that Tick, so `SteeringUnavailable` refusing to
+/// unsteer — traffic left pointed at a VPP about to be killed — appeared
+/// nowhere at all. Nothing an ordinary tick produces can substitute,
+/// because no ordinary tick produces it.
+///
+/// `Adopted { steered: true }` is what puts an `Unsteer` in the teardown
+/// at all: an unsteered VPP has nothing to tear down first.
+#[test]
+fn a_failing_verifys_teardown_failures_are_published_and_retained() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-verifyfail",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: false,
+            // Routes install and ack; only the readback disagrees.
+            verify_mismatch: true,
+        },
+    );
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                // Refuses both directions until slice 5 builds MCAM.
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: true }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    // The FIRST nonempty failure set is the discriminator, and it has to
+    // be: a loop that discarded the injection still reports an `Unsteer`
+    // failure eventually, because the backoff's next `Spawn` fails and
+    // fails again into the same teardown. What only the injected verdict
+    // can produce is a refused `Unsteer` with **no `Spawn` beside it** —
+    // the teardown that ran the moment verification failed, before any
+    // retry existed.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let first = loop {
+        let s = svc.status().expect("published");
+        if !s.last_failures.is_empty() {
+            break s.last_failures;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no failure was ever published; state {:?}",
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    };
+    assert!(
+        first.iter().any(|f| f.starts_with("Unsteer:")),
+        "the failing verify's teardown must be the first thing reported: {first:?}"
+    );
+    assert!(
+        !first.iter().any(|f| f.starts_with("Spawn:")),
+        "this is the retry cycle's teardown, not the verdict's — the injected Tick was \
+         discarded and its failures lost: {first:?}"
+    );
+
+    // And it is RETAINED. The teardown is followed by backoff ticks with
+    // empty outcomes; republishing those verbatim cleared the reason
+    // within one 50 ms poll while the service stayed unwell for seconds,
+    // so an operator polling status would essentially always miss it.
+    // Held across many times the poll cap here.
+    let hold_until = Instant::now() + Duration::from_millis(400);
+    while Instant::now() < hold_until {
+        let s = svc.status().expect("published");
+        assert!(
+            !s.last_failures.is_empty(),
+            "the reason was dropped by a later tick, leaving only a failure count: {:?}",
+            s.state
+        );
+        assert_ne!(
+            s.report.overall,
+            HealthState::Healthy,
+            "a VPP whose FIB failed verification must not read as healthy: {:?}",
+            s.report
+        );
+        std::thread::sleep(Duration::from_millis(15));
+    }
 
     let _ = svc.stop();
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -644,3 +644,113 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
 
     let _ = svc.stop();
 }
+
+/// A loop that panics AFTER its first publish must not read as a clean stop.
+///
+/// `is_finished()` is true for a panicked thread, so `stop()` reached its
+/// success path and returned the last snapshot — which may well say
+/// `Ready`/Healthy. Meanwhile the stop transition never ran, and dropping
+/// `Runtime` drops the process handle rather than terminating VPP: the
+/// process and its VF can still be live while detach reports success.
+///
+/// Timing is the whole difficulty. Everything that can fail during a SMALL
+/// convergence fails inside the initial injection, before the first publish —
+/// which makes `start()` return the factory-panicked error instead, a
+/// different and already-handled path. So the table here is large enough that
+/// the drain spans ticks: the first publish happens mid-drain, and the verify
+/// and the steer that follows it land after it. `Adopted { steered: true }` is
+/// what makes the machine steer at all.
+#[test]
+fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
+    struct PanicOnSteer;
+    impl packetframe_vpp_offload::runtime::Steering for PanicOnSteer {
+        fn steer(&mut self) -> Result<(), String> {
+            panic!("supervision loop panic, on purpose");
+        }
+        fn unsteer(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+    }
+
+    let fake = Fake::start("svc-panic");
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                // Large enough that the drain spans several ticks
+                // (DRAIN_BATCH bounds one tick's work), so verify and the
+                // steer that follows it land AFTER the first publish.
+                Box::new(Mirror(
+                    (0..12_000u32)
+                        .map(|i| fake_vpp::v4((i >> 8) as u8, (i & 0xff) as u8))
+                        .collect(),
+                )),
+                Box::new(PanicOnSteer),
+                Box::new(NullStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready(), "the fake must answer the handshake");
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: true }],
+            ))
+        }),
+    )
+    .expect("start succeeds: the panic comes later");
+    assert!(
+        svc.status().is_some(),
+        "the first publish must have happened; that is the precondition"
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while svc.is_alive() && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    assert!(!svc.is_alive(), "the loop was expected to panic");
+
+    let last = svc.stop().expect("a status, even after a panic");
+    assert!(
+        last.resources_leaked,
+        "nothing confirmed a release, so resources must be reported as possibly held: {:?}",
+        last.teardown_failures
+    );
+    assert!(
+        last.teardown_failures
+            .iter()
+            .any(|f| f.contains("PANICKED")),
+        "the panic must be named, not swallowed: {:?}",
+        last.teardown_failures
+    );
+    assert_eq!(
+        last.report.overall,
+        HealthState::Unhealthy,
+        "a panicked supervisor reported as healthy: {:?}",
+        last.report
+    );
+    assert!(
+        last.metrics.is_empty(),
+        "stale gauges outlived the loop that rendered them: {}",
+        last.metrics
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -70,11 +70,11 @@ fn the_service_converges_publishes_health_and_stops_clean() {
                 let (mut obs, _) = runtime.views();
                 assert!(obs.api_ready(), "fake must answer the handshake");
             }
-            (
+            Ok((
                 Driver::new(),
                 runtime,
                 vec![Event::Adopted { steered: false }],
-            )
+            ))
         }),
     )
     .expect("service starts");
@@ -125,12 +125,87 @@ fn the_service_converges_publishes_health_and_stops_clean() {
     assert!(svc.is_alive());
 
     // Stop: the machine is handed StopRequested, settles in Stopped,
-    // and the final snapshot says so.
+    // and the final snapshot says so — INCLUDING the failures the stop
+    // transition produced after the supervisor was already Stopped.
+    // The runtime's release_resources refuses by design until the
+    // attach wiring exists, and that refusal must reach the caller
+    // rather than vanish with a discarded Tick.
     let last = svc.stop().expect("final status");
     assert_eq!(last.state, State::Stopped, "{:?}", last.report);
     assert!(
         last.metrics.contains("state=\"stopped\"} 1"),
         "{}",
         last.metrics
+    );
+    assert!(
+        last.teardown_failures
+            .iter()
+            .any(|f| f.contains("attach wiring")),
+        "the refused resource release must be on the record: {:?}",
+        last.teardown_failures
+    );
+}
+
+/// A VPP speaking a different API version must fail ATTACH, with the
+/// skew on the record — not be adopted into a supervision loop that
+/// restarts it every 60 s while the explanation sits unread.
+///
+/// The check lives in the factory because that is where the real attach
+/// wiring verifies the API before adopting: adoption injected against a
+/// dead transport runs `attach_devices` synchronously, fails
+/// `NotConnected`, and lands in backoff without ever polling
+/// `api_ready` — so discovering the skew there would be too late to
+/// name it. (The loop ALSO checks `api_incompatible` for a VPP that
+/// becomes incompatible mid-life, e.g. a respawn into an upgraded
+/// binary. That path needs a real spawn and stays hardware territory
+/// with the failover drills.)
+#[test]
+fn an_incompatible_api_fails_attach_with_the_reason() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-crc",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: true,
+        },
+    );
+    let sock = fake.path.clone();
+
+    let err = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let mut engine = ConvergenceEngine::new(
+                &sock,
+                Vec::new(),
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            // Exactly what the attach wiring does: confirm the API
+            // answers BEFORE committing to adopt it.
+            if !engine.api_ready() {
+                return Err(format!(
+                    "VPP's binary API did not answer usably: {}{}",
+                    engine.last_api_error().unwrap_or("(no detail)"),
+                    if engine.api_incompatible() {
+                        " (permanently incompatible — retrying cannot fix this)"
+                    } else {
+                        ""
+                    }
+                ));
+            }
+            unreachable!("the fake advertises garbage CRCs; the handshake must refuse");
+        }),
+    )
+    .err()
+    .expect("attach must fail on a version-skewed VPP");
+
+    assert!(
+        err.contains("API mismatch"),
+        "the CRC detail must survive: {err}"
+    );
+    assert!(
+        err.contains("permanently incompatible"),
+        "and it must be marked terminal, not retryable: {err}"
     );
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -19,7 +19,9 @@ use packetframe_vpp_offload::attach::PortAttach;
 use packetframe_vpp_offload::driver::Driver;
 use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
 use packetframe_vpp_offload::fib_sync::FamilyPolicy;
-use packetframe_vpp_offload::runtime::{NullStore, Runtime, SteeringUnavailable};
+use packetframe_vpp_offload::runtime::{
+    IdentityStore, NullStore, ProcessIdentity, Runtime, SteeringUnavailable,
+};
 use packetframe_vpp_offload::service::SupervisionService;
 use packetframe_vpp_offload::supervisor::{Event, State};
 
@@ -208,4 +210,106 @@ fn an_incompatible_api_fails_attach_with_the_reason() {
         err.contains("permanently incompatible"),
         "and it must be marked terminal, not retryable: {err}"
     );
+}
+
+/// A store that cannot persist the interface indices.
+struct RefusingStore;
+impl IdentityStore for RefusingStore {
+    fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+        Ok(())
+    }
+    fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+        Err("state dir is read-only".into())
+    }
+}
+
+/// An unpersisted interface identity must DEGRADE health, not pass
+/// silently. Convergence continues by design — the interfaces work —
+/// but the consequence lands at the worst moment: the next daemon
+/// restart cannot adopt, and cycles VPP instead of taking it over.
+#[test]
+fn an_unpersisted_identity_degrades_health_and_is_named() {
+    let fake = Fake::start("svc-store");
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(RefusingStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let ready = loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Ready {
+            break s;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Ready: {:?}",
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    // Converged — the interfaces really do work.
+    assert!(
+        ready
+            .store_error
+            .as_deref()
+            .is_some_and(|e| e.contains("read-only")),
+        "the persistence failure must be carried, not dropped: {:?}",
+        ready.store_error
+    );
+    assert_eq!(
+        ready.report.overall,
+        HealthState::Degraded,
+        "Healthy over an unpersisted identity hides a restart that will fail: {:?}",
+        ready.report
+    );
+    assert!(
+        ready
+            .report
+            .subsystems
+            .iter()
+            .any(|s| s.name == "state-file"
+                && s.message
+                    .as_deref()
+                    .is_some_and(|m| m.contains("refuse adoption"))),
+        "and it must name the consequence: {:?}",
+        ready.report.subsystems
+    );
+
+    let _ = svc.stop();
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -912,16 +912,36 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
     .expect("service starts");
 
     let report = svc.stop();
-    assert!(
-        report.published.is_some(),
-        "a snapshot must come back either way"
-    );
+    let published = report
+        .published
+        .clone()
+        .expect("a snapshot must come back either way");
 
     // Whether the budget expires is a race against the stalled ping, so
     // BOTH outcomes assert something — a conditional assertion that can
     // silently do nothing is the shape this PR has produced five times.
     // Locally this takes the pending branch; the settled branch is asserted
     // in case a slower runner beats the stall.
+    // When the budget expired, the CORRECTION must already be in the shared
+    // window — not only in the returned value. A caller polling the handle
+    // (which is what the timeout message tells the operator to do) used to
+    // read the stale `Ready`/Healthy snapshot for the rest of
+    // `STOP_PATIENCE`.
+    if let Some(p) = &report.pending {
+        assert_eq!(
+            published.report.overall,
+            HealthState::Unhealthy,
+            "the returned snapshot must carry the correction"
+        );
+        let via_handle = p.status().expect("the shared window must have a snapshot");
+        assert_eq!(
+            via_handle.report.overall,
+            HealthState::Unhealthy,
+            "the shared window still advertises health: {:?}",
+            via_handle.report
+        );
+    }
+
     let Some(pending) = report.pending else {
         assert_eq!(
             report.published.as_ref().map(|p| p.state),
@@ -939,9 +959,7 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
             pending.is_finished(),
             "the background teardown never settled"
         );
-        let final_status = pending
-            .status()
-            .expect("the final publish must be reachable through the handle");
+        let final_status = pending.settle();
         assert_eq!(
             final_status.state,
             State::Stopped,

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -951,13 +951,17 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
         return;
     };
     {
-        let deadline = Instant::now() + Duration::from_secs(30);
-        while !pending.is_finished() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        // `settle()` is called WHILE the teardown is still running — that
+        // is the case the handle exists for, and waiting for
+        // `is_finished()` first is what hid a defect: `settle` read the
+        // shared snapshot BEFORE joining, so the loop's real final publish
+        // (arriving during the join) was discarded in favour of the
+        // timeout snapshot. Waiting first meant the final publish had
+        // already landed, and the pre-join read happened to be correct.
         assert!(
-            pending.is_finished(),
-            "the background teardown never settled"
+            !pending.is_finished(),
+            "the teardown finished before settle() was called; this test is not exercising \
+             the case it exists for"
         );
         let final_status = pending.settle();
         assert_eq!(
@@ -968,4 +972,87 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
             final_status.teardown_failures
         );
     }
+}
+
+/// The timeout correction must SURVIVE the tick that was in flight.
+///
+/// `stop()` sets the flag and writes its corrected snapshot while a tick is
+/// blocked in a socket read. When that tick returns — up to a full ping
+/// budget later — the loop's ordinary publish overwrote the correction with
+/// a snapshot carrying no timeout failure and `resources_leaked = false`, so
+/// a caller polling the handle lost the warning until teardown finished.
+///
+/// Watched until the teardown settles rather than sampled once: a single
+/// check right after `stop()` returns happens BEFORE the blocked tick can
+/// republish, which is how the first version of this missed it entirely.
+#[test]
+fn the_timeout_correction_survives_the_in_flight_tick() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-window",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: false,
+            stall_pings_after: Some(1),
+            verify_mismatch: false,
+        },
+    );
+    let sock = fake.path.clone();
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let report = svc.stop();
+    let Some(pending) = report.pending else {
+        // The loop settled inside the budget; nothing was in flight to
+        // overwrite anything, which is also correct.
+        return;
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(20);
+    while !pending.is_finished() && Instant::now() < deadline {
+        let s = pending.status().expect("a snapshot");
+        assert!(
+            s.resources_leaked || !s.teardown_failures.is_empty(),
+            "an ordinary publish overwrote the timeout correction; a poller sees no \
+             warning while the teardown is still running: {:?} / {:?}",
+            s.report.overall,
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(pending.is_finished(), "the teardown never settled");
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -422,6 +422,16 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
          discarded and its failures lost: {first:?}"
     );
 
+    // NOTE: the FIB subsystem's reporting of this verdict is deliberately
+    // NOT asserted here. `VerifyFailed` injects `Kill`, and `kill`
+    // returns early when nothing is supervised — this test has no real
+    // process — so `on_process_gone` never runs and the engine's verdict
+    // survives. Asserting on it would pass whether or not the loop
+    // retains its own copy, which is worse than no assertion: it reads as
+    // coverage. The premise the retention defends against is pinned in
+    // `engine.rs` (`on_process_gone` clears `last_verify`), and the
+    // loop-level consequence needs a real spawn — the failover drills.
+
     // And it is RETAINED. The teardown is followed by backoff ticks with
     // empty outcomes; republishing those verbatim cleared the reason
     // within one 50 ms poll while the service stayed unwell for seconds,
@@ -443,6 +453,69 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
         );
         std::thread::sleep(Duration::from_millis(15));
     }
+
+    let _ = svc.stop();
+}
+
+/// The INITIAL injection's failures must reach the first published
+/// snapshot.
+///
+/// `attach` hands the loop a `StartRequested` (or an `Adopted`), and its
+/// actions run before the first publish. Discarding that Tick meant the
+/// snapshot `SupervisionService::start` guarantees to have published came
+/// out with an empty `last_failures` — and if the failed spawn left an
+/// undead process blocking retries, no later tick could ever reconstruct
+/// the reason. The first thing an operator looks at would be blank about
+/// the only thing that had happened.
+///
+/// `/nonexistent/vpp` fails identically on macOS (the Linux-only pidfd
+/// stub) and Linux (ENOENT), so the assertion is on the action rather
+/// than the platform's wording.
+#[test]
+fn the_initial_injections_failures_reach_the_first_snapshot() {
+    let fake = Fake::start("svc-initial");
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                Vec::new(),
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror(Vec::new())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/nonexistent/vpp",
+                "/tmp/startup.conf",
+            );
+            // StartRequested, not Adopted: the loop does the spawning,
+            // exactly as the attach wiring arranges it.
+            Ok((Driver::new(), runtime, vec![Event::StartRequested]))
+        }),
+    )
+    .expect("the service starts even though the spawn cannot");
+
+    // `start()` blocked on the first publish, so this is the FIRST
+    // snapshot and not a later one that happened to catch a retry.
+    let first = svc.status().expect("start guarantees a published snapshot");
+    assert!(
+        first.last_failures.iter().any(|f| f.starts_with("Spawn:")),
+        "the initial injection's failure was discarded; the first snapshot an operator \
+         reads says nothing about the only thing that happened: {:?}",
+        first.last_failures
+    );
+    assert_ne!(
+        first.report.overall,
+        HealthState::Healthy,
+        "a VPP that never started must not read as healthy: {:?}",
+        first.report
+    );
 
     let _ = svc.stop();
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -754,3 +754,98 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
         last.metrics
     );
 }
+
+/// An unhealthy episode keeps its ROOT CAUSE, not just its latest symptom.
+///
+/// A failed verify puts VPP into backoff; the respawn then fails too. An
+/// operator needs both — "the FIB did not verify" is why the restart is
+/// happening, "cannot spawn" is why it is not finishing. Three writers of
+/// `last_failures` used to disagree about this: the verify path appended
+/// while the tick paths assigned, so which survived came down to ordering.
+#[test]
+fn an_episode_keeps_its_root_cause_alongside_the_latest_symptom() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-episode",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: false,
+            stall_pings_after: None,
+            // Verification fails, which is the root cause.
+            verify_mismatch: true,
+        },
+    );
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                // And the respawn cannot succeed, which is the symptom.
+                "/nonexistent/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let p = svc.status().expect("published");
+        let has_verify = p
+            .last_failures
+            .iter()
+            .any(|f| f.starts_with("Verify:") && f.contains("verify FAIL"));
+        let has_spawn = p.last_failures.iter().any(|f| f.starts_with("Spawn:"));
+        if has_spawn {
+            assert!(
+                has_verify,
+                "the spawn failure replaced the verify failure that caused the restart; \
+                 the root cause is gone: {:?}",
+                p.last_failures
+            );
+            // Bounded: a backoff loop must not grow this without limit.
+            assert!(
+                p.last_failures.len() <= 8,
+                "episode reasons grew unbounded: {:?}",
+                p.last_failures
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the respawn never failed; state {:?} failures {:?}",
+            p.state,
+            p.last_failures
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
+
+    let _ = svc.stop();
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -146,6 +146,25 @@ fn the_service_converges_publishes_health_and_stops_clean() {
         "the refused resource release must be on the record: {:?}",
         last.teardown_failures
     );
+    // The teardown killed the process, so the verdict it produced no longer
+    // describes anything. The stopped snapshot used to carry it — the
+    // invalidation lived inside the main loop, and teardown is a second exit
+    // path — so `packetframe_vpp_fib_verified 1` went out for a VPP that had
+    // just been killed.
+    assert!(
+        last.metrics
+            .contains("packetframe_vpp_fib_verified{module=\"vpp-offload\"} 0"),
+        "the stopped snapshot claims a verified FIB for a killed process: {}",
+        last.metrics
+    );
+    assert!(
+        !last.report.subsystems.iter().any(|s| s.name == "fib-synced"
+            && s.message
+                .as_deref()
+                .is_some_and(|m| m.contains("verified on"))),
+        "and the report must agree with the gauge: {:?}",
+        last.report.subsystems
+    );
 }
 
 /// A VPP speaking a different API version must fail ATTACH, with the

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -169,6 +169,7 @@ fn an_incompatible_api_fails_attach_with_the_reason() {
             hangup_after: None,
             reject_deletes: 0,
             garbage_crcs: true,
+            stall_pings_after: None,
             verify_mismatch: false,
         },
     );
@@ -349,6 +350,7 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
             reject_deletes: 0,
             garbage_crcs: false,
             // Routes install and ack; only the readback disagrees.
+            stall_pings_after: None,
             verify_mismatch: true,
         },
     );
@@ -516,6 +518,110 @@ fn the_initial_injections_failures_reach_the_first_snapshot() {
         "a VPP that never started must not read as healthy: {:?}",
         first.report
     );
+
+    let _ = svc.stop();
+}
+
+/// A verdict must not outlive the process it describes — in either
+/// polarity — and the REASON must survive the verdict.
+///
+/// A passing verdict kept after the process died reported a verified FIB,
+/// and `packetframe_vpp_fib_verified 1`, for something that no longer
+/// existed. A failing one kept for the same reason then survived into the
+/// *replacement*, describing a process it had never seen for the whole
+/// startup budget. Both are fixed by tying the verdict's lifetime to
+/// `has_process()`; what keeps that from losing information is that the
+/// failed verify's summary moves into `last_failures`, the field that
+/// exists to retain reasons.
+#[test]
+fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-inherit",
+        fake_vpp::Behaviour {
+            hangup_after: None,
+            reject_deletes: 0,
+            garbage_crcs: false,
+            stall_pings_after: None,
+            verify_mismatch: true,
+        },
+    );
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                "/nonexistent/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let fib_msg = |p: &packetframe_vpp_offload::service::Published| {
+        p.report
+            .subsystems
+            .iter()
+            .find(|s| s.name == "fib-synced")
+            .and_then(|s| s.message.clone())
+            .unwrap_or_default()
+    };
+
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let p = svc.status().expect("published");
+        if p.state == State::Backoff {
+            // The verdict is gone: it described a process that no longer
+            // exists, and the FIB subsystem speaks for the current one.
+            assert!(
+                !fib_msg(&p).contains("verify FAIL"),
+                "the verdict outlived its process: {:?}",
+                fib_msg(&p)
+            );
+            // But the reason is not gone.
+            assert!(
+                p.last_failures
+                    .iter()
+                    .any(|f| f.starts_with("Verify:") && f.contains("verify FAIL")),
+                "the failed verify's summary was dropped with the verdict; nothing now \
+                 explains the backoff: {:?}",
+                p.last_failures
+            );
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "never reached Backoff; state {:?}",
+            p.state
+        );
+        std::thread::sleep(Duration::from_millis(5));
+    }
 
     let _ = svc.stop();
 }


### PR DESCRIPTION
The last piece before `Module::attach()` is glue: the tick loop on its own thread, with a stop protocol and a continuously published `HealthReport` + metrics snapshot for `health_check`/`sample_metrics` to read without touching the loop.

## Design points

- **Construction happens on the loop thread.** `Runtime` is deliberately `!Send` (its trait views share an `Rc<RefCell>` core), so the service takes a **factory** and calls it from the spawned thread — the ownership story stated in types, not a workaround.
- **`start()` blocks on the first publish.** The first version returned immediately and its own test caught the race: "status is never `None`" was a claim about ticks, not thread scheduling. The handshake makes the guarantee true, and makes a factory failure (bad socket, failed adoption) a **synchronous attach error** rather than a dead thread discovered later by a health check reading frozen status. `is_alive()` covers the loop dying after startup.
- **The stop protocol runs the machine's own teardown**: inject `StopRequested` (unsteer-if-steered → abort convergence → kill → release, in the supervisor's ordering), tick until `Stopped` or bounded patience expires — an undead VPP can legitimately refuse to die, and hanging detach forever is worse than reporting it. The final snapshot is published either way.
- The idle loop is a **bounded 50 ms flag-poll**, not a reactor: ~20 wakeups/second at idle, each a flag check, no spin. Named explicitly given this project's rules about synthetic load.

Also: `Driver::api_health()` (the detector stays private — exposing it raw invites consulting it before the first pong, the exact window it must not exist in) and `StatusSnapshot::observe_parts` for callers holding a `RuntimeStatus` instead of the `PendingMap`.

## Tests

[tests/vpp_service.rs](crates/modules/vpp-offload/tests/vpp_service.rs) drives the real thread against the fake VPP on the wall clock: converge to `Ready`, `Healthy` report, state one-hot in the metrics, clean stop ending in `Stopped`. The unit test pins the synchronous-failure contract for a dying factory.

523 workspace tests pass; fmt + clippy clean on host and all four cross targets.

## Remaining

`Module::attach()`/`detach()`: `acquire` + `startup_conf` render + this service + `release`, refusing without a route source. Next PR — and the last one before the module actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)