### PR TITLE
feat(vpp-offload): the steering rule policy, and a probe that reports it

### DIFF
--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -8,6 +8,7 @@ use std::path::Path;
 
 use packetframe_common::{
     config::{Config, ModuleDirective},
+    fib::IpPrefix,
     probe::{run_iface_probes, run_probes, Capability, CapabilityStatus, FeasibilityReport},
 };
 
@@ -50,6 +51,35 @@ pub fn vpp_ports_from_config(config: &Config) -> Vec<String> {
     ports
 }
 
+/// The fast-path allowlist, as the steering probe needs it.
+///
+/// It comes from the **fast-path** section, not vpp-offload's: steered
+/// prefixes inherit the allowlist rather than declaring their own, which
+/// is what makes "the offload carries a slice of the same traffic"
+/// true by construction instead of by two lists agreeing.
+pub fn allowlist_from_config(config: &Config) -> Vec<IpPrefix> {
+    let mut out = Vec::new();
+    for m in &config.modules {
+        if m.name != "fast-path" {
+            continue;
+        }
+        for d in &m.directives {
+            match d {
+                ModuleDirective::AllowPrefix4(p) => out.push(IpPrefix::V4 {
+                    addr: p.addr.octets(),
+                    prefix_len: p.prefix_len,
+                }),
+                ModuleDirective::AllowPrefix6(p) => out.push(IpPrefix::V6 {
+                    addr: p.addr.octets(),
+                    prefix_len: p.prefix_len,
+                }),
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
 /// The `vpp-binary` override from a `vpp-offload` section, if set, so
 /// feasibility probes the executable the module will actually run.
 pub fn vpp_binary_from_config(config: &Config) -> Option<String> {
@@ -69,6 +99,7 @@ pub fn probe_and_render(
     attach_ifaces: &[String],
     vpp_ports: &[String],
     vpp_binary: Option<&str>,
+    allowlist: &[IpPrefix],
     human: bool,
 ) -> Rendered {
     let mut report = run_probes(bpffs_root);
@@ -94,12 +125,13 @@ pub fn probe_and_render(
     // the module's attach enforces.
     #[cfg(feature = "vpp-offload")]
     if !vpp_ports.is_empty() {
-        for cap in packetframe_vpp_offload::run_feasibility_probes(vpp_ports, vpp_binary) {
+        for cap in packetframe_vpp_offload::run_feasibility_probes(vpp_ports, vpp_binary, allowlist)
+        {
             report.capabilities.push(cap);
         }
     }
     #[cfg(not(feature = "vpp-offload"))]
-    let _ = (vpp_ports, vpp_binary);
+    let _ = (vpp_ports, vpp_binary, allowlist);
     // `passed` needs recomputing after the iface probes; the trial
     // attach caps are non-required (a native-XDP failure shouldn't
     // abort startup), but we preserve the existing `passed` logic.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -322,7 +322,7 @@ fn main() -> ExitCode {
 }
 
 fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
-    let (bpffs_root, attach_ifaces, vpp_ports, vpp_binary) = match &config {
+    let (bpffs_root, attach_ifaces, vpp_ports, vpp_binary, allowlist) = match &config {
         Some(path) => match Config::from_file(path) {
             Ok(c) => {
                 if let Err(e) = c.validate_interfaces() {
@@ -336,7 +336,14 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                 let ifaces = feasibility::attach_ifaces_from_config(&c);
                 let vpp_ports = feasibility::vpp_ports_from_config(&c);
                 let vpp_binary = feasibility::vpp_binary_from_config(&c);
-                (c.global.bpffs_root, ifaces, vpp_ports, vpp_binary)
+                let allowlist = feasibility::allowlist_from_config(&c);
+                (
+                    c.global.bpffs_root,
+                    ifaces,
+                    vpp_ports,
+                    vpp_binary,
+                    allowlist,
+                )
             }
             Err(e) => {
                 eprintln!("config parse error: {e}");
@@ -348,6 +355,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             Vec::new(),
             Vec::new(),
             None,
+            Vec::new(),
         ),
     };
 
@@ -356,6 +364,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
         &attach_ifaces,
         &vpp_ports,
         vpp_binary.as_deref(),
+        &allowlist,
         human,
     );
     if let Some(json) = report.json_output {

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -65,6 +65,7 @@ pub mod service;
 pub mod sink;
 pub mod startup_conf;
 pub mod status;
+pub mod steer;
 pub mod supervisor;
 pub mod verify;
 pub mod vpp_api;
@@ -619,14 +620,18 @@ impl Module for VppOffloadModule {
 /// Feasibility probes for `packetframe feasibility`, mirroring how the
 /// fast-path's per-interface probes graft into the report. All
 /// non-required: feasibility output informs, attach enforces.
-pub fn run_feasibility_probes(ports: &[String], vpp_binary: Option<&str>) -> Vec<Capability> {
+pub fn run_feasibility_probes(
+    ports: &[String],
+    vpp_binary: Option<&str>,
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Vec<Capability> {
     #[cfg(target_os = "linux")]
     {
-        probe_linux::run(ports, vpp_binary)
+        probe_linux::run(ports, vpp_binary, allowlist)
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (ports, vpp_binary);
+        let _ = (ports, vpp_binary, allowlist);
         Vec::new()
     }
 }

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -52,14 +52,26 @@ fn probe_steering_budget(allowlist: &[packetframe_common::fib::IpPrefix]) -> Cap
 
     let budget = McamBudget::default();
     match RuleSet::plan(allowlist, budget) {
-        Ok(set) if set.rules.is_empty() && set.skipped_v6 > 0 => Capability::fail(
+        // Nothing to steer is a FAIL however it arose. The two ways there
+        // read very differently to an operator, so they are named
+        // separately — but neither may pass: a port that steers nothing
+        // diverts no traffic while every other line in this report, and
+        // the module's own health, says the offload is fine.
+        Ok(set) if set.rules.is_empty() => Capability::fail(
             "vpp.steering.budget",
-            format!(
-                "none of the allowlist can be steered: all {} prefix(es) are IPv6, and `ip6` \
-                 ntuple is rejected by this NIC's AF (gate 0b round 4). The offload would \
-                 forward nothing while reporting healthy",
-                set.skipped_v6
-            ),
+            if set.skipped_v6 > 0 {
+                format!(
+                    "none of the allowlist can be steered: all {} prefix(es) are IPv6, and \
+                     `ip6` ntuple is rejected by this NIC's AF (gate 0b round 4). The offload \
+                     would forward nothing while reporting healthy",
+                    set.skipped_v6
+                )
+            } else {
+                "the fast-path allowlist is empty, so there is nothing to steer. Steered \
+                 prefixes are inherited from fast-path's `allow-prefix`/`allow-prefix6`; \
+                 without any, the offload would forward nothing while reporting healthy"
+                    .to_string()
+            },
             false,
         ),
         Ok(set) => {
@@ -217,4 +229,54 @@ pub(crate) fn default_hugepage_bytes() -> u64 {
         }
     }
     0
+}
+
+#[cfg(test)]
+mod steering_probe_tests {
+    use super::*;
+    use packetframe_common::fib::IpPrefix;
+    use packetframe_common::probe::CapabilityStatus;
+
+    fn v4(a: u8, len: u8) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [10, a, 0, 0],
+            prefix_len: len,
+        }
+    }
+
+    /// Nothing to steer is a FAIL however it arose.
+    ///
+    /// Two ways to get there and they read very differently to an
+    /// operator, so both are named — but neither may pass. A port that
+    /// steers nothing diverts no traffic while every other line in the
+    /// report, and the module's own health, says the offload is fine.
+    /// The empty case is the one that slipped through: it is also what
+    /// `validate_vpp_offload` permits, since nothing requires fast-path
+    /// to declare an allowlist when a port asks to steer.
+    #[test]
+    fn an_allowlist_that_steers_nothing_never_passes() {
+        let empty = probe_steering_budget(&[]);
+        assert_eq!(empty.status, CapabilityStatus::Fail, "{empty:?}");
+        assert!(
+            empty.detail.contains("allowlist is empty"),
+            "names which of the two ways it got here: {}",
+            empty.detail
+        );
+
+        let v6_only = probe_steering_budget(&[IpPrefix::V6 {
+            addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            prefix_len: 32,
+        }]);
+        assert_eq!(v6_only.status, CapabilityStatus::Fail, "{v6_only:?}");
+        assert!(
+            v6_only.detail.contains("IPv6"),
+            "and names the other: {}",
+            v6_only.detail
+        );
+
+        // A steerable prefix passes, so the failures above are about
+        // having nothing to steer rather than the probe always failing.
+        let ok = probe_steering_budget(&[v4(0, 24)]);
+        assert_eq!(ok.status, CapabilityStatus::Pass, "{ok:?}");
+    }
 }

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -11,7 +11,11 @@ use std::path::Path;
 
 use packetframe_common::probe::Capability;
 
-pub(crate) fn run(ports: &[String], vpp_binary: Option<&str>) -> Vec<Capability> {
+pub(crate) fn run(
+    ports: &[String],
+    vpp_binary: Option<&str>,
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Vec<Capability> {
     let mut caps = Vec::with_capacity(4 + ports.len());
     caps.push(probe_iommu());
     caps.push(probe_vfio());
@@ -25,7 +29,60 @@ pub(crate) fn run(ports: &[String], vpp_binary: Option<&str>) -> Vec<Capability>
     for iface in ports {
         caps.push(probe_sriov(iface));
     }
+    caps.push(probe_steering_budget(allowlist));
     caps
+}
+
+/// Can the configured allowlist actually be steered?
+///
+/// Two answers an operator wants before the canary and not during it.
+/// **Does it fit MCAM** — the rules are two per v4 prefix and the table
+/// is shared with UniFi's own, so an allowlist that overruns the budget
+/// cannot be steered at all (partially steering it would split the
+/// allowlist across both forwarding tiers, which is a policy nobody
+/// chose, so it is refused whole). And **how much of it is v6**, which
+/// cannot be steered on this NIC at any size: `ip6` ntuple is rejected
+/// by the AF, so a v6-heavy allowlist means the offload covers far less
+/// traffic than the config reads like it does.
+///
+/// Read-only and non-required, like every probe here: it computes the
+/// plan the module would install, and installs nothing.
+fn probe_steering_budget(allowlist: &[packetframe_common::fib::IpPrefix]) -> Capability {
+    use crate::steer::{McamBudget, RuleSet};
+
+    let budget = McamBudget::default();
+    match RuleSet::plan(allowlist, budget) {
+        Ok(set) if set.rules.is_empty() && set.skipped_v6 > 0 => Capability::fail(
+            "vpp.steering.budget",
+            format!(
+                "none of the allowlist can be steered: all {} prefix(es) are IPv6, and `ip6` \
+                 ntuple is rejected by this NIC's AF (gate 0b round 4). The offload would \
+                 forward nothing while reporting healthy",
+                set.skipped_v6
+            ),
+            false,
+        ),
+        Ok(set) => {
+            let detail = format!(
+                "{} rule(s) for {} steerable prefix(es), budget {} from slot {}{}",
+                set.rules.len(),
+                set.rules.len() / 2,
+                budget.count,
+                budget.base,
+                if set.skipped_v6 > 0 {
+                    format!(
+                        "; {} IPv6 prefix(es) NOT steerable on this NIC and left on the \
+                         kernel path",
+                        set.skipped_v6
+                    )
+                } else {
+                    String::new()
+                }
+            );
+            Capability::pass("vpp.steering.budget", detail, false)
+        }
+        Err(e) => Capability::fail("vpp.steering.budget", e, false),
+    }
 }
 
 /// An SMMU registered in /sys/class/iommu is the difference between

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -1,0 +1,252 @@
+//! MCAM steering: the ntuple rules that divert allowlisted traffic to
+//! VPP's VF, and the canary lever the rollout turns.
+//!
+//! ## What is being asked of the NIC
+//!
+//! One rule per (allowlisted prefix × direction). A packet whose source
+//! *or* destination falls in the allowlist is redirected to the VF VPP
+//! owns; everything else stays on the kernel path with the eBPF
+//! fast-path in front of it. That asymmetry is the whole design: the
+//! offload takes a slice of traffic and the fallback tier keeps the
+//! rest, so a VPP that dies costs only the steered slice.
+//!
+//! ## The two details that are not guessable
+//!
+//! **`ring_cookie` is `(vf + 1) << 32`.** `ethtool`'s own `vf N`
+//! keyword mis-encodes this on the rvu driver — gate 0a established the
+//! raw form works and the keyword does not, by inserting both and
+//! reading back what the NIC actually stored. Nothing about the uapi
+//! documents it.
+//!
+//! **`loc` must be an allocated slot.** The driver rejects an
+//! out-of-range location rather than assigning one, so this module
+//! tracks the locations it owns and hands back exactly those. The
+//! reference NIC has 2048 MCAM entries with ~1689 free, so the budget
+//! is real but not tight at allowlist scale.
+//!
+//! ## v4 only, by probe rather than by choice
+//!
+//! Gate 0b round 4: `ip6` ntuple insertion is rejected by the AF (error
+//! 710) while the v4 control inserts cleanly — the vendor NPC profile
+//! has no v6 extraction. So no IPv6 packet can be steered into VPP, and
+//! a v6 prefix in the allowlist is skipped here rather than attempted.
+//! [`crate::fib_sync::FamilyPolicy`] encodes the same verdict on the FIB
+//! side; when a kernel bump makes v6 work, both flip together.
+//!
+//! ## What is here, and what is not
+//!
+//! This is the **policy** half only: which rules should exist, in which
+//! slots, and what is refused. It touches no NIC, which is the point —
+//! every mistake that silently misroutes traffic (a direction missed, a
+//! family attempted that cannot work, a budget overrun leaving a port
+//! half-steered) is decided here and tested without hardware.
+//!
+//! The ioctl half is deliberately absent rather than sketched.
+//! `ethtool_rx_flow_spec` is not in `libc`, so its layout would be
+//! hand-written from a header this machine cannot read, and a field in
+//! the wrong place produces rules that install cleanly and match the
+//! wrong traffic. When it lands it must **read every rule back** with
+//! `ETHTOOL_GRXCLSRULE` and compare against what was asked for, so the
+//! layout is self-validating on the first real NIC instead of trusted —
+//! the same reasoning the FIB readback verify rests on.
+
+use std::net::Ipv4Addr;
+
+use packetframe_common::fib::IpPrefix;
+
+/// One steering rule, before it becomes bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SteerRule {
+    /// The allowlisted prefix.
+    pub prefix: Ipv4Addr,
+    pub prefix_len: u8,
+    /// Which side of the packet this rule matches.
+    pub side: Side,
+    /// MCAM slot. Assigned by [`RuleSet::plan`], not by the driver.
+    pub location: u32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Src,
+    Dst,
+}
+
+/// What steering *should* look like for a port, derived from the
+/// allowlist.
+///
+/// Separated from the ioctl so the policy — which prefixes, which
+/// directions, how many slots, what gets skipped — is decided and
+/// tested without a NIC. Every mistake that silently misroutes traffic
+/// lives in here rather than in the syscall.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct RuleSet {
+    pub rules: Vec<SteerRule>,
+    /// v6 prefixes skipped because the NIC cannot match them. Reported
+    /// rather than dropped: an operator whose allowlist is mostly v6
+    /// should see that steering covers almost none of it.
+    pub skipped_v6: u32,
+}
+
+/// How many MCAM slots a port may use.
+///
+/// A budget rather than a constant because the NIC's table is shared —
+/// UniFi's own rules live in it too — and overrunning it fails the
+/// insert of whichever rule happens to be last, leaving a *partially*
+/// steered port: some allowlisted traffic diverted to VPP, the rest on
+/// the kernel path. That is not a degraded version of steering, it is a
+/// different forwarding policy than either tier was configured for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct McamBudget {
+    /// First slot this module may use.
+    pub base: u32,
+    /// How many consecutive slots from `base`.
+    pub count: u32,
+}
+
+impl Default for McamBudget {
+    fn default() -> Self {
+        // Measured on the reference NIC: 2048 entries, ~1689 free, and
+        // UniFi's own rules sit low. Starting at 1024 keeps this module
+        // clear of them without needing to enumerate what the vendor
+        // installed — which changes under us on every controller push.
+        Self {
+            base: 1024,
+            count: 512,
+        }
+    }
+}
+
+impl RuleSet {
+    /// Decide the rules for one port.
+    ///
+    /// Two per v4 prefix, source and destination, because the allowlist
+    /// names *networks we forward for* and traffic to them and from them
+    /// are both ours. Steering only one direction would send a flow's
+    /// two halves down different tiers, which is precisely the
+    /// asymmetric-path case that breaks PMTUD and anything stateful
+    /// downstream.
+    ///
+    /// Fails rather than truncates when the budget cannot hold them all:
+    /// a partially steered port forwards some allowlisted traffic
+    /// through VPP and the rest through the kernel, which is a policy
+    /// nobody chose.
+    pub fn plan(allowlist: &[IpPrefix], budget: McamBudget) -> Result<Self, String> {
+        let mut out = RuleSet::default();
+        let mut next = budget.base;
+        for p in allowlist {
+            let (addr, prefix_len) = match p {
+                IpPrefix::V4 { addr, prefix_len } => (Ipv4Addr::from(*addr), *prefix_len),
+                IpPrefix::V6 { .. } => {
+                    out.skipped_v6 += 1;
+                    continue;
+                }
+            };
+            for side in [Side::Src, Side::Dst] {
+                if next >= budget.base + budget.count {
+                    return Err(format!(
+                        "allowlist needs more MCAM slots than the budget allows ({} rules for \
+                         {} prefixes, budget {} from {}); steering part of the allowlist would \
+                         split it across both forwarding tiers, so none is installed",
+                        out.rules.len() + 1,
+                        allowlist.len(),
+                        budget.count,
+                        budget.base
+                    ));
+                }
+                out.rules.push(SteerRule {
+                    prefix: addr,
+                    prefix_len,
+                    side,
+                    location: next,
+                });
+                next += 1;
+            }
+        }
+        Ok(out)
+    }
+
+    /// The slots this set occupies, for the state file — teardown must
+    /// remove exactly what was installed and nothing else.
+    pub fn locations(&self) -> Vec<u32> {
+        self.rules.iter().map(|r| r.location).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn v4(a: u8, b: u8, c: u8, d: u8, len: u8) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [a, b, c, d],
+            prefix_len: len,
+        }
+    }
+
+    /// Both directions, in slot order, with v6 counted rather than
+    /// silently dropped.
+    #[test]
+    fn a_plan_covers_both_directions_and_reports_skipped_v6() {
+        let allow = vec![
+            v4(23, 191, 200, 0, 24),
+            IpPrefix::V6 {
+                addr: [0x26, 0x02, 0xf7, 0xd8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                prefix_len: 48,
+            },
+            v4(10, 88, 1, 0, 24),
+        ];
+        let set = RuleSet::plan(&allow, McamBudget::default()).expect("fits");
+
+        assert_eq!(set.skipped_v6, 1, "the v6 prefix is reported, not hidden");
+        assert_eq!(set.rules.len(), 4, "two v4 prefixes, both directions");
+        assert_eq!(
+            set.rules.iter().filter(|r| r.side == Side::Src).count(),
+            2,
+            "one source rule per v4 prefix"
+        );
+        assert_eq!(
+            set.locations(),
+            vec![1024, 1025, 1026, 1027],
+            "consecutive slots from the budget's base, so teardown can find them"
+        );
+    }
+
+    /// An allowlist that does not fit installs NOTHING.
+    ///
+    /// The failure mode this prevents is worse than no steering: a
+    /// partially steered port forwards some allowlisted traffic through
+    /// VPP and the rest through the kernel, which is a forwarding policy
+    /// neither tier was configured for and which no counter names.
+    #[test]
+    fn an_allowlist_that_exceeds_the_budget_is_refused_whole() {
+        let allow: Vec<IpPrefix> = (0..4).map(|i| v4(10, i, 0, 0, 16)).collect();
+        let budget = McamBudget { base: 0, count: 5 };
+        let e = RuleSet::plan(&allow, budget).expect_err("must refuse");
+        assert!(e.contains("MCAM slots"), "{e}");
+        assert!(
+            e.contains("none is installed"),
+            "the message must say the port is left unsteered: {e}"
+        );
+
+        // One more slot and the same allowlist fits, so the refusal is
+        // about the budget and not about the allowlist's shape.
+        let ok = RuleSet::plan(&allow, McamBudget { base: 0, count: 8 }).expect("fits exactly");
+        assert_eq!(ok.rules.len(), 8);
+    }
+
+    /// An allowlist with no v4 in it produces no rules and says why.
+    #[test]
+    fn a_v6_only_allowlist_produces_nothing_to_steer() {
+        let allow = vec![IpPrefix::V6 {
+            addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            prefix_len: 32,
+        }];
+        let set = RuleSet::plan(&allow, McamBudget::default()).expect("no rules is not an error");
+        assert!(set.rules.is_empty());
+        assert_eq!(
+            set.skipped_v6, 1,
+            "the operator has to be able to see that steering covers none of their allowlist"
+        );
+    }
+}

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -117,6 +117,9 @@ impl Default for McamBudget {
     }
 }
 
+/// Source and destination — see [`RuleSet::plan`] for why both.
+const RULES_PER_PREFIX: usize = 2;
+
 impl RuleSet {
     /// Decide the rules for one port.
     ///
@@ -132,38 +135,42 @@ impl RuleSet {
     /// through VPP and the rest through the kernel, which is a policy
     /// nobody chose.
     pub fn plan(allowlist: &[IpPrefix], budget: McamBudget) -> Result<Self, String> {
-        let mut out = RuleSet::default();
-        let mut next = budget.base;
-        for p in allowlist {
-            let (addr, prefix_len) = match p {
-                IpPrefix::V4 { addr, prefix_len } => (Ipv4Addr::from(*addr), *prefix_len),
-                IpPrefix::V6 { .. } => {
-                    out.skipped_v6 += 1;
-                    continue;
-                }
-            };
-            for side in [Side::Src, Side::Dst] {
-                if next >= budget.base + budget.count {
-                    return Err(format!(
-                        "allowlist needs more MCAM slots than the budget allows ({} rules for \
-                         {} prefixes, budget {} from {}); steering part of the allowlist would \
-                         split it across both forwarding tiers, so none is installed",
-                        out.rules.len() + 1,
-                        allowlist.len(),
-                        budget.count,
-                        budget.base
-                    ));
-                }
-                out.rules.push(SteerRule {
+        // Partition first, then check capacity, then build. The order is
+        // what makes the refusal's numbers true: counting as we go can
+        // only ever report how far we got, which is the budget size — the
+        // one number the operator already knows.
+        let steerable: Vec<(Ipv4Addr, u8)> = allowlist
+            .iter()
+            .filter_map(|p| match p {
+                IpPrefix::V4 { addr, prefix_len } => Some((Ipv4Addr::from(*addr), *prefix_len)),
+                IpPrefix::V6 { .. } => None,
+            })
+            .collect();
+        let skipped_v6 = (allowlist.len() - steerable.len()) as u32;
+        let needed = steerable.len() * RULES_PER_PREFIX;
+
+        if needed > budget.count as usize {
+            return Err(format!(
+                "the allowlist needs {needed} MCAM rule(s) ({} steerable prefix(es) × {}                  directions) but the budget allows {} from slot {}; steering part of the                  allowlist would split it across both forwarding tiers, so none is installed",
+                steerable.len(),
+                RULES_PER_PREFIX,
+                budget.count,
+                budget.base
+            ));
+        }
+
+        let mut rules = Vec::with_capacity(needed);
+        for (i, (addr, prefix_len)) in steerable.into_iter().enumerate() {
+            for (j, side) in [Side::Src, Side::Dst].into_iter().enumerate() {
+                rules.push(SteerRule {
                     prefix: addr,
                     prefix_len,
                     side,
-                    location: next,
+                    location: budget.base + (i * RULES_PER_PREFIX + j) as u32,
                 });
-                next += 1;
             }
         }
-        Ok(out)
+        Ok(RuleSet { rules, skipped_v6 })
     }
 
     /// The slots this set occupies, for the state file — teardown must
@@ -212,18 +219,33 @@ mod tests {
         );
     }
 
-    /// An allowlist that does not fit installs NOTHING.
+    /// An allowlist that does not fit installs NOTHING, and says how
+    /// many rules it actually needed.
     ///
-    /// The failure mode this prevents is worse than no steering: a
+    /// The failure mode the refusal prevents is worse than no steering: a
     /// partially steered port forwards some allowlisted traffic through
-    /// VPP and the rest through the kernel, which is a forwarding policy
-    /// neither tier was configured for and which no counter names.
+    /// VPP and the rest through the kernel, a policy neither tier was
+    /// configured for and which no counter names.
+    ///
+    /// The *number* is asserted because it is the number an operator
+    /// sizes the budget from. Counting rules as they are built can only
+    /// report how far the loop got — which is the budget size, the one
+    /// figure they already have — so this asserts the true requirement
+    /// and, explicitly, that the old understated figure is gone.
     #[test]
     fn an_allowlist_that_exceeds_the_budget_is_refused_whole() {
         let allow: Vec<IpPrefix> = (0..4).map(|i| v4(10, i, 0, 0, 16)).collect();
         let budget = McamBudget { base: 0, count: 5 };
         let e = RuleSet::plan(&allow, budget).expect_err("must refuse");
-        assert!(e.contains("MCAM slots"), "{e}");
+
+        assert!(
+            e.contains("needs 8 MCAM rule(s)"),
+            "must name the TRUE requirement, not how far it got: {e}"
+        );
+        assert!(
+            !e.contains("6 MCAM"),
+            "reporting budget+1 tells the operator to try a size that also fails: {e}"
+        );
         assert!(
             e.contains("none is installed"),
             "the message must say the port is left unsteered: {e}"
@@ -233,6 +255,30 @@ mod tests {
         // about the budget and not about the allowlist's shape.
         let ok = RuleSet::plan(&allow, McamBudget { base: 0, count: 8 }).expect("fits exactly");
         assert_eq!(ok.rules.len(), 8);
+    }
+
+    /// The refusal counts STEERABLE prefixes, not every line in the
+    /// allowlist.
+    ///
+    /// A v6 prefix consumes no slot, so including it in the count would
+    /// overstate the shortfall and send an operator looking for a budget
+    /// increase they do not need — the inverse of the understatement
+    /// above, and equally a number they would act on.
+    #[test]
+    fn the_refusal_does_not_count_prefixes_that_consume_no_slots() {
+        let allow = vec![
+            v4(10, 0, 0, 0, 16),
+            v4(10, 1, 0, 0, 16),
+            IpPrefix::V6 {
+                addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                prefix_len: 32,
+            },
+        ];
+        let e = RuleSet::plan(&allow, McamBudget { base: 0, count: 3 }).expect_err("must refuse");
+        assert!(
+            e.contains("needs 4 MCAM rule(s)") && e.contains("2 steerable prefix(es)"),
+            "the v6 prefix is not steerable and must not inflate either number: {e}"
+        );
     }
 
     /// An allowlist with no v4 in it produces no rules and says why.


### PR DESCRIPTION
First half of slice 5 (#28). **No NIC is touched.** This decides which ntuple rules *should* exist and refuses the cases that cannot work — which is where every mistake that silently misroutes traffic lives. The ioctl that installs them is deliberately not here; see below.

## What it decides

- **Two rules per allowlisted v4 prefix**, source and destination. The allowlist names networks we forward *for*, and steering one direction would send a flow's two halves down different tiers — the asymmetric-path case that breaks PMTUD and anything stateful downstream.
- **An allowlist that exceeds the MCAM budget is refused whole**, not truncated. A partially steered port forwards some allowlisted traffic through VPP and the rest through the kernel: not a degraded version of steering but a third forwarding policy, one nobody configured and no counter names.
- **v6 is counted and skipped, not attempted.** Gate 0b round 4 established `ip6` ntuple is rejected by this NIC's AF (error 710) while the v4 control inserts cleanly. `FamilyPolicy` already encodes the same verdict on the FIB side; when a kernel bump makes v6 work, both flip together.

Budget defaults to 512 slots from 1024 — clear of the vendor's own rules without enumerating them, since those change on every controller push — against a table measured at 2048 entries with ~1689 free.

## The caller

`packetframe feasibility`, which already has the whole config and can therefore answer two questions **before** a canary rather than during one:

```
vpp.steering.budget  pass  4 rule(s) for 2 steerable prefix(es), budget 512 from slot 1024;
                           1 IPv6 prefix(es) NOT steerable on this NIC and left on the kernel path
```

A v6-only allowlist is a `fail` with the consequence spelled out — the offload would forward nothing while reporting healthy.

The allowlist is read from the **fast-path** section, because steered prefixes inherit it rather than declaring their own. That is what makes "both tiers carry the same traffic" true by construction instead of by two lists agreeing.

## What I left out, and why

**`ring_cookie` and `mask_for`** were written and then removed. They are ioctl-layer helpers, and shipping them ahead of their caller is the dead-code smell clippy caught one level down — two ethtool constants I'd written for code that doesn't exist yet. The `(vf + 1) << 32` encoding, and why `ethtool`'s own `vf N` keyword gets it wrong on this driver, are recorded in the module docs so the knowledge survives without the dead code.

**The ioctl.** `ethtool_rx_flow_spec` is not in `libc`, so its ~168-byte layout would be hand-written from a header this machine cannot read, and a field in the wrong place produces rules that install cleanly and match the wrong traffic. When it lands it must **read every rule back** with `ETHTOOL_GRXCLSRULE` and compare against what was asked for, so the layout validates itself on the first real NIC instead of being trusted. That requirement is written into the module docs as a requirement, not asserted as done.

## Testing

Five tests on the policy: both directions covered, v6 reported rather than hidden, slot assignment consecutive from the budget base so teardown can find them, an over-budget allowlist refused whole with the message saying so, and a v6-only allowlist producing nothing to steer.

595 tests; fmt, host clippy, and `--workspace --all-targets --all-features` clippy on all four published targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)