### PR TITLE
feat(vpp-offload): Module::attach() — the composition, and the hazards it exposed

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1002,6 +1002,36 @@ fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
         return Ok(()); // nothing was ever acquired
     };
 
+    // Recorded MCAM rules mean traffic is DIVERTED to a VF this function is
+    // about to unbind. Refuse.
+    //
+    // The module's teardown ordering is unsteer → abort → kill → release, and
+    // the first step is not decoration: releasing a VF that MCAM still points
+    // at leaves steered traffic arriving at a function nothing services — a
+    // blackhole, which is the failure the whole `Disposition::MustLeak`
+    // discipline exists to avoid, reached from the other direction. This path
+    // cannot unsteer, because MCAM is not implemented until slice 5.
+    //
+    // `steer_rules` is always empty today for exactly that reason, so this is
+    // a guard against a future state rather than a live bug. It is a guard
+    // and not a comment deliberately: "when steering ships, unsteer here
+    // first" is the kind of note this session has watched expire more than
+    // once, and a refusal cannot be forgotten.
+    if !state.steer_rules.is_empty() {
+        let ifaces: Vec<&str> = state
+            .steer_rules
+            .iter()
+            .map(|(iface, _)| iface.as_str())
+            .collect();
+        return Err(format!(
+            "vpp-offload: the state file records MCAM steering rules on {}, so traffic is \
+             being diverted to VF(s) this teardown would unbind — that would blackhole it. \
+             This command cannot remove those rules (MCAM steering is not implemented yet); \
+             clear them first, then re-run.",
+            ifaces.join(", ")
+        ));
+    }
+
     // Kill the recorded VPP first, if it is still the process we recorded.
     //
     // The identity must be COMPLETE — pid, start_ticks AND boot_id — before
@@ -1323,6 +1353,33 @@ mod vpp_detach_tests {
         assert!(
             ResourceState::load(&dir).unwrap().is_some(),
             "the record must survive so a later attempt can act on it"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Recorded steering rules must block the teardown.
+    ///
+    /// The module unsteers before it releases, because releasing a VF that
+    /// MCAM still points at blackholes the traffic it diverts. This path
+    /// cannot unsteer (no MCAM yet), so it must refuse rather than release.
+    /// Latent today — `steer_rules` is always empty — which is precisely why
+    /// it is a guard with a test rather than a note for later.
+    #[test]
+    fn recorded_steering_rules_block_the_teardown() {
+        use packetframe_vpp_offload::resources::ResourceState;
+
+        let dir = std::env::temp_dir().join(format!("pf-detach-steer-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut state = ResourceState::empty();
+        state.steer_rules = vec![("eth5".to_string(), vec![0, 1])];
+        state.save(&dir).unwrap();
+
+        let e = detach_vpp_offload(&dir).expect_err("must refuse");
+        assert!(e.contains("eth5"), "the steered port must be named: {e}");
+        assert!(e.contains("blackhole"), "and the consequence stated: {e}");
+        assert!(
+            ResourceState::load(&dir).unwrap().is_some(),
+            "the record must survive"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -807,19 +807,31 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         ));
     }
 
-    let (bpffs_root, state_dir, settle_time) = match config {
+    // `config_has_vpp` decides whether a SCOPED detach may touch VPP.
+    //
+    // `--all` means "tear down modules beyond those in the supplied config",
+    // so `detach --config fast-path-only.conf` must leave the VPP dataplane
+    // alone — the first version of this teardown ran unconditionally and
+    // would have terminated a VPP the operator never asked about, purely
+    // because it shares the state dir.
+    let (bpffs_root, state_dir, settle_time, config_has_vpp) = match config {
         Some(p) => {
             let c = Config::from_file(p).map_err(|e| format!("config parse: {e}"))?;
+            let has_vpp = c.modules.iter().any(|m| m.name == "vpp-offload");
             (
                 c.global.bpffs_root,
                 c.global.state_dir,
                 c.global.attach_settle_time,
+                has_vpp,
             )
         }
+        // No config at all: nothing scopes the request, so only `--all`
+        // authorises reaching past fast-path.
         None => (
             PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
             PathBuf::from(packetframe_common::config::DEFAULT_STATE_DIR),
             packetframe_common::config::DEFAULT_ATTACH_SETTLE_TIME,
+            false,
         ),
     };
 
@@ -831,12 +843,59 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // tells the operator to run `packetframe detach --all`, and that command
     // touched nothing but fast-path pins. The recovery path advertised
     // everywhere did not exist.
-    let _ = all;
+    //
+    // Every module is attempted and the failures are aggregated, rather than
+    // the first `?` ending the run. These teardowns are independent, and this
+    // command IS the recovery path: a corrupt fast-path registry must not be
+    // the reason a supervised VPP keeps holding its VF and hugepages.
+    // `mut` is unused in the build with neither module feature enabled —
+    // nothing can push. Not a CI configuration (clippy runs
+    // `--all-features`), but a warning is a warning.
+    #[cfg_attr(
+        not(any(feature = "fast-path", feature = "vpp-offload")),
+        allow(unused_mut)
+    )]
+    let mut errors: Vec<String> = Vec::new();
 
     #[cfg(feature = "fast-path")]
+    if let Err(e) = detach_fast_path(&bpffs_root, &state_dir, settle_time) {
+        errors.push(e);
+    }
+
+    #[cfg(feature = "vpp-offload")]
+    if all || config_has_vpp {
+        if let Err(e) = detach_vpp_offload(&state_dir) {
+            errors.push(e);
+        }
+    } else {
+        tracing::info!(
+            "vpp-offload state left alone: this detach is scoped to the supplied config; \
+             use `--all` to tear down modules it does not declare"
+        );
+    }
+    #[cfg(not(feature = "vpp-offload"))]
+    let _ = (all, config_has_vpp);
+
+    if !errors.is_empty() {
+        return Err(errors.join("; AND "));
+    }
+    Ok(())
+}
+
+/// The fast-path half of `detach`, unchanged except for being callable.
+///
+/// Split out so its `?`s abort only its own teardown: as one inline block its
+/// first error returned from `detach` entirely, which meant an unrelated
+/// module's failure could strand VPP's VFs.
+#[cfg(feature = "fast-path")]
+fn detach_fast_path(
+    bpffs_root: &Path,
+    state_dir: &Path,
+    settle_time: std::time::Duration,
+) -> Result<(), String> {
     {
         use packetframe_fast_path::registry::load as registry_load;
-        match registry_load(&state_dir) {
+        match registry_load(state_dir) {
             Ok(Some(file)) => {
                 tracing::info!(
                     module = %file.module,
@@ -865,10 +924,10 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         // post-rc5 fix for the EFG kernel-panic-on-detach observed
         // during Phase 4 cutover testing. Map + program pins are
         // housekeeping with no kernel-link side effects, no pacing.
-        packetframe_fast_path::pin::remove_all_paced(&bpffs_root, settle_time)
+        packetframe_fast_path::pin::remove_all_paced(bpffs_root, settle_time)
             .map_err(|e| format!("remove pins under {}: {e}", bpffs_root.display()))?;
         tracing::info!(
-            pin_root = %packetframe_fast_path::pin::module_root(&bpffs_root).display(),
+            pin_root = %packetframe_fast_path::pin::module_root(bpffs_root).display(),
             settle_secs = settle_time.as_secs_f64(),
             "pins removed; kernel detached"
         );
@@ -878,19 +937,16 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         // record. No-op when tc-links.json doesn't exist.
         #[cfg(target_os = "linux")]
         {
-            let n = packetframe_fast_path::tc_detach_from_state_dir(&state_dir)
+            let n = packetframe_fast_path::tc_detach_from_state_dir(state_dir)
                 .map_err(|e| format!("tc filter teardown: {e}"))?;
             if n > 0 {
                 tracing::info!(count = n, "tc filters detached");
             }
         }
 
-        packetframe_fast_path::registry::remove(&state_dir)
+        packetframe_fast_path::registry::remove(state_dir)
             .map_err(|e| format!("registry remove: {e}"))?;
     }
-
-    #[cfg(feature = "vpp-offload")]
-    detach_vpp_offload(&state_dir)?;
 
     Ok(())
 }

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -174,10 +174,31 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 Box::new(FastPathModule::new()) as Box<dyn Module>,
             )),
             #[cfg(feature = "vpp-offload")]
-            "vpp-offload" => modules.push((
-                section.name.clone(),
-                Box::new(packetframe_vpp_offload::VppOffloadModule::new()) as Box<dyn Module>,
-            )),
+            "vpp-offload" => {
+                // Refused HERE, before fast-path attaches, rather than
+                // discovered as a mid-attach unwind.
+                //
+                // The module is complete except for its route feed: nothing
+                // calls `set_route_source`, because reaching across to the
+                // fast-path RouteController's mirror touches the live
+                // control plane and carries an unresolved access decision
+                // (the mirror lives inside the programmer task and is
+                // reachable only by command; a full-table reply, a shared
+                // lock, and a second mirror all trade differently). Until
+                // that lands, `attach` correctly refuses — a VPP with an
+                // empty FIB passes every health check and blackholes every
+                // steered packet — and letting startup discover that after
+                // fast-path has already attached just makes the operator
+                // read an unwind log to learn it.
+                return Err(RunError::Startup(
+                    "module vpp-offload cannot run yet: its route feed is not wired, so \
+                     VPP would come up with an empty FIB. Remove the `module vpp-offload` \
+                     section to start. (Everything else — resources, supervision, \
+                     convergence, health — is in place; `packetframe feasibility` still \
+                     reports its probes.)"
+                        .into(),
+                ));
+            }
             other => {
                 return Err(RunError::Startup(format!(
                     "unknown module `{other}` in {}",
@@ -1037,7 +1058,24 @@ fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
         }
     }
 
-    let paths = SysPaths::live(state_dir, packetframe_vpp_offload::default_hugepage_bytes());
+    // Point release at the pool the state file RECORDS, not the pool that
+    // happens to be the default now.
+    //
+    // `release` deliberately refuses a pool mismatch — freeing the wrong
+    // pool while leaking the real reservation is worse than failing — so
+    // using the current default meant that if the kernel's default page size
+    // changed between attach and detach (a reboot between the fleet's 512 MiB
+    // and 2 MiB defaults does it), release would free the VFs, refuse the
+    // pool, keep the reservation in state, and then recompute the same wrong
+    // default on every retry. The advertised recovery command could never
+    // restore that pool. A recorded `0` means attach owned no reservation, so
+    // there is nothing to match and the current default is fine.
+    let pool_bytes = if state.hugepage_pool_bytes != 0 {
+        state.hugepage_pool_bytes
+    } else {
+        packetframe_vpp_offload::default_hugepage_bytes()
+    };
+    let paths = SysPaths::live(state_dir, pool_bytes);
     release(&paths, state).map_err(|e| format!("vpp-offload: {e}"))?;
     tracing::info!("vpp-offload: VFs rebound and hugepages restored");
     Ok(())

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -823,9 +823,14 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         ),
     };
 
-    // v0.1 has one module (fast-path), so `--all` and the default case
-    // behave identically, both tear down every pin under the module's
-    // pin root. `--all` becomes meaningful once a second module ships.
+    // `--all` used to be a no-op with a comment saying it would "become
+    // meaningful once a second module ships". A second module has now
+    // shipped, and the comment outlived its truth: every message this
+    // codebase prints about held VFs — from the module, from `bring_up`'s
+    // rollback, from the supervision service's timeout and panic paths —
+    // tells the operator to run `packetframe detach --all`, and that command
+    // touched nothing but fast-path pins. The recovery path advertised
+    // everywhere did not exist.
     let _ = all;
 
     #[cfg(feature = "fast-path")]
@@ -884,6 +889,101 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
             .map_err(|e| format!("registry remove: {e}"))?;
     }
 
+    #[cfg(feature = "vpp-offload")]
+    detach_vpp_offload(&state_dir)?;
+
+    Ok(())
+}
+
+/// Release what vpp-offload's state file records: the supervised VPP, its
+/// VFs and vfio bindings, and the hugepage reservation.
+///
+/// This is the standalone recovery path, and it has to exist separately from
+/// `Module::detach` because the two run at different times. `Module::detach`
+/// needs a live daemon holding the supervision handle; but the daemon's
+/// ordinary SIGTERM exit deliberately PRESERVES VPP for adoption (SPEC.md
+/// §8.5), and `packetframe detach` refuses to run while a daemon is alive.
+/// So by the time an operator can invoke this, the in-memory handle is gone
+/// and the state file is the only record of what is held.
+///
+/// **Ordering is the same discipline the module's teardown uses, for the same
+/// reason.** VPP is killed first and resources are released only if it is
+/// confirmed gone: unbinding a VF or handing back hugepages while a process
+/// can still DMA through them is memory corruption, whereas leaking a VF is a
+/// line in `packetframe status` and a reboot's worth of inconvenience.
+/// Steering is not unwound here because MCAM is not implemented yet; when it
+/// is, it must come first (before the kill), or traffic is left pointed at a
+/// VF nothing services.
+#[cfg(feature = "vpp-offload")]
+fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
+    use packetframe_vpp_offload::acquire::{release, SysPaths};
+    use packetframe_vpp_offload::process::{terminate_or_leak, Disposition, VppProcess};
+    use packetframe_vpp_offload::resources::ResourceState;
+    use packetframe_vpp_offload::runtime::TERM_GRACE;
+
+    let Some(state) = ResourceState::load(state_dir).map_err(|e| format!("vpp state: {e}"))? else {
+        return Ok(()); // nothing was ever acquired
+    };
+
+    // Kill the recorded VPP first, if it is still the process we recorded.
+    // `adopt` verifies (pid, start_ticks, boot_id), so a recycled PID cannot
+    // be signalled and a reboot invalidates the record entirely.
+    if let Some(pid) = state.vpp_pid {
+        let identity = (pid, state.vpp_start_ticks, state.vpp_boot_id.clone());
+        match identity {
+            (pid, Some(ticks), boot) => {
+                match VppProcess::adopt(pid, ticks, boot.as_deref()) {
+                    Ok(Some(mut p)) => {
+                        tracing::info!(pid, "vpp-offload: terminating the recorded VPP");
+                        if terminate_or_leak(&mut p, TERM_GRACE) == Disposition::MustLeak {
+                            // Refuse to release. The process survived
+                            // SIGKILL — most likely parked in an
+                            // uninterruptible VFIO/DMA call — and the state
+                            // file stays intact so a later attempt can
+                            // finish the job.
+                            return Err(format!(
+                                "vpp-offload: VPP (pid {pid}) survived SIGKILL, so its VF \
+                                 and hugepages were deliberately NOT released — releasing \
+                                 them under a process that can still DMA through them is \
+                                 worse than leaking them. The state file still records \
+                                 everything; retry once `ps {pid}` is empty."
+                            ));
+                        }
+                    }
+                    // Gone already, or not ours: nothing to kill.
+                    Ok(None) => tracing::info!(
+                        pid,
+                        "vpp-offload: the recorded VPP is gone; releasing its resources"
+                    ),
+                    Err(e) => {
+                        return Err(format!(
+                            "vpp-offload: could not establish whether the recorded VPP \
+                             (pid {pid}) is still running ({e}); refusing to release its \
+                             VF and hugepages while that is unknown"
+                        ))
+                    }
+                }
+            }
+            // A pid with no start-time cookie cannot be identified, so it
+            // cannot be safely signalled — and it cannot be ruled out
+            // either. `(pid, start_ticks)` is what makes an identity
+            // verifiable across PID reuse; signalling without it risks
+            // SIGKILLing a stranger as root, and releasing without it risks
+            // unbinding a VF under a live VPP.
+            (pid, None, _) => {
+                return Err(format!(
+                    "vpp-offload: the state file records pid {pid} with no start-time \
+                     cookie, so that process cannot be identified and must not be \
+                     signalled. Confirm by hand that no VPP is running, then remove the \
+                     state file."
+                ))
+            }
+        }
+    }
+
+    let paths = SysPaths::live(state_dir, packetframe_vpp_offload::default_hugepage_bytes());
+    release(&paths, state).map_err(|e| format!("vpp-offload: {e}"))?;
+    tracing::info!("vpp-offload: VFs rebound and hugepages restored");
     Ok(())
 }
 
@@ -1052,4 +1152,51 @@ fn trial_attach_probes(ifaces: &[String]) -> Vec<(String, String)> {
 #[cfg(not(all(target_os = "linux", feature = "fast-path")))]
 fn trial_attach_probes(_ifaces: &[String]) -> Vec<(String, String)> {
     Vec::new()
+}
+
+#[cfg(all(test, feature = "vpp-offload"))]
+mod vpp_detach_tests {
+    use super::*;
+
+    /// A recorded pid with no start-time cookie must not be signalled, and
+    /// its resources must not be released either.
+    ///
+    /// The pair `(pid, start_ticks)` is what makes a process identity
+    /// verifiable across PID reuse; without the cookie we can neither
+    /// confirm the recorded VPP is still running nor rule it out. Signalling
+    /// would risk SIGKILLing a stranger as root; releasing would risk
+    /// unbinding a VF under a live VPP. So it refuses and says what to do —
+    /// and it refuses BEFORE touching sysfs, which is what makes this
+    /// testable off a router.
+    #[test]
+    fn a_pid_without_a_start_cookie_is_refused() {
+        use packetframe_vpp_offload::resources::ResourceState;
+
+        let dir = std::env::temp_dir().join(format!("pf-detach-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut state = ResourceState::empty();
+        state.vpp_pid = Some(4242);
+        state.vpp_start_ticks = None; // the cookie is missing
+        state.save(&dir).unwrap();
+
+        let e = detach_vpp_offload(&dir).expect_err("must refuse");
+        assert!(e.contains("4242"), "{e}");
+        assert!(
+            e.contains("must not be signalled"),
+            "the reason must be stated: {e}"
+        );
+        // The record survives, so a later attempt can still act on it.
+        assert!(ResourceState::load(&dir).unwrap().is_some());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// No state file means nothing was ever acquired: a clean no-op, so
+    /// `detach --all` stays idempotent for operators who run it habitually.
+    #[test]
+    fn no_state_file_is_a_clean_no_op() {
+        let dir = std::env::temp_dir().join(format!("pf-detach-none-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(detach_vpp_offload(&dir).is_ok());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1003,56 +1003,64 @@ fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
     };
 
     // Kill the recorded VPP first, if it is still the process we recorded.
-    // `adopt` verifies (pid, start_ticks, boot_id), so a recycled PID cannot
-    // be signalled and a reboot invalidates the record entirely.
+    //
+    // The identity must be COMPLETE — pid, start_ticks AND boot_id — before
+    // either action is safe, and that is the whole of this block's caution.
+    // `VppProcess::adopt` returns `Ok(None)` for two very different reasons:
+    // the process is genuinely gone, or the identity could not be verified
+    // and it refused to guess. Reading the second as the first is what makes
+    // it dangerous — this code passed `boot_id: None` straight through and
+    // then treated the refusal as "gone", releasing the VF under a VPP that
+    // may well have still been running. `process.rs` has a test named
+    // `adoption_without_a_recorded_boot_id_is_refused` whose doc says exactly
+    // that a boot-id-less record "cannot establish identity at all, and must
+    // be refused rather than trusted".
+    //
+    // With a complete identity, `Ok(None)` really does mean gone: the pid is
+    // dead, or its start time or boot id no longer match, and in every one of
+    // those cases the process we recorded does not exist.
     if let Some(pid) = state.vpp_pid {
-        let identity = (pid, state.vpp_start_ticks, state.vpp_boot_id.clone());
-        match identity {
-            (pid, Some(ticks), boot) => {
-                match VppProcess::adopt(pid, ticks, boot.as_deref()) {
-                    Ok(Some(mut p)) => {
-                        tracing::info!(pid, "vpp-offload: terminating the recorded VPP");
-                        if terminate_or_leak(&mut p, TERM_GRACE) == Disposition::MustLeak {
-                            // Refuse to release. The process survived
-                            // SIGKILL — most likely parked in an
-                            // uninterruptible VFIO/DMA call — and the state
-                            // file stays intact so a later attempt can
-                            // finish the job.
-                            return Err(format!(
-                                "vpp-offload: VPP (pid {pid}) survived SIGKILL, so its VF \
-                                 and hugepages were deliberately NOT released — releasing \
-                                 them under a process that can still DMA through them is \
-                                 worse than leaking them. The state file still records \
-                                 everything; retry once `ps {pid}` is empty."
-                            ));
-                        }
-                    }
-                    // Gone already, or not ours: nothing to kill.
-                    Ok(None) => tracing::info!(
-                        pid,
-                        "vpp-offload: the recorded VPP is gone; releasing its resources"
-                    ),
-                    Err(e) => {
-                        return Err(format!(
-                            "vpp-offload: could not establish whether the recorded VPP \
-                             (pid {pid}) is still running ({e}); refusing to release its \
-                             VF and hugepages while that is unknown"
-                        ))
-                    }
+        let (Some(ticks), Some(boot)) = (state.vpp_start_ticks, state.vpp_boot_id.clone()) else {
+            let missing = match (state.vpp_start_ticks, &state.vpp_boot_id) {
+                (None, None) => "start-time cookie and boot id",
+                (None, Some(_)) => "start-time cookie",
+                _ => "boot id",
+            };
+            return Err(format!(
+                "vpp-offload: the state file records pid {pid} with no {missing}, so that \
+                 process can neither be identified nor ruled out. It must not be signalled \
+                 (that risks SIGKILLing an unrelated process as root) and its VF and \
+                 hugepages must not be released (that risks unbinding under a live VPP). \
+                 Confirm by hand that no VPP is running, then remove the state file."
+            ));
+        };
+        match VppProcess::adopt(pid, ticks, Some(&boot)) {
+            Ok(Some(mut p)) => {
+                tracing::info!(pid, "vpp-offload: terminating the recorded VPP");
+                if terminate_or_leak(&mut p, TERM_GRACE) == Disposition::MustLeak {
+                    // Refuse to release. The process survived SIGKILL — most
+                    // likely parked in an uninterruptible VFIO/DMA call — and
+                    // the state file stays intact so a later attempt can
+                    // finish the job.
+                    return Err(format!(
+                        "vpp-offload: VPP (pid {pid}) survived SIGKILL, so its VF and \
+                         hugepages were deliberately NOT released — releasing them under a \
+                         process that can still DMA through them is worse than leaking \
+                         them. The state file still records everything; retry once \
+                         `ps {pid}` is empty."
+                    ));
                 }
             }
-            // A pid with no start-time cookie cannot be identified, so it
-            // cannot be safely signalled — and it cannot be ruled out
-            // either. `(pid, start_ticks)` is what makes an identity
-            // verifiable across PID reuse; signalling without it risks
-            // SIGKILLing a stranger as root, and releasing without it risks
-            // unbinding a VF under a live VPP.
-            (pid, None, _) => {
+            // Verified against a complete identity, so this is genuinely gone.
+            Ok(None) => tracing::info!(
+                pid,
+                "vpp-offload: the recorded VPP is gone; releasing its resources"
+            ),
+            Err(e) => {
                 return Err(format!(
-                    "vpp-offload: the state file records pid {pid} with no start-time \
-                     cookie, so that process cannot be identified and must not be \
-                     signalled. Confirm by hand that no VPP is running, then remove the \
-                     state file."
+                    "vpp-offload: could not establish whether the recorded VPP (pid {pid}) \
+                     is still running ({e}); refusing to release its VF and hugepages while \
+                     that is unknown"
                 ))
             }
         }
@@ -1286,6 +1294,39 @@ mod vpp_detach_tests {
 
     /// No state file means nothing was ever acquired: a clean no-op, so
     /// `detach --all` stays idempotent for operators who run it habitually.
+    /// A record with a start-time cookie but NO boot id must be refused too.
+    ///
+    /// `VppProcess::adopt` returns `Ok(None)` here because it cannot verify
+    /// the identity, not because the process is gone — `start_ticks` counts
+    /// from boot while the state file under /var/lib survives a reboot, so
+    /// without the boot id an unrelated process can satisfy a (pid, ticks)
+    /// check. Treating that refusal as "gone" released the VF under a VPP
+    /// that may still have been running.
+    #[test]
+    fn a_pid_without_a_boot_id_is_refused() {
+        use packetframe_vpp_offload::resources::ResourceState;
+
+        let dir = std::env::temp_dir().join(format!("pf-detach-boot-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let mut state = ResourceState::empty();
+        state.vpp_pid = Some(4242);
+        state.vpp_start_ticks = Some(99_999);
+        state.vpp_boot_id = None; // the third leg is missing
+        state.save(&dir).unwrap();
+
+        let e = detach_vpp_offload(&dir).expect_err("must refuse");
+        assert!(e.contains("boot id"), "the missing leg must be named: {e}");
+        assert!(
+            e.contains("must not be signalled"),
+            "and the reason stated: {e}"
+        );
+        assert!(
+            ResourceState::load(&dir).unwrap().is_some(),
+            "the record must survive so a later attempt can act on it"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
     #[test]
     fn no_state_file_is_a_clean_no_op() {
         let dir = std::env::temp_dir().join(format!("pf-detach-none-{}", std::process::id()));

--- a/crates/common/src/module.rs
+++ b/crates/common/src/module.rs
@@ -119,6 +119,31 @@ pub enum HealthState {
     Unhealthy,
 }
 
+impl HealthState {
+    /// The more severe of two states.
+    ///
+    /// `HealthState` deliberately does not derive `Ord` — the variants
+    /// are a severity scale, but a derived ordering would also imply
+    /// comparisons like `Degraded > Healthy` are meaningful in
+    /// arithmetic, and callers writing their own `match` to escalate got
+    /// it right only for the cases they thought of. This is the one
+    /// operation that is actually wanted: adding a finding to a report
+    /// may make it worse, never better.
+    #[must_use]
+    pub fn worse_of(self, other: Self) -> Self {
+        let rank = |s: Self| match s {
+            Self::Healthy => 0u8,
+            Self::Degraded => 1,
+            Self::Unhealthy => 2,
+        };
+        if rank(other) > rank(self) {
+            other
+        } else {
+            self
+        }
+    }
+}
+
 /// Per-subsystem health entry within a [`HealthReport`]. `name` is
 /// stable for dashboards; changing it breaks operator tooling that
 /// keys on the string.

--- a/crates/modules/vpp-offload/Cargo.toml
+++ b/crates/modules/vpp-offload/Cargo.toml
@@ -11,6 +11,8 @@ tracing = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
+# Unconditional, as in `common` and `cli`: most of the syscall surface
+# here is Linux-only, but `bringup`'s executability check runs on the
+# macOS dev loop too, and one implementation of it beats a cfg-split pair
+# that can disagree.
 libc = { workspace = true }

--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -142,17 +142,37 @@ pub fn acquire(
             // Sizing identity. Checked alongside the pool identity below
             // and for the same reason: both describe memory a running
             // VPP committed to at start, and neither can be renegotiated
-            // by adopting it. See `ResourceState::expected_routes`. A
-            // recorded `0` predates the field and cannot be compared.
-            if state.expected_routes != 0 && state.expected_routes != expected_routes {
-                return Err(format!(
-                    "state was sized for expected-routes {} but this run is configured for \
-                     {expected_routes}; VPP fixes its main heap and stats segment at start, \
-                     so adopting it under the new figure would let the route ledger fill \
-                     past what the running instance holds — run `packetframe detach --all` \
-                     and start fresh to apply the new sizing",
-                    state.expected_routes
-                ));
+            // by adopting it. See `ResourceState::expected_routes`.
+            //
+            // A recorded `0` is refused too, rather than read as "no
+            // constraint". It means the sizing this VPP started under is
+            // UNKNOWN, and nothing can recover it — VPP does not report
+            // the figure back, so stamping the current config's number
+            // onto the record would be an observation we fabricated.
+            // That is the same call made for the process identity: a pid
+            // without its boot_id is refused rather than guessed. The
+            // configured value cannot itself be `0` (config parse
+            // requires >= 1, absence defaults to
+            // `DEFAULT_EXPECTED_ROUTES`), so the sentinel is unambiguous.
+            if state.expected_routes != expected_routes {
+                return Err(if state.expected_routes == 0 {
+                    format!(
+                        "state records no `expected-routes`, so the sizing the running VPP \
+                         started under cannot be established; adopting it under this run's \
+                         {expected_routes} would apply a route ceiling its main heap and \
+                         stats segment may not hold — run `packetframe detach --all` and \
+                         start fresh"
+                    )
+                } else {
+                    format!(
+                        "state was sized for expected-routes {} but this run is configured \
+                         for {expected_routes}; VPP fixes its main heap and stats segment at \
+                         start, so adopting it under the new figure would let the route \
+                         ledger fill past what the running instance holds — run \
+                         `packetframe detach --all` and start fresh to apply the new sizing",
+                        state.expected_routes
+                    )
+                });
             }
             // The pool identity check comes BEFORE any reservation
             // touch. Raising the currently-configured pool while the
@@ -194,11 +214,11 @@ pub fn acquire(
             if resume_from == ports.len() {
                 return Ok((state, Acquired::Adopted));
             }
-            // Resuming an interrupted acquisition: the tail is acquired
-            // fresh below and saved, so this is the moment a pre-field
-            // record can record its sizing. Equal values make it a no-op;
-            // a differing one was already refused above.
-            state.expected_routes = expected_routes;
+            // Resuming an interrupted acquisition. No sizing assignment
+            // here on purpose: the check above leaves
+            // `state.expected_routes == expected_routes` on every path
+            // that reaches this line, so writing it would be a no-op
+            // that reads like a migration.
             state
         }
         None => {
@@ -1047,12 +1067,18 @@ mod tests {
         assert_eq!(how, Acquired::Adopted);
     }
 
-    /// A state file written before the field existed records `0`, which
-    /// means "unknown" and must not be compared — those files predate
-    /// any release that could adopt a VPP at all, so refusing them would
-    /// wedge an upgrade for no safety gain.
+    /// A record with no sizing is refused rather than adopted under the
+    /// current figure. `0` means the heap and stats segment the running
+    /// VPP started under are **unknown**, not unconstrained: VPP does not
+    /// report the figure back, so writing this run's number onto the
+    /// record would be an observation we invented, and the adoption it
+    /// permitted could then fill the ledger past what that instance
+    /// holds — gate 0b's OOM abort by a longer route. It cannot happen in
+    /// practice (no released build wrote such a file), which is why the
+    /// answer is a clean refusal naming `detach --all` rather than a
+    /// migration path.
     #[test]
-    fn an_unrecorded_sizing_does_not_refuse_adoption() {
+    fn an_unrecorded_sizing_refuses_adoption() {
         let f = Fixture::new(
             "sizing-old",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
@@ -1062,8 +1088,18 @@ mod tests {
         state.expected_routes = 0;
         state.save(&f.paths.state_dir).unwrap();
 
-        let (_, how) = acquire(&f.paths, &two_ports(), 8, 2_000_000).unwrap();
-        assert_eq!(how, Acquired::Adopted);
+        // Refused under a raised figure AND under the one that actually
+        // sized it — the point is that neither can be *established*, so
+        // agreeing by luck must not be the difference.
+        for routes in [2_000_000, 1_600_000] {
+            let err = acquire(&f.paths, &two_ports(), 8, routes).unwrap_err();
+            assert!(err.contains("records no `expected-routes`"), "{err}");
+            assert!(err.contains("detach --all"), "{err}");
+        }
+        // And the refusal is inert: the record still says what it said,
+        // so `detach --all` can still release against it.
+        let after = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
+        assert_eq!(after.expected_routes, 0);
     }
 
     /// Release refuses to restore into a different pool than the state

--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -27,7 +27,7 @@ use crate::resources::{
     bind_vfio_in, ensure_vf_in, release_vf_in, reserve_hugepages_in, sweep_stale_hugepage_maps,
     unbind_vfio_in, verify_port_in, PortState, ResourceState,
 };
-use crate::runtime::{IdentityStore, ProcessIdentity};
+use crate::runtime::{IdentityStore, ProcessIdentity, ResourceRelease};
 
 /// The kernel driver that owns cnxk VFs when vfio does not.
 /// Rebinding to it on release is what hands the VF back to the kernel
@@ -59,6 +59,32 @@ pub struct SysPaths {
     pub hugetlbfs: PathBuf,
     /// Where the state file lives (`<state-dir>`).
     pub state_dir: PathBuf,
+}
+
+impl SysPaths {
+    /// The real locations on a running kernel.
+    ///
+    /// `hugepage_bytes` is the **default** page size from
+    /// `/proc/meminfo` (`crate::default_hugepage_bytes`), which selects
+    /// the pool directory — the fleet's 64 K-page kernel offers a 2 MiB
+    /// and a 512 MiB pool, and reserving from the wrong one is how a
+    /// startup.conf asking for `default-hugepage` pages finds none.
+    /// Callers must reject a `0` (unknown) page size before getting
+    /// here; the pool path it would build does not exist.
+    pub fn live(state_dir: impl Into<PathBuf>, hugepage_bytes: u64) -> Self {
+        Self {
+            sysfs_net: PathBuf::from("/sys/class/net"),
+            pci_devices: PathBuf::from("/sys/bus/pci/devices"),
+            pci_drivers: PathBuf::from("/sys/bus/pci/drivers"),
+            hugepage_pool: PathBuf::from(format!(
+                "/sys/kernel/mm/hugepages/hugepages-{}kB",
+                hugepage_bytes / 1024
+            )),
+            hugepage_bytes,
+            hugetlbfs: PathBuf::from("/dev/hugepages"),
+            state_dir: state_dir.into(),
+        }
+    }
 }
 
 /// What acquisition produced, and how.
@@ -96,6 +122,7 @@ pub fn acquire(
     paths: &SysPaths,
     ports: &[(String, u16)],
     pages: u32,
+    expected_routes: u64,
 ) -> Result<(ResourceState, Acquired), String> {
     // How many leading ports are already recorded. Adoption with a
     // complete record returns early below; a PARTIAL record — a daemon
@@ -112,6 +139,21 @@ pub fn acquire(
         Some(mut state) => {
             resume_from = verify_adoptable(paths, &state, ports)?;
 
+            // Sizing identity. Checked alongside the pool identity below
+            // and for the same reason: both describe memory a running
+            // VPP committed to at start, and neither can be renegotiated
+            // by adopting it. See `ResourceState::expected_routes`. A
+            // recorded `0` predates the field and cannot be compared.
+            if state.expected_routes != 0 && state.expected_routes != expected_routes {
+                return Err(format!(
+                    "state was sized for expected-routes {} but this run is configured for \
+                     {expected_routes}; VPP fixes its main heap and stats segment at start, \
+                     so adopting it under the new figure would let the route ledger fill \
+                     past what the running instance holds — run `packetframe detach --all` \
+                     and start fresh to apply the new sizing",
+                    state.expected_routes
+                ));
+            }
             // The pool identity check comes BEFORE any reservation
             // touch. Raising the currently-configured pool while the
             // state owns a reservation in a DIFFERENT one would create
@@ -152,10 +194,16 @@ pub fn acquire(
             if resume_from == ports.len() {
                 return Ok((state, Acquired::Adopted));
             }
+            // Resuming an interrupted acquisition: the tail is acquired
+            // fresh below and saved, so this is the moment a pre-field
+            // record can record its sizing. Equal values make it a no-op;
+            // a differing one was already refused above.
+            state.expected_routes = expected_routes;
             state
         }
         None => {
             let mut state = ResourceState::empty();
+            state.expected_routes = expected_routes;
             // Hugepages first. Record the PRIOR count before touching
             // the pool: release restores this value, because zeroing
             // is only correct when the reservation was created from
@@ -440,7 +488,8 @@ pub struct FileStore {
 
 impl FileStore {
     /// Wrap the state `acquire` produced. The store owns it from here;
-    /// `into_state` gives it back for release at detach.
+    /// release goes through [`ResourceOwner`], which shares this record
+    /// rather than taking it back.
     pub fn new(state: ResourceState, state_dir: impl Into<PathBuf>) -> Self {
         Self {
             state,
@@ -452,8 +501,14 @@ impl FileStore {
         &self.state
     }
 
-    pub fn into_state(self) -> ResourceState {
-        self.state
+    /// Adopt what the file now says, without writing.
+    ///
+    /// For [`ResourceOwner::release`], which changes the file
+    /// underneath this record: a release that partially fails rewrites
+    /// it with only what is still held, and an in-memory copy that kept
+    /// the pre-release ports would resurrect them on the next save.
+    pub fn replace_state(&mut self, state: ResourceState) {
+        self.state = state;
     }
 }
 
@@ -499,6 +554,129 @@ impl IdentityStore for FileStore {
             port.sw_if_index = Some(*idx);
         }
         self.state.save(&self.state_dir)
+    }
+}
+
+/// The single owner of everything attach acquired: the state file and
+/// the sysfs paths needed to hand the resources back.
+///
+/// Exists because the runtime needs two seams —
+/// [`IdentityStore`] and [`ResourceRelease`] — over **one** record. The
+/// obvious alternative, giving the releaser its own clone of the
+/// [`ResourceState`], has a specific failure: `release` removes the
+/// state file on success, and the supervision loop keeps ticking
+/// afterwards (it runs until the machine settles in `Stopped`). A
+/// `process_changed(None)` arriving in that window would save the
+/// releaser-unaware clone straight back to disk, re-creating a file that
+/// claims VFs which are already unbound — and the next daemon start
+/// would then refuse to attach, or try to adopt them.
+///
+/// Share it with `Rc<RefCell<_>>`; the runtime is single-threaded by
+/// construction (see the module docs on `!Send`), so there is no lock to
+/// contend and no ordering to reason about.
+pub struct ResourceOwner {
+    store: FileStore,
+    paths: SysPaths,
+    /// Set once `release` has confirmed everything gone. A second call
+    /// then answers `Ok` from this rather than re-running a teardown
+    /// against an emptied record — `release` on an empty state would
+    /// find no ports, skip the hugepage branch, and try to remove a
+    /// state file that is already gone.
+    released: bool,
+}
+
+impl ResourceOwner {
+    pub fn new(state: ResourceState, paths: SysPaths) -> Self {
+        let store = FileStore::new(state, paths.state_dir.clone());
+        Self {
+            store,
+            paths,
+            released: false,
+        }
+    }
+}
+
+impl IdentityStore for ResourceOwner {
+    fn process_changed(&mut self, identity: Option<ProcessIdentity>) -> Result<(), String> {
+        if self.released {
+            // The resources are gone and the file with them. Recording
+            // an identity now would re-create a state file describing
+            // VFs nothing holds — see the type docs. The process fact
+            // itself is still true, and still surfaces: the runtime
+            // reports store failures rather than swallowing them.
+            return Err(
+                "resources were already released; refusing to re-create the state file".into(),
+            );
+        }
+        self.store.process_changed(identity)
+    }
+
+    fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String> {
+        if self.released {
+            return Err(
+                "resources were already released; refusing to re-create the state file".into(),
+            );
+        }
+        self.store.interfaces_attached(indices)
+    }
+}
+
+impl ResourceRelease for ResourceOwner {
+    fn release(&mut self) -> Result<(), String> {
+        if self.released {
+            return Ok(());
+        }
+        // `release` consumes a copy of the state and, on PARTIAL
+        // failure, writes back what is still held. The store's own copy
+        // therefore goes stale in exactly the case that matters: a later
+        // `process_changed` would save the pre-release record and
+        // resurrect ports the teardown did free. So re-read the file the
+        // release just wrote — that file IS the record of what remains,
+        // and re-deriving the subtraction here would be a second
+        // implementation of it.
+        let outcome = release(&self.paths, self.store.state().clone());
+        match ResourceState::load(&self.paths.state_dir) {
+            // Released cleanly: the file is gone and so is the record.
+            Ok(None) => self.store.replace_state(ResourceState::empty()),
+            Ok(Some(remaining)) => self.store.replace_state(remaining),
+            // The file cannot be read back. The in-memory copy is now of
+            // unknown accuracy, so it must not be written again; treat
+            // that as released-for-writing purposes regardless of the
+            // release outcome below, which still reports the truth.
+            Err(_) => self.released = true,
+        }
+        outcome?;
+        self.released = true;
+        Ok(())
+    }
+}
+
+/// Shared handle: the same owner behind both runtime seams.
+///
+/// `Rc<RefCell<ResourceOwner>>` cannot implement the traits directly
+/// (the borrow has to happen per call), so this thin wrapper does, and
+/// two clones of it go into [`crate::runtime::Runtime::new`].
+#[derive(Clone)]
+pub struct SharedOwner(std::rc::Rc<std::cell::RefCell<ResourceOwner>>);
+
+impl SharedOwner {
+    pub fn new(owner: ResourceOwner) -> Self {
+        Self(std::rc::Rc::new(std::cell::RefCell::new(owner)))
+    }
+}
+
+impl IdentityStore for SharedOwner {
+    fn process_changed(&mut self, identity: Option<ProcessIdentity>) -> Result<(), String> {
+        self.0.borrow_mut().process_changed(identity)
+    }
+    fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String> {
+        self.0.borrow_mut().interfaces_attached(indices)
+    }
+}
+
+impl ResourceRelease for SharedOwner {
+    fn release(&mut self) -> Result<(), String> {
+        self.0.borrow_mut().release()
     }
 }
 
@@ -571,13 +749,35 @@ mod tests {
         vec![("eth2".into(), 1), ("eth3".into(), 1)]
     }
 
+    /// The `expected-routes` these fixtures acquire under. Only its
+    /// stability matters to most of them; the tests that care about the
+    /// sizing-identity check pass their own.
+    const ROUTES: u64 = 1_600_000;
+
+    /// The fixture's `bind` files are plain files; a real kernel responds
+    /// to the bind write by creating the `driver` symlink that
+    /// `verify_port_in` checks. Play the kernel's part so a second
+    /// `acquire` can reach the adoption path.
+    fn plant_vfio_links(f: &Fixture, pcis: &[&str]) {
+        #[cfg(unix)]
+        for pci in pcis {
+            std::os::unix::fs::symlink(
+                f.paths.pci_drivers.join("vfio-pci"),
+                f.paths.pci_devices.join(pci).join("driver"),
+            )
+            .unwrap();
+        }
+        #[cfg(not(unix))]
+        let _ = (f, pcis);
+    }
+
     #[test]
     fn fresh_acquisition_records_everything_it_holds() {
         let f = Fixture::new(
             "fresh",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, how) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Fresh);
         assert_eq!(state.hugepage_pages, 8);
         assert_eq!(state.hugepage_prior_pages, 0);
@@ -600,7 +800,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "0").unwrap(); // no virtfn0
 
-        let err = acquire(&f.paths, &two_ports(), 8).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("eth3"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
 
@@ -638,24 +838,14 @@ mod tests {
             "adopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (first, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
-        // The fixture's `bind` files are plain files; a real kernel
-        // responds to the bind write by creating the `driver` symlink
-        // that verify_port_in checks. Play the kernel's part.
-        #[cfg(unix)]
-        for pci in ["0002:07:00.0", "0002:07:00.1"] {
-            std::os::unix::fs::symlink(
-                f.paths.pci_drivers.join("vfio-pci"),
-                f.paths.pci_devices.join(pci).join("driver"),
-            )
-            .unwrap();
-        }
-        let (second, how) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (first, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
+        let (second, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(second, first);
 
         // A config whose port set changed must be refused, not merged.
-        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8).unwrap_err();
+        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8, ROUTES).unwrap_err();
         assert!(err.contains("cannot change across an adoption"), "{err}");
     }
 
@@ -669,7 +859,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "3").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(state.hugepage_prior_pages, 3);
 
         release(&f.paths, state).unwrap();
@@ -692,7 +882,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "10").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(state.hugepage_pages, 0, "we own nothing");
 
         release(&f.paths, state).unwrap();
@@ -713,7 +903,7 @@ mod tests {
             "store",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut store = FileStore::new(state, &f.paths.state_dir);
 
         store
@@ -772,7 +962,7 @@ mod tests {
         // breaks.
         fs::create_dir_all(f.paths.state_dir.join("vpp-offload.json.tmp")).unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("could not record"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
         // Nothing survives: the hugepage reservation is back to prior.
@@ -794,7 +984,7 @@ mod tests {
             "hpadopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (_state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (_state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -806,7 +996,7 @@ mod tests {
         // The reset nobody asked for.
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let (_, how) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(
             fs::read_to_string(f.paths.hugepage_pool.join("nr_hugepages"))
@@ -826,10 +1016,54 @@ mod tests {
             "cores",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let changed = vec![("eth2".to_string(), 1u16), ("eth3".to_string(), 4u16)];
-        let err = acquire(&f.paths, &changed, 8).unwrap_err();
+        let err = acquire(&f.paths, &changed, 8, ROUTES).unwrap_err();
         assert!(err.contains("core counts"), "{err}");
+    }
+
+    /// A raised `expected-routes` is refused for the same reason a
+    /// `cores` change is: VPP fixes its main heap and stats segment at
+    /// start, so the adopted instance cannot hold the larger table the
+    /// new figure would let the ledger install. Accepting it would
+    /// reproduce gate 0b's mid-resync OOM abort through the adoption
+    /// door.
+    #[test]
+    fn adoption_refuses_a_sizing_change() {
+        let f = Fixture::new(
+            "sizing",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        assert_eq!(state.expected_routes, 1_600_000, "sizing was not recorded");
+        plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
+
+        let err = acquire(&f.paths, &two_ports(), 8, 2_000_000).unwrap_err();
+        assert!(err.contains("expected-routes 1600000"), "{err}");
+        assert!(err.contains("detach --all"), "{err}");
+
+        // The unchanged figure still adopts.
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        assert_eq!(how, Acquired::Adopted);
+    }
+
+    /// A state file written before the field existed records `0`, which
+    /// means "unknown" and must not be compared — those files predate
+    /// any release that could adopt a VPP at all, so refusing them would
+    /// wedge an upgrade for no safety gain.
+    #[test]
+    fn an_unrecorded_sizing_does_not_refuse_adoption() {
+        let f = Fixture::new(
+            "sizing-old",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
+        state.expected_routes = 0;
+        state.save(&f.paths.state_dir).unwrap();
+
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, 2_000_000).unwrap();
+        assert_eq!(how, Acquired::Adopted);
     }
 
     /// Release refuses to restore into a different pool than the state
@@ -841,7 +1075,7 @@ mod tests {
             "wrongpool",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut wrong = f.paths.clone();
         wrong.hugepage_bytes = 2 << 20; // detach pointed at the 2 MiB pool
         let err = release(&wrong, state).unwrap_err();
@@ -866,7 +1100,7 @@ mod tests {
             "gonevf",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         // eth3's VF disappears out from under the record.
         fs::remove_dir_all(f.paths.pci_devices.join("0002:07:00.1")).unwrap();
 
@@ -895,7 +1129,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "3").unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("refuses to guess"), "{err}");
         assert_eq!(
             fs::read_to_string(dev.join("sriov_numvfs")).unwrap(),
@@ -917,7 +1151,7 @@ mod tests {
         // Simulate the interruption: acquire both, then rewrite the
         // state as if the daemon died before eth3's save — eth3's VF
         // exists and is vfio-bound, but the record stops at eth2.
-        let (mut state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         state.ports.truncate(1);
         state.save(&f.paths.state_dir).unwrap();
         #[cfg(unix)]
@@ -929,7 +1163,7 @@ mod tests {
             .unwrap();
         }
 
-        let (resumed, how) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (resumed, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Resumed);
         assert_eq!(resumed.ports.len(), 2);
         assert_eq!(
@@ -950,7 +1184,7 @@ mod tests {
             "poolchg",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -967,7 +1201,7 @@ mod tests {
         fs::create_dir_all(&wrong.hugepage_pool).unwrap();
         fs::write(wrong.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let err = acquire(&wrong, &two_ports(), 8).unwrap_err();
+        let err = acquire(&wrong, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("wrong pool"), "{err}");
         assert_eq!(
             fs::read_to_string(wrong.hugepage_pool.join("nr_hugepages"))
@@ -987,7 +1221,7 @@ mod tests {
             "sweep",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_0"), "").unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_7"), "").unwrap();
 
@@ -997,5 +1231,85 @@ mod tests {
                 && !f.paths.hugetlbfs.join("rtemap_7").exists(),
             "stale maps must be swept before the pool release"
         );
+    }
+
+    /// The reason [`ResourceOwner`] exists. The supervision loop keeps
+    /// ticking after `ReleaseResources` — it runs until the machine
+    /// settles in `Stopped` — so a `process_changed(None)` can arrive
+    /// after the release. With a releaser holding its own copy of the
+    /// state, that save re-creates a state file naming VFs which are
+    /// already unbound, and the next daemon start then tries to adopt
+    /// them.
+    #[test]
+    fn a_record_written_after_release_cannot_resurrect_the_state_file() {
+        let f = Fixture::new(
+            "owner",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
+
+        // A spawn is recorded the ordinary way, while resources are held.
+        owner
+            .process_changed(Some(ProcessIdentity {
+                pid: 4242,
+                start_ticks: 99,
+                boot_id: Some("boot".into()),
+            }))
+            .unwrap();
+        assert!(ResourceState::load(&f.paths.state_dir).unwrap().is_some());
+
+        owner.release().unwrap();
+        assert!(
+            ResourceState::load(&f.paths.state_dir).unwrap().is_none(),
+            "a clean release must remove the state file"
+        );
+
+        // The late observation. It must be refused, and above all it
+        // must not write.
+        let e = owner.process_changed(None).unwrap_err();
+        assert!(e.contains("already released"), "{e}");
+        assert!(
+            ResourceState::load(&f.paths.state_dir).unwrap().is_none(),
+            "the state file was resurrected after release"
+        );
+        // Idempotent: a second release is not a second teardown.
+        owner.release().unwrap();
+    }
+
+    /// A release that only partially succeeds leaves the file describing
+    /// what is STILL held — and the owner's in-memory copy has to follow
+    /// it. Keeping the pre-release copy would let a later save put the
+    /// freed ports back.
+    #[test]
+    fn a_partial_release_leaves_the_owner_agreeing_with_the_file() {
+        let f = Fixture::new(
+            "owner-partial",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
+
+        // Make eth2's release fail: remove the netdev dir the numvfs
+        // write targets, leaving eth3 releasable.
+        fs::remove_dir_all(f.paths.sysfs_net.join("eth2")).unwrap();
+
+        let e = owner.release().unwrap_err();
+        assert!(e.contains("eth2"), "{e}");
+
+        let on_disk = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
+        assert_eq!(
+            on_disk
+                .ports
+                .iter()
+                .map(|p| p.iface.as_str())
+                .collect::<Vec<_>>(),
+            vec!["eth2"],
+            "the file must name only what is still held"
+        );
+        // And a save from that state must not put eth3 back.
+        owner.process_changed(None).unwrap();
+        let after = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
+        assert_eq!(after.ports.len(), 1, "eth3 was resurrected by a later save");
     }
 }

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -122,6 +122,37 @@ pub fn bring_up(
     if cfg.ports.is_empty() {
         return Err("no `port` lines; there is no forwarding domain to bring up".into());
     }
+    // `steer on` is REFUSED until slice 5 builds MCAM, in the pure phase
+    // before anything is touched.
+    //
+    // Accepting it was a silent no-op with a healthy face on it. The steering
+    // flag is dropped here (the attach step needs only iface and cores), a
+    // fresh supervisor starts with `steer_wanted = false`, and a first attach
+    // deliberately never steers itself — so `SteeringUnavailable` is never
+    // called, convergence settles in `Ready`, and `nominal()` returns true
+    // because `steer_intended()` is false. An operator who asked for traffic
+    // diversion would get a Healthy module that never attempted it, which is
+    // precisely the "requested, not observed" shape this phase keeps
+    // producing.
+    //
+    // Refusing is safe: the plan's staging state is every port `steer off`
+    // (members up, FIB synced and verified, zero traffic diverted), and that
+    // is exactly what this module can honestly deliver today.
+    let asked_to_steer: Vec<&str> = cfg
+        .ports
+        .iter()
+        .filter(|(_, _, steer)| *steer)
+        .map(|(iface, _, _)| iface.as_str())
+        .collect();
+    if !asked_to_steer.is_empty() {
+        return Err(format!(
+            "port(s) {} are configured `steer on`, but MCAM steering is not implemented \
+             until slice 5 — attaching would report Healthy while diverting nothing. Set \
+             every port to `steer off` (the designed staging state: members up, FIB synced \
+             and verified, no traffic diverted) until steering ships.",
+            asked_to_steer.join(", ")
+        ));
+    }
     let workers = cfg.total_workers();
     let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
     let core_map = cores::derive_from_sysfs(&paths.sysfs_cpu, workers)?;

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -1,0 +1,393 @@
+//! `Module::attach()`, as a function of its inputs.
+//!
+//! Every layer below this exists and is tested; this is where they are
+//! composed into one sequence. It is a free function taking its host
+//! paths rather than a method reaching for `/sys` and `/run`, so the
+//! whole thing — the refusals, the ordering, the rollback — runs against
+//! a tempdir on a dev laptop. [`crate::VppOffloadModule::attach`] calls
+//! it with the live paths and keeps the returned handle.
+//!
+//! ## The sequence, and what each step protects
+//!
+//! ```text
+//! derive sizing + core map     pure; no mutation yet, so a bad config
+//!                              costs nothing
+//! acquire hugepages → VF → vfio   rollback-safe, state file per step
+//! render + write startup.conf  the last thing before a process could exist
+//! adopt (only if the record names a live VPP)
+//! start the supervision loop   which does the spawning, if any
+//! ```
+//!
+//! **Nothing here spawns VPP.** The supervisor owns that: `attach`
+//! injects `StartRequested` and the loop's `Start` action spawns,
+//! records the identity, and arms backoff on failure. Spawning here
+//! instead would duplicate that path — and duplicate it in the one
+//! direction that matters, since a spawn this function performed and
+//! then failed to hand over would be a VPP nothing supervises, holding a
+//! VF nothing can release.
+//!
+//! Adoption is the exception, because it is an *observation* rather than
+//! an action: whether a VPP from a previous daemon is still alive is a
+//! fact about the box, and the supervisor cannot discover it. So this
+//! establishes it and injects `Adopted { steered }`, which is
+//! deliberately distinct from `StartRequested` — an adopted VPP may be
+//! carrying live traffic, and rule 3 says resync and verify must NOT
+//! tear its steering down first.
+
+use std::path::{Path, PathBuf};
+
+use crate::acquire::{self, Acquired, ResourceOwner, SharedOwner, SysPaths};
+use crate::attach::PortAttach;
+use crate::cores;
+use crate::driver::Driver;
+use crate::engine::{ConvergenceEngine, RouteSource};
+use crate::fib_sync::FamilyPolicy;
+use crate::process::VppProcess;
+use crate::resources::ResourceState;
+use crate::runtime::{Runtime, SteeringUnavailable};
+use crate::service::{LoopFactory, SupervisionService};
+use crate::startup_conf;
+use crate::supervisor::Event;
+use crate::{VppOffloadConfig, MODULE_NAME};
+
+/// Where VPP's binary API socket lives.
+///
+/// Under packetframe's own runtime dir, not `/run/vpp`, so a
+/// distro-packaged `vpp.service` (which UniFi's install leaves masked but
+/// present) cannot collide with the instance this module supervises.
+pub const API_SOCKET: &str = "/run/packetframe/vpp/api.sock";
+
+/// The rendered startup.conf. Regenerated on every attach — it is
+/// derived entirely from config, and VPP reads it once at start.
+pub const STARTUP_CONF: &str = "/run/packetframe/vpp/startup.conf";
+
+/// The default VPP binary, overridable with `vpp-binary` in config.
+pub const DEFAULT_VPP_BINARY: &str = "/usr/bin/vpp";
+
+/// Host paths the sequence touches, all injectable.
+#[derive(Debug, Clone)]
+pub struct AttachPaths {
+    pub sys: SysPaths,
+    /// `/sys/devices/system/cpu`, for the worker placement.
+    pub sysfs_cpu: PathBuf,
+    pub api_socket: PathBuf,
+    pub startup_conf: PathBuf,
+}
+
+impl AttachPaths {
+    pub fn live(state_dir: impl Into<PathBuf>, hugepage_bytes: u64) -> Self {
+        Self {
+            sys: SysPaths::live(state_dir, hugepage_bytes),
+            sysfs_cpu: PathBuf::from(cores::SYSFS_CPU),
+            api_socket: PathBuf::from(API_SOCKET),
+            startup_conf: PathBuf::from(STARTUP_CONF),
+        }
+    }
+}
+
+/// What a successful bring-up produced, for the module to hold.
+pub struct Attached {
+    pub service: SupervisionService,
+    /// The core map that was rendered, so the operator can move PF IRQs
+    /// off it — on the reference NIC every CPU carries an rx-queue IRQ,
+    /// so this is not optional work. Logged at attach for that reason.
+    pub cores: cores::CoreMap,
+    /// How the resources were obtained, and whether a running VPP was
+    /// adopted. `packetframe status` reads differently for an adopted
+    /// dataplane: it may already be forwarding.
+    pub acquired: Acquired,
+    pub adopted_process: bool,
+}
+
+/// Acquire, render, adopt-or-arm, and start supervising.
+///
+/// On any failure after acquisition, everything acquired is released
+/// before returning — a failed attach must leave the box as it found it,
+/// or say precisely what it could not hand back.
+pub fn bring_up(
+    cfg: &VppOffloadConfig,
+    paths: &AttachPaths,
+    source: Box<dyn RouteSource + Send + Sync>,
+) -> Result<Attached, String> {
+    // --- Everything pure first. A config that cannot work must cost no
+    // sysfs writes; the alternative is a rollback path exercised by
+    // ordinary operator typos.
+    //
+    // Zero ports is refused rather than treated as a no-op attach.
+    // `Module::load` already rejects it, but this is reachable directly,
+    // and the result would be a supervised VPP with no interfaces: every
+    // route unresolvable, every verify sampling an empty pool, and
+    // membership — which is all-or-nothing across the forwarding domain —
+    // vacuously satisfied.
+    if cfg.ports.is_empty() {
+        return Err("no `port` lines; there is no forwarding domain to bring up".into());
+    }
+    let workers = cfg.total_workers();
+    let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
+    let core_map = cores::derive_from_sysfs(&paths.sysfs_cpu, workers)?;
+
+    let hugepage_bytes = paths.sys.hugepage_bytes;
+    if hugepage_bytes == 0 {
+        return Err(
+            "the default hugepage size could not be read from /proc/meminfo; VPP cannot be \
+             sized without it (run `packetframe feasibility` for the platform state)"
+                .into(),
+        );
+    }
+    let pages = match cfg.hugepages {
+        Some(p) => {
+            // Also checked at load; re-checked here because `bring_up`
+            // is reachable without it and the failure it prevents is a
+            // cryptic VPP init abort.
+            startup_conf::check_hugepage_budget(&sizing, p, hugepage_bytes)?;
+            p
+        }
+        None => u32::try_from(sizing.total_bytes.div_ceil(hugepage_bytes)).map_err(|_| {
+            format!(
+                "derived hugepage count for {} routes does not fit in u32; \
+                                  lower `expected-routes`",
+                cfg.expected_routes
+            )
+        })?,
+    };
+
+    let vpp_binary = PathBuf::from(
+        cfg.vpp_binary
+            .clone()
+            .unwrap_or_else(|| DEFAULT_VPP_BINARY.to_string()),
+    );
+    // Checked before acquiring rather than discovered by the loop's
+    // first `Start`. A missing binary is a permanent condition, and the
+    // supervisor's answer to a failed spawn is backoff-and-retry — so
+    // without this, a typo'd `vpp-binary` becomes an attach that
+    // "succeeds", holds VFs and hugepages, and retries forever.
+    if !vpp_binary.is_file() {
+        return Err(format!(
+            "VPP binary {} does not exist; set `vpp-binary <path>` or install the pinned \
+             VPP package",
+            vpp_binary.display()
+        ));
+    }
+
+    // --- The first mutation.
+    let ports: Vec<(String, u16)> = cfg
+        .ports
+        .iter()
+        .map(|(iface, cores, _)| (iface.clone(), *cores))
+        .collect();
+    let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
+
+    // From here, every failure releases. `?` would return holding VFs
+    // and a hugepage reservation that only the state file knows about —
+    // recoverable by `detach --all`, but an attach that leaves the box
+    // changed after reporting failure is how leaks become normal.
+    match finish(
+        paths,
+        source,
+        &sizing,
+        &core_map,
+        state.clone(),
+        acquired,
+        &vpp_binary,
+    ) {
+        Ok(attached) => Ok(attached),
+        // A supervision panic is the one failure that must NOT roll back.
+        //
+        // NOT covered by a test, and the reason is structural: the window
+        // only opens once a process exists, i.e. after an adoption or a
+        // successful spawn. On the fresh path the spawn is the first thing
+        // that can fail, so nothing walks the route source inside `start`
+        // and the panic cannot be provoked; adoption needs a live VPP. It
+        // belongs with the failover drills. The guard is one comparison and
+        // its absence risks memory corruption, so it ships unproven rather
+        // than not at all.
+        //
+        // Everything else here failed before any process could exist, so
+        // releasing is right. But a panic inside `SupervisionService::start`
+        // may have unwound with a VPP already adopted or spawned — the
+        // handle is dropped by the unwind without terminating the process —
+        // and releasing then unbinds a VF that a live VPP can still DMA
+        // through. That is the hazard `Disposition::MustLeak` exists to
+        // avoid, arriving by a different route. A leaked VF is a line in
+        // `packetframe status`; memory corruption is not.
+        Err(e) if crate::service::may_hold_resources(&e) => Err(format!(
+            "{e} The acquired VF(s) and hugepage reservation were deliberately NOT released \
+             for that reason; the state file still records them, so `packetframe detach \
+             --all` can release them once VPP is confirmed gone."
+        )),
+        Err(e) => Err(match acquire::release(&paths.sys, state) {
+            Ok(()) => format!("{e}; everything acquired was released"),
+            Err(re) => format!(
+                "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
+            ),
+        }),
+    }
+}
+
+/// The part that runs with resources held, split out so `bring_up` has
+/// exactly one rollback site.
+#[allow(clippy::too_many_arguments)]
+fn finish(
+    paths: &AttachPaths,
+    source: Box<dyn RouteSource + Send + Sync>,
+    sizing: &startup_conf::Sizing,
+    core_map: &cores::CoreMap,
+    state: ResourceState,
+    acquired: Acquired,
+    vpp_binary: &Path,
+) -> Result<Attached, String> {
+    // --- startup.conf. Written before any process could read it, and
+    // rewritten on every attach: it is a pure function of config, and
+    // VPP consults it once at start.
+    let api_socket = paths
+        .api_socket
+        .to_str()
+        .ok_or_else(|| format!("API socket path {:?} is not UTF-8", paths.api_socket))?;
+    let conf = startup_conf::render(
+        sizing,
+        &core_map.workers,
+        core_map.main,
+        api_socket,
+        paths.sys.hugepage_bytes,
+    );
+    for dir in [paths.startup_conf.parent(), paths.api_socket.parent()]
+        .into_iter()
+        .flatten()
+    {
+        std::fs::create_dir_all(dir).map_err(|e| format!("create {}: {e}", dir.display()))?;
+    }
+    std::fs::write(&paths.startup_conf, &conf)
+        .map_err(|e| format!("write {}: {e}", paths.startup_conf.display()))?;
+
+    // --- The attach step's inputs, from what acquisition recorded. The
+    // VF PCI addresses are the state file's, not re-derived: the record
+    // is what release will act on, so attaching a device the record does
+    // not name would be a VF nothing can hand back.
+    let port_attach: Vec<PortAttach> = state
+        .ports
+        .iter()
+        .map(|p| PortAttach {
+            port: p.iface.clone(),
+            pci_addr: p.vf_pci.clone(),
+            port_id: 0,
+            num_rx_queues: p.cores,
+        })
+        .collect();
+    // Every member port, whether or not it steers: a steered packet's
+    // best path may egress any of them, so the nexthop mapping must
+    // resolve all of them (plan v5, membership vs steering).
+    let members: Vec<String> = state.ports.iter().map(|p| p.iface.clone()).collect();
+    let recorded: Vec<(String, u32)> = state
+        .ports
+        .iter()
+        .filter_map(|p| p.sw_if_index.map(|i| (p.iface.clone(), i)))
+        .collect();
+
+    // --- Adoption is an observation: is the VPP the record names still
+    // alive? `adopt` verifies (pid, start_ticks, boot_id) and declines
+    // on any mismatch, so a recycled PID cannot be adopted — and a
+    // decline simply means we start one instead.
+    let prior = match (state.vpp_pid, state.vpp_start_ticks) {
+        (Some(pid), Some(ticks)) => Some((pid, ticks, state.vpp_boot_id.clone())),
+        _ => None,
+    };
+    let adopted: Option<VppProcess> = match prior {
+        // A FAILED adoption is marked, because failing is not the same as
+        // finding nothing: `adopt` declines cleanly (`Ok(None)`) when the
+        // recorded process is gone, so an `Err` here means it is probably
+        // still there and we could not take it over — an unreadable boot
+        // id, a pidfd that would not open. Rolling back then unbinds the VF
+        // underneath a VPP that is still running and still able to DMA
+        // through it.
+        Some((pid, ticks, boot)) => {
+            VppProcess::adopt(pid, ticks, boot.as_deref()).map_err(|e| {
+                format!(
+                    "{}: could not adopt the recorded VPP (pid {pid}): {e}. That process is \
+                     probably still running and still holds its VF and hugepages.",
+                    crate::service::MAY_HOLD_RESOURCES
+                )
+            })?
+        }
+        None => None,
+    };
+    // Whether that VPP is diverting traffic right now. From the recorded
+    // steering rules, because that is the only durable evidence — and
+    // getting it wrong in the `false` direction would run the resync on
+    // the relaxed 10 s socket budget while packets are on VPP, defeating
+    // the published ≤2 s wedge bound.
+    let steered = !state.steer_rules.is_empty();
+    let adopted_process = adopted.is_some();
+
+    let capacity = startup_conf::route_capacity(sizing);
+    let api_socket_path = paths.api_socket.clone();
+    let startup_conf_path = paths.startup_conf.clone();
+    let vpp_binary = vpp_binary.to_path_buf();
+    let sys = paths.sys.clone();
+
+    // The factory runs on the loop thread because `Runtime` is `!Send`
+    // (see `service`), which is also why the resource owner is built in
+    // here rather than passed in: it shares one record between the
+    // identity store and the release seam through an `Rc`.
+    let factory: LoopFactory = Box::new(move || {
+        let engine = ConvergenceEngine::new(
+            api_socket_path,
+            port_attach,
+            members,
+            capacity,
+            FamilyPolicy::V4Only,
+        )
+        .with_recorded_indices(recorded);
+        let owner = SharedOwner::new(ResourceOwner::new(state, sys));
+        let runtime = Runtime::new(
+            engine,
+            source,
+            Box::new(SteeringUnavailable),
+            Box::new(owner.clone()),
+            Box::new(owner),
+            vpp_binary,
+            startup_conf_path,
+        );
+        let initial = match adopted {
+            Some(p) => {
+                // Order matters and is contractual: `adopt_process`
+                // first, with the same `steered`, so the engine's socket
+                // deadline is already the steered one when `inject`
+                // synchronously runs AttachDevices and StartResync.
+                runtime.adopt_process(p, steered);
+                vec![Event::Adopted { steered }]
+            }
+            None => vec![Event::StartRequested],
+        };
+        Ok((Driver::new(), runtime, initial))
+    });
+
+    // `start` MUST be the last fallible step, and nothing may be added
+    // after it that can fail.
+    //
+    // `bring_up` releases everything on any `Err` from here. Once `start`
+    // has succeeded a supervision loop is running against these VFs and
+    // hugepages, and a later failure would hand them back underneath it —
+    // unbinding a VF while VPP may be DMAing through it. The ordering is
+    // the only thing preventing that, so it is stated rather than left to
+    // be noticed.
+    let service = SupervisionService::start(MODULE_NAME, factory).map_err(|e| {
+        // Once a process was adopted, the factory owns its handle — and a
+        // failure inside `start` drops that handle without terminating the
+        // process. So every error from here is resource-bearing when we
+        // adopted, not just the panic that already marks itself.
+        if adopted_process && !crate::service::may_hold_resources(&e) {
+            format!(
+                "{}: {e} (the adopted VPP is still running and still holds its VF)",
+                crate::service::MAY_HOLD_RESOURCES
+            )
+        } else {
+            e
+        }
+    })?;
+    Ok(Attached {
+        service,
+        cores: core_map.clone(),
+        acquired,
+        adopted_process,
+    })
+}

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -380,6 +380,51 @@ fn finish(
         );
         let initial = match adopted {
             Some(p) => {
+                // The API handshake MUST happen before the adoption is
+                // injected, and this is the only place it can.
+                //
+                // `Event::Adopted` runs `AttachDevices` and `StartResync`
+                // synchronously. Against an engine whose transport has never
+                // connected, both return `NotConnected` → `ConvergenceFailed`
+                // → `fail()` → **Kill** — so the adopted VPP, the one thing
+                // preserve-on-restart exists to keep, was killed and replaced
+                // by a full restart and reconvergence. That is drill (d)
+                // inverted, and every adoption test in `vpp_service.rs` does
+                // this handshake in its factory with a comment saying the
+                // attach wiring does the same. The comment was aspirational.
+                {
+                    use crate::driver::Observe as _;
+                    let (mut obs, _) = runtime.views();
+                    if !obs.api_ready() {
+                        // Do NOT kill it and do NOT release anything. VPP is
+                        // running and may be forwarding steered traffic; the
+                        // one thing we now know is that we cannot talk to it.
+                        // Deciding to restart it is the supervisor's job on
+                        // evidence, and we have none beyond a refused
+                        // handshake — so this reports and leaves the box
+                        // alone. `MAY_HOLD_RESOURCES` suppresses the caller's
+                        // rollback, because the VF is still under a live
+                        // process.
+                        let detail = runtime
+                            .status()
+                            .api_error
+                            .unwrap_or_else(|| "(no detail recorded)".into());
+                        let permanent = if runtime.api_incompatible() {
+                            " This is a permanent incompatibility (CRC/version skew); \
+                             retrying cannot fix it."
+                        } else {
+                            ""
+                        };
+                        return Err(format!(
+                            "{}: adopted VPP (pid {}) does not answer its binary API: \
+                             {detail}.{permanent} It is still running and still holds its \
+                             VF and hugepages — nothing was killed or released. Investigate, \
+                             or `packetframe detach --all` to clear it and start fresh.",
+                            crate::service::MAY_HOLD_RESOURCES,
+                            p.pid()
+                        ));
+                    }
+                }
                 // Order matters and is contractual: `adopt_process`
                 // first, with the same `steered`, so the engine's socket
                 // deadline is already the steered one when `inject`
@@ -387,6 +432,9 @@ fn finish(
                 runtime.adopt_process(p, steered);
                 vec![Event::Adopted { steered }]
             }
+            // Nothing to hand over: VPP does not exist yet, so there is no
+            // API to handshake with. The loop's `Start` spawns it and the
+            // driver polls `api_ready` while `Starting`.
             None => vec![Event::StartRequested],
         };
         Ok((Driver::new(), runtime, initial))

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -318,9 +318,42 @@ fn finish(
     // alive? `adopt` verifies (pid, start_ticks, boot_id) and declines
     // on any mismatch, so a recycled PID cannot be adopted — and a
     // decline simply means we start one instead.
-    let prior = match (state.vpp_pid, state.vpp_start_ticks) {
-        (Some(pid), Some(ticks)) => Some((pid, ticks, state.vpp_boot_id.clone())),
-        _ => None,
+    // The recorded identity must be COMPLETE before adoption is attempted,
+    // and an incomplete one with a pid is a refusal, not a "no process".
+    //
+    // This is the same defect the standalone detach had, in the startup path,
+    // and it is worse here. `VppProcess::adopt` returns `Ok(None)` when it
+    // cannot verify an identity — not when the process is confirmed gone — so
+    // passing `boot_id: None` through and reading the refusal as "nothing
+    // running" made `finish` emit `StartRequested`: a SECOND VPP on the same
+    // VF and the same API socket, with the recorded pid overwritten and the
+    // original orphaned holding the hardware.
+    //
+    // (I fixed this in the CLI and did not check this path, having audited
+    // the CLI against the module's rules and not the module against itself.)
+    let prior = match (state.vpp_pid, state.vpp_start_ticks, &state.vpp_boot_id) {
+        (Some(pid), Some(ticks), Some(boot)) => Some((pid, ticks, boot.clone())),
+        // Nothing was running when the record was last written.
+        (None, _, _) => None,
+        // A pid with an incomplete cookie: it can be neither identified nor
+        // ruled out, so it must not be adopted, and a fresh spawn on the same
+        // VF is exactly what must not happen.
+        (Some(pid), ticks, boot) => {
+            let missing = match (ticks, boot) {
+                (None, None) => "start-time cookie and boot id",
+                (None, Some(_)) => "start-time cookie",
+                _ => "boot id",
+            };
+            return Err(format!(
+                "{}: the state file records VPP pid {pid} with no {missing}, so it can \
+                 neither be adopted nor ruled out. Starting a fresh VPP would put a second \
+                 process on the same VF and API socket and orphan the first, so this \
+                 refuses. Confirm by hand whether that process is running: if it is, \
+                 `packetframe detach --all` after stopping it; if not, remove the state \
+                 file.",
+                crate::service::MAY_HOLD_RESOURCES
+            ));
+        }
     };
     let adopted: Option<VppProcess> = match prior {
         // A FAILED adoption is marked, because failing is not the same as
@@ -330,15 +363,13 @@ fn finish(
         // id, a pidfd that would not open. Rolling back then unbinds the VF
         // underneath a VPP that is still running and still able to DMA
         // through it.
-        Some((pid, ticks, boot)) => {
-            VppProcess::adopt(pid, ticks, boot.as_deref()).map_err(|e| {
-                format!(
-                    "{}: could not adopt the recorded VPP (pid {pid}): {e}. That process is \
+        Some((pid, ticks, boot)) => VppProcess::adopt(pid, ticks, Some(&boot)).map_err(|e| {
+            format!(
+                "{}: could not adopt the recorded VPP (pid {pid}): {e}. That process is \
                      probably still running and still holds its VF and hugepages.",
-                    crate::service::MAY_HOLD_RESOURCES
-                )
-            })?
-        }
+                crate::service::MAY_HOLD_RESOURCES
+            )
+        })?,
         None => None,
     };
     // Whether that VPP is diverting traffic right now. From the recorded

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -199,6 +199,22 @@ pub fn bring_up(
             vpp_binary.display()
         ));
     }
+    // Existing is not enough: `is_file()` says nothing about the execute
+    // bit or the mount it sits on. A `chmod -x` binary, or one dropped
+    // somewhere mounted `noexec` (which is how UniFi OS mounts `/tmp` —
+    // the obvious place to park a hand-built VPP), fails at execve with
+    // EACCES. That would be discovered by the loop's first `Start`, i.e.
+    // one step too late: it is permanent, the supervisor answers a failed
+    // spawn with backoff-and-retry, and so attach would report success
+    // and hold the VFs and hugepages forever — the exact outcome the
+    // existence check above exists to prevent, arriving one stat later.
+    if let Err(e) = check_executable(&vpp_binary) {
+        return Err(format!(
+            "VPP binary {} is not executable ({e}); `chmod +x` it, or move it off a \
+             `noexec` mount (`/tmp` is one on UniFi OS)",
+            vpp_binary.display()
+        ));
+    }
 
     // --- The first mutation.
     let ports: Vec<(String, u16)> = cfg
@@ -252,6 +268,27 @@ pub fn bring_up(
                 "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
             ),
         }),
+    }
+}
+
+/// Can this process actually `execve` `path`?
+///
+/// `access(2)` rather than the mode bits, because the mode bits are only
+/// half the question: the kernel's `do_faccessat` checks `path_noexec()`
+/// for `X_OK` on a regular file, so this is the one call that answers for
+/// the permission *and* the mount. Real-uid semantics (`access`, not
+/// `faccessat(AT_EACCESS)`) — packetframe is not setuid, so the two
+/// coincide, and it keeps libc out of its AT_EACCESS emulation paths.
+fn check_executable(path: &Path) -> Result<(), std::io::Error> {
+    use std::os::unix::ffi::OsStrExt as _;
+    let c = std::ffi::CString::new(path.as_os_str().as_bytes())
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    // SAFETY: `c` is NUL-terminated and outlives the call, which does not
+    // retain it.
+    if unsafe { libc::access(c.as_ptr(), libc::X_OK) } == 0 {
+        Ok(())
+    } else {
+        Err(std::io::Error::last_os_error())
     }
 }
 

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -1,0 +1,299 @@
+//! CPU placement for VPP's main and worker threads.
+//!
+//! The config grammar promises `cores <n>` per port and nothing more: it
+//! says *how many* workers, never *which* CPUs. `startup_conf::render`
+//! needs the second — plan v5 is explicit that the operator's `cores`
+//! promise is honoured by rendering an explicit `corelist-workers`
+//! rather than trusting VPP's round-robin default. So the map is derived
+//! here, from what the host reports about itself, by a pure function
+//! whose whole behaviour is unit-testable on a dev laptop.
+//!
+//! ## The policy, and why each exclusion is in it
+//!
+//! Workers are taken from the **highest-numbered usable CPUs,
+//! descending**, and the main thread takes the next one below them.
+//!
+//! - **CPU 0 is never used.** It carries the boot processor's timers and
+//!   unbound workqueues on every kernel this runs on. A poll-mode worker
+//!   there starves them at 100% duty cycle.
+//! - **Isolated CPUs are never used.** On the reference fleet
+//!   `isolcpus=12` exists and belongs to `unifi-core`, not to us
+//!   (`docs/runbooks/` platform notes). Isolation means "reserved for
+//!   somebody's latency-sensitive workload"; the one thing you must not
+//!   do with a CPU somebody else reserved is put a busy-poll thread on
+//!   it.
+//! - **Descending** because the low end is where the exclusions and the
+//!   default IRQ/RPS spread cluster, so counting down keeps the map
+//!   stable as `cores` grows — adding a worker does not renumber the
+//!   ones already placed, and an operator's IRQ-affinity work therefore
+//!   survives a config bump.
+//!
+//! ## What this deliberately does not solve
+//!
+//! On the reference NIC all 18 CPUs carry an rx-queue IRQ 1:1 (18 cores
+//! = 18 queues, no idle silicon), so **no** map avoids sharing a CPU
+//! with a PF interrupt. That is an operator action — move the PF IRQs
+//! off the derived worker set — not something this function can do, and
+//! it is why the derived map is logged at attach: the log line is the
+//! input to that work. Plan v5's "explicit core map" (set A for PF
+//! IRQs, set B for workers, C for housekeeping) is the target state;
+//! this is the half of it that does not require new config grammar, and
+//! a `cpu-map` directive that lets the operator state set B directly
+//! remains the honest end point.
+
+/// VPP's thread placement, ready for `startup_conf::render`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CoreMap {
+    /// `main-core`: VPP's main thread. Answers the binary API, executes
+    /// our route batches, and is NOT a poll-mode thread — so it shares
+    /// a CPU far more gracefully than a worker does.
+    pub main: u16,
+    /// `corelist-workers`, in ascending order for a readable config
+    /// (placement is a set; the descending walk is only how it is
+    /// chosen).
+    pub workers: Vec<u16>,
+}
+
+/// Derive the map from the host's own CPU accounting.
+///
+/// `online` and `isolated` are the parsed contents of
+/// `/sys/devices/system/cpu/{online,isolated}`. `workers` is
+/// `VppOffloadConfig::total_workers()`.
+///
+/// Errors rather than degrading: a map that quietly drops a worker would
+/// hand VPP fewer threads than the sizing arithmetic reserved a stats
+/// segment for, and `render` asserts the two agree precisely because
+/// that mismatch surfaces hours later as an OOM abort mid-resync.
+pub fn derive_core_map(online: &[u16], isolated: &[u16], workers: u32) -> Result<CoreMap, String> {
+    let mut usable: Vec<u16> = online
+        .iter()
+        .copied()
+        .filter(|c| *c != 0 && !isolated.contains(c))
+        .collect();
+    usable.sort_unstable();
+    usable.dedup();
+
+    // One main thread plus every worker, all from distinct CPUs.
+    let needed = workers as usize + 1;
+    if usable.len() < needed {
+        return Err(format!(
+            "{} usable CPU(s) after excluding cpu0 and the isolated set {isolated:?}, but \
+             {} worker(s) plus VPP's main thread need {needed}; reduce the `cores` totals \
+             or free an isolated CPU",
+            usable.len(),
+            workers,
+        ));
+    }
+
+    // Workers off the top, main immediately below them.
+    let split = usable.len() - workers as usize;
+    let mut chosen: Vec<u16> = usable[split..].to_vec();
+    chosen.sort_unstable();
+    Ok(CoreMap {
+        main: usable[split - 1],
+        workers: chosen,
+    })
+}
+
+/// Parse a kernel CPU list: comma-separated singles and `a-b` ranges,
+/// as written by every file under `/sys/devices/system/cpu/`.
+///
+/// An empty or whitespace-only string is an empty list, which is the
+/// normal content of `isolated` on a host with no `isolcpus=`. A
+/// malformed list is an error rather than a silently-shorter list:
+/// treating an unparseable `isolated` as empty would place a worker on
+/// the CPU somebody reserved.
+pub fn parse_cpu_list(s: &str) -> Result<Vec<u16>, String> {
+    let mut out = Vec::new();
+    let s = s.trim();
+    if s.is_empty() {
+        return Ok(out);
+    }
+    for part in s.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            return Err(format!("empty element in CPU list {s:?}"));
+        }
+        match part.split_once('-') {
+            Some((lo, hi)) => {
+                let lo: u16 = lo
+                    .trim()
+                    .parse()
+                    .map_err(|e| format!("bad CPU range start {lo:?} in {s:?}: {e}"))?;
+                let hi: u16 = hi
+                    .trim()
+                    .parse()
+                    .map_err(|e| format!("bad CPU range end {hi:?} in {s:?}: {e}"))?;
+                if hi < lo {
+                    return Err(format!("inverted CPU range {part:?} in {s:?}"));
+                }
+                out.extend(lo..=hi);
+            }
+            None => out.push(
+                part.parse()
+                    .map_err(|e| format!("bad CPU {part:?} in {s:?}: {e}"))?,
+            ),
+        }
+    }
+    out.sort_unstable();
+    out.dedup();
+    Ok(out)
+}
+
+/// Read the host's map inputs from sysfs and derive the placement.
+///
+/// `online` missing is fatal — without it there is no CPU set to choose
+/// from, and guessing `0..nproc` would ignore offline CPUs. `isolated`
+/// missing is not: the file only exists on kernels built with
+/// `CONFIG_CPU_ISOLATION`, and its absence genuinely means "nothing is
+/// isolated". A *read error* on a file that exists is still fatal, for
+/// the reason `parse_cpu_list` refuses malformed input.
+pub fn derive_from_sysfs(sysfs_cpu: &std::path::Path, workers: u32) -> Result<CoreMap, String> {
+    let online_path = sysfs_cpu.join("online");
+    let online = std::fs::read_to_string(&online_path)
+        .map_err(|e| format!("read {}: {e}", online_path.display()))?;
+    let online = parse_cpu_list(&online)?;
+
+    let isolated_path = sysfs_cpu.join("isolated");
+    let isolated = match std::fs::read_to_string(&isolated_path) {
+        Ok(s) => parse_cpu_list(&s)?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => return Err(format!("read {}: {e}", isolated_path.display())),
+    };
+
+    derive_core_map(&online, &isolated, workers)
+}
+
+/// Where the CPU topology lives on a running kernel.
+pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The reference fleet: 18 cores, `isolcpus=12` owned by
+    /// unifi-core, four member ports at one worker each.
+    #[test]
+    fn the_reference_fleet_places_four_workers_off_the_top() {
+        let online: Vec<u16> = (0..18).collect();
+        let map = derive_core_map(&online, &[12], 4).unwrap();
+        assert_eq!(map.workers, vec![14, 15, 16, 17]);
+        assert_eq!(map.main, 13);
+    }
+
+    /// cpu0 and the isolated set are not merely deprioritised; they are
+    /// unreachable. A map that lands on either is the bug this function
+    /// exists to prevent, so assert it at the size where the walk would
+    /// otherwise have to reach them.
+    #[test]
+    fn cpu0_and_isolated_cpus_are_never_chosen() {
+        let online: Vec<u16> = (0..6).collect();
+        // Usable: 1,2,4,5 → four CPUs, so 3 workers + main is the
+        // tightest fit that still succeeds.
+        let map = derive_core_map(&online, &[3], 3).unwrap();
+        assert_eq!(map.main, 1);
+        assert_eq!(map.workers, vec![2, 4, 5]);
+        assert!(!map.workers.contains(&0) && map.main != 0);
+        assert!(!map.workers.contains(&3) && map.main != 3);
+    }
+
+    /// Growing `cores` must not renumber the workers already placed —
+    /// that is the whole reason the walk is descending, and an operator
+    /// who affinitised PF IRQs away from the old set would otherwise
+    /// find their work silently invalidated by a config bump.
+    #[test]
+    fn adding_a_worker_extends_the_set_downward_instead_of_renumbering() {
+        let online: Vec<u16> = (0..18).collect();
+        let two = derive_core_map(&online, &[12], 2).unwrap();
+        let three = derive_core_map(&online, &[12], 3).unwrap();
+        assert_eq!(two.workers, vec![16, 17]);
+        assert_eq!(three.workers, vec![15, 16, 17]);
+        for c in &two.workers {
+            assert!(three.workers.contains(c), "worker {c} was renumbered");
+        }
+    }
+
+    /// Offline CPUs are not placeable. `online` is the input precisely
+    /// so a sparse set is respected rather than assumed contiguous.
+    #[test]
+    fn offline_cpus_are_not_placeable() {
+        let map = derive_core_map(&[0, 1, 2, 7, 8], &[], 2).unwrap();
+        assert_eq!(map.workers, vec![7, 8]);
+        assert_eq!(map.main, 2);
+    }
+
+    /// Refusing beats degrading: `render` asserts that the worker count
+    /// matches the count the stats segment was sized for, so a map that
+    /// dropped a worker would either trip that assert or (if the two
+    /// were derived from the same short list) undersize the segment and
+    /// abort VPP mid-resync.
+    #[test]
+    fn an_impossible_request_is_refused_rather_than_shortened() {
+        let e = derive_core_map(&[0, 1, 2], &[2], 2).unwrap_err();
+        assert!(e.contains("need 3"), "{e}");
+        // The exact boundary: two usable CPUs serve one worker, not two.
+        assert!(derive_core_map(&[0, 1, 2], &[], 1).is_ok());
+        assert!(derive_core_map(&[0, 1, 2], &[], 2).is_err());
+    }
+
+    /// A zero-worker config is legal (`cores 0` on every port) and must
+    /// still place the main thread — VPP's main thread answers the
+    /// binary API, so a map without one has nothing to converge.
+    #[test]
+    fn zero_workers_still_places_the_main_thread() {
+        let map = derive_core_map(&[0, 1, 2, 3], &[], 0).unwrap();
+        assert_eq!(map.main, 3);
+        assert!(map.workers.is_empty());
+    }
+
+    #[test]
+    fn cpu_lists_parse_in_every_shape_sysfs_writes() {
+        assert_eq!(
+            parse_cpu_list("0-17\n").unwrap(),
+            (0..18).collect::<Vec<_>>()
+        );
+        assert_eq!(parse_cpu_list("12").unwrap(), vec![12]);
+        assert_eq!(parse_cpu_list("0-1,4,6-7").unwrap(), vec![0, 1, 4, 6, 7]);
+        // The normal content of `isolated` with no isolcpus=.
+        assert_eq!(parse_cpu_list("\n").unwrap(), Vec::<u16>::new());
+        assert_eq!(parse_cpu_list("").unwrap(), Vec::<u16>::new());
+        // Duplicates collapse; a hand-edited overlap is not an error.
+        assert_eq!(parse_cpu_list("2,2-3").unwrap(), vec![2, 3]);
+    }
+
+    /// Malformed input must not read as an empty list. An unparseable
+    /// `isolated` that returned `vec![]` would place a poll-mode worker
+    /// on the CPU somebody else reserved — silently, and only on the
+    /// hosts whose format we failed to anticipate.
+    #[test]
+    fn a_malformed_cpu_list_is_an_error_not_an_empty_set() {
+        for bad in ["x", "1-", "-1", "3-1", "1,,2", "1,x"] {
+            assert!(parse_cpu_list(bad).is_err(), "{bad:?} parsed");
+        }
+    }
+
+    /// The sysfs reader: `isolated` absent means nothing is isolated
+    /// (the file only exists with CONFIG_CPU_ISOLATION), while `online`
+    /// absent is fatal.
+    #[test]
+    fn a_missing_isolated_file_means_nothing_is_isolated() {
+        let dir = std::env::temp_dir().join(format!("pf-cores-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("online"), "0-3\n").unwrap();
+        let map = derive_from_sysfs(&dir, 2).unwrap();
+        assert_eq!(map.workers, vec![2, 3]);
+        assert_eq!(map.main, 1);
+
+        std::fs::write(dir.join("isolated"), "3\n").unwrap();
+        let map = derive_from_sysfs(&dir, 1).unwrap();
+        assert_eq!(map.workers, vec![2], "isolated cpu3 was still used");
+        assert_eq!(map.main, 1);
+
+        std::fs::remove_file(dir.join("online")).unwrap();
+        assert!(
+            derive_from_sysfs(&dir, 1).is_err(),
+            "missing online tolerated"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -12,18 +12,32 @@
 //! startup.conf renderer and its route-count-driven memory arithmetic),
 //! slice 2 (VF/vfio/hugepage lifecycle, state file, pidfd adopt,
 //! teardown ordering), slice 3 ([`vpp_api`] — generated wire structs,
-//! socket transport, CRC-checked handshake) and most of slice 4:
+//! socket transport, CRC-checked handshake) and slice 4:
 //! [`sink`] (pending map, nexthop mapping, three-valued route ledger),
 //! [`supervisor`] + [`process`] + [`liveness`] + [`schedule`] +
 //! [`executor`] + [`driver`] (the supervision loop), [`attach`] and
-//! [`verify`] (device bring-up and readback), and [`status`]
-//! (health/metrics).
+//! [`verify`] (device bring-up and readback), [`status`]
+//! (health/metrics), [`engine`] (transport, ledger, diffing resync,
+//! static neighbours), [`runtime`] + [`service`] (the loop, on a
+//! thread, with a published status window), and [`bringup`] — the
+//! composition [`Module::attach`] performs.
 //!
-//! **None of it runs yet.** [`Module::attach`] is still
-//! `not_implemented`, so every piece above is exercised only by unit
-//! tests and a fake-VPP loopback. Merged is not proven; the first real
-//! execution is the attach wiring, and the failover numbers in the plan
-//! stay unmeasured until then.
+//! ## What "built" does and does not mean here
+//!
+//! [`Module::attach`] runs, end to end, against a fixture sysfs and a
+//! fake VPP on a real socket (`tests/vpp_bringup.rs`). What has **never**
+//! run is any of it against a real VPP process on real hardware: spawn,
+//! the octeon device attach, a full-table convergence through this path,
+//! and every one of the three published failover numbers. The
+//! convergence budget was measured separately (gate 0b, 40.32 s of 60 s)
+//! by a bench driving the same engine, not by this module.
+//!
+//! Two things are deliberately absent rather than stubbed:
+//! **MCAM steering** ([`runtime::SteeringUnavailable`] refuses both
+//! directions until slice 5) and **stats-segment gauges** (they need a
+//! shared-memory parser that does not exist). A config with every port
+//! `steer off` — the designed staging state — never reaches the steering
+//! seam.
 //!
 //! Design record: `.claude/plans/` phase-4 plan v7. Key invariants
 //! enforced from day one:
@@ -35,6 +49,8 @@
 
 pub mod acquire;
 pub mod attach;
+pub mod bringup;
+pub mod cores;
 pub mod driver;
 pub mod engine;
 pub mod executor;
@@ -123,6 +139,30 @@ impl VppOffloadConfig {
 
 pub struct VppOffloadModule {
     cfg: VppOffloadConfig,
+    /// From [`LoaderCtx`] at load; `attach` has no ctx of its own.
+    state_dir: std::path::PathBuf,
+    /// Where routes and neighbours come from. Set before `attach` by
+    /// whoever owns the RouteController; see [`Self::set_route_source`].
+    source: Option<Box<dyn engine::RouteSource + Send + Sync>>,
+    /// `Some` once supervision is running.
+    attached: Option<bringup::Attached>,
+    /// A teardown still running in the background after `detach` returned.
+    ///
+    /// `stop()` bounds its wait at the `Module::detach` budget and hands
+    /// back a handle when the loop has not settled; keeping it is what lets
+    /// `health_check` report the eventual result — released, or still held
+    /// and why — instead of the message pointing at a status nobody can
+    /// reach.
+    teardown_pending: Option<service::PendingTeardown>,
+    /// Set when a `detach` could not confirm the teardown.
+    ///
+    /// Outlives the attachment on purpose. `detach` takes `attached` before
+    /// it can discover a failure — the service is consumed by `stop()` — so
+    /// without this a second `detach` found `None` and returned `Ok`,
+    /// reporting a clean detach over VFs and hugepages that were still
+    /// held. `packetframe detach --all` retries, so that is the likely
+    /// path, not a hypothetical one.
+    teardown_failure: Option<String>,
 }
 
 impl VppOffloadModule {
@@ -130,8 +170,124 @@ impl VppOffloadModule {
     pub fn new() -> Self {
         Self {
             cfg: VppOffloadConfig::default(),
+            state_dir: std::path::PathBuf::new(),
+            source: None,
+            attached: None,
+            teardown_pending: None,
+            teardown_failure: None,
         }
     }
+
+    /// Hand the module its route source.
+    ///
+    /// Required before [`Module::attach`], which refuses without one.
+    /// That refusal is the point: the source is the fast-path
+    /// RouteController's mirror, and a VPP brought up without it would
+    /// pass every check this module makes — process alive, API
+    /// answering, devices attached, zero routes installed, verify
+    /// trivially passing on an empty sample — and then blackhole every
+    /// steered packet. An empty FIB is indistinguishable from a healthy
+    /// one to everything except the traffic.
+    ///
+    /// Separate from `load` because the wiring across to the fast-path
+    /// crate is its own change (it touches the live control plane); this
+    /// is the seam it plugs into.
+    pub fn set_route_source(&mut self, source: Box<dyn engine::RouteSource + Send + Sync>) {
+        self.source = Some(source);
+    }
+
+    /// Record a teardown that could not be confirmed, and build the error
+    /// for it. One place, so the recording cannot be forgotten at one of
+    /// `detach`'s two failure exits.
+    fn remember_teardown_failure(&mut self, why: String) -> ModuleError {
+        self.teardown_failure = Some(why.clone());
+        ModuleError::other(MODULE_NAME, why)
+    }
+
+    /// The last published supervision snapshot, if the loop has run.
+    pub fn published(&self) -> Option<service::Published> {
+        self.attached.as_ref().and_then(|a| a.service.status())
+    }
+}
+
+/// Turn a published snapshot into the module's health report.
+///
+/// Pure, so the reporting rules are testable without a supervision
+/// thread — and so the several failure kinds `Published` carries cannot
+/// be dropped on the way out, which is exactly what happened to two of
+/// them at the publish boundary one layer down.
+fn report_from(published: Option<&service::Published>, alive: bool) -> HealthReport {
+    use packetframe_common::module::{HealthState, SubsystemHealth};
+
+    let Some(p) = published else {
+        // Attached but nothing published yet cannot happen —
+        // `SupervisionService::start` blocks on the first publish — so
+        // this is the unattached case: loaded, orchestrating nothing.
+        return HealthReport::healthy();
+    };
+    let mut report = p.report.clone();
+    fn degrade_to(report: &mut HealthReport, state: HealthState) {
+        report.overall = report.overall.worse_of(state);
+    }
+
+    // A dead loop thread means nothing is supervising VPP. The last
+    // published report is frozen at whatever it said, so reporting it
+    // as-is would show a healthy dataplane nobody is watching.
+    if !alive {
+        degrade_to(&mut report, HealthState::Unhealthy);
+        report.subsystems.push(SubsystemHealth {
+            name: "supervision".into(),
+            state: HealthState::Unhealthy,
+            message: Some(
+                "the supervision loop is not running; VPP is unmonitored and will not be \
+                 restarted or unsteered — `packetframe detach` then re-attach"
+                    .into(),
+            ),
+            last_success_age_seconds: None,
+        });
+    }
+    // Supervision ended itself: an API this VPP can never speak. Not a
+    // transient failure and not retried, so it must not read as one.
+    if let Some(why) = &p.terminal {
+        degrade_to(&mut report, HealthState::Unhealthy);
+        report.subsystems.push(SubsystemHealth {
+            name: "supervision".into(),
+            state: HealthState::Unhealthy,
+            message: Some(format!("supervision ended and will not resume: {why}")),
+            last_success_age_seconds: None,
+        });
+    }
+    // Held resources after a teardown. Deliberate — releasing a VF a
+    // live process may still DMA into is worse — but it needs an
+    // operator, because nothing else will ever free them.
+    if p.resources_leaked {
+        degrade_to(&mut report, HealthState::Unhealthy);
+        report.subsystems.push(SubsystemHealth {
+            name: "resources".into(),
+            state: HealthState::Unhealthy,
+            message: Some(format!(
+                "VF/hugepage resources are still held after teardown{}",
+                if p.teardown_failures.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", p.teardown_failures.join("; "))
+                }
+            )),
+            last_success_age_seconds: None,
+        });
+    }
+    // The reason behind a retry loop. The supervisor counts failures;
+    // only this says what they were.
+    if !p.last_failures.is_empty() {
+        degrade_to(&mut report, HealthState::Degraded);
+        report.subsystems.push(SubsystemHealth {
+            name: "last-tick".into(),
+            state: HealthState::Degraded,
+            message: Some(p.last_failures.join("; ")),
+            last_success_age_seconds: None,
+        });
+    }
+    report
 }
 
 impl Module for VppOffloadModule {
@@ -145,8 +301,12 @@ impl Module for VppOffloadModule {
         Vec::new()
     }
 
-    fn load(&mut self, cfg: &ModuleConfig<'_>, _ctx: &LoaderCtx<'_>) -> ModuleResult<()> {
+    fn load(&mut self, cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<()> {
         self.cfg = VppOffloadConfig::from_directives(&cfg.section.directives);
+        // `attach` gets no ctx of its own, and the state file is the
+        // whole basis of adoption and of `detach --all` — so capture the
+        // directory here rather than assuming a default location.
+        self.state_dir = ctx.state_dir.to_path_buf();
         if self.cfg.ports.is_empty() {
             return Err(ModuleError::other(
                 MODULE_NAME,
@@ -168,38 +328,192 @@ impl Module for VppOffloadModule {
         Ok(())
     }
 
+    /// hugepages → VF → vfio → startup.conf → adopt-or-arm → supervise.
+    ///
+    /// Returns **no [`Attachment`]s**: the module owns no BPF programs
+    /// or links, which is what `hook_spec() == []` already declares. Its
+    /// attachment is a supervised process and a set of held host
+    /// resources, both tracked in the state file rather than in the
+    /// loader's registry.
+    ///
+    /// Blocks only until the supervision loop publishes its first
+    /// snapshot — long enough for a dead API socket or a version-skewed
+    /// VPP to surface here as the attach failure it is, and no longer.
+    /// Convergence (up to the ≤60 s budget) continues on the loop
+    /// thread; `health_check` reports where it got to.
     fn attach(&mut self, _cfg: &ModuleConfig<'_>) -> ModuleResult<Vec<Attachment>> {
-        // Slice 2: hugepages → VF → vfio → startup.conf → spawn/adopt
-        // → resync-verify → steer.
-        Err(ModuleError::not_implemented(MODULE_NAME))
+        if self.attached.is_some() {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                "vpp-offload is already attached; detach first",
+            ));
+        }
+        let source = self.source.take().ok_or_else(|| {
+            ModuleError::other(
+                MODULE_NAME,
+                "no route source is wired to vpp-offload; refusing to attach — VPP would come \
+                 up with an empty FIB, pass every health check, and blackhole every steered \
+                 packet (see `set_route_source`)",
+            )
+        })?;
+        // `load` supplies the state directory, and the state file is the
+        // whole basis of adoption and of `detach --all`. Without it,
+        // `AttachPaths::live` would build a RELATIVE state path — a
+        // record written into whatever the daemon's cwd happens to be,
+        // which the next start would not find and no detach could act on.
+        // Reachable only by attaching an unloaded module, which is a
+        // programming error, so it says so.
+        if self.state_dir.as_os_str().is_empty() {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                "attach() called before load(): no state directory, so nothing acquired could \
+                 be recorded or later released",
+            ));
+        }
+        let paths = bringup::AttachPaths::live(&self.state_dir, default_hugepage_bytes());
+        let attached = match bringup::bring_up(&self.cfg, &paths, source) {
+            Ok(a) => a,
+            Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
+        };
+        // The derived worker placement, logged because it is an operator
+        // input: on the reference NIC every CPU carries an rx-queue IRQ
+        // 1:1, so nothing this module can do keeps a poll-mode worker off
+        // one — moving the PF IRQs is manual, and this names the set to
+        // move them off. See [`cores`].
+        tracing::info!(
+            main_core = attached.cores.main,
+            workers = ?attached.cores.workers,
+            acquired = ?attached.acquired,
+            adopted_process = attached.adopted_process,
+            "vpp-offload attached; move PF IRQ affinity off the worker cores"
+        );
+        self.attached = Some(attached);
+        Ok(Vec::new())
     }
 
     fn reconfigure(&mut self, _cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+        // Allowlist deltas become steering deltas, which needs the MCAM
+        // implementation (slice 5). Port and cores changes are
+        // restart-only by design — `acquire` refuses to adopt across
+        // them, and so does a changed `expected-routes`, because VPP
+        // fixes its heap and stats segment at start.
         Err(ModuleError::not_implemented(MODULE_NAME))
     }
 
     fn detach(&mut self) -> ModuleResult<()> {
-        // Nothing attached in slice 1; detach of nothing succeeds so
-        // `packetframe detach --all` stays idempotent.
+        // A teardown that already failed keeps failing. The service is
+        // consumed by `stop()`, so there is nothing left to retry — but
+        // answering `Ok` because `attached` is now `None` would report a
+        // clean detach over resources that are still held, on exactly the
+        // retry an operator is most likely to run.
+        if let Some(why) = &self.teardown_failure {
+            return Err(ModuleError::other(MODULE_NAME, why.clone()));
+        }
+        // Detach of nothing succeeds, so `packetframe detach --all`
+        // stays idempotent.
+        let Some(attached) = self.attached.take() else {
+            return Ok(());
+        };
+        // `stop` drives the supervisor's full teardown ordering —
+        // unsteer if steered, abort convergence, kill, release — and
+        // waits out its bounded patience. The final snapshot is the only
+        // record of what that left behind.
+        let report = attached.service.stop();
+        // A teardown still running past the detach budget is kept, not
+        // dropped: `stop()`'s message sends the operator to `packetframe
+        // status`, and this is what makes that reachable — `health_check`
+        // below reports through it until the loop settles.
+        self.teardown_pending = report.pending;
+        let Some(p) = report.published else {
+            return Err(self.remember_teardown_failure(
+                "the supervision loop published no final status; whether VPP stopped and \
+                 whether its VFs were released are both unknown — check `ip link show` and \
+                 the state file before re-attaching"
+                    .to_string(),
+            ));
+        };
+        if p.resources_leaked || !p.teardown_failures.is_empty() {
+            // Loud, and NOT converted into a clean detach. The resources
+            // are deliberately still held (releasing a VF a live process
+            // may still DMA into is worse), but only an operator can
+            // finish this.
+            return Err(self.remember_teardown_failure(format!(
+                "teardown did not complete{}{}",
+                if p.resources_leaked {
+                    "; VF/hugepage resources are still held"
+                } else {
+                    ""
+                },
+                if p.teardown_failures.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", p.teardown_failures.join("; "))
+                }
+            )));
+        }
         Ok(())
     }
 
-    fn sample_metrics(&self, _out: &mut MetricsWriter<'_>) -> ModuleResult<()> {
-        // Nothing to sample: there is no supervised VPP until
-        // `attach()` exists. The rendering itself lives in
-        // [`status::render_metrics`], which takes an observed
-        // [`status::StatusSnapshot`] — the attach wiring supplies one.
-        // Emitting zeroed gauges from here instead would publish a
-        // healthy-looking series for a module that is not running.
+    fn sample_metrics(&self, out: &mut MetricsWriter<'_>) -> ModuleResult<()> {
+        // Only what the loop actually published. An unattached module
+        // emits nothing rather than zeroed gauges — a zero series is
+        // indistinguishable from a healthy idle one, and would keep
+        // reporting after a detach.
+        if let Some(p) = self.published() {
+            out.out.push_str(&p.metrics);
+        }
         Ok(())
     }
 
     fn health_check(&self, _ctx: &HealthCtx) -> ModuleResult<HealthReport> {
-        // Same reason. [`status::StatusSnapshot::report`] is the real
-        // surface; it needs a live `Supervisor` to observe, and an
-        // unattached module has none. Reporting healthy here is accurate
-        // for "loaded but not orchestrating anything".
-        Ok(HealthReport::healthy())
+        // A teardown still in flight outranks a recorded failure: it is
+        // the more current fact, and it may yet resolve to success.
+        if let Some(pending) = &self.teardown_pending {
+            use packetframe_common::module::{HealthState, SubsystemHealth};
+            let settled = pending.is_finished();
+            let detail = pending
+                .status()
+                .map(|p| {
+                    if p.resources_leaked || !p.teardown_failures.is_empty() {
+                        format!("resources still held: {}", p.teardown_failures.join("; "))
+                    } else {
+                        "everything was released".into()
+                    }
+                })
+                .unwrap_or_else(|| "no snapshot published".into());
+            return Ok(HealthReport {
+                overall: HealthState::Unhealthy,
+                subsystems: vec![SubsystemHealth {
+                    name: "resources".into(),
+                    state: HealthState::Unhealthy,
+                    message: Some(if settled {
+                        format!("teardown finished after detach returned; {detail}")
+                    } else {
+                        format!("teardown still running after detach returned; {detail}")
+                    }),
+                    last_success_age_seconds: None,
+                }],
+            });
+        }
+        // An unconfirmed teardown outranks everything else. The module is
+        // no longer attached, so there is no snapshot left to report, and
+        // `report_from(None, _)` answers "loaded, orchestrating nothing" —
+        // which over still-held VFs is the same lie the `detach` retry used
+        // to tell.
+        if let Some(why) = &self.teardown_failure {
+            use packetframe_common::module::{HealthState, SubsystemHealth};
+            return Ok(HealthReport {
+                overall: HealthState::Unhealthy,
+                subsystems: vec![SubsystemHealth {
+                    name: "resources".into(),
+                    state: HealthState::Unhealthy,
+                    message: Some(why.clone()),
+                    last_success_age_seconds: None,
+                }],
+            });
+        }
+        let alive = self.attached.as_ref().is_some_and(|a| a.service.is_alive());
+        Ok(report_from(self.published().as_ref(), alive))
     }
 }
 
@@ -230,5 +544,221 @@ pub fn default_hugepage_bytes() -> u64 {
     #[cfg(not(target_os = "linux"))]
     {
         0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use packetframe_common::module::{HealthState, SubsystemHealth};
+    use supervisor::State;
+
+    /// A published snapshot the loop would produce in the designed
+    /// resting state: verified, nothing steered, nothing wrong.
+    fn healthy_published() -> service::Published {
+        service::Published {
+            report: HealthReport::healthy(),
+            metrics: String::new(),
+            state: State::Ready,
+            api_error: None,
+            terminal: None,
+            teardown_failures: Vec::new(),
+            resources_leaked: false,
+            last_failures: Vec::new(),
+            store_error: None,
+        }
+    }
+
+    /// An unattached module orchestrates nothing, and says so honestly
+    /// rather than inventing a fault.
+    #[test]
+    fn nothing_attached_reports_healthy() {
+        assert_eq!(report_from(None, false).overall, HealthState::Healthy);
+    }
+
+    /// A dead loop thread is the worst thing this surface can report:
+    /// the last published snapshot is frozen, so it may well say
+    /// "Healthy, steered, verified" — about a VPP that will never be
+    /// restarted, never unsteered, and never observed again.
+    #[test]
+    fn a_dead_supervision_thread_is_unhealthy_and_named() {
+        let p = healthy_published();
+        let r = report_from(Some(&p), false);
+        assert_eq!(r.overall, HealthState::Unhealthy, "{r:?}");
+        let s = r
+            .subsystems
+            .iter()
+            .find(|s| s.name == "supervision")
+            .expect("the dead loop must be named");
+        assert_eq!(s.state, HealthState::Unhealthy);
+        assert!(
+            s.message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("unmonitored"),
+            "{s:?}"
+        );
+    }
+
+    /// A terminal reason means supervision ENDED. Reporting it as an
+    /// ordinary degradation would read as "retrying", which is exactly
+    /// what it is not.
+    #[test]
+    fn a_terminal_reason_is_unhealthy_and_says_it_will_not_resume() {
+        let mut p = healthy_published();
+        p.terminal = Some("VPP's API is permanently incompatible: CRC mismatch".into());
+        let r = report_from(Some(&p), true);
+        assert_eq!(r.overall, HealthState::Unhealthy);
+        assert!(
+            r.subsystems.iter().any(|s| s
+                .message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("will not resume")),
+            "{r:?}"
+        );
+    }
+
+    /// Leaked resources need an operator: nothing else will ever free
+    /// them, and the state file is the only record that they exist.
+    #[test]
+    fn leaked_resources_are_unhealthy_and_carry_the_teardown_detail() {
+        let mut p = healthy_published();
+        p.resources_leaked = true;
+        p.teardown_failures = vec!["Unsteer: MCAM rules could not be removed".into()];
+        let r = report_from(Some(&p), true);
+        assert_eq!(r.overall, HealthState::Unhealthy);
+        let s = r
+            .subsystems
+            .iter()
+            .find(|s| s.name == "resources")
+            .expect("held resources must be named");
+        assert!(
+            s.message
+                .as_deref()
+                .unwrap_or_default()
+                .contains("MCAM rules"),
+            "the teardown reason must survive: {s:?}"
+        );
+    }
+
+    /// The supervisor counts failures; only `last_failures` says what
+    /// they were. Dropping it leaves an operator watching a retry loop
+    /// with no way to learn why.
+    #[test]
+    fn tick_failures_degrade_and_are_reported_verbatim() {
+        let mut p = healthy_published();
+        p.last_failures = vec!["Start: no such file or directory".into()];
+        let r = report_from(Some(&p), true);
+        assert_eq!(r.overall, HealthState::Degraded);
+        assert!(
+            r.subsystems.iter().any(|s| s.name == "last-tick"
+                && s.message.as_deref() == Some("Start: no such file or directory")),
+            "{r:?}"
+        );
+    }
+
+    /// A `detach` that could not confirm the teardown must keep saying so.
+    ///
+    /// `detach` takes `attached` before it can discover a failure — the
+    /// service is consumed by `stop()` — so the second call found `None`
+    /// and answered `Ok`, reporting a clean detach over VFs and hugepages
+    /// that were still held. `packetframe detach --all` retries, which
+    /// makes that the likely path rather than a hypothetical one.
+    ///
+    /// Driven through the recorder rather than a real teardown: reaching a
+    /// failed `stop()` needs a supervision thread, and what is under test
+    /// is that the record OUTLIVES the attachment.
+    #[test]
+    fn an_unconfirmed_teardown_keeps_failing_and_stays_unhealthy() {
+        use packetframe_common::config::{GlobalConfig, ModuleSection};
+        use packetframe_common::module::{Module as _, ModuleConfig};
+
+        let mut m = VppOffloadModule::new();
+        let e = m.remember_teardown_failure(
+            "teardown did not complete; VF/hugepage resources are still held".to_string(),
+        );
+        assert!(e.to_string().contains("still held"));
+
+        // The retry must NOT read as a clean detach just because there is
+        // no attachment left.
+        let again = m
+            .detach()
+            .expect_err("a retry after an unconfirmed teardown must not report success");
+        assert!(again.to_string().contains("still held"), "{again}");
+
+        // And health must not read as "loaded, orchestrating nothing".
+        let r = m.health_check(&HealthCtx::new()).unwrap();
+        assert_eq!(r.overall, HealthState::Unhealthy, "{r:?}");
+        assert!(
+            r.subsystems.iter().any(|s| s.name == "resources"
+                && s.message
+                    .as_deref()
+                    .is_some_and(|x| x.contains("still held"))),
+            "{:?}",
+            r.subsystems
+        );
+
+        // Re-attaching must not paper over it either: the route-source
+        // refusal comes first, but the record is still there afterwards.
+        let section = ModuleSection {
+            name: "vpp-offload".into(),
+            directives: Vec::new(),
+        };
+        let global = GlobalConfig::default();
+        let _ = m.attach(&ModuleConfig::new(&section, &global));
+        assert!(m.teardown_failure.is_some(), "the record was lost");
+    }
+
+    /// The invariant, asserted as an invariant: whatever this function
+    /// adds, the result may never be cheerier than the worst thing in
+    /// it. A `match` that escalated only from `Healthy` — the shape this
+    /// replaced — would silently downgrade an Unhealthy report to
+    /// Degraded when a tick failure arrived after a leak.
+    #[test]
+    fn the_overall_state_is_never_cheerier_than_its_worst_finding() {
+        let mut p = healthy_published();
+        p.report.overall = HealthState::Unhealthy;
+        p.report.subsystems.push(SubsystemHealth {
+            name: "vpp-process".into(),
+            state: HealthState::Unhealthy,
+            message: None,
+            last_success_age_seconds: None,
+        });
+        // A merely-Degraded finding arrives on top of an Unhealthy
+        // report.
+        p.last_failures = vec!["Resync: socket closed".into()];
+        let r = report_from(Some(&p), true);
+        assert_eq!(r.overall, HealthState::Unhealthy, "{r:?}");
+
+        for worst in [HealthState::Degraded, HealthState::Unhealthy] {
+            let mut p = healthy_published();
+            p.report.subsystems.push(SubsystemHealth {
+                name: "x".into(),
+                state: worst,
+                message: None,
+                last_success_age_seconds: None,
+            });
+            p.report.overall = worst;
+            let r = report_from(Some(&p), true);
+            assert_eq!(r.overall, worst, "a clean pass must not improve {worst:?}");
+        }
+    }
+
+    /// `worse_of` is the ordering the report relies on; check it directly
+    /// rather than only through its callers.
+    #[test]
+    fn severity_escalates_in_one_direction_only() {
+        use HealthState::*;
+        for (a, b, want) in [
+            (Healthy, Degraded, Degraded),
+            (Degraded, Healthy, Degraded),
+            (Degraded, Unhealthy, Unhealthy),
+            (Unhealthy, Degraded, Unhealthy),
+            (Unhealthy, Healthy, Unhealthy),
+            (Healthy, Healthy, Healthy),
+        ] {
+            assert_eq!(a.worse_of(b), want, "{a:?}.worse_of({b:?})");
+        }
     }
 }

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -407,6 +407,31 @@ impl Module for VppOffloadModule {
                 "vpp-offload is already attached; detach first",
             ));
         }
+        // A previous teardown must be RESOLVED before another attach.
+        //
+        // `detach` takes `attached` before it can discover a failure, so
+        // `attached.is_none()` is not evidence that nothing is going on: the
+        // background loop may still be killing VPP and releasing the VF, or a
+        // recorded failure may mean resources are still held. Attaching over
+        // either starts a new supervisor against hardware the old teardown is
+        // concurrently releasing — two supervisors, one VF — and even after a
+        // clean background finish the stale handle would make `health_check`
+        // report the old teardown instead of the new attachment.
+        self.reconcile_pending_teardown();
+        if self.teardown_pending.is_some() {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                "a previous teardown is still running in the background (it kills VPP and                  releases its VF); attaching now would race it. Wait for it to settle —                  `health_check` reports when it has — and retry.",
+            ));
+        }
+        if let Some(why) = &self.teardown_failure {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!(
+                    "a previous teardown did not complete, so its resources may still be                      held: {why}. Resolve that first (`packetframe detach --all` once VPP                      is confirmed gone); attaching over it would put a second supervisor on                      the same VF."
+                ),
+            ));
+        }
         let source = self.source.take().ok_or_else(|| {
             ModuleError::other(
                 MODULE_NAME,
@@ -626,6 +651,16 @@ mod tests {
     use packetframe_common::module::{HealthState, SubsystemHealth};
     use supervisor::State;
 
+    struct NoRoutes;
+    impl engine::RouteSource for NoRoutes {
+        fn for_each_route(
+            &self,
+            _: &mut dyn FnMut(packetframe_common::fib::IpPrefix, &[std::net::IpAddr]),
+        ) {
+        }
+        fn for_each_neighbour(&self, _: &mut dyn FnMut(std::net::IpAddr, &str, [u8; 6])) {}
+    }
+
     /// A published snapshot the loop would produce in the designed
     /// resting state: verified, nothing steered, nothing wrong.
     fn healthy_published() -> service::Published {
@@ -728,6 +763,41 @@ mod tests {
             r.subsystems.iter().any(|s| s.name == "last-tick"
                 && s.message.as_deref() == Some("Start: no such file or directory")),
             "{r:?}"
+        );
+    }
+
+    /// An unresolved teardown must block another attach.
+    ///
+    /// `detach` takes `attached` before it can discover a failure, so
+    /// `attached.is_none()` is not evidence that nothing is happening. A
+    /// caller that rewires the route source and retries `attach` would start a
+    /// second supervisor against a VF the previous teardown may still be
+    /// releasing.
+    #[test]
+    fn a_failed_teardown_blocks_a_reattach() {
+        use packetframe_common::config::{GlobalConfig, ModuleSection};
+        use packetframe_common::module::{Module as _, ModuleConfig};
+
+        let mut m = VppOffloadModule::new();
+        m.state_dir = std::path::PathBuf::from("/tmp/pf-reattach-guard");
+        m.set_route_source(Box::new(NoRoutes));
+        let _ = m.remember_teardown_failure(
+            "teardown did not complete; VF/hugepage resources are still held".to_string(),
+        );
+
+        let section = ModuleSection {
+            name: "vpp-offload".into(),
+            directives: Vec::new(),
+        };
+        let global = GlobalConfig::default();
+        let e = m
+            .attach(&ModuleConfig::new(&section, &global))
+            .expect_err("must refuse while the teardown is unresolved");
+        let msg = e.to_string();
+        assert!(msg.contains("did not complete"), "{msg}");
+        assert!(
+            msg.contains("second supervisor"),
+            "the consequence must be stated: {msg}"
         );
     }
 

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -196,6 +196,37 @@ impl VppOffloadModule {
         self.source = Some(source);
     }
 
+    /// Settle a finished background teardown and replace the provisional
+    /// verdict with what actually happened.
+    ///
+    /// `stop()` bounds its wait at the detach budget, so a teardown delayed
+    /// by an in-flight API call gets recorded as a failure while it is still
+    /// in progress. That verdict is provisional by construction: the loop
+    /// runs on under `STOP_PATIENCE` and usually finishes. Without this,
+    /// the provisional failure was permanent — `health_check` reported
+    /// Unhealthy and every `detach` retried into an error, over resources
+    /// that had in fact been released.
+    ///
+    /// Only consumes the handle once the thread has finished, so a teardown
+    /// still in flight keeps being reported as in flight rather than being
+    /// waited on inside a health check.
+    fn reconcile_pending_teardown(&mut self) {
+        let Some(pending) = &self.teardown_pending else {
+            return;
+        };
+        if !pending.is_finished() {
+            return;
+        }
+        let final_status = self
+            .teardown_pending
+            .take()
+            .expect("checked just above")
+            .settle();
+        // `None` clears the provisional failure: it finished cleanly after
+        // all, and the failure was about the budget rather than the outcome.
+        self.teardown_failure = settled_verdict(&final_status);
+    }
+
     /// Record a teardown that could not be confirmed, and build the error
     /// for it. One place, so the recording cannot be forgotten at one of
     /// `detach`'s two failure exits.
@@ -208,6 +239,34 @@ impl VppOffloadModule {
     pub fn published(&self) -> Option<service::Published> {
         self.attached.as_ref().and_then(|a| a.service.status())
     }
+}
+
+/// What a FINISHED teardown actually amounted to: `Some(reason)` if
+/// something is still held, `None` if everything was released.
+///
+/// Pure, because the alternative is untestable. The verdict recorded when
+/// `stop()` times out is provisional — the loop keeps working under its own
+/// patience — and getting the reconciliation wrong in the clearing direction
+/// reports a leak that does not exist, while getting it wrong the other way
+/// reports a clean detach over held VFs. Both need to be checkable without
+/// standing up a supervision thread that misses its budget.
+fn settled_verdict(final_status: &service::Published) -> Option<String> {
+    if !final_status.resources_leaked && final_status.teardown_failures.is_empty() {
+        return None;
+    }
+    Some(format!(
+        "teardown finished but did not complete{}{}",
+        if final_status.resources_leaked {
+            "; VF/hugepage resources are still held"
+        } else {
+            ""
+        },
+        if final_status.teardown_failures.is_empty() {
+            String::new()
+        } else {
+            format!(": {}", final_status.teardown_failures.join("; "))
+        }
+    ))
 }
 
 /// Turn a published snapshot into the module's health report.
@@ -401,7 +460,16 @@ impl Module for VppOffloadModule {
     }
 
     fn detach(&mut self) -> ModuleResult<()> {
-        // A teardown that already failed keeps failing. The service is
+        // Reconcile a background teardown before answering. The failure
+        // recorded when `stop()` timed out is PROVISIONAL: the loop kept
+        // working under its own patience and may have released everything
+        // after `detach` returned. Reporting the provisional failure forever
+        // — which is what happens without this — makes an
+        // otherwise-successful teardown permanently Unhealthy and every
+        // retry an error, purely because an in-flight API call pushed it
+        // past the 900 ms budget.
+        self.reconcile_pending_teardown();
+        // A teardown that really did fail keeps failing. The service is
         // consumed by `stop()`, so there is nothing left to retry — but
         // answering `Ok` because `attached` is now `None` would report a
         // clean detach over resources that are still held, on exactly the
@@ -471,6 +539,11 @@ impl Module for VppOffloadModule {
         if let Some(pending) = &self.teardown_pending {
             use packetframe_common::module::{HealthState, SubsystemHealth};
             let settled = pending.is_finished();
+            // `&self` cannot consume the handle, so this reports what the
+            // loop has published so far. A finished teardown that released
+            // everything is reconciled — and the provisional failure
+            // cleared — on the next `detach`; see
+            // `reconcile_pending_teardown`.
             let detail = pending
                 .status()
                 .map(|p| {
@@ -656,6 +729,41 @@ mod tests {
                 && s.message.as_deref() == Some("Start: no such file or directory")),
             "{r:?}"
         );
+    }
+
+    /// A teardown that finished cleanly clears the provisional failure.
+    ///
+    /// `stop()` records a failure when it times out, but that verdict is
+    /// about the BUDGET, not the outcome: the loop keeps working under its
+    /// own patience and usually finishes. Without reconciliation the
+    /// provisional failure was permanent — health Unhealthy forever and
+    /// every retry an error — over resources that had in fact been released.
+    #[test]
+    fn a_clean_finish_clears_the_provisional_failure() {
+        let clean = healthy_published();
+        assert!(
+            settled_verdict(&clean).is_none(),
+            "a teardown that released everything must not stay reported as failed"
+        );
+    }
+
+    /// And a teardown that finished BADLY must be reported, with the detail.
+    /// Clearing on any finish would report a clean detach over held VFs,
+    /// which is the opposite and worse mistake.
+    #[test]
+    fn a_dirty_finish_is_reported_with_its_detail() {
+        let mut leaked = healthy_published();
+        leaked.resources_leaked = true;
+        leaked.teardown_failures = vec!["Unsteer: rules could not be removed".into()];
+        let why = settled_verdict(&leaked).expect("must be reported");
+        assert!(why.contains("still held"), "{why}");
+        assert!(why.contains("Unsteer"), "the detail must survive: {why}");
+
+        // Failures without the leak flag still count: the teardown said
+        // something went wrong.
+        let mut failed = healthy_published();
+        failed.teardown_failures = vec!["Kill: process did not exit".into()];
+        assert!(settled_verdict(&failed).is_some());
     }
 
     /// A `detach` that could not confirm the teardown must keep saying so.

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -110,10 +110,14 @@ pub struct ResourceState {
     /// abort gate 0b found, arriving through the adoption door instead of
     /// the sizing one, so `acquire` refuses the change.
     ///
-    /// `serde(default)` for state files written before this field: their
-    /// `0` reads as "unknown", which cannot be compared and so does not
-    /// refuse. Those files predate any release that could have adopted
-    /// a VPP at all.
+    /// `serde(default)` so a file written before this field still
+    /// **parses** — `detach --all` never reads the sizing, and a parse
+    /// error would wedge the release door as well as the adoption one.
+    /// Its `0` is then refused for adoption: unknown sizing is not the
+    /// same as no constraint, and nothing can recover the figure a
+    /// running VPP started under. (No such file can exist in practice —
+    /// `acquire` has only ever been reachable from `bringup`, which is
+    /// newer than this field.)
     #[serde(default)]
     pub expected_routes: u64,
     /// Hugepages reserved at attach: (pool bytes, page count).

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -97,6 +97,25 @@ pub struct PortState {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResourceState {
     pub version: u32,
+    /// The `expected-routes` this attach sized VPP for.
+    ///
+    /// Recorded because it is the independent variable of the memory
+    /// arithmetic: it sets the main heap and the stats segment in the
+    /// rendered startup.conf, and VPP fixes both **at start**. An
+    /// adoption under a raised `expected-routes` would therefore apply
+    /// the new, larger route ceiling
+    /// ([`crate::startup_conf::route_capacity`]) to a VPP still running
+    /// on the old, smaller segments — and the route ledger would happily
+    /// fill past what they hold. That is precisely the mid-resync OOM
+    /// abort gate 0b found, arriving through the adoption door instead of
+    /// the sizing one, so `acquire` refuses the change.
+    ///
+    /// `serde(default)` for state files written before this field: their
+    /// `0` reads as "unknown", which cannot be compared and so does not
+    /// refuse. Those files predate any release that could have adopted
+    /// a VPP at all.
+    #[serde(default)]
+    pub expected_routes: u64,
     /// Hugepages reserved at attach: (pool bytes, page count).
     /// `(0, 0)` = attach found a sufficient pre-existing reservation
     /// and owns nothing (release then leaves reservations alone).
@@ -152,6 +171,7 @@ impl ResourceState {
     pub fn empty() -> Self {
         Self {
             version: STATE_VERSION,
+            expected_routes: 0,
             hugepage_pool_bytes: 0,
             hugepage_pages: 0,
             hugepage_prior_pages: 0,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -94,6 +94,28 @@ pub trait IdentityStore {
     fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String>;
 }
 
+/// Hands back the VF/vfio/hugepage resources attach acquired.
+///
+/// Separate from [`IdentityStore`] because the two are called by
+/// different actors at different moments — the store on every observed
+/// identity change, this exactly once, from the executor's
+/// `ReleaseResources`, and only when teardown reported clean. It is a
+/// constructor argument rather than an optional setter for the reason
+/// this phase keeps relearning: an omitted-by-default seam is one nobody
+/// notices is unwired, and the symptom here would be a `detach` that
+/// reports success over still-held VFs.
+///
+/// The implementation ([`crate::acquire::ResourceOwner`]) shares one
+/// [`crate::resources::ResourceState`] with the identity store, so that
+/// a `process_changed` arriving after the release cannot re-create a
+/// state file describing resources that are gone.
+pub trait ResourceRelease {
+    /// `Ok` means everything the state recorded is confirmed released
+    /// and the state file is gone. `Err` means some of it is still held,
+    /// and the message names what.
+    fn release(&mut self) -> Result<(), String>;
+}
+
 /// Store that records nothing. Tests only — a production runtime with a
 /// null store produces orphans no future daemon can adopt.
 #[derive(Debug, Default)]
@@ -105,6 +127,19 @@ impl IdentityStore for NullStore {
     }
     fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
         Ok(())
+    }
+}
+
+/// Releases nothing, and says so. Tests only, and it must keep
+/// **refusing**: `Ok` from a release the supervisor believes is real
+/// would clear `resources_leaked` and let `detach` report freed VFs that
+/// are still bound to vfio.
+#[derive(Debug, Default)]
+pub struct NoResources;
+
+impl ResourceRelease for NoResources {
+    fn release(&mut self) -> Result<(), String> {
+        Err("this runtime holds no resources to release".into())
     }
 }
 
@@ -151,6 +186,7 @@ struct Core {
     source: Box<dyn RouteSource>,
     steering: Box<dyn Steering>,
     store: Box<dyn IdentityStore>,
+    resources: Box<dyn ResourceRelease>,
     vpp_binary: PathBuf,
     startup_conf: PathBuf,
     /// Whether this convergence adopts interfaces VPP already has.
@@ -191,6 +227,7 @@ impl Runtime {
         source: Box<dyn RouteSource>,
         steering: Box<dyn Steering>,
         store: Box<dyn IdentityStore>,
+        resources: Box<dyn ResourceRelease>,
         vpp_binary: impl Into<PathBuf>,
         startup_conf: impl Into<PathBuf>,
     ) -> Self {
@@ -201,6 +238,7 @@ impl Runtime {
                 source,
                 steering,
                 store,
+                resources,
                 vpp_binary: vpp_binary.into(),
                 startup_conf: startup_conf.into(),
                 attach_mode: crate::attach::AttachMode::Fresh,
@@ -569,11 +607,12 @@ impl Effects for EffectsView {
     }
 
     fn release_resources(&mut self) -> Result<(), String> {
-        // Owned by the attach wiring, which holds the ResourceState
-        // and the sysfs paths. The runtime cannot release what it
-        // never acquired; wiring this to a no-op Ok would report
-        // resources freed that are still held.
-        Err("resource release is owned by the attach wiring (not yet built)".into())
+        // The state file and the sysfs paths belong to the attach
+        // wiring, so this delegates rather than reaching for them; see
+        // [`ResourceRelease`]. The executor only ever calls this after
+        // teardown reported clean, so a live VPP cannot be DMAing into
+        // what it releases.
+        self.core.borrow_mut().resources.release()
     }
 }
 
@@ -609,6 +648,7 @@ mod tests {
             Box::new(EmptySource),
             Box::new(SteeringUnavailable),
             Box::new(NullStore),
+            Box::new(NoResources),
             "/usr/bin/vpp",
             "/tmp/startup.conf",
         )
@@ -715,6 +755,7 @@ mod tests {
             Box::new(EmptySource),
             Box::new(SteeringUnavailable),
             Box::new(FailingStore),
+            Box::new(NoResources),
             // Any spawnable binary will do; it is killed immediately.
             "/bin/sleep",
             "/dev/null",
@@ -749,6 +790,7 @@ mod tests {
             Box::new(EmptySource),
             Box::new(SteeringUnavailable),
             Box::new(Recording(Arc::clone(&log))),
+            Box::new(NoResources),
             // `VppProcess::spawn(binary, conf)` execs `binary -c conf`;
             // /bin/true exits immediately regardless of arguments,
             // which is exactly what this test wants.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -709,9 +709,15 @@ mod tests {
         assert_eq!(fx.kill(), Disposition::SafeToRelease);
     }
 
-    /// `release_resources` refuses rather than no-ops: reporting
-    /// resources freed that the (unbuilt) attach wiring still holds is
-    /// the requested-vs-observed bug in its purest form.
+    /// `release_resources` refuses rather than no-ops: reporting resources
+    /// freed that something else still holds is the requested-vs-observed
+    /// bug in its purest form.
+    ///
+    /// This runtime is built with [`NoResources`], so the refusal comes from
+    /// the seam having nothing to release — not from the attach wiring being
+    /// absent, which it no longer is. (The earlier wording said "unbuilt".
+    /// A comment whose truth expires is how `detach --all` came to promise a
+    /// recovery path it did not have.)
     #[test]
     fn release_refuses_until_the_owner_exists() {
         let rt = runtime();

--- a/crates/modules/vpp-offload/src/startup_conf.rs
+++ b/crates/modules/vpp-offload/src/startup_conf.rs
@@ -198,6 +198,71 @@ pub fn check_hugepage_budget(
     Ok(())
 }
 
+/// Main-heap bytes per route as **measured**, not as provisioned.
+///
+/// [`HEAP_BYTES_PER_ROUTE`] is this figure with ~2.2× of deliberate
+/// margin, because being wrong low there aborts VPP mid-resync. The
+/// margin is exactly what makes it the wrong number for a *capacity*
+/// question: sizing asks "how much do I reserve", capacity asks "how
+/// many routes actually fit in what was reserved", and answering the
+/// second with the padded figure would report the forecast back as the
+/// ceiling.
+pub const HEAP_BYTES_PER_ROUTE_MEASURED: u64 = 463;
+
+/// Stats-segment bytes per route per thread as **measured**: 97 B/route
+/// at two threads ⇒ 48.5, rounded up. Same relationship to
+/// [`STATSEG_BYTES_PER_ROUTE_PER_THREAD`] as above.
+pub const STATSEG_BYTES_PER_ROUTE_PER_THREAD_MEASURED: u64 = 49;
+
+/// How much of each segment the route ledger may fill before it starts
+/// withholding.
+///
+/// Not 100%: the measured per-route costs come from **one** table shape
+/// (the reference fleet's v4 table, gate 0b item 10). A table with more
+/// distinct path-lists or more ECMP groups costs more per route, and the
+/// consequence of being wrong at 100% is the OOM abort this whole
+/// arithmetic exists to prevent. 80% turns that into withheld routes and
+/// a Degraded health report, which is the designed degradation.
+pub const CAPACITY_UTILISATION_PCT: u64 = 80;
+
+/// How many routes actually fit in the VPP this sizing describes.
+///
+/// The high-water mark the route ledger withholds above. Plan v5 asks
+/// for this to come from a measured heap gauge rather than from
+/// `expected-routes` "wearing a second hat", and that gauge needs a
+/// stats-segment reader that does not exist yet. This is the honest
+/// interim: the capacity of the segments **as rendered**, computed at
+/// the measured per-route costs rather than the padded ones, and
+/// derated. It tracks `expected-routes` because the segments do — but it
+/// is meaningfully larger than it (the padding becomes real headroom),
+/// so a table that outgrows the operator's forecast keeps forwarding
+/// instead of being withheld at the forecast line.
+///
+/// **Both** segments are considered, and the smaller wins. The heap is
+/// the one everybody thinks of; the stats segment is the one that
+/// actually aborted VPP at gate 0b, and at these constants it is the
+/// binding constraint at every configuration. Deriving this from the
+/// heap alone would have put the ceiling above the segment that fails
+/// first.
+pub fn route_capacity(sizing: &Sizing) -> u64 {
+    let heap_for_routes = sizing
+        .main_heap_bytes
+        .saturating_sub(HEAP_FLOOR_BYTES)
+        .saturating_mul(CAPACITY_UTILISATION_PCT)
+        / 100;
+    let heap_routes = heap_for_routes / HEAP_BYTES_PER_ROUTE_MEASURED;
+
+    let statseg_per_route =
+        STATSEG_BYTES_PER_ROUTE_PER_THREAD_MEASURED * thread_count(sizing.workers);
+    let statseg_routes = sizing
+        .statseg_bytes
+        .saturating_mul(CAPACITY_UTILISATION_PCT)
+        / 100
+        / statseg_per_route;
+
+    heap_routes.min(statseg_routes)
+}
+
 /// One VPP dataplane port: the VF's PCI address plus the worker count
 /// the operator promised for it.
 ///
@@ -624,6 +689,90 @@ mod tests {
                 "routes={routes}: rendered {mib} MiB < derived {} bytes",
                 s.main_heap_bytes
             );
+        }
+    }
+
+    /// The ledger's high-water mark must sit **above** the operator's
+    /// forecast. If it landed at or below `expected-routes`, a table that
+    /// merely reached the forecast would start withholding routes — the
+    /// forecast is an estimate of the table, not a limit on it, and the
+    /// padding in the sizing constants exists precisely so that reaching
+    /// it is uneventful.
+    #[test]
+    fn capacity_exceeds_the_forecast_at_every_worker_count() {
+        for workers in 0..=16u32 {
+            for routes in [100_000u64, 1_053_370, 1_600_000, 4_000_000] {
+                let s = derive_sizing(routes, workers).unwrap();
+                assert!(
+                    route_capacity(&s) > routes,
+                    "workers={workers} routes={routes}: capacity {} would withhold at the \
+                     forecast",
+                    route_capacity(&s)
+                );
+            }
+        }
+    }
+
+    /// And **below** the point where either segment actually runs out at
+    /// the measured per-route costs. This is the invariant, asserted
+    /// against the measured constants rather than against a copy of the
+    /// expected output: a capacity computed from itself passes for any
+    /// value, which is how a constant gets checked against nothing.
+    #[test]
+    fn capacity_stays_under_what_each_segment_really_holds() {
+        for workers in 0..=16u32 {
+            for routes in [100_000u64, 1_053_370, 1_600_000] {
+                let s = derive_sizing(routes, workers).unwrap();
+                let cap = route_capacity(&s);
+
+                let heap_exhausts_at =
+                    (s.main_heap_bytes - HEAP_FLOOR_BYTES) / HEAP_BYTES_PER_ROUTE_MEASURED;
+                let statseg_exhausts_at = s.statseg_bytes
+                    / (STATSEG_BYTES_PER_ROUTE_PER_THREAD_MEASURED * thread_count(workers));
+                assert!(
+                    cap < heap_exhausts_at,
+                    "workers={workers} routes={routes}: capacity {cap} reaches the heap's \
+                     real limit {heap_exhausts_at}"
+                );
+                assert!(
+                    cap < statseg_exhausts_at,
+                    "workers={workers} routes={routes}: capacity {cap} reaches the stats \
+                     segment's real limit {statseg_exhausts_at} — the segment that actually \
+                     aborted VPP at gate 0b"
+                );
+            }
+        }
+    }
+
+    /// The stats segment is the binding constraint, and the `min` is
+    /// what makes that true. Dropping it — deriving capacity from the
+    /// heap alone, which is the intuitive reading — would put the
+    /// ceiling above the segment that fails first.
+    #[test]
+    fn the_stats_segment_is_the_constraint_that_binds() {
+        let s = derive_sizing(1_600_000, 4).unwrap();
+        let heap_routes = (s.main_heap_bytes - HEAP_FLOOR_BYTES) * CAPACITY_UTILISATION_PCT
+            / 100
+            / HEAP_BYTES_PER_ROUTE_MEASURED;
+        assert!(
+            route_capacity(&s) < heap_routes,
+            "capacity {} is the heap figure {heap_routes}; the stats segment was not \
+             considered",
+            route_capacity(&s)
+        );
+    }
+
+    /// A bigger forecast must never buy a smaller ceiling.
+    #[test]
+    fn capacity_grows_with_the_forecast() {
+        let mut last = 0;
+        for routes in [50_000u64, 500_000, 1_053_370, 1_600_000, 3_000_000] {
+            let cap = route_capacity(&derive_sizing(routes, 2).unwrap());
+            assert!(
+                cap > last,
+                "capacity fell at routes={routes}: {cap} <= {last}"
+            );
+            last = cap;
         }
     }
 }

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -1,0 +1,392 @@
+//! `Module::attach()` end to end on a dev laptop: a fixture sysfs, the
+//! fake VPP on a real socket, and the real supervision thread.
+//!
+//! This is the composition nothing had exercised — slices 1–4 were each
+//! tested in isolation, and "merged" was never "runs". What it can and
+//! cannot prove is worth stating plainly, because the gap is the reason
+//! the hardware drills still exist:
+//!
+//! - **Proven here:** the ordering (pure checks → acquire → render →
+//!   supervise), the refusals, rollback on a failure after acquisition,
+//!   the state file's contents, the rendered startup.conf matching the
+//!   derived core map, health reporting through the real `Module` trait,
+//!   and a detach that stops the loop and releases everything.
+//! - **Not proven here:** anything requiring a real VPP process. Spawn
+//!   is deliberately made to fail (the configured binary is a
+//!   non-executable file), so the loop lands in backoff. That makes the
+//!   test deterministic on both macOS — where `VppProcess::spawn` is an
+//!   `ENOSYS` stub — and Linux, and it means the convergence path is
+//!   exercised by `vpp_service.rs` (which injects an adoption against
+//!   the fake) rather than by this one.
+
+use std::fs;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+#[path = "common/fake_vpp.rs"]
+mod fake_vpp;
+
+use packetframe_common::fib::IpPrefix;
+use packetframe_common::module::HealthState;
+use packetframe_vpp_offload::acquire::SysPaths;
+use packetframe_vpp_offload::bringup::{bring_up, AttachPaths};
+use packetframe_vpp_offload::engine::RouteSource;
+use packetframe_vpp_offload::resources::ResourceState;
+use packetframe_vpp_offload::VppOffloadConfig;
+
+/// A mirror with one route and one resolved neighbour. Enough to be a
+/// route source; convergence itself is `vpp_service.rs`'s job.
+struct Mirror;
+impl RouteSource for Mirror {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        visit(fake_vpp::v4(0, 0), &[fake_vpp::nh()]);
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        visit(fake_vpp::nh(), "eth4", fake_vpp::MAC);
+    }
+}
+
+/// Fixture sysfs + CPU topology + a stand-in VPP binary, on the same
+/// conventions as the `acquire` unit tests.
+struct Host {
+    base: PathBuf,
+    paths: AttachPaths,
+    vpp_binary: PathBuf,
+}
+
+impl Host {
+    fn new(tag: &str, ports: &[(&str, &str)], api_socket: PathBuf) -> Self {
+        let mut base = std::env::temp_dir();
+        base.push(format!("pf-bringup-{tag}-{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        let net = base.join("net");
+        let devices = base.join("devices");
+        let drivers = base.join("drivers");
+        let pool = base.join("hugepages-524288kB");
+        for d in ["vfio-pci", "rvu_nicvf"] {
+            fs::create_dir_all(drivers.join(d)).unwrap();
+        }
+        fs::create_dir_all(&pool).unwrap();
+        fs::write(pool.join("nr_hugepages"), "0").unwrap();
+        for (iface, pci) in ports {
+            let dev = net.join(iface).join("device");
+            fs::create_dir_all(&dev).unwrap();
+            fs::write(dev.join("sriov_numvfs"), "0").unwrap();
+            let pci_dev = devices.join(pci);
+            fs::create_dir_all(&pci_dev).unwrap();
+            std::os::unix::fs::symlink(&pci_dev, dev.join("virtfn0")).unwrap();
+        }
+        let hugetlbfs = base.join("dev-hugepages");
+        fs::create_dir_all(&hugetlbfs).unwrap();
+        let cpu = base.join("cpu");
+        fs::create_dir_all(&cpu).unwrap();
+        // The reference fleet's shape: 18 cores, cpu12 isolated for
+        // unifi-core.
+        fs::write(cpu.join("online"), "0-17\n").unwrap();
+        fs::write(cpu.join("isolated"), "12\n").unwrap();
+
+        // A plain, NON-executable file: `bring_up`'s existence check
+        // passes, and the loop's first spawn fails identically on macOS
+        // (ENOSYS stub) and Linux (EACCES). Keeping the process out of
+        // the picture is what makes this test deterministic.
+        let vpp_binary = base.join("vpp");
+        fs::write(&vpp_binary, "not really vpp").unwrap();
+
+        Self {
+            paths: AttachPaths {
+                sys: SysPaths {
+                    sysfs_net: net,
+                    pci_devices: devices,
+                    pci_drivers: drivers,
+                    hugepage_pool: pool,
+                    hugepage_bytes: 512 << 20,
+                    hugetlbfs,
+                    state_dir: base.join("state"),
+                },
+                sysfs_cpu: cpu,
+                api_socket,
+                startup_conf: base.join("startup.conf"),
+            },
+            vpp_binary,
+            base,
+        }
+    }
+
+    fn cfg(&self, ports: &[(&str, u16, bool)]) -> VppOffloadConfig {
+        VppOffloadConfig {
+            ports: ports
+                .iter()
+                .map(|(i, c, s)| (i.to_string(), *c, *s))
+                .collect(),
+            vpp_binary: Some(self.vpp_binary.to_string_lossy().into_owned()),
+            expected_routes: 1_600_000,
+            hugepages: None,
+        }
+    }
+
+    fn state(&self) -> Option<ResourceState> {
+        ResourceState::load(&self.paths.sys.state_dir).unwrap()
+    }
+}
+
+impl Drop for Host {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.base);
+    }
+}
+
+/// The whole sequence, in order, with everything it produced checked
+/// against what the next daemon and the next operator will read.
+#[test]
+fn a_fresh_attach_acquires_renders_and_supervises() {
+    let fake = fake_vpp::Fake::start("bringup");
+    let host = Host::new(
+        "fresh",
+        &[("eth4", "0002:07:00.0"), ("eth5", "0002:07:00.1")],
+        fake.path.clone(),
+    );
+    let cfg = host.cfg(&[("eth4", 1, false), ("eth5", 1, false)]);
+
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror)).expect("bring-up");
+
+    // --- The core map: workers off the top, main below them, cpu0 and
+    // the isolated cpu12 untouched.
+    assert_eq!(attached.cores.workers, vec![16, 17]);
+    assert_eq!(attached.cores.main, 15);
+
+    // --- startup.conf: the rendered file must name that exact map, and
+    // must carry the statseg stanza whose absence aborted VPP at gate
+    // 0b.
+    let conf = fs::read_to_string(&host.paths.startup_conf).expect("startup.conf written");
+    assert!(conf.contains("corelist-workers 16,17"), "{conf}");
+    assert!(conf.contains("main-core 15"), "{conf}");
+    assert!(conf.contains("statseg {"), "no stats segment: {conf}");
+    assert!(
+        conf.contains(&format!("socket-name {}", fake.path.display())),
+        "{conf}"
+    );
+
+    // --- The state file: both VFs recorded with the PCI addresses the
+    // attach step will use, the hugepage reservation owned, and the
+    // sizing recorded so a later adoption can refuse a changed forecast.
+    let state = host.state().expect("state file");
+    assert_eq!(
+        state
+            .ports
+            .iter()
+            .map(|p| p.iface.as_str())
+            .collect::<Vec<_>>(),
+        vec!["eth4", "eth5"]
+    );
+    assert_eq!(state.ports[0].vf_pci, "0002:07:00.0");
+    assert_eq!(state.expected_routes, 1_600_000);
+    assert!(state.hugepage_pages > 0, "reservation not recorded");
+    assert_eq!(
+        fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))
+            .unwrap()
+            .trim(),
+        state.hugepage_pages.to_string(),
+        "the pool must actually hold what the state claims"
+    );
+
+    // --- Supervision is running and publishing. The spawn cannot
+    // succeed here, so the interesting assertion is that the failure is
+    // REPORTED rather than swallowed: this is the diagnostic that tells
+    // an operator why a retry loop is looping.
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let failing = loop {
+        let p = attached.service.status().expect("published");
+        if !p.last_failures.is_empty() {
+            break p;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no spawn failure was ever reported; state {:?}",
+            p.state
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    // Asserted on the action, not on the OS's wording: macOS reports the
+    // Linux-only stub, Linux reports EACCES on a non-executable file, and
+    // both are the same finding — the spawn failed and the reason
+    // reached the caller.
+    assert!(
+        failing
+            .last_failures
+            .iter()
+            .any(|f| f.starts_with("Spawn:")),
+        "the spawn failure must be attributed to the action: {:?}",
+        failing.last_failures
+    );
+    // And it degrades health rather than passing silently.
+    assert_ne!(
+        failing.report.overall,
+        HealthState::Healthy,
+        "a VPP that will not start read as healthy: {:?}",
+        failing.report
+    );
+
+    // --- Teardown releases everything: VFs back to the kernel driver,
+    // the hugepage pool restored to its prior count, state file gone.
+    let last = attached.service.stop().published.expect("final status");
+    assert!(
+        !last.resources_leaked,
+        "nothing was steered and no process exists; the release must proceed: {:?}",
+        last.teardown_failures
+    );
+    assert!(
+        host.state().is_none(),
+        "the state file must be gone once everything is released"
+    );
+    assert_eq!(
+        fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))
+            .unwrap()
+            .trim(),
+        "0",
+        "the hugepage reservation was not restored to its prior count"
+    );
+}
+
+/// A config that cannot work must cost nothing. The rollback path exists,
+/// but it should not be reachable by an ordinary operator typo — so the
+/// pure checks all run before the first sysfs write.
+#[test]
+fn a_config_that_cannot_work_touches_nothing() {
+    let fake = fake_vpp::Fake::start("bringup-refuse");
+    let host = Host::new("refuse", &[("eth4", "0002:07:00.0")], fake.path.clone());
+
+    // More workers than there are usable CPUs (18 online, cpu0 and cpu12
+    // excluded ⇒ 16 usable, so 16 workers plus a main thread cannot fit).
+    let mut cfg = host.cfg(&[("eth4", 16, false)]);
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("must fail");
+    assert!(e.contains("usable CPU"), "{e}");
+
+    // A VPP binary that is not there.
+    cfg = host.cfg(&[("eth4", 1, false)]);
+    cfg.vpp_binary = Some(host.base.join("no-such-vpp").to_string_lossy().into_owned());
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("must fail");
+    assert!(e.contains("does not exist"), "{e}");
+
+    // Neither attempt may have created a VF, a reservation, or a record.
+    assert!(host.state().is_none(), "a refused attach left a state file");
+    assert_eq!(
+        fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))
+            .unwrap()
+            .trim(),
+        "0",
+        "a refused attach reserved hugepages"
+    );
+    assert_eq!(
+        fs::read_to_string(
+            host.paths
+                .sys
+                .sysfs_net
+                .join("eth4")
+                .join("device")
+                .join("sriov_numvfs")
+        )
+        .unwrap()
+        .trim(),
+        "0",
+        "a refused attach created a VF"
+    );
+    assert!(
+        !host.paths.startup_conf.exists(),
+        "a refused attach rendered a startup.conf"
+    );
+}
+
+/// A failure AFTER acquisition must release what it took. Provoked at
+/// the last step that can fail before the loop starts: an unwritable
+/// startup.conf path.
+#[test]
+fn a_failure_after_acquisition_releases_what_it_took() {
+    let fake = fake_vpp::Fake::start("bringup-rollback");
+    let mut host = Host::new("rollback", &[("eth4", "0002:07:00.0")], fake.path.clone());
+    // A directory where the file must go: `create_dir_all` succeeds on
+    // the parent, and the write then fails with EISDIR.
+    host.paths.startup_conf = host.base.join("conf-is-a-dir");
+    fs::create_dir_all(&host.paths.startup_conf).unwrap();
+
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("must fail");
+    assert!(e.contains("conf-is-a-dir"), "{e}");
+    assert!(
+        e.contains("was released"),
+        "the rollback must be reported, not silent: {e}"
+    );
+
+    assert!(
+        host.state().is_none(),
+        "acquisition survived a failed attach"
+    );
+    assert_eq!(
+        fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))
+            .unwrap()
+            .trim(),
+        "0",
+        "the hugepage reservation was not rolled back"
+    );
+}
+
+/// The module refuses to attach without a route source, and the refusal
+/// happens before anything is touched.
+///
+/// Not a nicety: a VPP with an empty FIB passes every check this module
+/// makes — process alive, API answering, devices attached, verify
+/// trivially passing on an empty sample — and blackholes every steered
+/// packet. There is no later point at which the mistake becomes visible.
+#[test]
+fn attaching_without_a_route_source_is_refused() {
+    use packetframe_common::config::{GlobalConfig, ModuleSection};
+    use packetframe_common::module::{Module, ModuleConfig};
+    use packetframe_vpp_offload::VppOffloadModule;
+
+    let mut m = VppOffloadModule::new();
+    let section = ModuleSection {
+        name: "vpp-offload".into(),
+        directives: Vec::new(),
+    };
+    let global = GlobalConfig::default();
+    let e = m
+        .attach(&ModuleConfig::new(&section, &global))
+        .expect_err("attach without a source must fail");
+    let msg = e.to_string();
+    assert!(msg.contains("route source"), "{msg}");
+    assert!(
+        msg.contains("blackhole"),
+        "the reason must be stated: {msg}"
+    );
+
+    // And health still reads as "loaded, orchestrating nothing" rather
+    // than inventing a fault from a failed attach.
+    assert_eq!(
+        m.health_check(&packetframe_common::module::HealthCtx::new())
+            .unwrap()
+            .overall,
+        HealthState::Healthy
+    );
+
+    // With a source wired, that particular refusal is gone — which is
+    // what proves the seam is consulted rather than being a setter
+    // nothing reads. The attach still fails, now on the next guard: this
+    // module was never `load`ed, so it has no state directory. That guard
+    // is also what keeps this test from reaching real sysfs.
+    m.set_route_source(Box::new(Mirror));
+    let msg = m
+        .attach(&ModuleConfig::new(&section, &global))
+        .expect_err("an unloaded module cannot attach")
+        .to_string();
+    assert!(
+        !msg.contains("route source"),
+        "the source was set and still not seen: {msg}"
+    );
+    assert!(msg.contains("before load()"), "{msg}");
+}

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -12,8 +12,9 @@
 //!   derived core map, health reporting through the real `Module` trait,
 //!   and a detach that stops the loop and releases everything.
 //! - **Not proven here:** anything requiring a real VPP process. Spawn
-//!   is deliberately made to fail (the configured binary is a
-//!   non-executable file), so the loop lands in backoff. That makes the
+//!   is deliberately made to fail (the configured binary is executable,
+//!   as `bring_up` insists, but is not a program), so the loop lands in
+//!   backoff. That makes the
 //!   test deterministic on both macOS — where `VppProcess::spawn` is an
 //!   `ENOSYS` stub — and Linux, and it means the convergence path is
 //!   exercised by `vpp_service.rs` (which injects an adoption against
@@ -21,6 +22,7 @@
 
 use std::fs;
 use std::net::IpAddr;
+use std::os::unix::fs::PermissionsExt as _;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -86,12 +88,16 @@ impl Host {
         fs::write(cpu.join("online"), "0-17\n").unwrap();
         fs::write(cpu.join("isolated"), "12\n").unwrap();
 
-        // A plain, NON-executable file: `bring_up`'s existence check
-        // passes, and the loop's first spawn fails identically on macOS
-        // (ENOSYS stub) and Linux (EACCES). Keeping the process out of
-        // the picture is what makes this test deterministic.
+        // Executable — `bring_up` requires it, and requires it before
+        // acquiring anything — but not a program: an exec of a file with
+        // no shebang and no ELF header fails ENOEXEC on Linux, and on
+        // macOS the process layer is the ENOSYS stub, so the loop's first
+        // spawn fails on both without ever producing a process. Keeping
+        // the process out of the picture is what makes these tests
+        // deterministic.
         let vpp_binary = base.join("vpp");
         fs::write(&vpp_binary, "not really vpp").unwrap();
+        fs::set_permissions(&vpp_binary, fs::Permissions::from_mode(0o755)).unwrap();
 
         Self {
             paths: AttachPaths {
@@ -272,7 +278,20 @@ fn a_config_that_cannot_work_touches_nothing() {
         .expect("must fail");
     assert!(e.contains("does not exist"), "{e}");
 
-    // Neither attempt may have created a VF, a reservation, or a record.
+    // A VPP binary that is there but cannot be executed. Distinct from
+    // the above, and worth its own case: this one used to pass the check
+    // and be discovered by the loop's first spawn — permanent, retried
+    // forever, with the VFs and the reservation already taken.
+    let unexecutable = host.base.join("vpp-no-x");
+    fs::write(&unexecutable, "not really vpp").unwrap();
+    fs::set_permissions(&unexecutable, fs::Permissions::from_mode(0o644)).unwrap();
+    cfg.vpp_binary = Some(unexecutable.to_string_lossy().into_owned());
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("must fail");
+    assert!(e.contains("is not executable"), "{e}");
+
+    // No attempt may have created a VF, a reservation, or a record.
     assert!(host.state().is_none(), "a refused attach left a state file");
     assert_eq!(
         fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -433,3 +433,63 @@ fn a_steer_on_port_is_refused_until_mcam_exists() {
         .expect("every port steer off is the staging state and must attach");
     let _ = attached.service.stop();
 }
+
+/// An incomplete recorded identity must REFUSE, not fall through to a fresh
+/// spawn.
+///
+/// `VppProcess::adopt` returns `Ok(None)` when it cannot verify an identity —
+/// not when the process is confirmed gone — so a record with a pid but no
+/// boot id used to read as "nothing running" and inject `StartRequested`:
+/// a second VPP on the same VF and the same API socket, with the recorded pid
+/// overwritten and the first process orphaned holding the hardware.
+///
+/// Refused before `adopt` is called at all, which is what makes it testable
+/// off a router.
+#[test]
+fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
+    let fake = fake_vpp::Fake::start("bringup-identity");
+    let host = Host::new("identity", &[("eth4", "0002:07:00.0")], fake.path.clone());
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+
+    // First attach records the ports. DROPPED rather than stopped: `stop()`
+    // releases and removes the state file, and dropping deliberately does not
+    // tear down (that is preserve-on-exit, §8.5), so the record survives —
+    // which is exactly the situation a daemon restart finds.
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror)).expect("first attach");
+    drop(attached);
+
+    // Play the kernel's part: a real bind creates the `driver` symlink that
+    // adoption verifies against.
+    let link = host
+        .paths
+        .sys
+        .pci_devices
+        .join("0002:07:00.0")
+        .join("driver");
+    if !link.exists() {
+        std::os::unix::fs::symlink(host.paths.sys.pci_drivers.join("vfio-pci"), &link).unwrap();
+    }
+
+    // Plant a record naming a VPP with an unverifiable identity.
+    let mut state = host.state().expect("state file");
+    state.vpp_pid = Some(4242);
+    state.vpp_start_ticks = Some(99_999);
+    state.vpp_boot_id = None; // the third leg is missing
+    state.save(&host.paths.sys.state_dir).unwrap();
+
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("an unverifiable identity must refuse");
+    assert!(e.contains("4242"), "the pid must be named: {e}");
+    assert!(e.contains("boot id"), "and the missing leg: {e}");
+    assert!(
+        e.contains("second process") || e.contains("second VPP"),
+        "and the consequence of spawning anyway: {e}"
+    );
+    // Marked, so the caller does not roll back and unbind the VF under a
+    // process that may still be running.
+    assert!(
+        e.starts_with("RESOURCES MAY BE HELD"),
+        "the rollback must be suppressed: {e}"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -390,3 +390,46 @@ fn attaching_without_a_route_source_is_refused() {
     );
     assert!(msg.contains("before load()"), "{msg}");
 }
+
+/// `steer on` must be REFUSED, not silently ignored.
+///
+/// The steering flag is dropped when ports are mapped for the attach step,
+/// a fresh supervisor starts with `steer_wanted = false`, and a first attach
+/// deliberately never steers itself — so `SteeringUnavailable` is never
+/// called, convergence settles in `Ready`, and `nominal()` returns true
+/// because `steer_intended()` is false. An operator who asked for traffic
+/// diversion would get a Healthy module that never attempted it.
+///
+/// Refused in the pure phase, so nothing is touched.
+#[test]
+fn a_steer_on_port_is_refused_until_mcam_exists() {
+    let fake = fake_vpp::Fake::start("bringup-steer");
+    let host = Host::new(
+        "steer",
+        &[("eth4", "0002:07:00.0"), ("eth5", "0002:07:00.1")],
+        fake.path.clone(),
+    );
+
+    let cfg = host.cfg(&[("eth4", 1, false), ("eth5", 1, true)]);
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror))
+        .err()
+        .expect("a steer-on port must be refused");
+    assert!(e.contains("eth5"), "the offending port must be named: {e}");
+    assert!(e.contains("steer off"), "and the remedy stated: {e}");
+
+    // Refused BEFORE any mutation: no VF, no reservation, no state file.
+    assert!(host.state().is_none(), "a refused config left a state file");
+    assert_eq!(
+        fs::read_to_string(host.paths.sys.hugepage_pool.join("nr_hugepages"))
+            .unwrap()
+            .trim(),
+        "0",
+        "a refused config reserved hugepages"
+    );
+
+    // All-off is the designed staging state and must still work.
+    let cfg_ok = host.cfg(&[("eth4", 1, false), ("eth5", 1, false)]);
+    let attached = bring_up(&cfg_ok, &host.paths, Box::new(Mirror))
+        .expect("every port steer off is the staging state and must attach");
+    let _ = attached.service.stop();
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -25,7 +25,7 @@ use packetframe_vpp_offload::attach::PortAttach;
 use packetframe_vpp_offload::driver::Driver;
 use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
 use packetframe_vpp_offload::fib_sync::FamilyPolicy;
-use packetframe_vpp_offload::runtime::{NullStore, Runtime, SteeringUnavailable};
+use packetframe_vpp_offload::runtime::{NoResources, NullStore, Runtime, SteeringUnavailable};
 use packetframe_vpp_offload::supervisor::{Event, State};
 
 struct Mirror {
@@ -64,6 +64,7 @@ fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
         Box::new(mirror),
         Box::new(SteeringUnavailable),
         Box::new(NullStore),
+        Box::new(NoResources),
         "/usr/bin/vpp",
         "/tmp/startup.conf",
     )
@@ -289,6 +290,7 @@ fn a_persist_that_recovers_clears_the_recorded_failure() {
         }),
         Box::new(SteeringUnavailable),
         Box::new(Flaky(Arc::clone(&failing))),
+        Box::new(packetframe_vpp_offload::runtime::NoResources),
         "/usr/bin/vpp",
         "/dev/null",
     );
@@ -366,6 +368,7 @@ fn a_successful_spawn_persist_clears_an_earlier_store_failure() {
         Box::new(Mirror { routes: vec![] }),
         Box::new(SteeringUnavailable),
         Box::new(Flaky(Arc::clone(&failing))),
+        Box::new(packetframe_vpp_offload::runtime::NoResources),
         // `spawn(binary, conf)` execs `binary -c conf`; /bin/true exits
         // immediately regardless, which is all this needs.
         "/bin/true",

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -20,7 +20,7 @@ use packetframe_vpp_offload::driver::Driver;
 use packetframe_vpp_offload::engine::{ConvergenceEngine, RouteSource};
 use packetframe_vpp_offload::fib_sync::FamilyPolicy;
 use packetframe_vpp_offload::runtime::{
-    IdentityStore, NullStore, ProcessIdentity, Runtime, SteeringUnavailable,
+    IdentityStore, NoResources, NullStore, ProcessIdentity, Runtime, SteeringUnavailable,
 };
 use packetframe_vpp_offload::service::SupervisionService;
 use packetframe_vpp_offload::supervisor::{Event, State};
@@ -62,6 +62,7 @@ fn the_service_converges_publishes_health_and_stops_clean() {
                 Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );
@@ -129,9 +130,13 @@ fn the_service_converges_publishes_health_and_stops_clean() {
     // Stop: the machine is handed StopRequested, settles in Stopped,
     // and the final snapshot says so — INCLUDING the failures the stop
     // transition produced after the supervisor was already Stopped.
-    // The runtime's release_resources refuses by design until the
-    // attach wiring exists, and that refusal must reach the caller
-    // rather than vanish with a discarded Tick.
+    // This runtime holds no resources, so its release seam refuses; that
+    // refusal must reach the caller rather than vanish with a discarded
+    // Tick, which is the property under test. Asserted on the ACTION,
+    // not on the seam's wording: the message belongs to whichever
+    // `ResourceRelease` is installed, and a test keyed to one
+    // implementation's prose stops checking anything the moment a real
+    // one is wired in.
     let last = svc.stop().published.expect("final status");
     assert_eq!(last.state, State::Stopped, "{:?}", last.report);
     assert!(
@@ -142,7 +147,7 @@ fn the_service_converges_publishes_health_and_stops_clean() {
     assert!(
         last.teardown_failures
             .iter()
-            .any(|f| f.contains("attach wiring")),
+            .any(|f| f.starts_with("ReleaseResources:")),
         "the refused resource release must be on the record: {:?}",
         last.teardown_failures
     );
@@ -273,6 +278,7 @@ fn an_unpersisted_identity_degrades_health_and_is_named() {
                 Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(RefusingStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );
@@ -396,6 +402,7 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
                 // Refuses both directions until slice 5 builds MCAM.
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );
@@ -512,6 +519,7 @@ fn the_initial_injections_failures_reach_the_first_snapshot() {
                 Box::new(Mirror(Vec::new())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/nonexistent/vpp",
                 "/tmp/startup.conf",
             );
@@ -586,6 +594,7 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
                 Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/nonexistent/vpp",
                 "/tmp/startup.conf",
             );
@@ -702,6 +711,7 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
                 )),
                 Box::new(PanicOnSteer),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );
@@ -797,6 +807,7 @@ fn an_episode_keeps_its_root_cause_alongside_the_latest_symptom() {
                 Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 // And the respawn cannot succeed, which is the symptom.
                 "/nonexistent/vpp",
                 "/tmp/startup.conf",
@@ -894,6 +905,7 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
                 Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );
@@ -1018,6 +1030,7 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
                 Box::new(Mirror((0..3).map(|i| fake_vpp::v4(0, i)).collect())),
                 Box::new(SteeringUnavailable),
                 Box::new(NullStore),
+                Box::new(NoResources),
                 "/usr/bin/vpp",
                 "/tmp/startup.conf",
             );


### PR DESCRIPTION
Closes slice 4 except the cross-crate route feed. `Module::attach()` was the
last piece: everything below it was merged and unit-tested, and composing it
is what found the bugs below.

## The sequence

```
derive sizing + core map     pure; no mutation, so a bad config costs nothing
acquire hugepages → VF → vfio   rollback-safe, state file per step
render + write startup.conf   the last thing before a process could exist
adopt (only if the record names a live VPP)
start the supervision loop    which does the spawning, if any
```

Ordering is load-bearing in both directions. Nothing mutates the box until
every derivable failure is ruled out, because the alternative is a rollback
path that ordinary operator typos walk through. And **nothing here spawns
VPP** — the supervisor owns that, so `attach` injects `StartRequested` and
lets the loop's `Start` action spawn, record the identity and arm backoff. A
spawn performed here and then not handed over would be a VPP nothing
supervises holding a VF nothing can release. Adoption is the exception
because it is an *observation*: whether a previous daemon's VPP is alive is a
fact about the box, and `Adopted { steered }` exists so resync and verify do
not tear its steering down first.

## Two hazards the composition exposed

**`expected-routes` could drift across an adoption.** VPP fixes its main heap
and stats segment at start, so a restart under a raised forecast would apply
the new, larger route ceiling to a VPP running on the old segments — gate
0b's mid-resync OOM abort, arriving through the adoption door. Recorded in
the state file and refused, next to the hugepage-pool identity check.

**The high-water mark had no honest source.** `route_capacity` computes what
the rendered segments actually hold at the *measured* per-route costs (463 B
heap, 48.5 B/route/thread statseg) rather than the ~2×-padded sizing ones,
derated to 80%. Both segments are considered and the smaller wins: at every
configuration the binding constraint is the stats segment — the one that
actually killed VPP — so deriving from the heap alone would have put the
ceiling above the segment that fails first.

## Also in here

- **The release seam.** `Effects::release_resources` had no implementation and
  the runtime could not have one. `ResourceRelease` is a constructor argument,
  not an optional setter, because an unwired seam here reports a clean detach
  over still-held VFs. `ResourceOwner` shares ONE record between the identity
  store and the release: the loop keeps ticking after `ReleaseResources`, and
  a releaser with its own copy would let a later `process_changed(None)`
  re-create a file naming VFs that are already unbound.
- **Core placement** (`cores.rs`). The grammar says how many workers, never
  which CPUs. Derived from `/sys/devices/system/cpu/{online,isolated}`: never
  cpu0, never an isolated CPU (`isolcpus=12` is unifi-core's), descending so
  growing `cores` extends the set instead of renumbering it — which keeps an
  operator's IRQ-affinity work valid across a config bump. What it cannot
  solve is stated rather than glossed: all 18 CPUs carry an rx-queue IRQ 1:1,
  so no map avoids sharing one, and the derived set is logged at attach
  because moving those IRQs is manual.
- **`attach()` refuses without a route source.** A VPP with an empty FIB
  passes every check this module makes — process alive, API answering, devices
  attached, verify trivially passing on an empty sample — and blackholes every
  steered packet.

## Swept before opening, not after review

#120 took fourteen review rounds on one file, every one of them "a fact the
code produces, lost at a boundary". So this branch got the sweep first: every
fallible step against every exit path. Two findings, both that class:

- **A failed `detach` forgot the attachment.** It takes `attached` before it
  can discover a failure (the service is consumed by `stop()`), so the second
  call found `None` and answered `Ok` — reporting a clean detach over held
  resources, on exactly the retry `detach --all` performs. The record now
  outlives the attachment, both failure exits go through one recorder, and
  `health_check` reports Unhealthy.
- **`SupervisionService::start` must stay the last fallible step in `finish`.**
  `bring_up` releases everything on any `Err` after acquisition, so a failure
  added after `start` succeeded would hand VFs back underneath a running
  supervisor.

Round 14 of #120 then landed a P1 whose other half lives here, and it is
fixed in this branch: an adoption that fails partway leaves the recorded VPP
running, so that error and any post-adoption `start` error are marked
`MAY_HOLD_RESOURCES` and **suppress the rollback** — unbinding a VF under a
process that can still DMA through it is worse than leaking it.

## What is and is not proven

`tests/vpp_bringup.rs` runs the whole sequence against a fixture sysfs and
the fake VPP on a real socket: ordering, refusals, rollback, the state file's
contents, the rendered conf matching the derived core map, health through the
real trait, and a detach that releases everything. **Spawn is deliberately
made to fail** so the test is identical on macOS and Linux.

So: no real VPP process has run this path. Spawn, the octeon device attach, a
full-table convergence through this code, and all three published failover
numbers remain unmeasured — they need the slice-5 drills. The ≤60 s
convergence budget was measured at 40.32 s by the gate-0b bench driving the
same engine, not by this module.

Two guards ship deliberately unproven and are labelled as such in-code: the
rollback suppression (the window needs an adoption or a successful spawn) and
the `undead` teardown retry (needs a process that survives SIGKILL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)