### PR TITLE
feat(vpp-offload): read VPP's FIB back so adoption can withdraw

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -41,12 +41,15 @@ use std::time::Duration;
 use packetframe_common::fib::IpPrefix;
 
 use crate::attach::{attach_ports, AttachError, AttachMode, AttachedPort, PortAttach};
-use crate::fib_sync::to_address;
+use crate::fib_sync::{from_prefix, to_address};
 use crate::fib_sync::{DrainStats, Drainer, FamilyPolicy, PortIndex, ResolvedPath, DEFAULT_WINDOW};
 use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
 use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
-use crate::vpp_api::generated::{IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply};
+use crate::vpp_api::generated::{
+    IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute, IpRouteDetails, IpRouteDump,
+    IpTable, FIB_API_PATH_TYPE_NORMAL,
+};
 use crate::vpp_api::{Transport, TransportError};
 
 /// `IP_API_NEIGHBOR_FLAG_STATIC` from ip_neighbor.api.
@@ -727,27 +730,106 @@ impl ConvergenceEngine {
         Ok(())
     }
 
+    /// Seed the ledger from VPP's own FIB, so an adoption can compute
+    /// withdrawals.
+    ///
+    /// Only acts when the ledger is **empty**, which is the condition
+    /// rather than an adoption flag: an empty ledger means this process
+    /// has no record of what VPP holds, whether because it just adopted
+    /// a survivor or because it is starting fresh. A freshly spawned VPP
+    /// answers with its own infrastructure routes and none of them pass
+    /// the filter below, so the fresh case seeds nothing and costs one
+    /// round trip.
+    ///
+    /// ## What it deliberately does NOT adopt, and why that matters
+    ///
+    /// VPP's FIB is not only ours. A fresh instance already holds drop
+    /// routes, connected routes for interface subnets, and local `/32`s
+    /// for interface addresses — all created by VPP itself. Seeding
+    /// those would hand them to the resync diff, which withdraws
+    /// everything the route source does not advertise, and the next
+    /// convergence would delete the infrastructure VPP needs to resolve
+    /// any adjacency at all.
+    ///
+    /// So a dumped route is adopted only if it looks like something this
+    /// module installed: at least one path that is
+    /// `FIB_API_PATH_TYPE_NORMAL`, egresses an interface **we** own, and
+    /// carries a **non-zero nexthop address**. That last clause is what
+    /// excludes connected routes, which are attached and therefore have
+    /// no nexthop; type excludes local and drop. Anything else is left
+    /// alone — an unadopted route is one we will not withdraw, which is
+    /// the safe direction.
+    pub fn adopt_vpp_fib(&mut self) -> Result<u64, EngineError> {
+        if !self.ledger.known_prefixes().is_empty() {
+            return Ok(0);
+        }
+        self.arm_timeout();
+        if self.transport.is_none() {
+            return Err(EngineError::NotConnected);
+        }
+
+        let mut adopted = 0u64;
+        for &is_ip6 in self.drainer.families().dump_families() {
+            let t = self.transport.as_mut().expect("checked just above");
+            let details: Vec<IpRouteDetails> = match t.dump(IpRouteDump {
+                context: 0,
+                table: IpTable {
+                    table_id: 0,
+                    is_ip6,
+                    name: String::new(),
+                },
+            }) {
+                Ok(d) => d,
+                Err(e) => {
+                    self.disconnect();
+                    return Err(EngineError::Transport(e));
+                }
+            };
+            for d in details {
+                let Some(prefix) = from_prefix(&d.route.prefix) else {
+                    continue;
+                };
+                if !self.drainer.families().carries(prefix) {
+                    continue;
+                }
+                if !self.looks_self_installed(&d.route) {
+                    continue;
+                }
+                self.ledger.adopt_installed(prefix);
+                adopted += 1;
+            }
+        }
+        Ok(adopted)
+    }
+
+    /// Whether a route read back from VPP is one this module installed.
+    /// See [`Self::adopt_vpp_fib`] for why the answer must be
+    /// conservative.
+    fn looks_self_installed(&self, route: &IpRoute) -> bool {
+        route.paths.iter().any(|p| {
+            p.r#type == FIB_API_PATH_TYPE_NORMAL
+                && self.port_index.owns(p.sw_if_index)
+                && p.nh.address.0.iter().any(|b| *b != 0)
+        })
+    }
+
     /// Queue a full-table resync as a **diff** against the route source.
     ///
-    /// ## Known gap: adoption cannot compute withdrawals
+    /// ## Adoption withdrawals: closed by the FIB readback
     ///
     /// The diff derives deletions from `ledger.known_prefixes()`, and on
-    /// **adoption** the ledger starts empty while VPP's FIB does not. A
-    /// prefix withdrawn while packetframe was down therefore stays
-    /// installed in the surviving VPP, where a stale more-specific can
-    /// keep overriding the live table — and verification cannot see it,
-    /// because it samples only what the ledger knows.
+    /// **adoption** the ledger starts empty while VPP's FIB does not — so
+    /// a prefix withdrawn while packetframe was down used to stay
+    /// installed in the surviving VPP, where a stale more-specific keeps
+    /// overriding the live table, invisible to verification because it
+    /// samples only what the ledger knows.
     ///
-    /// Closing it needs VPP's own FIB read back, and `ip_route_dump` is
-    /// **not in the generated API whitelist** — so it needs a codegen
-    /// addition plus the regenerate-and-diff CI, not a change here.
-    /// Persisting the installed prefix set to the state file is not the
-    /// alternative: that is 1.05M prefixes rewritten continuously.
-    ///
-    /// Until then an adopted VPP's FIB is only reconciled for prefixes
-    /// the source still advertises. Recorded rather than papered over,
-    /// because the adoption path is precisely the one that keeps
-    /// forwarding while it converges.
+    /// [`Self::adopt_vpp_fib`] now seeds the ledger from `ip_route_dump`
+    /// before this runs, so the diff below sees what VPP actually holds
+    /// and withdraws accordingly. Callers must invoke it first;
+    /// `Runtime::start_resync` does. Persisting the installed prefix set
+    /// to the state file was the alternative and is not one: that is
+    /// 1.05M prefixes rewritten continuously.
     ///
     /// Refreshes the nexthop→device mapping first: a route's
     /// resolvability depends on it, and resolving against a stale map

--- a/crates/modules/vpp-offload/src/fib_sync.rs
+++ b/crates/modules/vpp-offload/src/fib_sync.rs
@@ -94,6 +94,12 @@ impl PortIndex {
     pub fn indices(&self) -> std::collections::HashSet<u32> {
         self.idx.values().copied().collect()
     }
+
+    /// Whether `sw_if_index` is one of ours. Same source of truth as
+    /// [`Self::indices`], without materialising the set for one lookup.
+    pub fn owns(&self, sw_if_index: u32) -> bool {
+        self.idx.values().any(|v| *v == sw_if_index)
+    }
 }
 
 /// Wire form of an address, family tag and all.
@@ -136,6 +142,29 @@ fn withdraw_msg(prefix: IpPrefix) -> IpRouteAddDel {
 }
 
 /// Wire form of a prefix.
+/// `Prefix` back into an `IpPrefix`, for routes read out of VPP.
+///
+/// `None` for an address family we do not carry, rather than a guess:
+/// the caller uses this to decide what to withdraw, and inventing a
+/// prefix there deletes a route.
+pub fn from_prefix(p: &Prefix) -> Option<IpPrefix> {
+    match p.address.af {
+        ADDRESS_IP4 => {
+            let mut addr = [0u8; 4];
+            addr.copy_from_slice(&p.address.un.0[..4]);
+            Some(IpPrefix::V4 {
+                addr,
+                prefix_len: p.len,
+            })
+        }
+        ADDRESS_IP6 => Some(IpPrefix::V6 {
+            addr: p.address.un.0,
+            prefix_len: p.len,
+        }),
+        _ => None,
+    }
+}
+
 pub fn to_prefix(p: IpPrefix) -> Prefix {
     match p {
         IpPrefix::V4 { addr, prefix_len } => {
@@ -275,6 +304,19 @@ pub enum FamilyPolicy {
 }
 
 impl FamilyPolicy {
+    /// The `is_ip6` flags to issue an `ip_route_dump` for.
+    ///
+    /// Derived from the same policy that decides what gets installed, so
+    /// a readback can never cover a family the sink does not carry —
+    /// adopting v6 routes under `V4Only` would hand the resync diff a set
+    /// it will never re-install and therefore withdraw wholesale.
+    pub fn dump_families(self) -> &'static [bool] {
+        match self {
+            FamilyPolicy::Both => &[false, true],
+            FamilyPolicy::V4Only => &[false],
+        }
+    }
+
     pub fn carries(self, prefix: IpPrefix) -> bool {
         match self {
             FamilyPolicy::Both => true,
@@ -365,6 +407,12 @@ impl Drainer {
             window: window.max(1),
             families: FamilyPolicy::default(),
         }
+    }
+
+    /// Which families reach VPP, for callers that must apply the same
+    /// policy outside the drain path — the FIB readback especially.
+    pub fn families(&self) -> FamilyPolicy {
+        self.families
     }
 
     /// Override which families reach VPP. See [`FamilyPolicy`].

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -616,6 +616,19 @@ impl Effects for EffectsView {
         // Split borrow: the engine walks the source while both live in
         // the same core.
         let Core { engine, source, .. } = &mut *c;
+        // BEFORE the diff, because the diff is what consumes it: the
+        // ledger's contents are where withdrawals come from, and on an
+        // adoption it is empty while the surviving VPP's FIB is not.
+        // A no-op unless the ledger is empty, so a fresh spawn pays one
+        // round trip and adopts nothing.
+        let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
+        if adopted > 0 {
+            tracing::info!(
+                routes = adopted,
+                "adopted VPP's existing FIB; the resync diff can now withdraw what the \
+                 route source no longer advertises"
+            );
+        }
         let _plan = engine.begin_resync(source.as_ref());
         // Neighbours between attach and the first drain, and fatal on
         // refusal: a route through an unprogrammed adjacency installs

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -586,6 +586,31 @@ impl RouteLedger {
     }
 
     /// VPP acknowledged the route.
+    /// Record a prefix VPP is **observed** to already hold.
+    ///
+    /// For adoption, and only for adoption: the ledger starts empty
+    /// while a surviving VPP's FIB does not, so without this the resync
+    /// diff — which derives withdrawals from what the ledger knows —
+    /// cannot see a prefix that was withdrawn while packetframe was
+    /// down, and it stays installed where a stale more-specific keeps
+    /// overriding the live table.
+    ///
+    /// `Installed` is honest here rather than optimistic: the caller
+    /// read it out of VPP with `ip_route_dump`. That is a stronger
+    /// observation than the one `commit_installed` acts on, which is an
+    /// acknowledgement of our own write.
+    ///
+    /// Refuses to overwrite a prefix the ledger already tracks — a
+    /// readback must not stomp an in-flight `Installing`, and a
+    /// non-empty ledger means this is not an adoption.
+    pub fn adopt_installed(&mut self, prefix: IpPrefix) {
+        let key = PrefixKey::from(prefix);
+        if self.state.contains_key(&key) {
+            return;
+        }
+        self.set_state(key, RouteState::Installed);
+    }
+
     pub fn commit_installed(&mut self, prefix: IpPrefix) {
         let key = PrefixKey::from(prefix);
         if matches!(self.state.get(&key), Some(RouteState::Installing { .. })) {

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -29,6 +29,8 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "ip_route_add_del_reply", crc: "0x1992deab", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "ip_route_lookup", crc: "0x710d6471", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "ip_route_lookup_reply", crc: "0x5d8febcb", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "ip_route_dump", crc: "0xb9d2e09e", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "ip_route_details", crc: "0xbda8f315", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "ip_neighbor_add_del", crc: "0x0607c257", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "ip_neighbor_add_del_reply", crc: "0x1992deab", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_flags", crc: "0xf5aec1b8", context_offset: 6, client_index_prefix: true },
@@ -365,6 +367,41 @@ impl Decode for IpRoute {
             prefix,
             n_paths,
             paths,
+        })
+    }
+}
+
+/// `ip_table` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IpTable {
+    pub table_id: u32,
+    pub is_ip6: bool,
+    pub name: String,
+}
+
+impl Encode for IpTable {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.table_id).to_be_bytes());
+        buf.push(if self.is_ip6 { 1u8 } else { 0u8 });
+        {
+            let mut tmp = [0u8; 64];
+            let b = self.name.as_bytes();
+            let k = b.len().min(64);
+            tmp[..k].copy_from_slice(&b[..k]);
+            buf.extend_from_slice(&tmp);
+        }
+    }
+}
+
+impl Decode for IpTable {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let table_id = d.u32()?;
+        let is_ip6 = d.bool()?;
+        let name = d.string_fixed(64)?;
+        Ok(Self {
+            table_id,
+            is_ip6,
+            name,
         })
     }
 }
@@ -817,6 +854,75 @@ impl Decode for IpRouteLookupReply {
 impl Message for IpRouteLookupReply {
     const NAME: &'static str = "ip_route_lookup_reply";
     const CRC: &'static str = "0x5d8febcb";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `ip_route_dump` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IpRouteDump {
+    pub context: u32,
+    pub table: IpTable,
+}
+
+impl Encode for IpRouteDump {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        self.table.encode(buf);
+    }
+}
+
+impl Decode for IpRouteDump {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let table = IpTable::decode(d)?;
+        Ok(Self {
+            context,
+            table,
+        })
+    }
+}
+
+impl Message for IpRouteDump {
+    const NAME: &'static str = "ip_route_dump";
+    const CRC: &'static str = "0xb9d2e09e";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `ip_route_details` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IpRouteDetails {
+    pub context: u32,
+    pub route: IpRoute,
+}
+
+impl Encode for IpRouteDetails {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        self.route.encode(buf);
+    }
+}
+
+impl Decode for IpRouteDetails {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let route = IpRoute::decode(d)?;
+        Ok(Self {
+            context,
+            route,
+        })
+    }
+}
+
+impl Message for IpRouteDetails {
+    const NAME: &'static str = "ip_route_details";
+    const CRC: &'static str = "0xbda8f315";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;
     fn set_context(&mut self, context: u32) { self.context = context; }

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -23,10 +23,11 @@ use packetframe_vpp_offload::vpp_api::codec::{
     SOCKCLNT_CREATE_MSG_ID,
 };
 use packetframe_vpp_offload::vpp_api::generated::{
-    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpNeighborAddDel,
-    IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteLookupReply,
-    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
-    MESSAGE_META,
+    Address, AddressUnion, ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath,
+    FibPathNh, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply,
+    IpRouteDetails, IpRouteLookupReply, MessageTableEntry, Prefix, SockclntCreateReply,
+    SwInterfaceDetails, SwInterfaceSetFlagsReply, ADDRESS_IP4, FIB_API_PATH_NH_PROTO_IP4,
+    FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
 };
 
 /// The index the fake's `dev_create_port_if` hands out. Routes must
@@ -169,6 +170,17 @@ pub struct Behaviour {
     /// `VerifyFailed` teardown from a test, because the verdict arrives
     /// as an INJECTED event rather than from an ordinary tick.
     pub verify_mismatch: bool,
+    /// Prefixes this VPP already holds when the client connects, as
+    /// `(addr, len, sw_if_index, nexthop_is_set)`.
+    ///
+    /// Models a **surviving** VPP for the adoption path: its FIB is
+    /// populated and the freshly started packetframe's ledger is not.
+    /// `nexthop_is_set` false / an index we do not own reproduces VPP's
+    /// own infrastructure routes, which the readback must leave alone —
+    /// adopting those would hand them to the resync diff, and the next
+    /// convergence would delete the connected and local routes VPP needs
+    /// to resolve any adjacency at all.
+    pub existing_routes: &'static [([u8; 4], u8, u32, bool)],
 }
 
 impl Fake {
@@ -366,6 +378,18 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
             }
             // DUMP: one details frame per interface, no terminator — the
             // trailing control_ping's reply ends the stream, as VPP does.
+            "ip_route_dump" => {
+                for &(addr, len, sw_if_index, has_nh) in behaviour.existing_routes {
+                    let mut d = reply_head("ip_route_details");
+                    IpRouteDetails {
+                        context: ctx,
+                        route: existing_route(addr, len, sw_if_index, has_nh),
+                    }
+                    .encode(&mut d);
+                    write_frame(sock, &d);
+                }
+                continue;
+            }
             "sw_interface_dump" => {
                 let mut d = reply_head("sw_interface_details");
                 details(ASSIGNED_INDEX, "octeon0/0", 3, ctx).encode(&mut d);
@@ -392,6 +416,53 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
             other => panic!("fake got unexpected message {other}"),
         }
         write_frame(sock, &out);
+    }
+}
+
+/// One route as a surviving VPP would report it.
+///
+/// `has_nh` is the whole point: a real nexthop address plus a path type
+/// of NORMAL on an interface we own is what our own drainer emits, and
+/// is what the readback filter looks for. Leaving it zero produces the
+/// shape of a connected route — attached, no nexthop — which must NOT be
+/// adopted.
+fn existing_route(addr: [u8; 4], len: u8, sw_if_index: u32, has_nh: bool) -> IpRoute {
+    let mut un = [0u8; 16];
+    un[..4].copy_from_slice(&addr);
+    let mut nh_un = [0u8; 16];
+    if has_nh {
+        // 192.0.2.1, the same nexthop the tests' mirror advertises.
+        nh_un[..4].copy_from_slice(&[192, 0, 2, 1]);
+    }
+    IpRoute {
+        table_id: 0,
+        stats_index: 0,
+        prefix: Prefix {
+            address: Address {
+                af: ADDRESS_IP4,
+                un: AddressUnion(un),
+            },
+            len,
+        },
+        n_paths: 1,
+        paths: vec![FibPath {
+            sw_if_index,
+            table_id: 0,
+            rpf_id: 0,
+            weight: 1,
+            preference: 0,
+            r#type: FIB_API_PATH_TYPE_NORMAL,
+            flags: 0,
+            proto: FIB_API_PATH_NH_PROTO_IP4,
+            nh: FibPathNh {
+                address: AddressUnion(nh_un),
+                via_label: 0,
+                obj_id: 0,
+                classify_table_index: 0,
+            },
+            n_labels: 0,
+            label_stack: Default::default(),
+        }],
     }
 }
 

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -331,6 +331,7 @@ fn a_refused_derived_delete_is_retried() {
             garbage_crcs: false,
             stall_pings_after: None,
             verify_mismatch: false,
+            ..Default::default()
         },
     );
     let mut e = engine_for(&fake);
@@ -478,6 +479,7 @@ fn a_crc_mismatch_is_recorded_as_permanent() {
             garbage_crcs: true,
             stall_pings_after: None,
             verify_mismatch: false,
+            ..Default::default()
         },
     );
     let mut e = engine_for(&fake);
@@ -487,5 +489,77 @@ fn a_crc_mismatch_is_recorded_as_permanent() {
     assert!(
         e.api_incompatible(),
         "retrying cannot fix a version skew: {err}"
+    );
+}
+
+/// Adopting a surviving VPP withdraws what the source stopped
+/// advertising — and leaves VPP's own routes alone.
+///
+/// The gap this closes: the resync diff derives withdrawals from the
+/// ledger, and on adoption the ledger is empty while the surviving VPP's
+/// FIB is not. A prefix withdrawn while packetframe was down therefore
+/// stayed installed, where a stale more-specific keeps overriding the
+/// live table — and verification could not see it, because it samples
+/// only what the ledger knows about.
+///
+/// The second half is the dangerous one. VPP's FIB also holds routes VPP
+/// created: drop routes, connected routes, local `/32`s. Adopting those
+/// would hand them to the same diff, and the next convergence would
+/// delete the infrastructure VPP needs to resolve any adjacency. So the
+/// fake serves three routes and the test asserts on all three.
+#[test]
+fn adoption_withdraws_stale_routes_without_touching_vpps_own() {
+    // 10.0.1.0/24 — ours, and the source still advertises it.
+    // 10.0.9.0/24 — ours, withdrawn while we were down. Must go.
+    // 10.9.9.0/24 — no nexthop: a connected route's shape. Must stay.
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 9, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 9, 9, 0], 24, ASSIGNED_INDEX, false),
+    ];
+    let fake = Fake::start_behaving(
+        "adopt-fib",
+        Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    let mut engine = engine_for(&fake);
+    assert!(engine.api_ready(), "handshake");
+    engine.attach_devices(AttachMode::Fresh).expect("attach");
+
+    // The source advertises only 10.0.1.0/24 now.
+    let mirror = Mirror {
+        routes: vec![v4(0, 1)],
+    };
+    let adopted = engine.adopt_vpp_fib().expect("readback");
+    assert_eq!(
+        adopted, 2,
+        "both nexthop-bearing routes adopted; the connected-shaped one is not"
+    );
+
+    let plan = engine.begin_resync(&mirror);
+    assert_eq!(
+        plan.withdrawals, 1,
+        "exactly the prefix the source stopped advertising: {plan:?}"
+    );
+
+    while !engine.drain_batch().expect("drain").0 {}
+    let deleted: Vec<[u8; 4]> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Route(WireRoute {
+                is_add: false,
+                addr,
+                ..
+            }) => Some(addr),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        deleted,
+        vec![[10, 0, 9, 0]],
+        "the stale route is withdrawn and nothing else is: {deleted:?}"
     );
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -195,6 +195,7 @@ fn an_incompatible_api_fails_attach_with_the_reason() {
             garbage_crcs: true,
             stall_pings_after: None,
             verify_mismatch: false,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();
@@ -377,6 +378,7 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
             // Routes install and ack; only the readback disagrees.
             stall_pings_after: None,
             verify_mismatch: true,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();
@@ -570,6 +572,7 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
             garbage_crcs: false,
             stall_pings_after: None,
             verify_mismatch: true,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();
@@ -783,6 +786,7 @@ fn an_episode_keeps_its_root_cause_alongside_the_latest_symptom() {
             stall_pings_after: None,
             // Verification fails, which is the root cause.
             verify_mismatch: true,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();
@@ -882,6 +886,7 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
             garbage_crcs: false,
             stall_pings_after: Some(1),
             verify_mismatch: false,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();
@@ -1007,6 +1012,7 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
             garbage_crcs: false,
             stall_pings_after: Some(1),
             verify_mismatch: false,
+            ..Default::default()
         },
     );
     let sock = fake.path.clone();

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -38,6 +38,17 @@ const MESSAGES: &[&str] = &[
     "ip_route_add_del_reply",
     "ip_route_lookup",
     "ip_route_lookup_reply",
+    // Reading VPP's FIB back. Also a DUMP (streamed `ip_route_details`
+    // terminated by a trailing `control_ping`, same shape as
+    // `sw_interface_dump`). Adoption needs it and cannot be trusted
+    // without it: the resync diff derives withdrawals from the ledger,
+    // and on adoption the ledger starts empty while a surviving VPP's
+    // FIB does not — so a prefix withdrawn while packetframe was down
+    // stays installed, where a stale more-specific keeps overriding the
+    // live table. Verification cannot see it either, because it samples
+    // only what the ledger knows about.
+    "ip_route_dump",
+    "ip_route_details",
     "ip_neighbor_add_del",
     "ip_neighbor_add_del_reply",
     // Interface state.


### PR DESCRIPTION
Task #25. Closes a gap `begin_resync` has carried a `## Known gap` block about since #115.

## The gap

The resync diff derives withdrawals from `ledger.known_prefixes()`. On **adoption** the ledger starts empty while a surviving VPP's FIB does not — so a prefix withdrawn while packetframe was down stayed installed, where a stale more-specific keeps overriding the live table. Readback verification couldn't catch it either: it samples only what the ledger already knows about.

That matters most on exactly the path that keeps forwarding while it converges.

## What landed

`ip_route_dump` joins the codegen whitelist (with `ip_route_details` and the `ip_table_t` the type graph closes over) and reuses the existing `Transport::dump`, which already handles VPP's no-end-of-stream idiom by trailing a `control_ping` — the same shape `sw_interface_dump` uses. No new transport machinery.

`adopt_vpp_fib()` seeds the ledger from what VPP actually holds, and `Runtime::start_resync` calls it **before** `begin_resync`, because the diff is what consumes it.

## The dangerous half is what it refuses to adopt

VPP's FIB is not only ours. A fresh instance already holds drop routes, connected routes for interface subnets, and local `/32`s for interface addresses — all created by VPP itself. Seeding those would hand them to a diff that withdraws everything the route source does not advertise, and the next convergence would **delete the infrastructure VPP needs to resolve any adjacency at all**.

So a dumped route is adopted only if it looks like ours:

| clause | excludes |
|---|---|
| path type is `FIB_API_PATH_TYPE_NORMAL` | local, drop |
| egresses an interface **we** own | anything on `local0` or a foreign index |
| non-zero nexthop address | connected routes, which are attached and have no nexthop |

Anything unrecognised is left alone — an unadopted route is one we will never withdraw, which is the safe direction.

Gated on an **empty ledger** rather than an adoption flag, because that is the condition rather than a proxy for it: an empty ledger means this process has no record of what VPP holds, however it got there. A freshly spawned VPP answers with its own routes, none pass the filter, and the fresh path costs one round trip and adopts nothing.

## Testing

The fake VPP grows an `existing_routes` behaviour so a surviving VPP can be modelled at all. The test serves three routes — one ours and still advertised, one ours and withdrawn, one connected-shaped — and asserts on all three: two adopted, exactly one withdrawal planned, exactly one delete on the wire.

**Both halves verified to fail with their fix reverted:** 0 adopted without the readback, and 3 adopted with the connected route deleted if the nexthop clause is dropped. The second is the one that matters, since that clause is the judgement call.

592 tests; fmt, host clippy, all four cross-target clippy gates, and codegen confirmed idempotent so CI's regenerate-and-diff will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)