### PR TITLE
feat(fast-path): announce the resolved FIB to a second tier

### DIFF
--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -262,6 +262,73 @@ pub enum NeighEvent {
     Gone { ip: IpAddr },
 }
 
+// --- ResolvedRouteSink ------------------------------------------------
+
+/// A second consumer of the FIB, fed with what the programmer
+/// **resolved** rather than with what a peer advertised.
+///
+/// This exists so `vpp-offload` can mirror the forwarding table without
+/// re-deriving it. The obvious alternative — tee [`RouteEvent`]s where
+/// they enter the controller — looks cheaper and is a trap: a
+/// `RouteEvent::Add` carries one *advertisement* (`peer_id`, `path_id`,
+/// `local_pref`), and turning a prefix's advertisements into the nexthop
+/// set that actually forwards is the programmer's local-pref tiering and
+/// ADD-PATH aggregation. A second consumer of the raw events would have
+/// to reimplement that, which is two copies of the rule that decides
+/// where packets go — and the failure mode is the two tiers forwarding
+/// differently, discovered during a failover.
+///
+/// So the notification sites are the programmer's mirror commits, and
+/// what crosses this trait is the resolved best-path union. The
+/// consequence is deliberate and worth stating: the second tier inherits
+/// the first tier's resolution, **including its refusals**. A prefix the
+/// programmer declined on capacity is not announced here either. The two
+/// tiers agreeing is worth more than the second one being independently
+/// complete, because it means a failover cannot change forwarding.
+///
+/// ## Why nothing here can fail
+///
+/// No `Result`, no `async`, `&self`. The fallback tier must never be
+/// stalled by a sick consumer — that is the standing requirement for the
+/// eBPF path, which carries production traffic whenever the offload is
+/// down. A signature that cannot report failure cannot tempt a caller
+/// into waiting for one, so an implementation must absorb its own
+/// backpressure (a prefix-keyed map with last-write-wins collapses churn
+/// and is bounded by table size, not event rate) and must not block:
+/// anything held across these calls is held against the programmer's
+/// task, which is the fallback tier's control plane.
+pub trait ResolvedRouteSink: Send + Sync {
+    /// `prefix` now forwards over `nexthops` — the resolved, sorted,
+    /// deduplicated best-path union, exactly what the data plane reads.
+    /// Replaces any previous set for this prefix.
+    fn route_resolved(&self, prefix: IpPrefix, nexthops: &[IpAddr]);
+
+    /// `prefix` no longer forwards and must be withdrawn downstream.
+    ///
+    /// Distinct from `route_resolved(prefix, &[])`, which would read as
+    /// "still present, currently unresolvable" — a state that black-holes
+    /// rather than falls back, so conflating them would leave a withdrawn
+    /// route installed in the second tier.
+    fn route_withdrawn(&self, prefix: IpPrefix);
+
+    /// `nh` resolved to `mac` out of `ifindex`.
+    ///
+    /// Forwarded because a consumer running VPP has no way to learn it:
+    /// VPP runs without `linux-cp` and MCAM rules match IP fields, so an
+    /// ARP frame can never reach it. Every adjacency it has must be
+    /// programmed from what the kernel already resolved here.
+    fn neighbour_resolved(&self, nh: IpAddr, mac: [u8; 6], ifindex: u32);
+
+    /// `nh` is no longer resolved — the kernel dropped it, or resolution
+    /// failed after retries.
+    ///
+    /// Both cases collapse into one call on purpose: the consumer's
+    /// question is only "may I still forward through this adjacency",
+    /// and the answer is no either way. Why it failed is the fast-path
+    /// tier's diagnostic, and it already reports it.
+    fn neighbour_lost(&self, nh: IpAddr);
+}
+
 /// Errors a NeighborResolver can surface.
 #[derive(Debug)]
 pub struct NeighError {

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -47,6 +47,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::net::IpAddr;
 use std::path::Path;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use aya::maps::{lpm_trie::Key as LpmKey, Array, LpmTrie, Map, MapData};
@@ -55,7 +56,7 @@ use tokio::time::interval;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
-use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, RouteEvent};
+use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, ResolvedRouteSink, RouteEvent};
 
 use crate::fib::netlink_neigh::NeighborResolveHandle;
 use crate::fib::types::{
@@ -523,6 +524,18 @@ pub struct FibProgrammer {
     // --- Default-route reclaim queue (Phase 3) ---
     reclaim_queue: VecDeque<PendingReclaim>,
 
+    // --- Second tier (Phase 4) ---
+    /// Where the resolved FIB is announced, when a second forwarding
+    /// tier is configured. `None` in every harness and in any run
+    /// without `module vpp-offload`, and the notification sites are
+    /// `if let Some(..)` — so an absent sink costs one branch per
+    /// mirror commit and nothing else.
+    ///
+    /// See [`ResolvedRouteSink`] for why this carries the *resolved*
+    /// union rather than the events that produced it, and why it cannot
+    /// report failure back to this task.
+    route_sink: Option<Arc<dyn ResolvedRouteSink>>,
+
     // --- Destination cache (v0.2.8, default-off experiment) ---
     /// FIB_CACHE_CFG handle. `None` in harnesses that don't exercise
     /// the cache; production (RouteController) always passes `Some`.
@@ -688,6 +701,7 @@ impl FibProgrammer {
                 free_ecmp_ids: Vec::new(),
                 next_ecmp_id: 0,
                 reclaim_queue: VecDeque::new(),
+                route_sink: None,
                 cache_cfg,
                 cache_enabled: false,
                 cache_generation: 1,
@@ -696,6 +710,23 @@ impl FibProgrammer {
             },
             FibProgrammerHandle { tx: cmd_tx },
         )
+    }
+
+    /// Register the second forwarding tier's sink.
+    ///
+    /// Deliberately a setter taking `&mut self` rather than a
+    /// constructor argument, which pins it to the only window where it
+    /// is sound: `run` consumes `self` into the task, so a sink can only
+    /// be attached before the programmer starts. Registering one
+    /// mid-flight would hand it a mirror whose earlier commits it never
+    /// saw — a second tier silently missing every prefix resolved before
+    /// it arrived, which is the shape of bug that reports healthy and
+    /// black-holes.
+    ///
+    /// A consumer that needs to attach later must therefore do its own
+    /// full-table resync; it cannot get here.
+    pub fn set_route_sink(&mut self, sink: Arc<dyn ResolvedRouteSink>) {
+        self.route_sink = Some(sink);
     }
 
     /// Main event loop. Drains NeighEvents + Commands + the reclaim
@@ -1066,6 +1097,18 @@ impl FibProgrammer {
             None => return,
         };
 
+        // Captured before the match consumes `evt`, and captured
+        // **pre-pin**: the FDB-pin rewrite below swaps `ifindex` for a
+        // bridge-member port so the XDP path can skip the bridge stack,
+        // which is a fact about this tier's datapath shortcut, not about
+        // where the neighbour lives. A second tier maps its own ports
+        // from the kernel egress device, so handing it the pinned port
+        // would name an interface it has no VF for.
+        let learned = match &evt {
+            NeighEvent::Learned { mac, ifindex, .. } => Some((*mac, *ifindex)),
+            NeighEvent::Failed { .. } | NeighEvent::Gone { .. } => None,
+        };
+
         let entry = match evt {
             NeighEvent::Learned {
                 mac,
@@ -1144,6 +1187,23 @@ impl FibProgrammer {
 
         if let Err(e) = self.write_seqlock(id, entry) {
             warn!(?ip, id, error = %e, "NEXTHOPS update failed");
+        }
+
+        // Announced regardless of whether that write landed, which is the
+        // opposite of the rule the route path follows — and the asymmetry
+        // is the point. A route's nexthop union is *computed here*, so
+        // this tier's commit is what makes it true. A neighbour's
+        // resolution is the **kernel's**, and both tiers are downstream
+        // consumers of it; our own map write failing says nothing about
+        // the kernel's answer. Withholding it would turn one tier's map
+        // failure into an incomplete adjacency in the other tier as well,
+        // which is precisely the single-point-of-failure the second tier
+        // exists to avoid.
+        if let Some(sink) = self.route_sink.as_deref() {
+            match learned {
+                Some((mac, ifindex)) => sink.neighbour_resolved(ip, mac, ifindex),
+                None => sink.neighbour_lost(ip),
+            }
         }
     }
 
@@ -1496,6 +1556,17 @@ impl FibProgrammer {
             // of closing it, so the deferral is unconditional rather
             // than cache-gated — one lifecycle, strictly safer.
             self.reclaim_prior(Some(rec.fib_value), rec.nexthop_ips);
+            // The only place a prefix leaves the mirror — `desired_nhs`
+            // empty covers an explicit Withdraw, the last advertisement
+            // going away, and PeerDown, because all three arrive here by
+            // recomputing the union. `remove_mirror_direct` has exactly
+            // one caller (this one), which is what makes that claim
+            // checkable rather than hopeful: a second removal path would
+            // be a route the second tier keeps forwarding after this one
+            // stopped.
+            if let Some(sink) = self.route_sink.as_deref() {
+                sink.route_withdrawn(prefix);
+            }
             return Ok(());
         }
 
@@ -1568,6 +1639,20 @@ impl FibProgrammer {
             rec.nexthop_ips = allocated_ips;
         }
         self.reclaim_prior(prior_fib, prior_nh_ips);
+        // After the mirror commit, never before. The second tier is told
+        // what this one *installed*, so the announcement has to follow
+        // the write it describes — announcing the intent would republish
+        // a set that a later failure in this function had abandoned, and
+        // every `?` above returns before reaching here.
+        //
+        // Read back out of the mirror rather than cloning `allocated_ips`
+        // on the way in: it is the same bytes, and it keeps the no-sink
+        // case free of an allocation on the route-install path.
+        if let Some(sink) = self.route_sink.as_deref() {
+            if let Some(rec) = self.lookup_mirror(&prefix) {
+                sink.route_resolved(prefix, &rec.nexthop_ips);
+            }
+        }
         Ok(())
     }
 

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -1054,6 +1054,33 @@ impl FibProgrammer {
         self.seq_by_id.remove(&id);
         self.free_ids.push(id);
 
+        // The second tier's LAST chance to hear about this address.
+        //
+        // `on_neigh_event` ignores events for IPs absent from `by_ip`, so
+        // the line above makes every future `Gone`/`Failed` for `ip`
+        // unreachable — without this the other tier would hold the
+        // adjacency until its process restarted.
+        //
+        // The case that needs it is a route REWRITE, not a withdrawal. On
+        // withdrawal every referencing route was announced withdrawn
+        // first, so nothing there points at this adjacency anyway. But a
+        // prefix re-advertised from NH-A to NH-B releases NH-A through
+        // the grace queue while the prefix itself stays up: the sink is
+        // correctly told `route_resolved(P, [NH-B])` and, without this,
+        // is never told NH-A is gone. Those accumulate for every nexthop
+        // the box has ever used, and a consumer programming static
+        // neighbours re-installs the whole stale set on every resync —
+        // adjacency slots spent, and resync time spent, inside a budget
+        // that has one.
+        //
+        // Refcount zero means no route in THIS tier references it, and
+        // the two tiers cannot disagree in the direction that matters
+        // (a prefix refused here is never announced), so nothing on the
+        // other side is still forwarding through it.
+        if let Some(sink) = self.route_sink.as_deref() {
+            sink.neighbour_lost(ip);
+        }
+
         // Leave the NEXTHOPS slot marked Failed so any stale FIB
         // pointer still producing lookups gets CustomFibNoNeigh
         // rather than forwarding to a recycled MAC.

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -24,13 +24,13 @@
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Once;
+use std::sync::{Arc, Once};
 use std::time::Duration;
 
 use aya::maps::lpm_trie::Key as LpmKey;
 use aya::maps::{Array, LpmTrie, Map, MapData};
 use aya::Ebpf;
-use packetframe_common::fib::{IpPrefix, PeerId, RouteEvent};
+use packetframe_common::fib::{IpPrefix, NeighEvent, PeerId, ResolvedRouteSink, RouteEvent};
 use packetframe_fast_path::aligned_bpf_copy;
 use packetframe_fast_path::fib::programmer::FibProgrammer;
 use packetframe_fast_path::fib::types::{
@@ -170,6 +170,59 @@ fn open_lpm_v6(path: &Path) -> LpmTrie<MapData, [u8; 16], FibValue> {
     LpmTrie::try_from(Map::LpmTrie(map_data)).expect("LpmTrie try_from")
 }
 
+/// What the second tier was told, in order.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum SinkCall {
+    Resolved(IpPrefix, Vec<IpAddr>),
+    Withdrawn(IpPrefix),
+    NeighResolved(IpAddr, [u8; 6], u32),
+    NeighLost(IpAddr),
+}
+
+/// A [`ResolvedRouteSink`] that records rather than forwards.
+///
+/// Ordering matters as much as content here — a withdrawal announced
+/// before the mirror commit that produced it, or a resolve announced for
+/// a set the programmer then failed to install, are the two bugs this
+/// seam can have — so the recording is a `Vec`, not a map.
+#[derive(Default)]
+struct RecordingSink {
+    calls: std::sync::Mutex<Vec<SinkCall>>,
+}
+
+impl RecordingSink {
+    fn calls(&self) -> Vec<SinkCall> {
+        self.calls.lock().expect("sink mutex").clone()
+    }
+}
+
+impl ResolvedRouteSink for RecordingSink {
+    fn route_resolved(&self, prefix: IpPrefix, nexthops: &[IpAddr]) {
+        self.calls
+            .lock()
+            .expect("sink mutex")
+            .push(SinkCall::Resolved(prefix, nexthops.to_vec()));
+    }
+    fn route_withdrawn(&self, prefix: IpPrefix) {
+        self.calls
+            .lock()
+            .expect("sink mutex")
+            .push(SinkCall::Withdrawn(prefix));
+    }
+    fn neighbour_resolved(&self, nh: IpAddr, mac: [u8; 6], ifindex: u32) {
+        self.calls
+            .lock()
+            .expect("sink mutex")
+            .push(SinkCall::NeighResolved(nh, mac, ifindex));
+    }
+    fn neighbour_lost(&self, nh: IpAddr) {
+        self.calls
+            .lock()
+            .expect("sink mutex")
+            .push(SinkCall::NeighLost(nh));
+    }
+}
+
 /// Construct a FibProgrammer with handles to the pinned maps, spawn
 /// it on a fresh current-thread tokio runtime, return the handle +
 /// a shutdown token + a task join handle.
@@ -180,6 +233,10 @@ struct ProgrammerHarness {
     shutdown: CancellationToken,
     handle: packetframe_fast_path::fib::programmer::FibProgrammerHandle,
     task: Option<tokio::task::JoinHandle<()>>,
+    /// Retained only by the sink variant, which needs to inject
+    /// `NeighEvent`s. `new()`/`new_with_cache()` drop their sender, which
+    /// closes the channel — fine for route-only tests, fatal here.
+    events_tx: Option<tokio::sync::mpsc::Sender<NeighEvent>>,
 }
 
 impl ProgrammerHarness {
@@ -221,6 +278,7 @@ impl ProgrammerHarness {
             shutdown,
             handle,
             task: Some(task),
+            events_tx: None,
         }
     }
 
@@ -260,7 +318,62 @@ impl ProgrammerHarness {
             shutdown,
             handle,
             task: Some(task),
+            events_tx: None,
         }
+    }
+
+    /// Variant with a second-tier sink registered and the neigh-event
+    /// sender retained.
+    fn with_sink() -> (Self, Arc<RecordingSink>) {
+        let pins = PinDirs::setup();
+        let ebpf = load_and_pin(&pins);
+        let nexthops: Array<MapData, NexthopEntry> = open_array(&pins.path("NEXTHOPS"));
+        let fib_v4 = open_lpm_v4(&pins.path("FIB_V4"));
+        let fib_v6 = open_lpm_v6(&pins.path("FIB_V6"));
+        let ecmp_groups: Array<MapData, EcmpGroup> = open_array(&pins.path("ECMP_GROUPS"));
+        let shutdown = CancellationToken::new();
+        let (events_tx, events_rx) = tokio::sync::mpsc::channel(16);
+        let (mut programmer, handle) = FibProgrammer::new(
+            nexthops,
+            fib_v4,
+            fib_v6,
+            ecmp_groups,
+            events_rx,
+            shutdown.clone(),
+        );
+        let sink = Arc::new(RecordingSink::default());
+        programmer.set_route_sink(sink.clone());
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("runtime");
+        let task = rt.spawn(programmer.run());
+        (
+            Self {
+                pins,
+                _ebpf: ebpf,
+                rt,
+                shutdown,
+                handle,
+                task: Some(task),
+                events_tx: Some(events_tx),
+            },
+            sink,
+        )
+    }
+
+    /// Push a `NeighEvent` into the programmer and let it drain.
+    ///
+    /// The settle is a yield-and-wait rather than an ack: neigh events
+    /// are a fire-and-forget channel with no reply, so there is nothing
+    /// to await. 200 ms against a current-thread runtime whose only other
+    /// work is this event is generous by three orders of magnitude.
+    fn feed_neigh(&self, evt: NeighEvent) {
+        let tx = self.events_tx.as_ref().expect("sink harness only").clone();
+        self.run(async move {
+            tx.send(evt).await.expect("neigh channel open");
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        });
     }
 
     /// Read FIB_CACHE_CFG via a fresh handle.
@@ -1488,5 +1601,229 @@ fn fib_cache_generation_semantics() {
         h.read_cache_cfg().generation,
         5,
         "same-value toggle is a no-op"
+    );
+}
+
+// ========== Second-tier sink (Phase 4) ==========
+
+/// The announcement carries the **resolved** union, not the union of
+/// what peers advertised.
+///
+/// This is the test that pins the seam to the right layer. Two peers
+/// advertise the same prefix at different LOCAL_PREF; the programmer's
+/// tiering keeps only the winning tier, and the second tier must be told
+/// that — not both nexthops. Teeing `RouteEvent`s where they enter the
+/// controller would pass this prefix along with `10.0.0.2` included, and
+/// the two forwarding tiers would then disagree about where the traffic
+/// goes, discovered during a failover.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn the_sink_is_told_the_resolved_union_not_the_advertisements() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let prefix = IpPrefix::V4 {
+        addr: [203, 0, 113, 0],
+        prefix_len: 24,
+    };
+    let winner = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let loser = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 2));
+
+    h.run(async {
+        // Low tier first, so the second Add must *displace* it rather
+        // than merely fail to add to it.
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: PeerId(0x1111),
+                prefix,
+                nexthops: vec![loser],
+                path_id: None,
+                local_pref: Some(100),
+            })
+            .await
+            .expect("apply low-pref Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: PeerId(0x2222),
+                prefix,
+                nexthops: vec![winner],
+                path_id: None,
+                local_pref: Some(150),
+            })
+            .await
+            .expect("apply high-pref Add");
+    });
+
+    let calls = sink.calls();
+    assert_eq!(
+        calls.last(),
+        Some(&SinkCall::Resolved(prefix, vec![winner])),
+        "the latest announcement must be the winning tier alone; got {calls:?}"
+    );
+    assert!(
+        !calls
+            .iter()
+            .any(|c| matches!(c, SinkCall::Resolved(_, nhs) if nhs.contains(&loser) && nhs.contains(&winner))),
+        "no announcement may ever have merged the two local-pref tiers: {calls:?}"
+    );
+}
+
+/// A withdrawal reaches the sink, and by the same path for every way a
+/// prefix can stop forwarding.
+///
+/// `Del` and `PeerDown` are asserted together because the claim in the
+/// programmer is that they *share* the removal site — that is what makes
+/// "one notification site covers every withdrawal" true rather than
+/// hopeful. If they ever stop sharing it, one of these two halves fails.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn every_way_a_prefix_stops_forwarding_reaches_the_sink() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+    let by_del = IpPrefix::V4 {
+        addr: [198, 18, 0, 0],
+        prefix_len: 24,
+    };
+    let by_peer_down = IpPrefix::V4 {
+        addr: [198, 18, 1, 0],
+        prefix_len: 24,
+    };
+    let peer = PeerId(0x3333);
+
+    h.run(async {
+        for prefix in [by_del, by_peer_down] {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: peer,
+                    prefix,
+                    nexthops: vec![nh],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("apply Add");
+        }
+        h.handle
+            .apply_route_event(RouteEvent::Del {
+                peer_id: peer,
+                prefix: by_del,
+                path_id: None,
+            })
+            .await
+            .expect("apply Del");
+        h.handle
+            .apply_route_event(RouteEvent::PeerDown { peer_id: peer })
+            .await
+            .expect("apply PeerDown");
+    });
+
+    let calls = sink.calls();
+    assert!(
+        calls.contains(&SinkCall::Withdrawn(by_del)),
+        "an explicit Del must be announced: {calls:?}"
+    );
+    assert!(
+        calls.contains(&SinkCall::Withdrawn(by_peer_down)),
+        "a PeerDown's routes must be announced as withdrawn too — if this \
+         fails, PeerDown no longer shares the mirror-removal site: {calls:?}"
+    );
+    // Ordering, not just presence: a withdrawal announced before its
+    // install would leave the second tier forwarding a dead prefix.
+    let install = calls
+        .iter()
+        .position(|c| matches!(c, SinkCall::Resolved(p, _) if *p == by_del))
+        .expect("install announced");
+    let withdraw = calls
+        .iter()
+        .position(|c| *c == SinkCall::Withdrawn(by_del))
+        .expect("withdrawal announced");
+    assert!(install < withdraw, "install must precede withdrawal");
+}
+
+/// Re-advertising an identical nexthop set announces nothing.
+///
+/// Not an optimisation: under a peering flap the same prefix is
+/// re-advertised repeatedly with an unchanged union, and a sink that
+/// re-queued each one would turn churn into work for the second tier
+/// with nothing to show for it. The programmer already short-circuits
+/// this for its own maps; the sink must inherit that, not sit upstream
+/// of it.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn an_unchanged_nexthop_set_is_announced_once() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let prefix = IpPrefix::V4 {
+        addr: [198, 18, 2, 0],
+        prefix_len: 24,
+    };
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    h.run(async {
+        for _ in 0..3 {
+            h.handle
+                .apply_route_event(RouteEvent::Add {
+                    peer_id: PeerId(0x4444),
+                    prefix,
+                    nexthops: vec![nh],
+                    path_id: None,
+                    local_pref: None,
+                })
+                .await
+                .expect("apply Add");
+        }
+    });
+
+    let announcements = sink
+        .calls()
+        .iter()
+        .filter(|c| matches!(c, SinkCall::Resolved(p, _) if *p == prefix))
+        .count();
+    assert_eq!(
+        announcements, 1,
+        "three identical Adds must announce once, not three times"
+    );
+}
+
+/// Neighbour resolution and loss both reach the sink, with the egress
+/// ifindex the kernel reported.
+///
+/// The nexthop has to be registered first: the programmer ignores neigh
+/// events for IPs it holds no nexthop for, and that filter is upstream of
+/// the announcement — a sink told about every neighbour on the box would
+/// be told about ones it has no route through.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn neighbour_resolution_and_loss_reach_the_sink() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 7));
+    let mac = [0x02, 0x00, 0x5e, 0x10, 0x00, 0x07];
+    let ifindex = 4242;
+
+    h.run(async { h.handle.register_nexthop(nh).await })
+        .expect("register_nexthop");
+    h.feed_neigh(NeighEvent::Learned {
+        ip: nh,
+        mac,
+        ifindex,
+        src_mac: [0x02, 0x00, 0x5e, 0x10, 0x00, 0x01],
+    });
+    h.feed_neigh(NeighEvent::Gone { ip: nh });
+
+    let calls = sink.calls();
+    assert_eq!(
+        calls,
+        vec![
+            SinkCall::NeighResolved(nh, mac, ifindex),
+            SinkCall::NeighLost(nh),
+        ],
+        "resolution then loss, in that order and nothing else"
+    );
+
+    // An unregistered neighbour is not announced — the programmer's own
+    // filter, inherited rather than duplicated.
+    let stranger = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 8));
+    h.feed_neigh(NeighEvent::Gone { ip: stranger });
+    assert_eq!(
+        sink.calls().len(),
+        2,
+        "a neighbour we hold no nexthop for must not be announced"
     );
 }

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -1827,3 +1827,56 @@ fn neighbour_resolution_and_loss_reach_the_sink() {
         "a neighbour we hold no nexthop for must not be announced"
     );
 }
+
+/// Unregistering a nexthop tells the second tier it is gone.
+///
+/// This is the seam's only exit for an address, and the reason is a
+/// filter rather than a policy: `on_neigh_event` ignores events for IPs
+/// absent from `by_ip`, so once `unregister` removes the record no
+/// future `Gone` can reach the sink. Without a notification here the
+/// other tier keeps the adjacency for the life of the process.
+///
+/// Driven through `unregister_nexthop` rather than through the
+/// motivating scenario — a prefix re-advertised from NH-A to NH-B, which
+/// releases NH-A through the 100 ms grace queue — because both reach the
+/// same notification site and only one of them is deterministic.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn unregistering_a_nexthop_tells_the_sink_it_is_gone() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 9));
+    let mac = [0x02, 0x00, 0x5e, 0x10, 0x00, 0x09];
+
+    h.run(async { h.handle.register_nexthop(nh).await })
+        .expect("register_nexthop");
+    h.feed_neigh(NeighEvent::Learned {
+        ip: nh,
+        mac,
+        ifindex: 4242,
+        src_mac: [0x02, 0x00, 0x5e, 0x10, 0x00, 0x01],
+    });
+    assert_eq!(
+        sink.calls(),
+        vec![SinkCall::NeighResolved(nh, mac, 4242)],
+        "resolution reaches the sink first"
+    );
+
+    h.run(async { h.handle.unregister_nexthop(nh).await })
+        .expect("unregister_nexthop");
+    assert_eq!(
+        sink.calls().last(),
+        Some(&SinkCall::NeighLost(nh)),
+        "and its removal must too — nothing else can report it afterwards"
+    );
+
+    // The filter really is closed behind it: a kernel event arriving
+    // after the unregister is dropped, which is what makes the
+    // notification above the only one there will ever be.
+    let before = sink.calls().len();
+    h.feed_neigh(NeighEvent::Gone { ip: nh });
+    assert_eq!(
+        sink.calls().len(),
+        before,
+        "a post-unregister event is filtered, so it cannot substitute"
+    );
+}


### PR DESCRIPTION
First half of task #26 (cross-crate route feed). This adds the seam `vpp-offload` will read and **registers nothing** — the only caller of `set_route_sink` is the test harness, so this is inert on main. The consumer side, the engine's live-delta drain, and the loader wiring are the follow-up PR.

## Where the tee goes is the whole decision

The obvious placement is where `RouteEvent`s enter the controller, and it is wrong. A `RouteEvent::Add` carries one *advertisement* (`peer_id`, `path_id`, `local_pref`); turning a prefix's advertisements into the set that actually forwards is the programmer's local-pref tiering and ADD-PATH aggregation. A second consumer of the raw events would have to reimplement that — two copies of the rule deciding where packets go, whose failure mode is the two tiers forwarding differently, discovered during a failover.

So the notification sites are the programmer's **mirror commits**, and what crosses the trait is the resolved best-path union.

**Deliberate consequence, documented on the trait:** the second tier inherits the first tier's resolution *including its refusals* — a prefix declined on capacity is not announced. That departs from the phase plan's "VPP's FIB is a faithful mirror of bird's": it becomes a faithful mirror of what the fallback tier resolved. Worth more, because it means a failover cannot change forwarding.

## The four sites, and why the count is checkable

| Site | Rule |
|---|---|
| Install/rewrite | After the mirror commit, never before — every `?` above returns first, so announcing intent would republish a set a later failure abandoned |
| Withdrawal | The one place a prefix leaves the mirror; `remove_mirror_direct` has exactly **one** caller, which is what makes "Del, last-advertisement-gone, and PeerDown are all covered" a fact rather than a hope — all three arrive by recomputing an empty union |
| Neighbour learned | Carries the **pre-pin** ifindex; the FDB-pin rewrite names a bridge-member port for the XDP shortcut, and a consumer mapping ports from the kernel egress device has no VF for that |
| Neighbour lost | `Failed` and `Gone` collapse — the consumer's only question is "may I still forward through this adjacency" |

## One deliberate asymmetry

The neighbour half announces **regardless of whether the seqlock write landed**, inverting the route rule. A route's union is computed here, so this tier's commit makes it true. A neighbour's resolution is the *kernel's*, and both tiers are downstream consumers of it — our map write failing says nothing about the kernel's answer, and withholding it would turn one tier's map failure into an incomplete adjacency in the other. That is the single point of failure the second tier exists to remove.

## Nothing on this trait can fail

No `Result`, no `async`, `&self`. The eBPF tier carries production traffic whenever the offload is down and must never be stalled by a sick consumer, so a signature that cannot report failure cannot tempt a caller into waiting for one. Absorbing backpressure is the implementation's job, and the shape that does it — a prefix-keyed map with last-write-wins, bounded by table size rather than event rate — is named in the docs.

## Testing

Five tests against real BPF maps. The load-bearing one: a prefix advertised at two LOCAL_PREF tiers announces **only the winner** — that is what pins the seam to the right layer, and an event-entry tee would fail it. Also covered: Del and PeerDown asserted together (so the shared removal site cannot silently split), install-before-withdraw ordering, three identical Adds announcing once, and an unregistered neighbour not being announced.

They are `#[ignore]`d like the rest of that file and run in the qemu job on both kernels. **They need CAP_BPF, so they did not run on this laptop — qemu is their first execution.** Locally verified: `fmt`, host clippy, and `--workspace --all-targets --all-features` clippy on all four published targets; 578 host tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)