### PR TITLE
feat: the cross-crate route feed — vpp-offload can start

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -164,40 +164,94 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
     }
 }
 
+/// Whether a route feed is needed, and whether the config can support one.
+///
+/// Pure, so the two refusals are testable off a router — `run_linux`
+/// itself needs a live bpffs and real interfaces.
+///
+/// `Ok(true)` = build the feed and hand it to both tiers. `Ok(false)` =
+/// no vpp-offload section, nothing to wire. `Err` = a config that would
+/// bring VPP up against a table nobody is filling.
+#[cfg(all(target_os = "linux", feature = "fast-path", feature = "vpp-offload"))]
+fn feed_wiring(names: &[&str]) -> Result<bool, String> {
+    let vpp = names.iter().position(|n| *n == "vpp-offload");
+    let fp = names.iter().position(|n| *n == "fast-path");
+    match (vpp, fp) {
+        (None, _) => Ok(false),
+        (Some(_), None) => Err(
+            "module vpp-offload needs a `module fast-path` section: its FIB comes from the \
+             fast-path route controller, and without one VPP would come up with an empty table"
+                .into(),
+        ),
+        // Attach order is config order, and vpp-offload's first resync
+        // reads whatever the feed holds at that instant. Refused rather
+        // than reordered: an operator who wrote it this way should learn
+        // it from the error, not from a VPP that came up short.
+        (Some(v), Some(f)) if f > v => Err(
+            "module fast-path must be declared before module vpp-offload: modules attach in \
+             config order, and vpp-offload's first FIB resync reads what the fast-path route \
+             controller has already resolved"
+                .into(),
+        ),
+        (Some(_), Some(_)) => Ok(true),
+    }
+}
+
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
+    // The route feed, built before either module so both can be handed
+    // the SAME one.
+    //
+    // Two objects here would be two mirrors, and the vpp-offload engine
+    // would resync from a table nothing was writing to — which converges
+    // cleanly, verifies cleanly, and forwards nothing.
+    //
+    // Order is enforced rather than assumed. vpp-offload's first resync
+    // reads whatever the feed holds at that instant, so the fast-path
+    // programmer has to be running first. Config order is attach order,
+    // so a config listing them the other way round is refused with the
+    // reason rather than quietly reordered.
+    //
+    // What this does NOT guarantee, and cannot: that the table is
+    // *complete* when vpp-offload attaches. bird's initial dump takes
+    // time, so the first convergence may cover a fraction of it and the
+    // rest arrives as deltas. That is safe only because a first attach
+    // never steers — `bring_up` refuses any `steer on` port until MCAM
+    // steering ships — so nothing is diverted into a partial table. When
+    // slice 5 lands, "the table is complete" becomes a precondition of
+    // the first steer, and this is where to start looking.
+    #[cfg(feature = "vpp-offload")]
+    let feed = {
+        let names: Vec<&str> = config.modules.iter().map(|m| m.name.as_str()).collect();
+        match feed_wiring(&names).map_err(RunError::Startup)? {
+            true => Some(std::sync::Arc::new(
+                packetframe_vpp_offload::feed::RouteFeed::new(),
+            )),
+            false => None,
+        }
+    };
+
     let mut modules: Vec<(String, Box<dyn Module>)> = Vec::new();
     for section in &config.modules {
         match section.name.as_str() {
-            "fast-path" => modules.push((
-                section.name.clone(),
-                Box::new(FastPathModule::new()) as Box<dyn Module>,
-            )),
+            "fast-path" => {
+                #[allow(unused_mut)]
+                let mut m = FastPathModule::new();
+                #[cfg(feature = "vpp-offload")]
+                if let Some(f) = &feed {
+                    m.set_route_sink(f.clone());
+                }
+                modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
+            }
             #[cfg(feature = "vpp-offload")]
             "vpp-offload" => {
-                // Refused HERE, before fast-path attaches, rather than
-                // discovered as a mid-attach unwind.
-                //
-                // The module is complete except for its route feed: nothing
-                // calls `set_route_source`, because reaching across to the
-                // fast-path RouteController's mirror touches the live
-                // control plane and carries an unresolved access decision
-                // (the mirror lives inside the programmer task and is
-                // reachable only by command; a full-table reply, a shared
-                // lock, and a second mirror all trade differently). Until
-                // that lands, `attach` correctly refuses — a VPP with an
-                // empty FIB passes every health check and blackholes every
-                // steered packet — and letting startup discover that after
-                // fast-path has already attached just makes the operator
-                // read an unwind log to learn it.
-                return Err(RunError::Startup(
-                    "module vpp-offload cannot run yet: its route feed is not wired, so \
-                     VPP would come up with an empty FIB. Remove the `module vpp-offload` \
-                     section to start. (Everything else — resources, supervision, \
-                     convergence, health — is in place; `packetframe feasibility` still \
-                     reports its probes.)"
-                        .into(),
+                let mut m = packetframe_vpp_offload::VppOffloadModule::new();
+                // `feed` is `Some` whenever a vpp-offload section exists —
+                // the match above returns before here otherwise.
+                m.set_route_source(Box::new(
+                    feed.clone().expect("a vpp-offload section implies a feed"),
                 ));
+                modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }
             other => {
                 return Err(RunError::Startup(format!(
@@ -1289,6 +1343,45 @@ fn trial_attach_probes(_ifaces: &[String]) -> Vec<(String, String)> {
 #[cfg(all(test, feature = "vpp-offload"))]
 mod vpp_detach_tests {
     use super::*;
+
+    /// No vpp-offload section means no feed and no opinion about ordering.
+    ///
+    /// These three are gated exactly like `feed_wiring` itself. It is
+    /// pure, but its only non-test caller is `run_linux`, so ungating it
+    /// would make it dead code on a macOS build under `-D warnings`. They
+    /// run in CI's Linux test job.
+    #[cfg(all(target_os = "linux", feature = "vpp-offload"))]
+    #[test]
+    fn without_vpp_offload_there_is_nothing_to_wire() {
+        assert_eq!(feed_wiring(&["fast-path"]), Ok(false));
+        assert_eq!(feed_wiring(&[]), Ok(false));
+    }
+
+    /// vpp-offload alone is refused: there is no route controller to
+    /// resolve a FIB, so VPP would come up against an empty table — which
+    /// converges, verifies, and forwards nothing.
+    #[cfg(all(target_os = "linux", feature = "vpp-offload"))]
+    #[test]
+    fn vpp_offload_without_fast_path_is_refused() {
+        let e = feed_wiring(&["vpp-offload"]).expect_err("must refuse");
+        assert!(e.contains("needs a `module fast-path` section"), "{e}");
+    }
+
+    /// Declared the wrong way round is refused rather than reordered.
+    ///
+    /// Modules attach in config order, and vpp-offload's first resync
+    /// reads whatever the feed holds at that instant. Silently reordering
+    /// would work, and would also mean the file no longer describes what
+    /// the daemon did.
+    #[cfg(all(target_os = "linux", feature = "vpp-offload"))]
+    #[test]
+    fn vpp_offload_before_fast_path_is_refused() {
+        let e = feed_wiring(&["vpp-offload", "fast-path"]).expect_err("must refuse");
+        assert!(e.contains("must be declared before"), "{e}");
+        // The right order is accepted, so the test above is about order
+        // and not about the pair being rejected outright.
+        assert_eq!(feed_wiring(&["fast-path", "vpp-offload"]), Ok(true));
+    }
 
     /// A recorded pid with no start-time cookie must not be signalled, and
     /// its resources must not be released either.

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -132,6 +132,7 @@ impl RouteController {
         local_prefixes: Vec<LocalPrefixSpec>,
         fallback_default: Option<FallbackDefaultSpec>,
         fdb_pin_chains: std::collections::HashMap<u32, (u32, u16)>,
+        route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
     ) -> Result<Self, ControllerError> {
         // Dedicated runtime. `worker_threads(2)` keeps task count to
         // what Phase 3 actually needs; the resolver, programmer, and
@@ -157,7 +158,7 @@ impl RouteController {
         // every newly-allocated nexthop. Pre-fix this was wired but
         // never called, leaving nexthops dependent on multicast events
         // that don't fire for stable REACHABLE kernel entries.
-        let (programmer, prog_handle) = FibProgrammer::new_with_resolver(
+        let (mut programmer, prog_handle) = FibProgrammer::new_with_resolver(
             nexthops,
             fib_v4,
             fib_v6,
@@ -167,6 +168,15 @@ impl RouteController {
             shutdown_token.clone(),
             Some(neigh_handle.clone()),
         );
+        // Registered before the programmer is spawned, which is the only
+        // window `set_route_sink` accepts: a sink attached afterwards
+        // would have missed every route resolved in the meantime, and a
+        // second tier silently short those prefixes is the shape of bug
+        // that reports healthy and black-holes.
+        if let Some(sink) = route_sink {
+            programmer.set_route_sink(sink);
+            info!("second-tier route sink registered with the FibProgrammer");
+        }
 
         // v0.2.1: enable the connected fast-path when the operator
         // declared at least one `local-prefix`. The resolver gets the

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -74,11 +74,31 @@ pub const FAST_PATH_BPF_AVAILABLE: bool = !FAST_PATH_BPF.is_empty();
 pub struct FastPathModule {
     #[cfg(target_os = "linux")]
     state: Option<linux_impl::ActiveState>,
+    /// A second forwarding tier's sink, if one is configured.
+    ///
+    /// Set before `attach` and consumed there: the programmer can only
+    /// accept a sink before it starts, because one registered later would
+    /// have missed every route resolved in the meantime.
+    #[cfg(target_os = "linux")]
+    route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
 }
 
 impl FastPathModule {
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Announce the resolved FIB to a second tier.
+    ///
+    /// Must be called before [`Module::attach`]; after that the
+    /// programmer is running and cannot take one. The loader is the only
+    /// caller, because it is the only place that knows both tiers exist.
+    #[cfg(target_os = "linux")]
+    pub fn set_route_sink(
+        &mut self,
+        sink: std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>,
+    ) {
+        self.route_sink = Some(sink);
     }
 
     /// Snapshot of the current attach set for status reporting.
@@ -147,7 +167,7 @@ impl Module for FastPathModule {
             .state
             .as_mut()
             .ok_or_else(|| ModuleError::other(MODULE_NAME, "attach called before load"))?;
-        linux_impl::attach(state, cfg)
+        linux_impl::attach(state, cfg, self.route_sink.clone())
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1176,7 +1176,11 @@ fn populate_mss_clamp(ebpf: &mut Ebpf, mcfg: &ModuleConfig<'_>) -> ModuleResult<
     Ok(())
 }
 
-pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<Vec<Attachment>> {
+pub fn attach(
+    state: &mut ActiveState,
+    cfg: &ModuleConfig<'_>,
+    route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
+) -> ModuleResult<Vec<Attachment>> {
     // v0.2.5: load `finalize` first so its FD is available for the
     // MUTATION_PROGS[0] population below. Order matters: fast_path's
     // tail_call into MUTATION_PROGS[0] must succeed on every packet
@@ -1630,6 +1634,7 @@ pub fn attach(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<V
             local_prefixes,
             fallback_default,
             fdb_pin_chains,
+            route_sink,
         )
         .map_err(|e| {
             ModuleError::other(MODULE_NAME, format!("RouteController start failed: {e}"))

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -108,6 +108,15 @@ pub struct Tick {
 pub struct Driver {
     sup: Supervisor,
     sched: Schedule,
+    /// A drain lost the socket; the next tick must reconnect before it
+    /// can make progress.
+    ///
+    /// `api_ready` is the only thing that reconnects, and it is otherwise
+    /// called just once — while `detector` is `None`. Once armed, the
+    /// detector stays armed for the whole of steady state, so without
+    /// this flag a transport dropped by a failed drain could never come
+    /// back and every later drain would fail instantly on `NotConnected`.
+    reconnect_wanted: bool,
     /// Liveness tracking, from the first pong onward.
     ///
     /// `Option` because it must NOT exist before the API has answered
@@ -127,6 +136,7 @@ impl Driver {
         Self {
             sup: Supervisor::new(),
             sched: Schedule::new(),
+            reconnect_wanted: false,
             detector: None,
         }
     }
@@ -236,6 +246,13 @@ impl Driver {
             // out the verify instead — bounded, and the source's map
             // collapses per prefix, so waiting costs staleness rather
             // than depth.
+            // Reconnect first, if the last drain lost the socket. The
+            // engine drops its transport on any drain error, and nothing
+            // else on this path would ever call `api_ready` again.
+            if api_up_at_entry && self.reconnect_wanted {
+                self.reconnect_wanted = !obs.api_ready();
+            }
+
             let resyncing = matches!(before, State::Syncing | State::AdoptedResyncing);
             // `resyncing ||` and not `api_up_at_entry` alone: an ADOPTED
             // process is already in a resync state on the very first
@@ -255,7 +272,10 @@ impl Driver {
                     // Failing mid-resync is a convergence failure: the
                     // table is known-incomplete and nothing is forwarding
                     // through it yet.
-                    Err(_) if resyncing => events.push(Event::ConvergenceFailed),
+                    Err(_) if resyncing => {
+                        self.reconnect_wanted = true;
+                        events.push(Event::ConvergenceFailed);
+                    }
                     // Failing in steady state is NOT. The batch stays in
                     // the pending map, which is last-write-wins, so the
                     // retry is free and idempotent — and treating one bad
@@ -265,7 +285,17 @@ impl Driver {
                     // have installed. A VPP that has genuinely stopped
                     // answering is the wedge detector's job, and it has a
                     // measured budget for exactly that.
-                    Err(_) => more_to_drain = true,
+                    //
+                    // **Not** `more_to_drain`, which asks for an immediate
+                    // re-tick. The engine drops its transport on a drain
+                    // error, so the next call fails on `NotConnected`
+                    // without touching the socket — a zero-cost failure
+                    // requesting a zero-length sleep is a pegged core, and
+                    // one that never reconnects, ending in the very
+                    // restart this arm exists to avoid. The retry rides
+                    // the ordinary schedule instead, one attempt per ping
+                    // interval, after the reconnect above has had a turn.
+                    Err(_) => self.reconnect_wanted = true,
                 }
             }
 
@@ -450,6 +480,7 @@ mod tests {
         ping_fails: bool,
         pings: usize,
         drains: usize,
+        api_readies: usize,
     }
 
     impl Observe for World {
@@ -457,6 +488,7 @@ mod tests {
             self.exited
         }
         fn api_ready(&mut self) -> bool {
+            self.api_readies += 1;
             self.api
         }
         fn ping(&mut self) -> Result<(), String> {
@@ -580,6 +612,57 @@ mod tests {
     /// The supervisor ignores the event — but "an event was applied" is
     /// what asks for an immediate re-tick, so the loop would spin a core
     /// for the whole verify.
+    /// A steady-state drain failure must not peg a core, and must be
+    /// able to recover.
+    ///
+    /// Two halves of one bug. The engine drops its transport on any drain
+    /// error, so the next drain fails on `NotConnected` without touching
+    /// the socket — asking for an immediate re-tick after that is a
+    /// zero-cost failure requesting a zero-length sleep, i.e. a spin. And
+    /// `api_ready` is the only thing that reconnects, but it is otherwise
+    /// called just once, while `detector` is `None`; once armed it never
+    /// runs again, so the spin could never end in anything but the wedge
+    /// restart this arm exists to avoid.
+    #[test]
+    fn a_steady_state_drain_failure_neither_spins_nor_strands_the_socket() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            ..Default::default()
+        };
+        d.inject(t0, Event::StartRequested, &mut fx);
+        settle(&mut d, t0, &mut w, &mut fx);
+        // Drive to a settled steady state.
+        d.inject(t0, Event::VerifyPassed, &mut fx);
+        assert_eq!(d.state(), State::Ready);
+
+        let readies_before = w.api_readies;
+        w.drain_fails = true;
+        let t = d.tick(at(t0, 100), &mut w, &mut fx);
+
+        assert!(
+            !t.events.contains(&Event::ConvergenceFailed),
+            "a steady-state drain failure must not escalate: {:?}",
+            t.events
+        );
+        assert_ne!(
+            t.sleep,
+            Some(Duration::ZERO),
+            "a failed drain must not ask to be called again immediately — the              next attempt fails on a dropped socket without doing any I/O, so              that is a pegged core"
+        );
+
+        // And the next tick tries to reconnect, which is the only way the
+        // retry can ever succeed.
+        let _ = d.tick(at(t0, 200), &mut w, &mut fx);
+        assert!(
+            w.api_readies > readies_before,
+            "nothing attempted to reconnect, so the transport is stranded and              every later drain fails instantly on NotConnected"
+        );
+    }
+
     #[test]
     fn verification_does_not_drain_and_does_not_spin() {
         let t0 = Instant::now();

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -173,6 +173,12 @@ impl Driver {
         let before = self.sup.state();
         let mut events = Vec::new();
         let mut more_to_drain = false;
+        // Whether the API was already up **at entry**. Captured here
+        // because the block below may arm the detector during this very
+        // tick, and every observation in this loop reads the state as it
+        // was on entry — draining on the tick that first saw the API
+        // would act on a transition the supervisor has not applied yet.
+        let api_up_at_entry = self.detector.is_some();
 
         // Death first, and **before the deadline events**. A pidfd is
         // level-triggered, so an exit can still be readable on the very
@@ -206,20 +212,60 @@ impl Driver {
                 }
             }
 
-            // Only while the RESYNC is in flight — not merely while
-            // `is_converging()`, which also covers `Verifying`. Draining
-            // an already-empty map during verify would report
-            // `SyncComplete` on every pass; the supervisor ignores it,
-            // but "an event was applied" is what asks for an immediate
-            // re-tick, so it would spin a core through the whole verify.
-            if matches!(before, State::Syncing | State::AdoptedResyncing) {
+            // Drained in EVERY state with a live API, not only during a
+            // resync — because `drain_batch` also pulls the source's live
+            // changes, and after first convergence the module spends its
+            // life in `Ready`/`Steered`. Gated on the resync states (as
+            // this was) every route learned after attach would reach the
+            // eBPF tier and stop there: VPP would forward a frozen table,
+            // report healthy, and pass readback verification, since
+            // verify samples the mirror it was synced against.
+            //
+            // What stays gated is the *event*. `Ok(true)` outside a
+            // resync means "nothing pending", an unremarkable steady
+            // state; emitting `SyncComplete` for it would ask for an
+            // immediate re-tick on every pass and spin a core through
+            // the whole of `Verifying`.
+            //
+            // `Verifying` itself stays excluded, and for a second reason
+            // that outlives the spin: verify probes VPP for prefixes **the
+            // ledger believes are installed**, so a withdrawal applied
+            // between the sample and the probe makes VPP correctly answer
+            // "no route" and verify read it as a mismatch. That failure
+            // unsteers and restarts a VPP that was working. Deltas wait
+            // out the verify instead — bounded, and the source's map
+            // collapses per prefix, so waiting costs staleness rather
+            // than depth.
+            let resyncing = matches!(before, State::Syncing | State::AdoptedResyncing);
+            // `resyncing ||` and not `api_up_at_entry` alone: an ADOPTED
+            // process is already in a resync state on the very first
+            // tick, before the detector has been armed, and the old guard
+            // drained it there. Gating that behind `api_up_at_entry`
+            // withholds the first batch for one tick — long enough for
+            // the settled tick's sleep to run the resync phase deadline
+            // out and fail a convergence that was fine.
+            if (resyncing || api_up_at_entry) && before != State::Verifying {
                 match obs.drain_batch() {
                     // Empty means the resync is done — and only the
                     // drain can say so, which is why this is observed
                     // rather than assumed after issuing StartResync.
-                    Ok(true) => events.push(Event::SyncComplete),
+                    Ok(true) if resyncing => events.push(Event::SyncComplete),
+                    Ok(true) => {}
                     Ok(false) => more_to_drain = true,
-                    Err(_) => events.push(Event::ConvergenceFailed),
+                    // Failing mid-resync is a convergence failure: the
+                    // table is known-incomplete and nothing is forwarding
+                    // through it yet.
+                    Err(_) if resyncing => events.push(Event::ConvergenceFailed),
+                    // Failing in steady state is NOT. The batch stays in
+                    // the pending map, which is last-write-wins, so the
+                    // retry is free and idempotent — and treating one bad
+                    // round trip as a convergence failure would unsteer
+                    // and restart a VPP that is carrying traffic, at ~40 s
+                    // of resync, to fix a route that the next tick would
+                    // have installed. A VPP that has genuinely stopped
+                    // answering is the wedge detector's job, and it has a
+                    // measured budget for exactly that.
+                    Err(_) => more_to_drain = true,
                 }
             }
 

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -137,6 +137,54 @@ pub trait RouteSource {
     /// resolves), and traffic is dropped on the floor by an incomplete
     /// adjacency. Nothing in the module would report a fault.
     fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6]));
+
+    /// Changes since the last call, bounded by `max` routes.
+    ///
+    /// The default is "none", which is correct for a static snapshot: a
+    /// fixture mirror does not change under the engine, and every
+    /// in-tree implementation but the live feed is one of those. A source
+    /// that *does* change must override this, or its updates reach the
+    /// engine only at the next full resync.
+    ///
+    /// Both kinds come back from one call because they must be applied
+    /// together and in order — see [`SourceChanges`].
+    fn drain_changes(&self, _max: usize) -> SourceChanges {
+        SourceChanges::default()
+    }
+}
+
+/// One route change: the prefix, and its new nexthop set — or `None`
+/// if it was withdrawn.
+pub type RouteChange = (IpPrefix, Option<Vec<IpAddr>>);
+
+/// One neighbour change: the nexthop, and its (egress device, MAC) —
+/// or `None` if it is no longer resolved.
+pub type NeighbourChange = (IpAddr, Option<(String, [u8; 6])>);
+
+/// What changed at the source since it was last asked.
+///
+/// One struct rather than two calls so a tick cannot take the routes and
+/// leave the neighbours behind. The order they are applied in is not
+/// cosmetic: a route whose nexthop the engine's map has never seen is
+/// classified **unresolvable**, so neighbours must land first or a
+/// genuinely new nexthop black-holes its own routes until the next full
+/// resync.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SourceChanges {
+    /// Prefix → new nexthop set, or `None` for withdrawn.
+    pub routes: Vec<RouteChange>,
+    /// Nexthop → (egress device, MAC), or `None` for lost.
+    pub neighbours: Vec<NeighbourChange>,
+}
+
+impl SourceChanges {
+    pub fn is_empty(&self) -> bool {
+        self.routes.is_empty() && self.neighbours.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.routes.len() + self.neighbours.len()
+    }
 }
 
 /// What a full-table resync queued.
@@ -677,6 +725,43 @@ impl ConvergenceEngine {
     /// resolvability depends on it, and resolving against a stale map
     /// would classify routes unresolvable for a neighbour that has since
     /// been learned.
+    /// Pull live changes from the source into the pending map.
+    ///
+    /// Returns how many were taken. This only *queues* — sending is
+    /// `drain_batch`'s job, exactly as it is for a resync, so there is one
+    /// path to VPP rather than a steady-state one and a convergence one
+    /// that can disagree.
+    ///
+    /// **Neighbours before routes**, and the order is load-bearing: a
+    /// route whose nexthop the map has never seen is classified
+    /// unresolvable, so a new nexthop arriving in the same batch as the
+    /// routes that use it would black-hole them for a full resync cycle
+    /// if applied the other way round.
+    pub fn apply_changes(&mut self, src: &dyn RouteSource, max: usize) -> u64 {
+        let changes = src.drain_changes(max);
+        if changes.is_empty() {
+            return 0;
+        }
+        let n = changes.len() as u64;
+        for (nh, state) in changes.neighbours {
+            match state {
+                Some((dev, _mac)) => self.nexthops.set_device(nh, dev),
+                // Forgotten rather than left at its last known device —
+                // see `NexthopMap::forget_device`. The routes through it
+                // become unresolvable, which is the honest answer and the
+                // one health reports.
+                None => self.nexthops.forget_device(&nh),
+            }
+        }
+        for (prefix, nhs) in changes.routes {
+            match nhs {
+                Some(v) => self.pending.upsert(prefix, v),
+                None => self.pending.withdraw(prefix),
+            }
+        }
+        n
+    }
+
     pub fn begin_resync(&mut self, src: &dyn RouteSource) -> ResyncPlan {
         self.phase = Some(Phase::Resync);
 

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -151,6 +151,16 @@ pub trait RouteSource {
     fn drain_changes(&self, _max: usize) -> SourceChanges {
         SourceChanges::default()
     }
+
+    /// How many changes are queued but not yet handed over.
+    ///
+    /// Reported so a source that is filling faster than the engine drains
+    /// is visible as its own fault, rather than as an unexplained gap
+    /// between what bird advertises and what VPP holds. Default `0` for
+    /// the static sources, which never queue anything.
+    fn backlog(&self) -> u64 {
+        0
+    }
 }
 
 /// One route change: the prefix, and its new nexthop set — or `None`

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -672,41 +672,59 @@ impl ConvergenceEngine {
             });
         }
 
-        let t = self.transport.as_mut().expect("checked just above");
         let mut programmed = 0u64;
         for (ip, sw_if_index, mac_address) in wanted {
-            let reply =
-                match t.request::<IpNeighborAddDel, IpNeighborAddDelReply>(IpNeighborAddDel {
-                    context: 0,
-                    is_add: true,
-                    neighbor: IpNeighbor {
-                        sw_if_index,
-                        // Static: VPP must never age this out and never
-                        // ARP to refresh it, because it cannot receive
-                        // the reply.
-                        flags: IP_NEIGHBOR_STATIC,
-                        mac_address,
-                        ip_address: to_address(ip),
-                    },
-                }) {
-                    Ok(r) => r,
-                    Err(e) => {
-                        self.disconnect();
-                        return Err(EngineError::Transport(e));
-                    }
-                };
-            if reply.retval != 0 {
-                // Refused, not a broken socket. Loud rather than skipped:
-                // every route through this nexthop would install cleanly
-                // and then blackhole.
-                return Err(EngineError::NeighbourRefused {
-                    nexthop: ip,
-                    retval: reply.retval,
-                });
-            }
+            self.send_neighbour(ip, sw_if_index, mac_address, true)?;
             programmed += 1;
         }
         Ok(programmed)
+    }
+
+    /// One `ip_neighbor_add_del`, the single place this message is built.
+    ///
+    /// Extracted because there are now two callers — the resync walk and
+    /// the steady-state delta path — and a second hand-written copy of
+    /// this is how the tiers end up disagreeing about a flag. The static
+    /// bit especially: VPP must never age these out and never ARP to
+    /// refresh them, because it cannot receive the reply.
+    fn send_neighbour(
+        &mut self,
+        ip: IpAddr,
+        sw_if_index: u32,
+        mac_address: [u8; 6],
+        is_add: bool,
+    ) -> Result<(), EngineError> {
+        let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
+        let reply = match t.request::<IpNeighborAddDel, IpNeighborAddDelReply>(IpNeighborAddDel {
+            context: 0,
+            is_add,
+            neighbor: IpNeighbor {
+                sw_if_index,
+                flags: IP_NEIGHBOR_STATIC,
+                mac_address,
+                ip_address: to_address(ip),
+            },
+        }) {
+            Ok(r) => r,
+            Err(e) => {
+                self.disconnect();
+                return Err(EngineError::Transport(e));
+            }
+        };
+        if reply.retval != 0 {
+            // A removal VPP does not recognise is not a fault: the
+            // adjacency we wanted gone is gone. An *add* it refuses is,
+            // because every route through that nexthop would install
+            // cleanly and then blackhole.
+            if !is_add {
+                return Ok(());
+            }
+            return Err(EngineError::NeighbourRefused {
+                nexthop: ip,
+                retval: reply.retval,
+            });
+        }
+        Ok(())
     }
 
     /// Queue a full-table resync as a **diff** against the route source.
@@ -747,20 +765,54 @@ impl ConvergenceEngine {
     /// unresolvable, so a new nexthop arriving in the same batch as the
     /// routes that use it would black-hole them for a full resync cycle
     /// if applied the other way round.
-    pub fn apply_changes(&mut self, src: &dyn RouteSource, max: usize) -> u64 {
+    pub fn apply_changes(&mut self, src: &dyn RouteSource, max: usize) -> Result<u64, EngineError> {
         let changes = src.drain_changes(max);
         if changes.is_empty() {
-            return 0;
+            return Ok(0);
         }
         let n = changes.len() as u64;
         for (nh, state) in changes.neighbours {
             match state {
-                Some((dev, _mac)) => self.nexthops.set_device(nh, dev),
+                Some((dev, mac)) => {
+                    self.nexthops.set_device(nh, dev);
+                    // And PROGRAM it, which is the whole point.
+                    //
+                    // `set_device` alone makes `resolve` return `Some`, so
+                    // routes through this nexthop classify as resolvable
+                    // and install — while VPP, which runs without
+                    // linux-cp and can never ARP for the adjacency, has
+                    // nothing to send them to. Verification would not
+                    // catch it either: it checks a route exists on an
+                    // interface we own, deliberately not that its
+                    // adjacency resolves. That is #115's worst finding
+                    // exactly, arriving through the delta door instead of
+                    // the resync one.
+                    if let Some(idx) = self
+                        .nexthops
+                        .resolve(&nh)
+                        .and_then(|t| self.port_index.get(&t))
+                    {
+                        self.send_neighbour(nh, idx, mac, true)?;
+                    }
+                }
                 // Forgotten rather than left at its last known device —
                 // see `NexthopMap::forget_device`. The routes through it
                 // become unresolvable, which is the honest answer and the
                 // one health reports.
-                None => self.nexthops.forget_device(&nh),
+                //
+                // The adjacency is withdrawn from VPP first, while the
+                // mapping that names its interface is still there to
+                // withdraw it *with*.
+                None => {
+                    if let Some(idx) = self
+                        .nexthops
+                        .resolve(&nh)
+                        .and_then(|t| self.port_index.get(&t))
+                    {
+                        self.send_neighbour(nh, idx, [0; 6], false)?;
+                    }
+                    self.nexthops.forget_device(&nh);
+                }
             }
         }
         for (prefix, nhs) in changes.routes {
@@ -769,7 +821,7 @@ impl ConvergenceEngine {
                 None => self.pending.withdraw(prefix),
             }
         }
-        n
+        Ok(n)
     }
 
     pub fn begin_resync(&mut self, src: &dyn RouteSource) -> ResyncPlan {

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -52,11 +52,15 @@ use std::sync::Mutex;
 
 use packetframe_common::fib::{IpPrefix, ResolvedRouteSink};
 
-use crate::engine::RouteSource;
+use crate::engine::{RouteSource, SourceChanges};
 use crate::sink::PrefixKey;
 
 /// Index into [`Inner::sets`].
 type SetId = u32;
+
+/// A neighbour change as the feed stores it, before device names are
+/// resolved: the nexthop, and its (MAC, kernel ifindex) or `None`.
+type RawNeighChange = (IpAddr, Option<([u8; 6], u32)>);
 
 /// How many prefixes one lock acquisition copies out during a full-table
 /// walk.
@@ -83,6 +87,8 @@ pub struct FeedStats {
     /// route source, which is a different fault from VPP being slow.
     pub pending: u64,
     pub neighbours: u64,
+    /// Neighbour changes the engine has not drained yet.
+    pub pending_neighbours: u64,
     /// Distinct nexthop sets interned. Expected to sit near the
     /// topology's shape (129 nexthops / 2 devices as measured); an
     /// order-of-magnitude departure means the assumption behind
@@ -106,6 +112,17 @@ struct Inner {
     /// read path, not here: `if_indextoname` is a socket-and-ioctl on
     /// glibc, and this runs on the other tier's task.
     neighbours: HashMap<IpAddr, ([u8; 6], u32)>,
+    /// Neighbour → new state, or `None` for lost. Same shape and the same
+    /// reason as `pending`.
+    ///
+    /// Carried as deltas rather than re-walked, because the alternative
+    /// is a full neighbour refresh on every tick that has route changes —
+    /// ~129 entries and an `if_indextoname` each, repeatedly, to discover
+    /// that nothing moved. And it cannot simply be skipped: a route delta
+    /// naming a nexthop the engine's map has never seen classifies
+    /// **unresolvable**, so without this a genuinely new nexthop would
+    /// black-hole its routes until the next full resync.
+    neigh_pending: HashMap<IpAddr, Option<([u8; 6], u32)>>,
 }
 
 impl Inner {
@@ -138,30 +155,9 @@ impl RouteFeed {
             routes: g.routes.len() as u64,
             pending: g.pending.len() as u64,
             neighbours: g.neighbours.len() as u64,
+            pending_neighbours: g.neigh_pending.len() as u64,
             nexthop_sets: g.sets.len() as u64,
         }
-    }
-
-    /// Take up to `max` deltas in key order, removing them from the
-    /// pending map.
-    ///
-    /// `None` in the second position is a withdrawal. Returning owned
-    /// `Vec`s rather than borrowing the intern table is deliberate: the
-    /// caller applies them to the engine's own pending map, and holding
-    /// this lock while doing so would put the other tier's route updates
-    /// behind VPP's convergence.
-    pub fn drain(&self, max: usize) -> Vec<(IpPrefix, Option<Vec<IpAddr>>)> {
-        let mut g = self.lock();
-        let keys: Vec<PrefixKey> = g.pending.keys().take(max).copied().collect();
-        let mut out = Vec::with_capacity(keys.len());
-        for k in keys {
-            let Some(state) = g.pending.remove(&k) else {
-                continue;
-            };
-            let nhs = state.map(|id| g.sets[id as usize].clone());
-            out.push((k.into(), nhs));
-        }
-        out
     }
 
     /// `PoisonError` cannot mean what it usually means here.
@@ -200,15 +196,56 @@ impl ResolvedRouteSink for RouteFeed {
     }
 
     fn neighbour_resolved(&self, nh: IpAddr, mac: [u8; 6], ifindex: u32) {
-        self.lock().neighbours.insert(nh, (mac, ifindex));
+        let mut g = self.lock();
+        g.neighbours.insert(nh, (mac, ifindex));
+        g.neigh_pending.insert(nh, Some((mac, ifindex)));
     }
 
     fn neighbour_lost(&self, nh: IpAddr) {
-        self.lock().neighbours.remove(&nh);
+        let mut g = self.lock();
+        g.neighbours.remove(&nh);
+        // Queued even if the map held nothing, for the same reason a
+        // withdrawal is: the engine's nexthop map is filled by resync too,
+        // so it can know a mapping this feed has already dropped.
+        g.neigh_pending.insert(nh, None);
     }
 }
 
 impl RouteSource for RouteFeed {
+    fn drain_changes(&self, max: usize) -> SourceChanges {
+        // Neighbours are taken whole rather than bounded: there are ~129
+        // of them against ~1.05M routes, so a cap would add a resumption
+        // path for a set that cannot produce a batch worth resuming.
+        let (neigh_raw, routes) = {
+            let mut g = self.lock();
+            let neigh: Vec<RawNeighChange> = g.neigh_pending.drain().collect();
+            let keys: Vec<PrefixKey> = g.pending.keys().take(max).copied().collect();
+            let mut routes = Vec::with_capacity(keys.len());
+            for k in keys {
+                let Some(state) = g.pending.remove(&k) else {
+                    continue;
+                };
+                let nhs = state.map(|id| g.sets[id as usize].clone());
+                routes.push((IpPrefix::from(k), nhs));
+            }
+            (neigh, routes)
+        };
+        // Names resolved after the lock is dropped: `if_indextoname` is a
+        // syscall, and the writer is the other tier's task.
+        let neighbours = neigh_raw
+            .into_iter()
+            .map(|(ip, state)| {
+                let resolved = state.and_then(|(mac, idx)| {
+                    // A link that vanished between the notification and
+                    // here reads as a loss, not as a name we invented.
+                    if_indextoname(idx).map(|dev| (dev, mac))
+                });
+                (ip, resolved)
+            })
+            .collect();
+        SourceChanges { routes, neighbours }
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         // Chunked so the writer never waits for more than `WALK_CHUNK`
         // copies. `after` is the resume cursor; a prefix inserted below it
@@ -269,6 +306,9 @@ impl RouteSource for RouteFeed {
 /// to be a separate object, and two objects is two mirrors — the engine
 /// would resync from a table nothing was writing to.
 impl RouteSource for std::sync::Arc<RouteFeed> {
+    fn drain_changes(&self, max: usize) -> SourceChanges {
+        (**self).drain_changes(max)
+    }
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         (**self).for_each_route(visit)
     }
@@ -317,7 +357,7 @@ mod tests {
             f.route_resolved(v4(192, 0), &[nh(i)]);
         }
         assert_eq!(f.stats().pending, 1, "100 updates, one pending delta");
-        let drained = f.drain(64);
+        let drained = f.drain_changes(64).routes;
         assert_eq!(drained.len(), 1);
         assert_eq!(drained[0], (v4(192, 0), Some(vec![nh(99)])), "newest wins");
         assert_eq!(f.stats().pending, 0, "drain removes what it returned");
@@ -332,13 +372,17 @@ mod tests {
 
         f.route_resolved(v4(198, 18), &[nh(1)]);
         f.route_withdrawn(v4(198, 18));
-        assert_eq!(f.drain(64), vec![(v4(198, 18), None)], "withdraw wins");
+        assert_eq!(
+            f.drain_changes(64).routes,
+            vec![(v4(198, 18), None)],
+            "withdraw wins"
+        );
         assert_eq!(f.stats().routes, 0, "and leaves the mirror");
 
         f.route_withdrawn(v4(198, 19));
         f.route_resolved(v4(198, 19), &[nh(2)]);
         assert_eq!(
-            f.drain(64),
+            f.drain_changes(64).routes,
             vec![(v4(198, 19), Some(vec![nh(2)]))],
             "a fresh install must displace a queued withdrawal"
         );
@@ -355,7 +399,7 @@ mod tests {
     fn a_withdrawal_for_an_unknown_prefix_still_reaches_the_engine() {
         let f = RouteFeed::new();
         f.route_withdrawn(v4(203, 0));
-        assert_eq!(f.drain(64), vec![(v4(203, 0), None)]);
+        assert_eq!(f.drain_changes(64).routes, vec![(v4(203, 0), None)]);
     }
 
     /// `drain` is bounded and resumes in key order.
@@ -365,12 +409,12 @@ mod tests {
         for i in 0..10u8 {
             f.route_resolved(v4(10, i), &[nh(1)]);
         }
-        let first = f.drain(4);
+        let first = f.drain_changes(4).routes;
         assert_eq!(first.len(), 4);
         assert_eq!(first[0].0, v4(10, 0), "key order, lowest first");
         assert_eq!(f.stats().pending, 6, "the rest stay queued");
-        assert_eq!(f.drain(100).len(), 6);
-        assert!(f.drain(100).is_empty());
+        assert_eq!(f.drain_changes(100).routes.len(), 6);
+        assert!(f.drain_changes(100).routes.is_empty());
     }
 
     /// Equal nexthop sets share one intern entry; distinct ones do not.

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -246,6 +246,11 @@ impl RouteSource for RouteFeed {
         SourceChanges { routes, neighbours }
     }
 
+    fn backlog(&self) -> u64 {
+        let g = self.lock();
+        (g.pending.len() + g.neigh_pending.len()) as u64
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         // Chunked so the writer never waits for more than `WALK_CHUNK`
         // copies. `after` is the resume cursor; a prefix inserted below it
@@ -308,6 +313,9 @@ impl RouteSource for RouteFeed {
 impl RouteSource for std::sync::Arc<RouteFeed> {
     fn drain_changes(&self, max: usize) -> SourceChanges {
         (**self).drain_changes(max)
+    }
+    fn backlog(&self) -> u64 {
+        (**self).backlog()
     }
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         (**self).for_each_route(visit)

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -1,0 +1,484 @@
+//! The route feed: what the fast-path tier resolved, held for this one.
+//!
+//! One structure sits between the two tiers, written by the
+//! FibProgrammer's tokio task through [`ResolvedRouteSink`] and read by
+//! the supervision thread through [`crate::engine::RouteSource`]. It
+//! answers both of the engine's questions from the same state:
+//!
+//! - **"What is the whole table?"** — a resync walk, on first attach and
+//!   after every VPP restart.
+//! - **"What changed since I last asked?"** — the steady-state delta,
+//!   which before this had no entry point at all: the engine's pending
+//!   map was written only by resync, so a route learned after convergence
+//!   reached the eBPF tier and stopped there.
+//!
+//! ## Why deltas are a map and not a queue
+//!
+//! [`Inner::pending`] is keyed by prefix, so churn on one prefix collapses
+//! to one entry and the structure is bounded by **table size, not event
+//! rate**. A queue is the tempting shape and it fails exactly when it
+//! matters: under a peering flap it grows without bound, and the usual
+//! answer — drop the overflow and schedule a full resync — turns a flap
+//! into a resync loop that never converges, while the tier that is
+//! actually carrying traffic waits.
+//!
+//! `Option<SetId>` rather than two sets (changed + withdrawn), because
+//! two sets can hold the same prefix and then the answer depends on which
+//! one is read first. `None` is a withdrawal, and an insert overwrites,
+//! so last-write-wins is the structure's behaviour rather than a rule
+//! written next to it.
+//!
+//! ## Why nexthop sets are interned
+//!
+//! At the full table this holds ~1.05M prefixes. Storing a `Vec<IpAddr>`
+//! per prefix is a million small heap allocations and ~100 MB; storing a
+//! `u32` index into a table of distinct sets is ~40 MB and no per-route
+//! allocation. The table is small because the number of distinct nexthop
+//! sets is a property of the topology rather than of the table: the
+//! 2026-08-02 histogram of the live table found **129 nexthops across two
+//! egress devices** and zero ECMP groups.
+//!
+//! Nothing is ever evicted from it. Refcounting an intern table is a
+//! bookkeeping problem with a silent failure mode (a set freed while a
+//! prefix still names it), and the thing it would buy is bounded by that
+//! same topology: each entry is a `Vec` of a handful of addresses, so even
+//! a pathological ten thousand distinct sets is well under a megabyte.
+//! [`RouteFeed::stats`] exports the count so growth is visible rather
+//! than assumed.
+
+use std::collections::{BTreeMap, HashMap};
+use std::net::IpAddr;
+use std::sync::Mutex;
+
+use packetframe_common::fib::{IpPrefix, ResolvedRouteSink};
+
+use crate::engine::RouteSource;
+use crate::sink::PrefixKey;
+
+/// Index into [`Inner::sets`].
+type SetId = u32;
+
+/// How many prefixes one lock acquisition copies out during a full-table
+/// walk.
+///
+/// The walk cannot hold the lock throughout: the writer is the
+/// FibProgrammer's task, i.e. the control plane of the tier carrying
+/// production traffic, and a full-table copy takes long enough to be a
+/// visible stall in BGP convergence. Chunking bounds what a writer can
+/// ever wait for to one chunk's copy.
+///
+/// The cost of chunking is that the walk is not a coherent snapshot — a
+/// prefix can change after its chunk was copied. That is already the
+/// engine's normal condition (resync queues into the same prefix-keyed
+/// pending map that live deltas write, so the newer intent wins), which
+/// is what makes chunking free here rather than a correctness trade.
+const WALK_CHUNK: usize = 8192;
+
+/// Observable size of the feed, for health and metrics.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct FeedStats {
+    pub routes: u64,
+    /// Deltas the engine has not drained yet. Steady state is ~0; a
+    /// sustained non-zero means the engine is not keeping up with the
+    /// route source, which is a different fault from VPP being slow.
+    pub pending: u64,
+    pub neighbours: u64,
+    /// Distinct nexthop sets interned. Expected to sit near the
+    /// topology's shape (129 nexthops / 2 devices as measured); an
+    /// order-of-magnitude departure means the assumption behind
+    /// never-evicting has stopped holding.
+    pub nexthop_sets: u64,
+}
+
+#[derive(Default)]
+struct Inner {
+    /// The authoritative mirror: every prefix the other tier resolved.
+    routes: BTreeMap<PrefixKey, SetId>,
+    /// Interned nexthop sets, indexed by [`SetId`]. Append-only.
+    sets: Vec<Vec<IpAddr>>,
+    /// Reverse index for interning. Keyed by the set itself, which is
+    /// already sorted and deduplicated by the programmer — so equal sets
+    /// are equal `Vec`s and no canonicalisation is needed here.
+    set_ids: HashMap<Vec<IpAddr>, SetId>,
+    /// Prefix → new state, or `None` for withdrawn. See the module docs.
+    pending: BTreeMap<PrefixKey, Option<SetId>>,
+    /// Nexthop → (MAC, kernel egress ifindex). Names are resolved on the
+    /// read path, not here: `if_indextoname` is a socket-and-ioctl on
+    /// glibc, and this runs on the other tier's task.
+    neighbours: HashMap<IpAddr, ([u8; 6], u32)>,
+}
+
+impl Inner {
+    fn intern(&mut self, nexthops: &[IpAddr]) -> SetId {
+        if let Some(id) = self.set_ids.get(nexthops) {
+            return *id;
+        }
+        let id = self.sets.len() as SetId;
+        self.sets.push(nexthops.to_vec());
+        self.set_ids.insert(nexthops.to_vec(), id);
+        id
+    }
+}
+
+/// Shared between the two tiers. Cheap to clone the `Arc`; the lock is
+/// held only for map operations and bounded copies.
+#[derive(Default)]
+pub struct RouteFeed {
+    inner: Mutex<Inner>,
+}
+
+impl RouteFeed {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn stats(&self) -> FeedStats {
+        let g = self.lock();
+        FeedStats {
+            routes: g.routes.len() as u64,
+            pending: g.pending.len() as u64,
+            neighbours: g.neighbours.len() as u64,
+            nexthop_sets: g.sets.len() as u64,
+        }
+    }
+
+    /// Take up to `max` deltas in key order, removing them from the
+    /// pending map.
+    ///
+    /// `None` in the second position is a withdrawal. Returning owned
+    /// `Vec`s rather than borrowing the intern table is deliberate: the
+    /// caller applies them to the engine's own pending map, and holding
+    /// this lock while doing so would put the other tier's route updates
+    /// behind VPP's convergence.
+    pub fn drain(&self, max: usize) -> Vec<(IpPrefix, Option<Vec<IpAddr>>)> {
+        let mut g = self.lock();
+        let keys: Vec<PrefixKey> = g.pending.keys().take(max).copied().collect();
+        let mut out = Vec::with_capacity(keys.len());
+        for k in keys {
+            let Some(state) = g.pending.remove(&k) else {
+                continue;
+            };
+            let nhs = state.map(|id| g.sets[id as usize].clone());
+            out.push((k.into(), nhs));
+        }
+        out
+    }
+
+    /// `PoisonError` cannot mean what it usually means here.
+    ///
+    /// Every critical section is a map insert or a bounded copy, with no
+    /// `?`, no user callback, and nothing that can panic while the lock is
+    /// held — so a poisoned lock would mean a panic somewhere that cannot
+    /// panic. Recovering the guard keeps a bug in this file from taking
+    /// out the other tier's control plane, which is the one thing this
+    /// seam must never do.
+    fn lock(&self) -> std::sync::MutexGuard<'_, Inner> {
+        self.inner.lock().unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl ResolvedRouteSink for RouteFeed {
+    fn route_resolved(&self, prefix: IpPrefix, nexthops: &[IpAddr]) {
+        let mut g = self.lock();
+        let id = g.intern(nexthops);
+        let key = PrefixKey::from(prefix);
+        g.routes.insert(key, id);
+        g.pending.insert(key, Some(id));
+    }
+
+    fn route_withdrawn(&self, prefix: IpPrefix) {
+        let mut g = self.lock();
+        let key = PrefixKey::from(prefix);
+        g.routes.remove(&key);
+        // Queued even when the mirror held nothing. A withdrawal for a
+        // prefix this feed never saw still has to reach the engine: the
+        // engine's ledger is populated by resync as well as by these
+        // deltas, so it can hold prefixes the mirror has already lost, and
+        // swallowing the withdrawal here would leave one installed in VPP
+        // with nothing left to withdraw it.
+        g.pending.insert(key, None);
+    }
+
+    fn neighbour_resolved(&self, nh: IpAddr, mac: [u8; 6], ifindex: u32) {
+        self.lock().neighbours.insert(nh, (mac, ifindex));
+    }
+
+    fn neighbour_lost(&self, nh: IpAddr) {
+        self.lock().neighbours.remove(&nh);
+    }
+}
+
+impl RouteSource for RouteFeed {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        // Chunked so the writer never waits for more than `WALK_CHUNK`
+        // copies. `after` is the resume cursor; a prefix inserted below it
+        // mid-walk is missed by this pass and picked up as a pending
+        // delta, which is the same path every other live change takes.
+        let mut after: Option<PrefixKey> = None;
+        loop {
+            let chunk: Vec<(PrefixKey, Vec<IpAddr>)> = {
+                let g = self.lock();
+                let lower = match after {
+                    Some(k) => std::ops::Bound::Excluded(k),
+                    None => std::ops::Bound::Unbounded,
+                };
+                g.routes
+                    .range((lower, std::ops::Bound::Unbounded))
+                    .take(WALK_CHUNK)
+                    .map(|(k, id)| (*k, g.sets[*id as usize].clone()))
+                    .collect()
+            };
+            if chunk.is_empty() {
+                return;
+            }
+            after = Some(chunk[chunk.len() - 1].0);
+            for (k, nhs) in chunk {
+                visit(k.into(), &nhs);
+            }
+        }
+    }
+
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        // Copied out first, then resolved: `if_indextoname` is a syscall,
+        // and doing it under the lock would hold the other tier's task
+        // behind one per neighbour for no reason.
+        let snapshot: Vec<(IpAddr, [u8; 6], u32)> = {
+            let g = self.lock();
+            g.neighbours
+                .iter()
+                .map(|(ip, (mac, idx))| (*ip, *mac, *idx))
+                .collect()
+        };
+        for (ip, mac, ifindex) in snapshot {
+            // A vanished link is skipped rather than reported with a
+            // placeholder name: the caller matches the device against the
+            // configured ports, and an unresolvable name can only produce
+            // a wrong match or a confusing one. The neighbour is unusable
+            // either way, and its loss arrives as `neighbour_lost`.
+            if let Some(dev) = if_indextoname(ifindex) {
+                visit(ip, &dev, mac);
+            }
+        }
+    }
+}
+
+/// So the loader can hand the *same* feed to both tiers.
+///
+/// The programmer needs an `Arc<dyn ResolvedRouteSink>` and the engine
+/// needs a `Box<dyn RouteSource>`; without this the second one would have
+/// to be a separate object, and two objects is two mirrors — the engine
+/// would resync from a table nothing was writing to.
+impl RouteSource for std::sync::Arc<RouteFeed> {
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        (**self).for_each_route(visit)
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        (**self).for_each_neighbour(visit)
+    }
+}
+
+/// Kernel interface name for `ifindex`, or `None` if the link is gone.
+fn if_indextoname(ifindex: u32) -> Option<String> {
+    // IF_NAMESIZE, which `if_indextoname` requires the buffer to be.
+    let mut buf = [0u8; 16];
+    // SAFETY: `buf` is IF_NAMESIZE bytes as the call requires, and it
+    // writes a NUL-terminated name or returns null.
+    let rc = unsafe { libc::if_indextoname(ifindex, buf.as_mut_ptr() as *mut libc::c_char) };
+    if rc.is_null() {
+        return None;
+    }
+    let end = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+    std::str::from_utf8(&buf[..end]).ok().map(str::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn v4(a: u8, b: u8) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [a, b, 0, 0],
+            prefix_len: 16,
+        }
+    }
+
+    fn nh(last: u8) -> IpAddr {
+        IpAddr::V4(Ipv4Addr::new(10, 0, 0, last))
+    }
+
+    /// Churn on one prefix collapses to one delta. This is the property
+    /// that makes the feed bounded by table size instead of event rate,
+    /// so it is asserted as a count rather than inferred from the shape.
+    #[test]
+    fn churn_on_one_prefix_collapses_to_one_delta() {
+        let f = RouteFeed::new();
+        for i in 0..100u8 {
+            f.route_resolved(v4(192, 0), &[nh(i)]);
+        }
+        assert_eq!(f.stats().pending, 1, "100 updates, one pending delta");
+        let drained = f.drain(64);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0], (v4(192, 0), Some(vec![nh(99)])), "newest wins");
+        assert_eq!(f.stats().pending, 0, "drain removes what it returned");
+    }
+
+    /// A withdrawal after an upsert replaces it, and vice versa — the
+    /// direction that is easy to get backwards is the second one, where a
+    /// stale withdrawal must not survive a fresh install.
+    #[test]
+    fn the_newest_intent_wins_in_both_directions() {
+        let f = RouteFeed::new();
+
+        f.route_resolved(v4(198, 18), &[nh(1)]);
+        f.route_withdrawn(v4(198, 18));
+        assert_eq!(f.drain(64), vec![(v4(198, 18), None)], "withdraw wins");
+        assert_eq!(f.stats().routes, 0, "and leaves the mirror");
+
+        f.route_withdrawn(v4(198, 19));
+        f.route_resolved(v4(198, 19), &[nh(2)]);
+        assert_eq!(
+            f.drain(64),
+            vec![(v4(198, 19), Some(vec![nh(2)]))],
+            "a fresh install must displace a queued withdrawal"
+        );
+        assert_eq!(f.stats().routes, 1);
+    }
+
+    /// A withdrawal for a prefix the feed never held is still queued.
+    ///
+    /// The engine's ledger is filled by resync as well as by deltas, so it
+    /// can hold prefixes this mirror has already dropped. Swallowing the
+    /// withdrawal as "nothing to do" would leave that one installed in
+    /// VPP with nothing left to remove it.
+    #[test]
+    fn a_withdrawal_for_an_unknown_prefix_still_reaches_the_engine() {
+        let f = RouteFeed::new();
+        f.route_withdrawn(v4(203, 0));
+        assert_eq!(f.drain(64), vec![(v4(203, 0), None)]);
+    }
+
+    /// `drain` is bounded and resumes in key order.
+    #[test]
+    fn drain_is_bounded_and_ordered() {
+        let f = RouteFeed::new();
+        for i in 0..10u8 {
+            f.route_resolved(v4(10, i), &[nh(1)]);
+        }
+        let first = f.drain(4);
+        assert_eq!(first.len(), 4);
+        assert_eq!(first[0].0, v4(10, 0), "key order, lowest first");
+        assert_eq!(f.stats().pending, 6, "the rest stay queued");
+        assert_eq!(f.drain(100).len(), 6);
+        assert!(f.drain(100).is_empty());
+    }
+
+    /// Equal nexthop sets share one intern entry; distinct ones do not.
+    /// The count is the assertion because the memory argument for the
+    /// whole design rests on it.
+    #[test]
+    fn equal_nexthop_sets_are_interned_once() {
+        let f = RouteFeed::new();
+        for i in 0..50u8 {
+            f.route_resolved(v4(172, i), &[nh(1), nh(2)]);
+        }
+        assert_eq!(
+            f.stats().nexthop_sets,
+            1,
+            "50 prefixes over the same pair of nexthops is one set"
+        );
+        f.route_resolved(v4(172, 200), &[nh(1)]);
+        assert_eq!(f.stats().nexthop_sets, 2, "a different set is a new entry");
+        // Order matters for identity, and that is correct rather than a
+        // gap: the programmer hands over sorted, deduplicated unions, so
+        // two orderings of the same addresses cannot both arrive.
+        assert_eq!(f.stats().routes, 51);
+    }
+
+    /// The full-table walk visits every prefix exactly once, across more
+    /// chunks than one.
+    #[test]
+    fn the_walk_covers_the_table_across_chunk_boundaries() {
+        let f = RouteFeed::new();
+        let total = WALK_CHUNK * 2 + 7;
+        for i in 0..total {
+            f.route_resolved(
+                IpPrefix::V4 {
+                    addr: (i as u32).to_be_bytes(),
+                    prefix_len: 32,
+                },
+                &[nh(1)],
+            );
+        }
+        let mut seen = std::collections::HashSet::new();
+        let mut count = 0usize;
+        f.for_each_route(&mut |p, nhs| {
+            assert_eq!(nhs, [nh(1)]);
+            assert!(seen.insert(p), "{p:?} visited twice");
+            count += 1;
+        });
+        assert_eq!(count, total, "every prefix visited once");
+    }
+
+    /// The walk terminates on an empty table rather than spinning on the
+    /// resume cursor.
+    #[test]
+    fn the_walk_terminates_on_an_empty_table() {
+        let f = RouteFeed::new();
+        let mut count = 0;
+        f.for_each_route(&mut |_, _| count += 1);
+        assert_eq!(count, 0);
+    }
+
+    /// Neighbour resolution and loss are reflected in what the walk
+    /// reports. Loopback is used because it is the one ifindex a test can
+    /// rely on existing.
+    #[test]
+    fn neighbours_appear_and_disappear() {
+        let f = RouteFeed::new();
+        let lo = some_real_ifindex();
+        let mac = [2, 0, 0, 0, 0, 1];
+        f.neighbour_resolved(nh(1), mac, lo);
+        let mut seen = Vec::new();
+        f.for_each_neighbour(&mut |ip, dev, m| seen.push((ip, dev.to_string(), m)));
+        assert_eq!(seen.len(), 1, "the resolved neighbour is reported");
+        assert_eq!(seen[0].0, nh(1));
+        assert_eq!(seen[0].2, mac);
+        assert!(!seen[0].1.is_empty(), "with a device name");
+
+        f.neighbour_lost(nh(1));
+        let mut after = 0;
+        f.for_each_neighbour(&mut |_, _, _| after += 1);
+        assert_eq!(after, 0);
+    }
+
+    /// A neighbour whose link is gone is skipped, not reported with a
+    /// placeholder device.
+    #[test]
+    fn a_neighbour_on_a_vanished_link_is_skipped() {
+        let f = RouteFeed::new();
+        // No kernel assigns this ifindex; `if_indextoname` fails.
+        f.neighbour_resolved(nh(1), [2, 0, 0, 0, 0, 1], u32::MAX);
+        let mut seen = 0;
+        f.for_each_neighbour(&mut |_, _, _| seen += 1);
+        assert_eq!(seen, 0, "an unresolvable device name is not guessed at");
+        assert_eq!(
+            f.stats().neighbours,
+            1,
+            "but it stays recorded — the walk skipping it is not a delete"
+        );
+    }
+
+    /// Any ifindex this host will resolve to a name.
+    ///
+    /// Found by scanning rather than by naming loopback: `lo` on Linux is
+    /// `lo0` on macOS, and this file is not Linux-gated, so hard-coding
+    /// either one makes the test pass on one dev box and fail on the
+    /// other. Index 1 is loopback on both by convention, but scanning
+    /// does not need the convention to hold.
+    fn some_real_ifindex() -> u32 {
+        (1..=16)
+            .find(|i| if_indextoname(*i).is_some())
+            .expect("a host with no interfaces at index 1..16")
+    }
+}

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -54,6 +54,7 @@ pub mod cores;
 pub mod driver;
 pub mod engine;
 pub mod executor;
+pub mod feed;
 pub mod fib_sync;
 pub mod liveness;
 pub mod process;

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -67,6 +67,15 @@ use crate::supervisor::Event;
 /// blocking forever on a process the kernel will not release.
 pub const TERM_GRACE: Duration = Duration::from_millis(500);
 
+/// How many live route changes one tick pulls from the source.
+///
+/// Bounded for the same reason `drain_batch` is: this runs on the
+/// supervision thread, and an unbounded pull during a peering flap would
+/// hold the tick for as long as the flap lasted, sending no ping and
+/// noticing no exit. Whatever is left stays in the source's map — which
+/// collapses per prefix, so waiting costs staleness, never depth.
+const DELTA_BATCH: usize = 4096;
+
 /// The `(pid, start_ticks, boot_id)` triple that makes a recorded
 /// process identity safe to act on across restarts and PID reuse.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -456,9 +465,15 @@ impl Observe for ObserveView {
     }
 
     fn drain_batch(&mut self) -> Result<bool, String> {
-        self.core
-            .borrow_mut()
-            .engine
+        let mut c = self.core.borrow_mut();
+        // Live changes are pulled in FIRST, so a route learned while VPP
+        // was already converged goes out in this same batch rather than
+        // waiting for a resync that may never come. The engine's pending
+        // map is the single queue either way, so `done` below already
+        // accounts for whatever was just added.
+        let Core { engine, source, .. } = &mut *c;
+        engine.apply_changes(source.as_ref(), DELTA_BATCH);
+        engine
             .drain_batch()
             .map(|(done, _stats)| done)
             .map_err(|e| e.to_string())

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -213,6 +213,16 @@ struct Core {
     /// (an observed exit is a fact whether or not it can be recorded).
     /// Surfaced for status; never blocks the loop.
     last_store_error: Option<String>,
+    /// Why the last drain failed, or `None` if the last one succeeded.
+    ///
+    /// Recorded here rather than left to the caller because the caller
+    /// deliberately throws it away: outside a resync a failed batch is
+    /// retried, not escalated, so the driver's steady-state arm has no
+    /// event to carry a reason on. Without this the module would degrade
+    /// silently — the one shape this phase keeps producing — and the
+    /// operator would see a stalled `pending_ops` with nothing saying
+    /// why.
+    last_drain_error: Option<String>,
 }
 
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
@@ -253,6 +263,7 @@ impl Runtime {
                 attach_mode: crate::attach::AttachMode::Fresh,
                 pending: Vec::new(),
                 last_store_error: None,
+                last_drain_error: None,
             })),
         }
     }
@@ -327,6 +338,8 @@ impl Runtime {
             port_links: c.engine.port_links(),
             api_error: c.engine.last_api_error().map(str::to_string),
             store_error: c.last_store_error.clone(),
+            drain_error: c.last_drain_error.clone(),
+            source_backlog: c.source.backlog(),
         }
     }
 }
@@ -342,6 +355,15 @@ pub struct RuntimeStatus {
     pub port_links: Vec<crate::status::PortLink>,
     pub api_error: Option<String>,
     pub store_error: Option<String>,
+    /// Why the last drain failed. See `Core::last_drain_error`.
+    pub drain_error: Option<String>,
+    /// Changes the source is holding that the engine has not pulled yet.
+    ///
+    /// Distinct from `pending_ops`, which is what the engine has pulled
+    /// and not yet sent. Both can be non-zero at once and they fail
+    /// differently: a backlog here means the engine is not draining, a
+    /// backlog there means VPP is not accepting.
+    pub source_backlog: u64,
 }
 
 impl Core {
@@ -471,12 +493,23 @@ impl Observe for ObserveView {
         // waiting for a resync that may never come. The engine's pending
         // map is the single queue either way, so `done` below already
         // accounts for whatever was just added.
-        let Core { engine, source, .. } = &mut *c;
+        let Core {
+            engine,
+            source,
+            last_drain_error,
+            ..
+        } = &mut *c;
         engine.apply_changes(source.as_ref(), DELTA_BATCH);
-        engine
+        let r = engine
             .drain_batch()
             .map(|(done, _stats)| done)
-            .map_err(|e| e.to_string())
+            .map_err(|e| e.to_string());
+        // Set on failure and cleared on success, in one place, for the
+        // same reason `note_persist` is: a field that only ever gets set
+        // reports a fault that recovered as though it were still
+        // happening.
+        *last_drain_error = r.as_ref().err().cloned();
+        r
     }
 }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -499,11 +499,16 @@ impl Observe for ObserveView {
             last_drain_error,
             ..
         } = &mut *c;
-        engine.apply_changes(source.as_ref(), DELTA_BATCH);
-        let r = engine
-            .drain_batch()
-            .map(|(done, _stats)| done)
-            .map_err(|e| e.to_string());
+        // `?`-equivalent: a failed neighbour programming must not be
+        // followed by a route drain that installs paths through the
+        // adjacency that just failed to land.
+        let r = match engine.apply_changes(source.as_ref(), DELTA_BATCH) {
+            Err(e) => Err(e.to_string()),
+            Ok(_) => engine
+                .drain_batch()
+                .map(|(done, _stats)| done)
+                .map_err(|e| e.to_string()),
+        };
         // Set on failure and cleared on success, in one place, for the
         // same reason `note_persist` is: a field that only ever gets set
         // reports a fault that recovered as though it were still

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -711,6 +711,8 @@ fn run_loop(
             fib,
             rs.port_links,
             rs.store_error.clone(),
+            rs.drain_error.clone(),
+            rs.source_backlog,
         );
         let report = snap.report();
         let overall = report.overall;

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -278,6 +278,18 @@ impl NexthopMap {
         self.device_of.clear();
     }
 
+    /// Forget one nexthop's device, for a live loss between resyncs.
+    ///
+    /// The incremental half of [`Self::forget_devices`], and it exists
+    /// for exactly the failure that one describes: without it the delta
+    /// path is insert-only, so a nexthop the source reports as lost keeps
+    /// its last known device until the next full resync, and routes
+    /// naming it resolve as reachable through a stale interface rather
+    /// than being classified unresolvable.
+    pub fn forget_device(&mut self, nexthop: &IpAddr) {
+        self.device_of.remove(nexthop);
+    }
+
     /// Resolve one nexthop, or `None` if its device is excluded.
     pub fn resolve(&self, nexthop: &IpAddr) -> Option<NexthopTarget> {
         let dev = self.device_of.get(nexthop)?;

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -60,6 +60,8 @@ pub const SUBSYS_PORTS: &str = "ports";
 /// Reported only when a persist failed; see
 /// [`StatusSnapshot::store_error`].
 pub const SUBSYS_STATE_FILE: &str = "state-file";
+/// Subsystem name for the cross-tier route feed.
+pub const SUBSYS_ROUTE_FEED: &str = "route-feed";
 
 /// Liveness of the binary API, as observed from ping/pong timestamps.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -250,6 +252,20 @@ pub struct StatusSnapshot {
     /// patch existed to surface. Two surfaces, one condition, one place
     /// to encode it.
     pub store_error: Option<String>,
+    /// Why the last drain failed, or `None` if the last one succeeded.
+    ///
+    /// Its own field rather than folded into `api_error`, because the
+    /// two fail differently and only one of them is silent. An API error
+    /// already shows up as a ping failure and eventually a wedge; a drain
+    /// failure in steady state is deliberately *not* escalated — the
+    /// batch is retried — so without this the module would degrade with
+    /// nothing saying why.
+    pub drain_error: Option<String>,
+    /// Changes the route source is holding that the engine has not
+    /// pulled. Separate from `pending_ops`: a backlog here means the
+    /// engine is not draining, a backlog there means VPP is not
+    /// accepting.
+    pub source_backlog: u64,
 }
 
 impl StatusSnapshot {
@@ -275,6 +291,8 @@ impl StatusSnapshot {
             fib,
             ports,
             None,
+            None,
+            0,
         )
     }
 
@@ -293,6 +311,8 @@ impl StatusSnapshot {
         fib: FibSync,
         ports: Vec<PortLink>,
         store_error: Option<String>,
+        drain_error: Option<String>,
+        source_backlog: u64,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -307,6 +327,8 @@ impl StatusSnapshot {
             fib,
             ports,
             store_error,
+            drain_error,
+            source_backlog,
         }
     }
 
@@ -343,6 +365,22 @@ impl StatusSnapshot {
         // Only present when the runtime actually failed to persist
         // something, so the subsystem list does not carry a permanent
         // "state-file: fine" row nobody reads.
+        // Same shape and the same reason as the state-file row below:
+        // present only when it actually failed, so there is no permanent
+        // "route-feed: fine" line for an operator to learn to ignore.
+        if let Some(e) = &self.drain_error {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_ROUTE_FEED.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "could not apply route updates to VPP ({e}); {} change(s) waiting at the \
+                     source and {} queued for VPP. Retried every tick — the offload is forwarding \
+                     a table that is behind bird, not a wrong one.",
+                    self.source_backlog, self.pending_ops
+                )),
+                last_success_age_seconds: None,
+            });
+        }
         if let Some(e) = &self.store_error {
             subsystems.push(SubsystemHealth {
                 name: SUBSYS_STATE_FILE.into(),
@@ -431,6 +469,11 @@ impl StatusSnapshot {
             // restart", or the whitelist quietly stops covering the one
             // failure whose consequence is deferred.
             && self.store_error.is_none()
+            // A drain that is failing means VPP's FIB is drifting away
+            // from bird's with every update it misses. Nothing restarts
+            // over it by design, which is exactly why it must not read as
+            // nominal.
+            && self.drain_error.is_none()
     }
 
     fn process_health(&self) -> SubsystemHealth {
@@ -756,6 +799,28 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
         out,
         "packetframe_vpp_pending_ops{{module=\"{module}\"}} {}",
         snap.pending_ops
+    );
+
+    gauge(
+        &mut out,
+        "packetframe_vpp_source_backlog",
+        "route and neighbour changes the feed holds that the engine has not pulled",
+    );
+    let _ = writeln!(
+        out,
+        "packetframe_vpp_source_backlog{{module=\"{module}\"}} {}",
+        snap.source_backlog
+    );
+
+    gauge(
+        &mut out,
+        "packetframe_vpp_drain_failing",
+        "1 when the last attempt to push route updates to VPP failed",
+    );
+    let _ = writeln!(
+        out,
+        "packetframe_vpp_drain_failing{{module=\"{module}\"}} {}",
+        u8::from(snap.drain_error.is_some())
     );
 
     gauge(
@@ -1302,6 +1367,83 @@ mod tests {
             assert_eq!(ones, 1, "state {label} must be exactly one-hot:\n{m}");
             assert!(m.contains(&format!("state=\"{label}\"}} 1")), "{m}");
         }
+    }
+
+    /// A drain that keeps failing degrades health, names itself, and
+    /// says so on both surfaces.
+    ///
+    /// The policy is that a steady-state drain failure is retried rather
+    /// than escalated — nothing restarts, nothing unsteers. That is the
+    /// right call for a VPP carrying traffic, and it is exactly why this
+    /// has to be loud: the only thing distinguishing "retrying, will be
+    /// fine" from "VPP's FIB has been drifting from bird's for an hour"
+    /// is that somebody is told.
+    #[test]
+    fn a_failing_drain_degrades_and_is_named_on_both_surfaces() {
+        let clean = snap_of(
+            &steered_supervisor(),
+            &ledger_with(10, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::ZERO,
+            },
+            verified(1),
+            ports_up(),
+        );
+        assert_eq!(
+            clean.report().overall,
+            HealthState::Healthy,
+            "the control must be healthy or this proves nothing"
+        );
+
+        let mut degraded = clean.clone();
+        degraded.drain_error = Some("socket closed".into());
+        degraded.source_backlog = 12;
+        degraded.pending_ops = 34;
+
+        assert_eq!(degraded.report().overall, HealthState::Degraded);
+        assert!(
+            !degraded.nominal(),
+            "a drifting FIB must not read as nominal just because nothing restarted"
+        );
+
+        // Named, with both backlogs, because they point at different
+        // faults and the operator needs to know which one is stuck.
+        let sub = degraded
+            .report()
+            .subsystems
+            .into_iter()
+            .find(|s| s.name == SUBSYS_ROUTE_FEED)
+            .expect("the route feed must appear as its own subsystem");
+        assert_eq!(sub.state, HealthState::Degraded);
+        let msg = sub.message.unwrap_or_default();
+        assert!(msg.contains("socket closed"), "{msg}");
+        assert!(msg.contains("12"), "the source backlog is named: {msg}");
+        assert!(msg.contains("34"), "the queued count is named: {msg}");
+
+        // And Prometheus agrees. This is the pairing that `store_error`
+        // got wrong once: the report said Degraded while the gauge, built
+        // from a different input, went on saying healthy.
+        let m = render_metrics(&degraded, "vpp-offload");
+        assert!(
+            m.contains("packetframe_vpp_health{module=\"vpp-offload\",state=\"degraded\"} 1"),
+            "the gauge disagrees with the report: {m}"
+        );
+        assert!(
+            m.contains("packetframe_vpp_drain_failing{module=\"vpp-offload\"} 1"),
+            "{m}"
+        );
+        assert!(
+            m.contains("packetframe_vpp_source_backlog{module=\"vpp-offload\"} 12"),
+            "{m}"
+        );
+
+        // A recovered drain stops degrading — the clearing observation,
+        // without which a fault that healed reports forever.
+        let mut recovered = degraded.clone();
+        recovered.drain_error = None;
+        assert_eq!(recovered.report().overall, HealthState::Healthy);
+        assert!(!render_metrics(&recovered, "vpp-offload")
+            .contains("packetframe_vpp_drain_failing{module=\"vpp-offload\"} 1"));
     }
 
     #[test]

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -535,3 +535,102 @@ fn local_interface() -> (u32, String) {
     }
     panic!("no usable interface at index 1..16");
 }
+
+/// A nexthop first seen **after** convergence gets its static neighbour
+/// programmed, not just its device mapping.
+///
+/// This is #115's worst finding arriving through a different door. Giving
+/// the nexthop a device is enough for `NexthopMap::resolve` to return
+/// `Some`, so routes through it classify as resolvable and install — and
+/// VPP, which runs without linux-cp and can never ARP for the adjacency,
+/// has nothing to send them to. Readback verification does not catch it
+/// either: it checks a route exists on an interface we own, deliberately
+/// not that its adjacency resolves. Route acks, verify passes, every
+/// packet drops.
+#[test]
+fn a_nexthop_first_seen_after_convergence_gets_its_adjacency() {
+    use packetframe_common::fib::ResolvedRouteSink as _;
+    use packetframe_vpp_offload::driver::Observe as _;
+    use packetframe_vpp_offload::feed::RouteFeed;
+    use std::sync::Arc;
+
+    let (ifindex, dev) = local_interface();
+    let fake = Fake::start("late-nexthop");
+    let feed = Arc::new(RouteFeed::new());
+    feed.neighbour_resolved(fake_vpp::nh(), MAC, ifindex);
+    feed.route_resolved(fake_vpp::v4(0, 1), &[fake_vpp::nh()]);
+
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: dev.clone(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec![dev],
+        1_000_000,
+        FamilyPolicy::V4Only,
+    );
+    let rt = Runtime::new(
+        engine,
+        Box::new(feed.clone()),
+        Box::new(SteeringUnavailable),
+        Box::new(NullStore),
+        Box::new(NoResources),
+        "/usr/bin/vpp",
+        "/tmp/startup.conf",
+    );
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (mut now, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    let _ = fake.drain_events();
+
+    // A nexthop the engine has never seen, arriving with a route through
+    // it — the order the feed delivers them in is what the fix depends on.
+    let late_nh = std::net::IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 9));
+    let late_mac = [0x02, 0x00, 0x5e, 0x00, 0x00, 0x09];
+    feed.neighbour_resolved(late_nh, late_mac, ifindex);
+    feed.route_resolved(fake_vpp::v4(0, 201), &[late_nh]);
+
+    let mut saw_neigh = false;
+    for _ in 0..64 {
+        let t = {
+            let (mut obs, mut fx) = rt.views();
+            d.tick(now, &mut obs, &mut fx)
+        };
+        for e in rt.take_pending() {
+            let (_, mut fx) = rt.views();
+            d.inject(now, e, &mut fx);
+        }
+        for e in fake.drain_events() {
+            if let fake_vpp::Event::Neighbour { mac, .. } = e {
+                if mac == late_mac {
+                    saw_neigh = true;
+                }
+            }
+        }
+        if saw_neigh {
+            break;
+        }
+        now += t
+            .sleep
+            .unwrap_or(Duration::from_millis(100))
+            .max(Duration::from_millis(1));
+    }
+
+    assert!(
+        saw_neigh,
+        "the new nexthop's static neighbour was never programmed — its routes \
+         would install, verify clean, and blackhole"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -394,3 +394,144 @@ fn a_successful_spawn_persist_clears_an_earlier_store_failure() {
         rt.status().store_error
     );
 }
+
+/// A route learned **after** convergence reaches VPP.
+///
+/// The regression this exists for is a silent one. `drain_batch` used to
+/// be called only while a resync was in flight, so once the module
+/// settled into `Ready` — where it spends its life — nothing pulled the
+/// source again. VPP would forward a frozen table, report healthy, and
+/// pass readback verification, because verification samples the very
+/// mirror it was synced against. Nothing would have said a word.
+///
+/// So the assertion is deliberately about the wire, not about counters:
+/// the fake must actually receive the prefix.
+///
+/// The port is named after a real local interface, because the feed
+/// resolves a neighbour's egress device through `if_indextoname` and the
+/// engine matches that name against the configured ports. Inventing
+/// "eth4" here would make every route unresolvable for a reason that has
+/// nothing to do with what is under test.
+#[test]
+fn a_route_learned_after_convergence_still_reaches_vpp() {
+    use packetframe_common::fib::ResolvedRouteSink as _;
+    use packetframe_vpp_offload::driver::Observe as _;
+    use packetframe_vpp_offload::feed::RouteFeed;
+    use std::sync::Arc;
+
+    let (ifindex, dev) = local_interface();
+    let fake = Fake::start("late-route");
+    let feed = Arc::new(RouteFeed::new());
+    feed.neighbour_resolved(fake_vpp::nh(), MAC, ifindex);
+    feed.route_resolved(fake_vpp::v4(0, 1), &[fake_vpp::nh()]);
+
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: dev.clone(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+        }],
+        vec![dev],
+        1_000_000,
+        FamilyPolicy::V4Only,
+    );
+    let rt = Runtime::new(
+        engine,
+        Box::new(feed.clone()),
+        Box::new(SteeringUnavailable),
+        Box::new(NullStore),
+        Box::new(NoResources),
+        "/usr/bin/vpp",
+        "/tmp/startup.conf",
+    );
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (mut now, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    assert_eq!(
+        rt.status().counts.installed,
+        1,
+        "the seeded route converged before the part under test"
+    );
+    let _ = fake.drain_events();
+
+    // THE POINT: a new route arrives with the module already settled.
+    let late_addr = [10u8, 0, 200, 0];
+    feed.route_resolved(fake_vpp::v4(0, 200), &[fake_vpp::nh()]);
+
+    // Hand-rolled rather than `run_until`, because the stop condition has
+    // to accumulate the fake's events: `drain_events` empties the channel,
+    // so a closure that polled it would throw away the very sighting it
+    // was waiting for.
+    let mut saw_late = false;
+    let mut events = Vec::new();
+    for _ in 0..64 {
+        let t = {
+            let (mut obs, mut fx) = rt.views();
+            d.tick(now, &mut obs, &mut fx)
+        };
+        events.extend(t.events.clone());
+        // Same seam the real loop uses; without it a completed verify
+        // never lands and the module eventually reports a wedge, which
+        // would bury this test's actual finding under restart noise.
+        for e in rt.take_pending() {
+            let (_, mut fx) = rt.views();
+            events.extend(d.inject(now, e, &mut fx).events);
+        }
+        for e in fake.drain_events() {
+            if let fake_vpp::Event::Route(r) = e {
+                if r.addr == late_addr && r.is_add {
+                    saw_late = true;
+                }
+            }
+        }
+        if saw_late {
+            break;
+        }
+        now += t
+            .sleep
+            .unwrap_or(Duration::from_millis(100))
+            .max(Duration::from_millis(1));
+    }
+
+    assert!(
+        saw_late,
+        "a route learned after convergence never reached VPP; events: {events:?}"
+    );
+    assert_eq!(
+        d.state(),
+        State::Ready,
+        "and the module stayed Ready — a live delta is ordinary work, \
+         not a reason to resync, unsteer, or re-verify"
+    );
+}
+
+/// A real (ifindex, name) pair from this host.
+///
+/// Scanned rather than hard-coded: `lo` on Linux is `lo0` on macOS, and
+/// this test runs on both.
+fn local_interface() -> (u32, String) {
+    for idx in 1..=16u32 {
+        let mut buf = [0u8; 16];
+        // SAFETY: `buf` is IF_NAMESIZE bytes, as the call requires.
+        let rc = unsafe { libc::if_indextoname(idx, buf.as_mut_ptr() as *mut libc::c_char) };
+        if rc.is_null() {
+            continue;
+        }
+        let end = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+        if let Ok(name) = std::str::from_utf8(&buf[..end]) {
+            return (idx, name.to_string());
+        }
+    }
+    panic!("no usable interface at index 1..16");
+}


### PR DESCRIPTION
Task #26, the second half. #122 added the producer seam; this adds the consumer, the steady-state delta path, its health surface, and the loader wiring. **`module vpp-offload` is no longer refused at startup.**

## The four commits

| | |
|---|---|
| `RouteFeed` | One structure answering both of the engine's questions — the whole table, and what changed |
| Delta seam | A route learned *after* convergence now reaches VPP |
| Health | A drifting FIB says so on both surfaces |
| Loader | One feed, handed to both tiers; refusal removed |

## The bug that was waiting

`drain_batch` was called **only** while a resync was in flight. After first convergence the module lives in `Ready`/`Steered`, so nothing would ever have pulled the source again: every route learned after attach would have reached the eBPF tier and stopped there. VPP would forward a frozen table, report healthy, and pass readback verification — because verification samples the mirror it was synced against. Nothing would have said a word.

The drain now runs in every state with a live API. What stays gated is the *event*, which is what the narrow guard was really protecting.

**`Verifying` stays excluded, for a reason the old comment didn't give.** Verify probes VPP for prefixes the ledger believes are installed, so a withdrawal applied between the sample and the probe makes VPP correctly answer "no route" and verify reads it as a mismatch — unsteering and restarting a VPP that was working. The existing test asserted this and was right for a reason it didn't state; it's stated now.

## Design notes

- **Deltas are a prefix-keyed map, not a queue** — bounded by table size, not event rate. A queue fails exactly under a peering flap, and the usual rescue (drop the overflow, force a resync) turns a flap into a resync loop while the tier carrying traffic waits.
- **One map of `Option<SetId>`**, not a changed-set plus a withdrawn-set, so last-write-wins is what the structure *does* rather than a rule written beside it. Both directions tested, including the one that's easy to get backwards.
- **Nexthop sets are interned**, never evicted: ~1.05M prefixes at a `Vec` each is a million allocations and ~100 MB versus a `u32` and ~40 MB. The count is exported so the "distinct sets are a topology property" assumption is observable rather than assumed.
- **The full-table walk chunks its locking** — the writer is the programmer's task, i.e. the production tier's control plane, so holding the lock across a million copies would be a visible BGP convergence stall.
- **Neighbour changes ride the same path and apply first.** A route whose nexthop the map has never seen classifies unresolvable, so a new nexthop arriving with the routes that use it would black-hole them for a full resync cycle if applied the other way round.

## Failure policy (as decided)

Mid-resync failure is still `ConvergenceFailed` — the table is known-incomplete and nothing forwards through it. **Steady-state failure is not**: the batch stays in the last-write-wins pending map and is retried, because treating one bad round trip as a convergence failure would unsteer and restart a VPP carrying traffic, at ~40 s of resync, to fix a route the next tick would have installed. Escalation belongs to the wedge detector, which has a measured budget.

Writing that retry arm I dropped the error string on the floor — the exact defect class this phase keeps producing. The runtime now records it where it happens, set on failure and **cleared on success**, as a snapshot field so the report and the Prometheus gauge cannot disagree. Health gains a `route-feed` subsystem row and `nominal()` gains the clause: a FIB drifting further from bird's with every missed update must not read as nominal merely because nothing restarted over it.

## Ordering

The loader refuses `vpp-offload` without a `fast-path` section, and refuses them declared the wrong way round, rather than reordering silently. Both are a pure `feed_wiring()` so they're tested rather than reasoned about.

**Stated in the code where someone will find it:** this does *not* guarantee the table is complete when vpp-offload attaches — bird's initial dump takes time, so the first convergence may cover a fraction and the rest arrives as deltas. Safe only because a first attach never steers. When slice 5 lands, "the table is complete" becomes a precondition of the first steer.

## Testing

589 tests. The end-to-end one asserts the **wire**, not a counter: converge, push a route with the module already `Ready`, require the fake VPP to receive that prefix while the state never leaves `Ready` — verified to fail with the old guard. Two mistakes of mine were caught by existing driver tests: keying the new guard on state the same tick mutates, and then withholding the first batch from an *adopted* process (already in a resync state on tick one), which let the phase deadline expire and failed a convergence that was fine.

Locally: fmt, host clippy, and `--workspace --all-targets --all-features` clippy on all four published targets. The loader's ordering tests are Linux-gated and run in CI's Linux job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)