### PR TITLE
feat(vpp-offload): the canary lever turns without a restart

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -243,6 +243,15 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         }
     };
 
+    // One allowlist object, not a copy per consumer. The SIGHUP path
+    // republishes into it from the SAME derivation the startup path
+    // uses, which is what makes "vpp-offload steers exactly what
+    // fast-path allows" survive a reconfigure — see `SharedAllowlist`.
+    #[cfg(feature = "vpp-offload")]
+    let allowlist = std::sync::Arc::new(packetframe_vpp_offload::SharedAllowlist::new(
+        crate::feasibility::allowlist_from_config(&config),
+    ));
+
     let mut modules: Vec<(String, Box<dyn Module>)> = Vec::new();
     for section in &config.modules {
         match section.name.as_str() {
@@ -266,7 +275,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 // Steering diverts the fast-path allowlist, so it comes
                 // from that section. The loader is the only place that
                 // sees both.
-                m.set_allowlist(crate::feasibility::allowlist_from_config(&config));
+                m.set_allowlist(allowlist.clone());
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }
             other => {
@@ -389,8 +398,14 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 
     tracing::info!("fast-path running, SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
 
-    let termination = drive_signal_loop(config_path, &config.global.state_dir, &mut modules)
-        .map_err(RunError::Runtime)?;
+    let termination = drive_signal_loop(
+        config_path,
+        &config.global.state_dir,
+        &mut modules,
+        #[cfg(feature = "vpp-offload")]
+        &allowlist,
+    )
+    .map_err(RunError::Runtime)?;
 
     // Stop the exporter + breaker sampler(s) first so their final
     // writes complete before we touch module state.
@@ -543,6 +558,7 @@ fn drive_signal_loop(
     config_path: &Path,
     state_dir: &Path,
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+    #[cfg(feature = "vpp-offload")] allowlist: &packetframe_vpp_offload::SharedAllowlist,
 ) -> Result<Termination, String> {
     use signal_hook::{
         consts::{SIGHUP, SIGINT, SIGTERM, SIGUSR1},
@@ -554,7 +570,13 @@ fn drive_signal_loop(
 
     for sig in signals.forever() {
         match sig {
-            SIGHUP => reconfigure_from_signal(config_path, state_dir, modules),
+            SIGHUP => reconfigure_from_signal(
+                config_path,
+                state_dir,
+                modules,
+                #[cfg(feature = "vpp-offload")]
+                allowlist,
+            ),
             SIGTERM | SIGINT => {
                 tracing::info!(signal = sig, "termination requested");
                 return Ok(Termination::ExitPreserveAttach);
@@ -580,6 +602,7 @@ fn reconfigure_from_signal(
     config_path: &Path,
     state_dir: &Path,
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+    #[cfg(feature = "vpp-offload")] allowlist: &packetframe_vpp_offload::SharedAllowlist,
 ) {
     use packetframe_common::module::ModuleConfig;
 
@@ -595,6 +618,15 @@ fn reconfigure_from_signal(
             return;
         }
     };
+
+    // Before the module loop, and for the WHOLE config rather than per
+    // module. vpp-offload's steering target is derived from fast-path's
+    // `allow-prefix` lines, which its own `ModuleConfig` does not
+    // contain — so without this its `reconfigure` would re-derive the
+    // steering plan from the allowlist as it was at startup, find it
+    // unchanged, and report OK for a SIGHUP that changed nothing.
+    #[cfg(feature = "vpp-offload")]
+    allowlist.publish(crate::feasibility::allowlist_from_config(&new_config));
 
     let mut failures: Vec<String> = Vec::new();
     for (name, module) in modules.iter_mut() {

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1090,48 +1090,64 @@ fn detach_fast_path(
 /// confirmed gone: unbinding a VF or handing back hugepages while a process
 /// can still DMA through them is memory corruption, whereas leaking a VF is a
 /// line in `packetframe status` and a reboot's worth of inconvenience.
-/// Steering is not unwound here because MCAM is not implemented yet; when it
-/// is, it must come first (before the kill), or traffic is left pointed at a
-/// VF nothing services.
+/// **Steering comes down first**, before the kill, or traffic is left pointed
+/// at a VF nothing services.
 #[cfg(feature = "vpp-offload")]
 fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
     use packetframe_vpp_offload::acquire::{release, SysPaths};
+    use packetframe_vpp_offload::ntuple::NtupleSteering;
     use packetframe_vpp_offload::process::{terminate_or_leak, Disposition, VppProcess};
-    use packetframe_vpp_offload::resources::ResourceState;
-    use packetframe_vpp_offload::runtime::TERM_GRACE;
+    use packetframe_vpp_offload::resources::{
+        flatten_steer_rules, group_steer_rules, ResourceState,
+    };
+    use packetframe_vpp_offload::runtime::{Steering as _, TERM_GRACE};
+    use packetframe_vpp_offload::steer::RuleSet;
 
     let Some(state) = ResourceState::load(state_dir).map_err(|e| format!("vpp state: {e}"))? else {
         return Ok(()); // nothing was ever acquired
     };
 
     // Recorded MCAM rules mean traffic is DIVERTED to a VF this function is
-    // about to unbind. Refuse.
+    // about to unbind, so they come down FIRST.
     //
     // The module's teardown ordering is unsteer → abort → kill → release, and
     // the first step is not decoration: releasing a VF that MCAM still points
     // at leaves steered traffic arriving at a function nothing services — a
     // blackhole, which is the failure the whole `Disposition::MustLeak`
-    // discipline exists to avoid, reached from the other direction. This path
-    // cannot unsteer, because MCAM is not implemented until slice 5.
+    // discipline exists to avoid, reached from the other direction.
     //
-    // `steer_rules` is always empty today for exactly that reason, so this is
-    // a guard against a future state rather than a live bug. It is a guard
-    // and not a comment deliberately: "when steering ships, unsteer here
-    // first" is the kind of note this session has watched expire more than
-    // once, and a refusal cannot be forgotten.
+    // This used to be a REFUSAL, guarding a state that could not yet occur:
+    // nothing wrote `steer_rules`, so it was always empty. It is live now,
+    // and a refusal would be the wrong answer — `packetframe detach --all` is
+    // the remedy every error in this subsystem points an operator at, and
+    // refusing it whenever a steered VPP had been running would strand the
+    // box with no way forward. It can do the removal, so it does.
+    //
+    // Through `NtupleSteering` rather than a delete loop here, so this shares
+    // the module's removal routine — including the half that matters, that a
+    // rule the NIC will not delete stays on the record. A second
+    // implementation of "take steering down" is exactly the asymmetry that
+    // produced the release-a-steered-VF bug twice already.
     if !state.steer_rules.is_empty() {
-        let ifaces: Vec<&str> = state
-            .steer_rules
-            .iter()
-            .map(|(iface, _)| iface.as_str())
-            .collect();
-        return Err(format!(
-            "vpp-offload: the state file records MCAM steering rules on {}, so traffic is \
-             being diverted to VF(s) this teardown would unbind — that would blackhole it. \
-             This command cannot remove those rules (MCAM steering is not implemented yet); \
-             clear them first, then re-run.",
-            ifaces.join(", ")
-        ));
+        let recorded = flatten_steer_rules(&state.steer_rules);
+        let mut steering = NtupleSteering::new(Vec::new(), RuleSet::default());
+        steering.adopt_installed(recorded);
+        if let Err(e) = steering.unsteer() {
+            // Write back what is STILL in the NIC before refusing. The rules
+            // that came out must not be retried by the operator's next
+            // attempt, and the ones that did not have to stay findable —
+            // this file is the only record of them.
+            let mut state = state;
+            state.steer_rules = group_steer_rules(&steering.installed());
+            let _ = state.save(state_dir);
+            return Err(format!(
+                "vpp-offload: {e}. The VF(s) were NOT unbound, because MCAM is still \
+                 diverting traffic to them — unbinding now would blackhole it. The state \
+                 file records exactly which rules remain; remove them by hand \
+                 (`ethtool -N <iface> delete <loc>`) and re-run."
+            ));
+        }
+        tracing::info!("vpp-offload: MCAM steering rules removed");
     }
 
     // Kill the recorded VPP first, if it is still the process we recorded.
@@ -1498,16 +1514,25 @@ mod vpp_detach_tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
-    /// Recorded steering rules must block the teardown.
+    /// Steering that cannot be removed blocks the teardown, and the
+    /// record keeps naming exactly what is left.
     ///
-    /// The module unsteers before it releases, because releasing a VF that
-    /// MCAM still points at blackholes the traffic it diverts. This path
-    /// cannot unsteer (no MCAM yet), so it must refuse rather than release.
-    /// Latent today — `steer_rules` is always empty — which is precisely why
-    /// it is a guard with a test rather than a note for later.
+    /// Releasing a VF that MCAM still points at blackholes the traffic it
+    /// diverts, so the removal comes first and a refused removal stops the
+    /// release. What changed when `steer_rules` acquired a writer is the
+    /// *shape* of the guard: this path used to refuse unconditionally,
+    /// which was correct while the field was always empty and became wrong
+    /// the moment it was not — `detach --all` is the remedy every error in
+    /// this subsystem points at, and one that refuses whenever a steered
+    /// VPP had been running would strand the box.
+    ///
+    /// On this host no ethtool call can succeed, so what is exercised is
+    /// the refusal path. The assertion is on the RECORD rather than on the
+    /// message, because that is the invariant: rules that would not come
+    /// out must stay findable, or nothing can ever remove them.
     #[test]
-    fn recorded_steering_rules_block_the_teardown() {
-        use packetframe_vpp_offload::resources::ResourceState;
+    fn steering_that_will_not_come_down_blocks_the_teardown() {
+        use packetframe_vpp_offload::resources::{flatten_steer_rules, ResourceState};
 
         let dir = std::env::temp_dir().join(format!("pf-detach-steer-{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();
@@ -1515,12 +1540,21 @@ mod vpp_detach_tests {
         state.steer_rules = vec![("eth5".to_string(), vec![0, 1])];
         state.save(&dir).unwrap();
 
-        let e = detach_vpp_offload(&dir).expect_err("must refuse");
+        let e = detach_vpp_offload(&dir).expect_err("must refuse while rules remain");
         assert!(e.contains("eth5"), "the steered port must be named: {e}");
         assert!(e.contains("blackhole"), "and the consequence stated: {e}");
         assert!(
-            ResourceState::load(&dir).unwrap().is_some(),
-            "the record must survive"
+            e.contains("ethtool -N"),
+            "and the manual escape hatch, since nothing else can clear them: {e}"
+        );
+
+        let after = ResourceState::load(&dir)
+            .unwrap()
+            .expect("the record must survive");
+        assert_eq!(
+            flatten_steer_rules(&after.steer_rules),
+            vec![("eth5".to_string(), 0), ("eth5".to_string(), 1)],
+            "every rule still in the NIC must still be on the record"
         );
         std::fs::remove_dir_all(&dir).unwrap();
     }

--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -575,6 +575,22 @@ impl IdentityStore for FileStore {
         }
         self.state.save(&self.state_dir)
     }
+
+    fn steering_changed(&mut self, rules: &[(String, u32)]) -> Result<(), String> {
+        // Grouped by interface for the file's shape, and REPLACED rather
+        // than merged: the argument is the complete ledger, so an
+        // interface that no longer appears has no rules left. Merging
+        // would make `steer off` on one port unrecordable.
+        //
+        // Deliberately NOT validated against `self.ports` the way
+        // `interfaces_attached` validates its interface. That check
+        // exists to stop attach inventing a resource nothing holds; here
+        // the rule is already in the NIC, and refusing to write it down
+        // because the port record looks wrong would leave the one thing
+        // a later `detach --all` needs unrecorded.
+        self.state.steer_rules = crate::resources::group_steer_rules(rules);
+        self.state.save(&self.state_dir)
+    }
 }
 
 /// The single owner of everything attach acquired: the state file and
@@ -639,6 +655,23 @@ impl IdentityStore for ResourceOwner {
         }
         self.store.interfaces_attached(indices)
     }
+
+    fn steering_changed(&mut self, rules: &[(String, u32)]) -> Result<(), String> {
+        if self.released {
+            // Release only happens after a teardown reported clean,
+            // which requires an `Unsteer` that confirmed the rules gone
+            // — so the only steering change that can arrive here is one
+            // recording an empty set, and the file it would re-create
+            // describes VFs nothing holds. Refusing is right; a
+            // NON-empty set arriving here would mean the release rules
+            // were violated upstream, and that is worth the loud store
+            // error rather than a silent write.
+            return Err(
+                "resources were already released; refusing to re-create the state file".into(),
+            );
+        }
+        self.store.steering_changed(rules)
+    }
 }
 
 impl ResourceRelease for ResourceOwner {
@@ -691,6 +724,9 @@ impl IdentityStore for SharedOwner {
     }
     fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String> {
         self.0.borrow_mut().interfaces_attached(indices)
+    }
+    fn steering_changed(&mut self, rules: &[(String, u32)]) -> Result<(), String> {
+        self.0.borrow_mut().steering_changed(rules)
     }
 }
 
@@ -1347,5 +1383,71 @@ mod tests {
         owner.process_changed(None).unwrap();
         let after = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
         assert_eq!(after.ports.len(), 1, "eth3 was resurrected by a later save");
+    }
+
+    /// The steering ledger reaches the file, and reaches it in a shape
+    /// `bring_up` can read back.
+    ///
+    /// This is the seam that shipped missing: `ResourceState::steer_rules`
+    /// was read by `bring_up` — to decide whether an adopted VPP is
+    /// diverting traffic — and written by nothing. So a daemon restart
+    /// over a steered VPP believed nothing was steered, emitted no
+    /// `Unsteer` on teardown, and released the VF with MCAM still
+    /// pointing traffic into it.
+    ///
+    /// Asserted through a full round trip rather than on the field,
+    /// because the field alone proves nothing: what has to hold is that
+    /// the pairs written here are the pairs `NtupleSteering` gets back.
+    #[test]
+    fn the_steering_ledger_round_trips_through_the_state_file() {
+        let f = Fixture::new(
+            "owner-steer",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let mut owner = ResourceOwner::new(state, f.paths.clone());
+
+        let rules = vec![
+            ("eth2".to_string(), 1024u32),
+            ("eth2".to_string(), 1025),
+            ("eth3".to_string(), 1024),
+        ];
+        owner.steering_changed(&rules).unwrap();
+
+        // The flattening `bring_up` performs, against what it was given.
+        let on_disk = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
+        let restored = crate::resources::flatten_steer_rules(&on_disk.steer_rules);
+        assert_eq!(restored, rules, "what goes in is what comes back");
+        assert!(
+            !on_disk.steer_rules.is_empty(),
+            "and it is non-empty, which is what makes `Adopted {{ steered: true }}` reachable"
+        );
+    }
+
+    /// An empty ledger REPLACES the recorded one rather than merging.
+    ///
+    /// `steer off` on the last steered port produces exactly this call.
+    /// Merging would leave the removed rules on the record forever, and
+    /// the next daemon start would adopt them — believing itself steered,
+    /// and holding locations the NIC no longer has.
+    #[test]
+    fn clearing_the_steering_ledger_clears_the_record() {
+        let f = Fixture::new(
+            "owner-unsteer",
+            &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
+        );
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let mut owner = ResourceOwner::new(state, f.paths.clone());
+
+        owner
+            .steering_changed(&[("eth2".to_string(), 1024)])
+            .unwrap();
+        owner.steering_changed(&[]).unwrap();
+
+        let on_disk = ResourceState::load(&f.paths.state_dir).unwrap().unwrap();
+        assert!(
+            on_disk.steer_rules.is_empty(),
+            "an unsteer that confirmed removal must leave nothing for the next start to adopt"
+        );
     }
 }

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -423,6 +423,23 @@ fn finish(
     let steered = !state.steer_rules.is_empty();
     let adopted_process = adopted.is_some();
 
+    // Take ownership of the rules the record names, so `unsteer` can
+    // remove them.
+    //
+    // `steered` above is derived from the same field, and the two must
+    // not diverge: believing traffic is diverted while holding no way to
+    // undivert it is worse than either mistake alone — every teardown
+    // would emit an `Unsteer` that found an empty ledger, answered `Ok`,
+    // and released the VF with the rules still in the NIC.
+    //
+    // Rules recorded for an interface that is no longer a member port
+    // are adopted TOO, deliberately. They are in the NIC either way, and
+    // this object is the only thing that will ever remove them; dropping
+    // them here because the config changed is how a `steer on` port
+    // removed from the config keeps diverting traffic forever.
+    let mut steering = steering;
+    steering.adopt_installed(crate::resources::flatten_steer_rules(&state.steer_rules));
+
     let capacity = startup_conf::route_capacity(sizing);
     let api_socket_path = paths.api_socket.clone();
     let startup_conf_path = paths.startup_conf.clone();
@@ -509,6 +526,17 @@ fn finish(
             // Nothing to hand over: VPP does not exist yet, so there is no
             // API to handshake with. The loop's `Start` spawns it and the
             // driver polls `api_ready` while `Starting`.
+            //
+            // But the RULES may still be there. MCAM outlives the
+            // process, so a VPP that died steered leaves its rules
+            // diverting allowlisted traffic into a VF with nothing
+            // behind it — blackholing since the moment it died. Telling
+            // the supervisor makes its own teardown ordering handle it:
+            // `Unsteer` first, and if the NIC refuses, `steered` stays
+            // true and the VF stays withheld. Doing the removal here
+            // instead would be a second, unsupervised path to the same
+            // effect, whose failures nothing would ever retry.
+            None if steered => vec![Event::InheritedSteering, Event::StartRequested],
             None => vec![Event::StartRequested],
         };
         Ok((Driver::new(), runtime, initial))

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -516,6 +516,11 @@ mod tests {
     }
 
     impl Effects for Fx {
+        fn steering_in_place(&self) -> bool {
+            // No ledger in this fake; the driver tests never assert on
+            // `steered` after a failed steer.
+            false
+        }
         fn spawn(&mut self) -> Result<(), String> {
             self.calls.push("spawn");
             Ok(())
@@ -1298,6 +1303,9 @@ mod tests {
     fn failures_name_the_action_that_failed() {
         struct Bad;
         impl Effects for Bad {
+            fn steering_in_place(&self) -> bool {
+                false
+            }
             fn spawn(&mut self) -> Result<(), String> {
                 Err("no binary".into())
             }

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -46,6 +46,15 @@ pub trait Effects {
     /// Install MCAM steering rules.
     fn steer(&mut self) -> Result<(), String>;
 
+    /// Whether the steering ledger currently names any rule in the NIC.
+    ///
+    /// Read after a failed [`Self::steer`] so the supervisor is *told*
+    /// whether traffic is still diverted rather than assuming. A steer
+    /// that fails may leave the NIC empty or holding rules that would
+    /// not delete, and the two demand opposite handling — see
+    /// [`Event::SteerFailed`].
+    fn steering_in_place(&self) -> bool;
+
     /// Stop the process. Returns whether its resources may be released
     /// — see [`Disposition`].
     fn kill(&mut self) -> Disposition;
@@ -173,10 +182,17 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                 Ok(()) => Event::Steered,
                 Err(e) => {
                     out.failures.push((*action, e));
-                    // Verified but not steered: reported, not papered
-                    // over, and NOT a process restart — the dataplane
-                    // is fine.
-                    Event::SteerFailed
+                    // Verified but not steered as asked: reported, not
+                    // papered over, and NOT a process restart — the
+                    // dataplane is fine.
+                    //
+                    // `rules_remain` is read from the ledger AFTER the
+                    // failure, because only the ledger knows whether the
+                    // rollback emptied the NIC or left rules it could
+                    // not delete. See `Event::SteerFailed`.
+                    Event::SteerFailed {
+                        rules_remain: fx.steering_in_place(),
+                    }
                 }
             }),
             Action::AbortConvergence => fx.abort_convergence(),
@@ -211,9 +227,15 @@ mod tests {
         fail_verify: bool,
         fail_release: bool,
         kill_disposition: Option<Disposition>,
+        /// What the steering ledger reports after a failed steer.
+        rules_remain: bool,
     }
 
     impl Effects for Recorder {
+        /// Whatever the test says the ledger holds after a steer.
+        fn steering_in_place(&self) -> bool {
+            self.rules_remain
+        }
         fn spawn(&mut self) -> Result<(), String> {
             self.calls.push("spawn");
             err_if(self.fail_spawn, "no such binary")
@@ -410,7 +432,12 @@ mod tests {
             ..Default::default()
         };
         let out = execute(&[Action::Steer], &mut r);
-        assert_eq!(out.events, vec![Event::SteerFailed]);
+        assert_eq!(
+            out.events,
+            vec![Event::SteerFailed {
+                rules_remain: false
+            }]
+        );
         assert!(!out.events.contains(&Event::Steered));
     }
 

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -31,12 +31,12 @@ use crate::supervisor::{Action, Event};
 /// Everything the executor does to the world outside itself.
 ///
 /// A trait so the ordering and failure-handling rules can be tested
-/// against a recorder. The real implementation lands with the tick loop;
-/// `Steer`/`Unsteer` stay unimplemented until slice 5 builds MCAM, and
-/// deliberately **fail loudly** there rather than returning `Ok(())` —
-/// a no-op steer that reports success would let the supervisor believe
-/// traffic is diverted when nothing is, which is worse than not having
-/// the feature.
+/// against a recorder. `Steer`/`Unsteer` are real
+/// ([`crate::ntuple::NtupleSteering`]) and must **fail loudly** rather
+/// than returning `Ok(())` on any doubt — a no-op steer that reports
+/// success lets the supervisor believe traffic is diverted when nothing
+/// is, and a no-op unsteer releases a VF that MCAM is still pointing
+/// traffic at.
 pub trait Effects {
     fn spawn(&mut self) -> Result<(), String>;
 

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -231,6 +231,71 @@ impl SharedAllowlist {
     }
 }
 
+/// What steering should look like for a config + allowlist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SteeringTarget {
+    /// `(PF iface, VF index)` for every port configured `steer on`.
+    pub ports: Vec<(String, u32)>,
+    /// The rules those ports should hold. Empty when nothing steers.
+    pub plan: steer::RuleSet,
+    /// Whether traffic should be diverted once the target is in place.
+    pub want_steer: bool,
+}
+
+/// Derive the steering target.
+///
+/// A free function so the one rule that is easy to get backwards is
+/// testable without an attachment, a VPP or a NIC: **the plan is built
+/// only when something is going to be installed.**
+///
+/// `RuleSet::plan` refuses an allowlist that overruns the MCAM budget,
+/// which is right on the way in and wrong on the way out.
+/// [`crate::runtime::Steering::unsteer`] removes what the ledger names
+/// and never reads the plan, so validating it unconditionally lets an
+/// over-budget allowlist block `steer off` — the one reconfigure an
+/// operator must always be able to make, since it is how traffic comes
+/// off a misbehaving VPP. An allowlist growing past the budget is a
+/// plausible way to arrive at wanting exactly that.
+fn steering_target(
+    cfg: &VppOffloadConfig,
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Result<SteeringTarget, String> {
+    // VF 0 because `acquire` creates exactly one per PF.
+    let ports: Vec<(String, u32)> = cfg
+        .ports
+        .iter()
+        .filter(|(_, _, steer)| *steer)
+        .map(|(iface, _, _)| (iface.clone(), 0u32))
+        .collect();
+    let want_steer = !ports.is_empty();
+    if !want_steer {
+        // Nothing to install and nothing that reads a plan. An empty
+        // target is also the truthful one: no port steers.
+        return Ok(SteeringTarget {
+            ports,
+            plan: steer::RuleSet::default(),
+            want_steer: false,
+        });
+    }
+    let plan = steer::RuleSet::plan(allowlist, steer::McamBudget::default())?;
+    // `steer on` with nothing steerable is refused for the same reason
+    // `bring_up` refuses it: steering would divert nothing while every
+    // surface reported it on.
+    if plan.rules.is_empty() {
+        return Err(format!(
+            "port(s) are configured `steer on`, but the allowlist produces no steerable \
+             rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected by this NIC). \
+             Steering would divert nothing while reporting Healthy",
+            plan.skipped_v6
+        ));
+    }
+    Ok(SteeringTarget {
+        ports,
+        plan,
+        want_steer: true,
+    })
+}
+
 pub struct VppOffloadModule {
     cfg: VppOffloadConfig,
     /// From [`LoaderCtx`] at load; `attach` has no ctx of its own.
@@ -618,31 +683,8 @@ impl Module for VppOffloadModule {
             return Ok(());
         };
 
-        let allowlist = self.allowlist.get();
-        let plan = steer::RuleSet::plan(&allowlist, steer::McamBudget::default())
+        let target = steering_target(&new, &self.allowlist.get())
             .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
-        let ports: Vec<(String, u32)> = new
-            .ports
-            .iter()
-            .filter(|(_, _, steer)| *steer)
-            .map(|(iface, _, _)| (iface.clone(), 0u32))
-            .collect();
-        // `steer on` with nothing steerable is refused here for the same
-        // reason `bring_up` refuses it: steering would divert nothing
-        // while every surface reported it on.
-        if !ports.is_empty() && plan.rules.is_empty() {
-            return Err(ModuleError::other(
-                MODULE_NAME,
-                format!(
-                    "port(s) are configured `steer on`, but the allowlist produces no \
-                     steerable rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected \
-                     by this NIC). Steering would divert nothing while reporting Healthy",
-                    plan.skipped_v6
-                ),
-            ));
-        }
-
-        let want_steer = !ports.is_empty();
         // Did the operator actually turn the lever, or does the config
         // merely still say `steer on`?
         //
@@ -662,7 +704,7 @@ impl Module for VppOffloadModule {
             .ne(new.ports.iter().map(|(_, _, steer)| *steer));
         attached
             .service
-            .apply_steering(ports, plan, want_steer, lever_moved)
+            .apply_steering(target.ports, target.plan, target.want_steer, lever_moved)
             .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
         // Recorded only after the change landed. A `cfg` updated ahead of
         // the apply would make the NEXT reconfigure diff against a target
@@ -1245,6 +1287,62 @@ mod tests {
             m.allowlist.get(),
             vec![v4(0), v4(1)],
             "the module must see the republished list without being handed anything"
+        );
+    }
+
+    /// An over-budget allowlist must never block `steer off`.
+    ///
+    /// `RuleSet::plan` refuses an allowlist bigger than the MCAM budget,
+    /// which is correct when rules are about to be installed. Validating
+    /// it on the way OUT blocks the one reconfigure an operator must
+    /// always be able to make — turning traffic off a misbehaving VPP —
+    /// and `unsteer` never reads the plan anyway. An allowlist growing
+    /// past the budget is a plausible route to wanting exactly that
+    /// rollback.
+    #[test]
+    fn an_over_budget_allowlist_does_not_block_the_rollback() {
+        use packetframe_common::fib::IpPrefix;
+        // The default budget is 512 slots at two rules per prefix, so
+        // 300 v4 prefixes cannot fit.
+        let allow: Vec<IpPrefix> = (0..300u32)
+            .map(|i| IpPrefix::V4 {
+                addr: [10, (i >> 8) as u8, (i & 0xff) as u8, 0],
+                prefix_len: 24,
+            })
+            .collect();
+
+        // Steering ON is refused, and names the true requirement.
+        let on = cfg(&[("eth4", 1, true)], 1_600_000);
+        let e = steering_target(&on, &allow).expect_err("cannot fit");
+        assert!(e.contains("600 MCAM rule(s)"), "{e}");
+
+        // Steering OFF succeeds with the same allowlist. This is the
+        // assertion that matters: the rollback path must not consult a
+        // budget it does not spend.
+        let off = cfg(&[("eth4", 1, false)], 1_600_000);
+        let t = steering_target(&off, &allow).expect("rollback must be possible");
+        assert!(t.ports.is_empty() && !t.want_steer);
+        assert!(
+            t.plan.rules.is_empty(),
+            "and it carries an empty target, which is what no port steering means"
+        );
+    }
+
+    /// A `steer on` port with a v6-only allowlist is refused, not
+    /// silently accepted as steering nothing.
+    #[test]
+    fn steer_on_with_nothing_steerable_is_refused() {
+        use packetframe_common::fib::IpPrefix;
+        let allow = vec![IpPrefix::V6 {
+            addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            prefix_len: 32,
+        }];
+        let on = cfg(&[("eth4", 1, true)], 1_600_000);
+        let e = steering_target(&on, &allow).expect_err("must refuse");
+        assert!(e.contains("no steerable rules"), "{e}");
+        assert!(
+            e.contains("reporting Healthy"),
+            "the consequence has to be stated: {e}"
         );
     }
 }

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -32,12 +32,16 @@
 //! convergence budget was measured separately (gate 0b, 40.32 s of 60 s)
 //! by a bench driving the same engine, not by this module.
 //!
-//! Two things are deliberately absent rather than stubbed:
-//! **MCAM steering** ([`runtime::SteeringUnavailable`] refuses both
-//! directions until slice 5) and **stats-segment gauges** (they need a
-//! shared-memory parser that does not exist). A config with every port
-//! `steer off` — the designed staging state — never reaches the steering
-//! seam.
+//! **Stats-segment gauges** are deliberately absent rather than stubbed:
+//! they need a shared-memory parser that does not exist, and a field
+//! reporting "unavailable" forever would be a shim for a hypothetical
+//! state.
+//!
+//! MCAM steering is real ([`steer`] plans, [`ntuple`] installs and reads
+//! back), and [`Module::reconfigure`] turns it on and off under a
+//! running VPP — that is the canary lever, and making it cost a restart
+//! would put ~40 s of resync between an operator and every rollout step,
+//! including the rollback.
 //!
 //! Design record: `.claude/plans/` phase-4 plan v7. Key invariants
 //! enforced from day one:
@@ -126,6 +130,61 @@ impl VppOffloadConfig {
         out
     }
 
+    /// What in `new` cannot be applied without a restart.
+    ///
+    /// `Ok(())` means the only differences are ones `reconfigure` can
+    /// act on: the per-port `steer` flag. Everything else is fixed at
+    /// VPP's start or at VF acquisition, so the honest answer is to
+    /// refuse and say so — the alternative is a daemon whose running
+    /// configuration silently differs from the file an operator just
+    /// edited, which is how the wrong thing gets debugged for an hour.
+    ///
+    /// A pure function over two configs so the rule is testable without
+    /// a VPP, a NIC, or an attachment.
+    pub fn restart_only_delta(&self, new: &Self) -> Result<(), String> {
+        // Ports are compared as (iface, cores) IN ORDER. Order matters
+        // as much as membership: it decides which VF is created on which
+        // PF, and `acquire` refuses to adopt across a change to either.
+        let old_ports: Vec<(&str, u16)> = self
+            .ports
+            .iter()
+            .map(|(i, c, _)| (i.as_str(), *c))
+            .collect();
+        let new_ports: Vec<(&str, u16)> =
+            new.ports.iter().map(|(i, c, _)| (i.as_str(), *c)).collect();
+        if old_ports != new_ports {
+            return Err(format!(
+                "the `port` lines changed ({old_ports:?} → {new_ports:?}); VF and worker \
+                 topology is fixed when VPP starts, so this needs a restart \
+                 (`packetframe detach --all`, then start). Only `steer on|off` can change \
+                 under a running VPP"
+            ));
+        }
+        if self.expected_routes != new.expected_routes {
+            return Err(format!(
+                "`expected-routes` changed ({} → {}); it sizes VPP's main heap and stats \
+                 segment, both fixed at start. Applying the new ceiling to a VPP running on \
+                 the old segments is what aborts it mid-resync — restart to apply",
+                self.expected_routes, new.expected_routes
+            ));
+        }
+        if self.hugepages != new.hugepages {
+            return Err(format!(
+                "`hugepages` changed ({:?} → {:?}); the reservation is made at attach and \
+                 VPP maps it at start — restart to apply",
+                self.hugepages, new.hugepages
+            ));
+        }
+        if self.vpp_binary != new.vpp_binary {
+            return Err(format!(
+                "`vpp-binary` changed ({:?} → {:?}); the running VPP is the one that was \
+                 spawned — restart to apply",
+                self.vpp_binary, new.vpp_binary
+            ));
+        }
+        Ok(())
+    }
+
     /// Total VPP worker threads the config promises, across all ports.
     ///
     /// VPP's thread count is global, not per-interface, and its counter
@@ -140,6 +199,38 @@ impl VppOffloadConfig {
     }
 }
 
+/// The fast-path allowlist, as a live handle rather than a copy.
+///
+/// A handle because a copy is wrong at exactly one moment, and it is the
+/// moment that matters. `attach` reads the allowlist once at startup;
+/// `reconfigure` runs on SIGHUP, when the operator has *just changed
+/// it*. But the allowlist lives in the fast-path section, and
+/// `Module::reconfigure` is handed only its own module's `ModuleConfig`
+/// — so a module holding a `Vec` would compare the new steering target
+/// against a snapshot of the old allowlist, find no change, and silently
+/// do nothing. The one thing SIGHUP exists to do.
+///
+/// So the loader owns one of these, publishes into it from a single
+/// derivation, and hands the same object to the module. There is nothing
+/// to keep in sync because there is only one copy.
+#[derive(Debug, Default)]
+pub struct SharedAllowlist(std::sync::RwLock<Vec<packetframe_common::fib::IpPrefix>>);
+
+impl SharedAllowlist {
+    pub fn new(prefixes: Vec<packetframe_common::fib::IpPrefix>) -> Self {
+        Self(std::sync::RwLock::new(prefixes))
+    }
+
+    /// Replace the whole list. The loader is the only writer.
+    pub fn publish(&self, prefixes: Vec<packetframe_common::fib::IpPrefix>) {
+        *self.0.write().expect("allowlist lock") = prefixes;
+    }
+
+    pub fn get(&self) -> Vec<packetframe_common::fib::IpPrefix> {
+        self.0.read().expect("allowlist lock").clone()
+    }
+}
+
 pub struct VppOffloadModule {
     cfg: VppOffloadConfig,
     /// From [`LoaderCtx`] at load; `attach` has no ctx of its own.
@@ -149,7 +240,7 @@ pub struct VppOffloadModule {
     source: Option<Box<dyn engine::RouteSource + Send + Sync>>,
     /// Prefixes steering diverts, inherited from fast-path's allowlist.
     /// Empty until the loader sets it; see [`Self::set_allowlist`].
-    allowlist: Vec<packetframe_common::fib::IpPrefix>,
+    allowlist: std::sync::Arc<SharedAllowlist>,
     /// `Some` once supervision is running.
     attached: Option<bringup::Attached>,
     /// A teardown still running in the background after `detach` returned.
@@ -175,7 +266,7 @@ impl VppOffloadModule {
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {
-            allowlist: Vec::new(),
+            allowlist: std::sync::Arc::new(SharedAllowlist::default()),
             cfg: VppOffloadConfig::default(),
             state_dir: std::path::PathBuf::new(),
             source: None,
@@ -211,7 +302,10 @@ impl VppOffloadModule {
     /// same traffic" true by construction instead of by two lists
     /// agreeing. The loader is the only caller — it is the only place
     /// that sees both sections.
-    pub fn set_allowlist(&mut self, allowlist: Vec<packetframe_common::fib::IpPrefix>) {
+    ///
+    /// Takes the shared handle, not a snapshot: see [`SharedAllowlist`]
+    /// for why a snapshot is wrong on exactly the SIGHUP path.
+    pub fn set_allowlist(&mut self, allowlist: std::sync::Arc<SharedAllowlist>) {
         self.allowlist = allowlist;
     }
 
@@ -474,7 +568,7 @@ impl Module for VppOffloadModule {
             ));
         }
         let paths = bringup::AttachPaths::live(&self.state_dir, default_hugepage_bytes());
-        let attached = match bringup::bring_up(&self.cfg, &paths, source, &self.allowlist) {
+        let attached = match bringup::bring_up(&self.cfg, &paths, source, &self.allowlist.get()) {
             Ok(a) => a,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
         };
@@ -494,13 +588,71 @@ impl Module for VppOffloadModule {
         Ok(Vec::new())
     }
 
-    fn reconfigure(&mut self, _cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
-        // Allowlist deltas become steering deltas, which needs the MCAM
-        // implementation (slice 5). Port and cores changes are
-        // restart-only by design — `acquire` refuses to adopt across
-        // them, and so does a changed `expected-routes`, because VPP
-        // fixes its heap and stats segment at start.
-        Err(ModuleError::not_implemented(MODULE_NAME))
+    /// Allowlist and `steer on|off` deltas become MCAM deltas.
+    ///
+    /// This is the canary lever. The rollout turns it port by port, and
+    /// its rollback turns it back — so it must not cost a VPP restart:
+    /// that would be ~40 s of resync with the offload down, per step,
+    /// including the step whose whole purpose is to get traffic OFF a
+    /// misbehaving VPP quickly.
+    ///
+    /// Everything else in the section is restart-only, and refused with
+    /// the reason rather than silently ignored. `port` and `cores` are
+    /// VF and thread topology that VPP fixes at start (and `acquire`
+    /// refuses to adopt across); `expected-routes` sizes the main heap
+    /// and the stats segment, which VPP also fixes at start — applying a
+    /// raised ceiling to a VPP running on the old segments is the
+    /// mid-resync OOM abort gate 0b found; `vpp-binary` and `hugepages`
+    /// likewise only mean anything at spawn.
+    fn reconfigure(&mut self, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+        let new = VppOffloadConfig::from_directives(&cfg.section.directives);
+        if let Err(why) = self.cfg.restart_only_delta(&new) {
+            return Err(ModuleError::other(MODULE_NAME, why));
+        }
+
+        // Nothing to steer into. Not an error: a config with every port
+        // `steer off` and no attachment is a legitimate state, and so is
+        // a SIGHUP arriving between `load` and `attach`.
+        let Some(attached) = &self.attached else {
+            self.cfg = new;
+            return Ok(());
+        };
+
+        let allowlist = self.allowlist.get();
+        let plan = steer::RuleSet::plan(&allowlist, steer::McamBudget::default())
+            .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
+        let ports: Vec<(String, u32)> = new
+            .ports
+            .iter()
+            .filter(|(_, _, steer)| *steer)
+            .map(|(iface, _, _)| (iface.clone(), 0u32))
+            .collect();
+        // `steer on` with nothing steerable is refused here for the same
+        // reason `bring_up` refuses it: steering would divert nothing
+        // while every surface reported it on.
+        if !ports.is_empty() && plan.rules.is_empty() {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!(
+                    "port(s) are configured `steer on`, but the allowlist produces no \
+                     steerable rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected \
+                     by this NIC). Steering would divert nothing while reporting Healthy",
+                    plan.skipped_v6
+                ),
+            ));
+        }
+
+        let want_steer = !ports.is_empty();
+        attached
+            .service
+            .apply_steering(ports, plan, want_steer)
+            .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
+        // Recorded only after the change landed. A `cfg` updated ahead of
+        // the apply would make the NEXT reconfigure diff against a target
+        // that was never installed, so a failed canary step would look
+        // like a no-op change and never be retried.
+        self.cfg = new;
+        Ok(())
     }
 
     fn detach(&mut self) -> ModuleResult<()> {
@@ -961,5 +1113,121 @@ mod tests {
         ] {
             assert_eq!(a.worse_of(b), want, "{a:?}.worse_of({b:?})");
         }
+    }
+
+    fn cfg(ports: &[(&str, u16, bool)], routes: u64) -> VppOffloadConfig {
+        VppOffloadConfig {
+            ports: ports
+                .iter()
+                .map(|(i, c, s)| (i.to_string(), *c, *s))
+                .collect(),
+            vpp_binary: None,
+            expected_routes: routes,
+            hugepages: None,
+        }
+    }
+
+    /// The `steer` flag is the ONLY thing a SIGHUP may change.
+    ///
+    /// It has to be: it is the canary lever, and the rollout turns it
+    /// port by port. Making it restart-only would cost ~40 s of resync
+    /// with the offload down per rollout step — including the rollback
+    /// step, whose whole purpose is to get traffic off a misbehaving VPP
+    /// quickly.
+    #[test]
+    fn flipping_the_canary_lever_is_not_a_restart() {
+        let before = cfg(&[("eth4", 1, false), ("eth5", 1, false)], 1_600_000);
+        let after = cfg(&[("eth4", 1, false), ("eth5", 1, true)], 1_600_000);
+        before
+            .restart_only_delta(&after)
+            .expect("steer on|off must be applicable under a running VPP");
+    }
+
+    /// Everything VPP fixes at start is refused, and says which knob and
+    /// what to do.
+    ///
+    /// Silently ignoring any of these is the failure mode that matters:
+    /// the daemon's running configuration would differ from the file the
+    /// operator just edited, with nothing anywhere saying so.
+    #[test]
+    fn everything_fixed_at_start_is_refused_by_name() {
+        let base = cfg(&[("eth4", 1, false)], 1_600_000);
+
+        for (new, needle) in [
+            (
+                cfg(&[("eth4", 1, false), ("eth5", 1, false)], 1_600_000),
+                "`port` lines changed",
+            ),
+            (
+                cfg(&[("eth4", 2, false)], 1_600_000),
+                "`port` lines changed",
+            ),
+            (
+                cfg(&[("eth4", 1, false)], 2_000_000),
+                "`expected-routes` changed",
+            ),
+        ] {
+            let e = base.restart_only_delta(&new).expect_err("must refuse");
+            assert!(e.contains(needle), "{e}");
+            assert!(
+                e.contains("restart"),
+                "the operator needs to be told what to DO about it: {e}"
+            );
+        }
+
+        let mut pages = base.clone();
+        pages.hugepages = Some(12);
+        assert!(base
+            .restart_only_delta(&pages)
+            .expect_err("hugepages")
+            .contains("`hugepages` changed"));
+
+        let mut binary = base.clone();
+        binary.vpp_binary = Some("/opt/vpp/bin/vpp".into());
+        assert!(base
+            .restart_only_delta(&binary)
+            .expect_err("vpp-binary")
+            .contains("`vpp-binary` changed"));
+    }
+
+    /// A reordered port list is a change, not a permutation.
+    ///
+    /// Order decides which VF is created on which PF, and `acquire`
+    /// refuses to adopt across it — so accepting it here would produce a
+    /// reconfigure that reports OK and a next start that refuses.
+    #[test]
+    fn reordering_the_ports_is_a_restart() {
+        let before = cfg(&[("eth4", 1, false), ("eth5", 1, false)], 1_600_000);
+        let after = cfg(&[("eth5", 1, false), ("eth4", 1, false)], 1_600_000);
+        assert!(before.restart_only_delta(&after).is_err());
+    }
+
+    /// The shared allowlist is a window, not a copy.
+    ///
+    /// The defect it exists to prevent: `reconfigure` is handed only its
+    /// own module's section, so a module holding a `Vec` would compare
+    /// the new steering target against the allowlist as it was at
+    /// startup, find no change, and report OK for the one thing SIGHUP
+    /// was raised to do.
+    #[test]
+    fn a_republished_allowlist_is_visible_through_the_handle() {
+        use packetframe_common::fib::IpPrefix;
+        let v4 = |a: u8| IpPrefix::V4 {
+            addr: [10, a, 0, 0],
+            prefix_len: 16,
+        };
+        let shared = std::sync::Arc::new(SharedAllowlist::new(vec![v4(0)]));
+
+        let mut m = VppOffloadModule::new();
+        m.set_allowlist(shared.clone());
+        assert_eq!(m.allowlist.get(), vec![v4(0)]);
+
+        // What the loader does on SIGHUP, from the whole new config.
+        shared.publish(vec![v4(0), v4(1)]);
+        assert_eq!(
+            m.allowlist.get(),
+            vec![v4(0), v4(1)],
+            "the module must see the republished list without being handed anything"
+        );
     }
 }

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -643,9 +643,26 @@ impl Module for VppOffloadModule {
         }
 
         let want_steer = !ports.is_empty();
+        // Did the operator actually turn the lever, or does the config
+        // merely still say `steer on`?
+        //
+        // The two must not look the same. A `steer on` port that has
+        // never steered is in the designed staging state, and a SIGHUP
+        // for an unrelated reason — an added `allow-prefix`, a changed
+        // global — must not divert its traffic as a side effect. Only the
+        // flag moving is the operator asking.
+        //
+        // Positional comparison is sound because `restart_only_delta`
+        // has already established the port list is identical, in order.
+        let lever_moved = self
+            .cfg
+            .ports
+            .iter()
+            .map(|(_, _, steer)| *steer)
+            .ne(new.ports.iter().map(|(_, _, steer)| *steer));
         attached
             .service
-            .apply_steering(ports, plan, want_steer)
+            .apply_steering(ports, plan, want_steer, lever_moved)
             .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
         // Recorded only after the change landed. A `cfg` updated ahead of
         // the apply would make the NEXT reconfigure diff against a target

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -172,7 +172,7 @@ fn matches(asked: &RxFlowSpec, got: &RxFlowSpec) -> bool {
         && asked.m_u.hdata[..8] == got.m_u.hdata[..8]
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(all(target_os = "linux", not(test)))]
 mod sys {
     use super::Rxnfc;
 
@@ -222,11 +222,110 @@ mod sys {
     }
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"), not(test)))]
 mod sys {
     use super::Rxnfc;
     pub(super) fn ethtool(_iface: &str, _req: &mut Rxnfc) -> Result<(), String> {
         Err("ntuple steering is Linux-only".into())
+    }
+}
+
+/// An in-memory NIC standing in for `SIOCETHTOOL`, tests only.
+///
+/// Exists because without it **nothing in [`NtupleSteering::steer`] or
+/// [`NtupleSteering::unsteer`] had ever executed** — every `ethtool`
+/// call fails on a dev host and fails for a different reason on a CI
+/// runner with no such interface, so both routines could only ever be
+/// tested along their failure paths. The sequencing they encode
+/// (reconcile stale rules before installing, all-or-nothing rollback,
+/// a ledger that is a set) is exactly what a failure-only test cannot
+/// see.
+///
+/// **What this does NOT prove**: the wire format. The fake stores
+/// whatever `flow_spec` produced and hands the same bytes back, so a
+/// field at the wrong offset round-trips perfectly here. That check has
+/// one real venue — the `ETHTOOL_GRXCLSRULE` readback against a real
+/// NIC — and it is still unrun. This substitutes for a NIC's
+/// *behaviour*, not for its *layout*.
+#[cfg(test)]
+pub(super) mod sys {
+    use super::{Rxnfc, ETHTOOL_GRXCLSRULE, ETHTOOL_SRXCLSRLDEL, ETHTOOL_SRXCLSRLINS};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    #[derive(Default)]
+    pub(crate) struct FakeNic {
+        rules: HashMap<(String, u32), super::RxFlowSpec>,
+        /// Locations whose delete must fail, modelling the rule that
+        /// will not come out — the case the release rules turn on.
+        undeletable: Vec<u32>,
+        /// Locations whose insert must fail, modelling a full or
+        /// otherwise refusing MCAM.
+        uninsertable: Vec<u32>,
+    }
+
+    thread_local! {
+        static NIC: RefCell<FakeNic> = RefCell::new(FakeNic::default());
+    }
+
+    /// Start from an empty NIC. Call at the top of any test that
+    /// installs rules; the state is per-thread, and Rust runs each test
+    /// on its own.
+    pub(crate) fn reset() {
+        NIC.with(|n| *n.borrow_mut() = FakeNic::default());
+    }
+
+    pub(crate) fn wedge_delete(locations: &[u32]) {
+        NIC.with(|n| n.borrow_mut().undeletable = locations.to_vec());
+    }
+
+    pub(crate) fn wedge_insert(locations: &[u32]) {
+        NIC.with(|n| n.borrow_mut().uninsertable = locations.to_vec());
+    }
+
+    /// Every `(iface, loc)` the NIC currently holds, sorted — the
+    /// ground truth a test compares the ledger against.
+    pub(crate) fn rules() -> Vec<(String, u32)> {
+        NIC.with(|n| {
+            let mut v: Vec<(String, u32)> = n.borrow().rules.keys().cloned().collect();
+            v.sort();
+            v
+        })
+    }
+
+    pub(super) fn ethtool(iface: &str, req: &mut Rxnfc) -> Result<(), String> {
+        NIC.with(|n| {
+            let mut nic = n.borrow_mut();
+            let key = (iface.to_string(), req.fs.location);
+            match req.cmd {
+                ETHTOOL_SRXCLSRLINS => {
+                    if nic.uninsertable.contains(&req.fs.location) {
+                        return Err("ENOSPC: no free MCAM entry".into());
+                    }
+                    // A real insert at an occupied slot replaces it,
+                    // which is what makes re-asserting cheap.
+                    nic.rules.insert(key, req.fs);
+                    Ok(())
+                }
+                ETHTOOL_GRXCLSRULE => match nic.rules.get(&key) {
+                    Some(stored) => {
+                        req.fs = *stored;
+                        Ok(())
+                    }
+                    None => Err("ENOENT: no rule at that location".into()),
+                },
+                ETHTOOL_SRXCLSRLDEL => {
+                    if nic.undeletable.contains(&req.fs.location) {
+                        return Err("EBUSY: rule is pinned".into());
+                    }
+                    match nic.rules.remove(&key) {
+                        Some(_) => Ok(()),
+                        None => Err("ENOENT: no rule at that location".into()),
+                    }
+                }
+                other => Err(format!("fake NIC got an unexpected command {other:#x}")),
+            }
+        })
     }
 }
 
@@ -342,8 +441,24 @@ impl NtupleSteering {
     /// installed, and a fresh object has installed nothing. The rules
     /// would outlive every process that knew about them and keep
     /// diverting traffic to a VF nobody owns.
+    ///
+    /// The record comes from
+    /// [`crate::resources::ResourceState::steer_rules`], written by
+    /// [`crate::runtime::IdentityStore::steering_changed`] after every
+    /// change. Both halves shipped in #127 with nothing between them.
     pub fn adopt_installed(&mut self, installed: Vec<(String, u32)>) {
         self.installed = installed;
+    }
+
+    /// What the NIC should hold, from the current ports and plan.
+    fn desired(&self) -> Vec<(String, u32)> {
+        let mut out = Vec::with_capacity(self.ports.len() * self.plan.rules.len());
+        for (iface, _) in &self.ports {
+            for rule in &self.plan.rules {
+                out.push((iface.clone(), rule.location));
+            }
+        }
+        out
     }
 }
 
@@ -356,6 +471,40 @@ impl crate::runtime::Steering for NtupleSteering {
                     .into(),
             );
         }
+        // Clear anything the ledger holds that the current target does
+        // not — rules from a previous allowlist, or from a port that has
+        // since gone `steer off`. Without this, a reconfigure would
+        // install the new set ALONGSIDE the old one and leave prefixes
+        // diverted that the operator had just removed from the
+        // allowlist, with nothing naming them.
+        //
+        // Before the inserts, not after: the two sets can overlap in
+        // slot numbers, and removing afterwards would delete rules the
+        // insert loop had just written.
+        let desired = self.desired();
+        let stale: Vec<(String, u32)> = self
+            .installed
+            .iter()
+            .filter(|e| !desired.contains(e))
+            .cloned()
+            .collect();
+        self.installed.retain(|e| !stale.contains(e));
+        let failed = self.remove_all(stale);
+        if !failed.is_empty() {
+            // Refusing here rather than installing over them. A rule
+            // that would not come out is still matching its old prefix,
+            // and the new set may reuse its slot — so proceeding would
+            // leave the NIC in a state neither the ledger nor the
+            // operator could describe.
+            return Err(format!(
+                "{} stale ntuple rule(s) from the previous steering target could not be \
+                 removed ({}); the new rules were NOT installed, because they may reuse \
+                 those slots",
+                failed.len(),
+                failed.join(", ")
+            ));
+        }
+
         for (iface, vf_index) in &self.ports {
             for rule in &self.plan.rules {
                 if let Err(e) = insert(iface, rule, *vf_index) {
@@ -378,7 +527,19 @@ impl crate::runtime::Steering for NtupleSteering {
                         )
                     });
                 }
-                self.installed.push((iface.clone(), rule.location));
+                // A SET, not a log. The supervisor re-emits `Action::Steer`
+                // for a VPP it already believes steered — the UniFi
+                // controller wipes classifier state on provisioning, so
+                // re-asserting is the reconcile step — and appending
+                // unconditionally recorded every slot twice. `unsteer`
+                // then deleted each twice, the second delete failed
+                // because the rule was already gone, and a perfectly
+                // clean teardown reported rules it could not remove and
+                // withheld the VF.
+                let entry = (iface.clone(), rule.location);
+                if !self.installed.contains(&entry) {
+                    self.installed.push(entry);
+                }
             }
         }
         Ok(())
@@ -399,6 +560,15 @@ impl crate::runtime::Steering for NtupleSteering {
                 failed.join(", ")
             ))
         }
+    }
+
+    fn installed(&self) -> Vec<(String, u32)> {
+        self.installed.clone()
+    }
+
+    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: RuleSet) {
+        self.ports = ports;
+        self.plan = plan;
     }
 }
 
@@ -520,12 +690,12 @@ mod tests {
     /// `Ok` from unsteer is precisely what releases the VF — handing back
     /// a VF with a live rule still steering traffic into it.
     ///
-    /// Both paths now share `remove_all`, so they cannot disagree. Driven
-    /// through it directly because every `delete` fails on a non-Linux
-    /// host, which is exactly the condition under test.
+    /// Both paths now share `remove_all`, so they cannot disagree.
     #[test]
     fn a_rule_that_will_not_delete_stays_recorded() {
         use crate::runtime::Steering as _;
+        sys::reset();
+        sys::wedge_delete(&[1024, 1025]);
         let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], RuleSet::default());
         s.adopt_installed(vec![("eth0".into(), 1024), ("eth0".into(), 1025)]);
 
@@ -571,5 +741,169 @@ mod tests {
             &[("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
             "the previous process's rules are now this one's to remove"
         );
+    }
+
+    fn plan_for(prefixes: &[[u8; 4]]) -> RuleSet {
+        let allow: Vec<IpPrefix> = prefixes
+            .iter()
+            .map(|a| IpPrefix::V4 {
+                addr: *a,
+                prefix_len: 24,
+            })
+            .collect();
+        RuleSet::plan(&allow, McamBudget::default()).expect("fits")
+    }
+
+    /// The happy path, which had never executed anywhere.
+    ///
+    /// Asserts the ledger against the NIC rather than against itself:
+    /// `installed()` is the list teardown acts on, and the only thing
+    /// that makes it meaningful is that it names exactly the rules the
+    /// hardware holds.
+    #[test]
+    fn a_steer_installs_the_plan_and_an_unsteer_removes_all_of_it() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+
+        s.steer().expect("installs");
+        assert_eq!(
+            sys::rules(),
+            vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
+            "both directions, in the planned slots"
+        );
+        assert_eq!(
+            s.installed(),
+            sys::rules(),
+            "the ledger names what the NIC holds"
+        );
+
+        s.unsteer().expect("removes");
+        assert!(sys::rules().is_empty(), "nothing left in the NIC");
+        assert!(s.installed().is_empty(), "and nothing left in the ledger");
+    }
+
+    /// Re-asserting steering must not record the same slot twice.
+    ///
+    /// The supervisor deliberately re-emits `Action::Steer` for a VPP it
+    /// already believes steered, because the UniFi controller wipes
+    /// classifier state on provisioning. With the ledger appending, the
+    /// second pass recorded every slot a second time; `unsteer` then
+    /// deleted each twice, the second delete returned ENOENT, and a
+    /// teardown that had in fact removed every rule reported failures
+    /// and **withheld the VF**.
+    ///
+    /// So the assertion is on the ledger's cardinality, not on the
+    /// removal succeeding — the removal succeeding is the symptom, the
+    /// set property is the invariant.
+    #[test]
+    fn re_asserting_steering_records_each_slot_once() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+
+        s.steer().expect("first");
+        s.steer()
+            .expect("re-assert, as the supervisor does on every Ready");
+        assert_eq!(
+            s.installed().len(),
+            2,
+            "two rules exist, so two must be recorded — however many times they were asserted"
+        );
+        s.unsteer()
+            .expect("a clean teardown must stay clean across a re-assert");
+    }
+
+    /// A retarget removes what the old target had and installs the new,
+    /// leaving nothing behind.
+    ///
+    /// This is the reconfigure path: an operator drops a prefix from the
+    /// allowlist and SIGHUPs. Without the stale-removal the old rules
+    /// stay in the NIC — traffic for a prefix the operator explicitly
+    /// removed keeps being diverted, and nothing anywhere names it,
+    /// because the ledger only ever describes the current plan.
+    #[test]
+    fn a_retarget_leaves_only_the_new_rules() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0], [10, 1, 0, 0]]),
+        );
+        s.steer().expect("installs four");
+        assert_eq!(sys::rules().len(), 4);
+
+        // Down to one prefix: slots 1026/1027 are no longer wanted.
+        s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        s.steer().expect("reconciles");
+
+        assert_eq!(
+            sys::rules(),
+            vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
+            "the withdrawn prefix's rules are gone from the NIC, not merely unrecorded"
+        );
+        assert_eq!(s.installed(), sys::rules());
+    }
+
+    /// A retarget that cannot clear a stale rule installs NOTHING.
+    ///
+    /// The new plan may reuse the slot the old rule is sitting in, so
+    /// proceeding would leave the NIC holding a mix of two targets that
+    /// neither the ledger nor the operator could describe. And the
+    /// undeletable rule stays recorded — it is still steering traffic,
+    /// and it is what a later `detach --all` has to find.
+    #[test]
+    fn a_retarget_that_cannot_clear_the_old_rules_installs_nothing() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0], [10, 1, 0, 0]]),
+        );
+        s.steer().expect("installs four");
+
+        sys::wedge_delete(&[1026]);
+        s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        let e = s.steer().expect_err("must refuse");
+
+        assert!(
+            e.contains("could not be removed") && e.contains("NOT installed"),
+            "the operator has to learn both halves: what stayed, and that nothing new landed: {e}"
+        );
+        assert!(
+            s.installed().contains(&("eth0".to_string(), 1026)),
+            "the rule that would not come out must stay in the ledger, or detach cannot find it"
+        );
+    }
+
+    /// A failed insert backs out everything, including rules that were
+    /// already installed before this attempt.
+    ///
+    /// All-or-nothing is the point: a port holding half its rules
+    /// forwards some allowlisted traffic through VPP and the rest
+    /// through the kernel. Slot 1027 — the last of four — is made to
+    /// refuse, so three rules are already in the NIC when the failure
+    /// lands.
+    #[test]
+    fn a_failed_insert_leaves_the_port_unsteered() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        sys::wedge_insert(&[1027]);
+        let mut s = NtupleSteering::new(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0], [10, 1, 0, 0]]),
+        );
+
+        let e = s.steer().expect_err("the last rule cannot be installed");
+        assert!(
+            e.contains("every rule installed before it was removed"),
+            "{e}"
+        );
+        assert!(
+            sys::rules().is_empty(),
+            "the three that landed must not survive the failure — a half-steered port is \
+             a forwarding policy nobody chose"
+        );
+        assert!(s.installed().is_empty());
     }
 }

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -407,11 +407,6 @@ impl NtupleSteering {
         }
     }
 
-    /// What is installed right now, for the state file.
-    pub fn installed(&self) -> &[(String, u32)] {
-        &self.installed
-    }
-
     /// Remove `victims`, **keeping whatever would not come out**.
     ///
     /// One routine because there are two callers — `steer`'s rollback and
@@ -724,6 +719,7 @@ mod tests {
     /// knew about them, still steering into a VF nobody owns.
     #[test]
     fn adopted_locations_are_what_unsteer_removes() {
+        use crate::runtime::Steering as _;
         let allow = vec![IpPrefix::V4 {
             addr: [23, 191, 200, 0],
             prefix_len: 24,
@@ -738,7 +734,7 @@ mod tests {
         s.adopt_installed(vec![("eth0".into(), 1024), ("eth0".into(), 1025)]);
         assert_eq!(
             s.installed(),
-            &[("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
+            vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
             "the previous process's rules are now this one's to remove"
         );
     }

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -13,8 +13,9 @@
 //!   (different VF address than recorded, foreign driver bound) is an
 //!   error, and it names the manual escape hatch.
 //! - **Teardown ordering is load-bearing.** Steering rules die first
-//!   (slice 5 owns them; the state file records them so release can
-//!   clear them even when the in-memory module never saw them), then
+//!   ([`crate::ntuple`] owns them; `steer_rules` here records them so
+//!   release can clear them even when the in-memory module never saw
+//!   them — MCAM outlives both the VPP process and the daemon), then
 //!   the VPP process (slice 4), then vfio unbind → rebind to the
 //!   kernel VF driver → `sriov_numvfs = 0` → hugepage release. The
 //!   inverse of acquisition, always.
@@ -90,10 +91,10 @@ pub struct PortState {
 }
 
 /// Everything attach acquired, in acquisition order. Release walks it
-/// in reverse. Steering rules are recorded here from slice 5 onward so
-/// a crash between "rules installed" and "state updated" stays
-/// recoverable (rules are re-derived idempotently from config, but
-/// release must be able to clear rules the config no longer names).
+/// in reverse. Steering rules are recorded here so a crash between
+/// "rules installed" and "state updated" stays recoverable: the plan is
+/// re-derived idempotently from config, but release must be able to
+/// clear rules the config no longer names.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ResourceState {
     pub version: u32,
@@ -136,9 +137,20 @@ pub struct ResourceState {
     #[serde(default)]
     pub hugepage_prior_pages: u32,
     pub ports: Vec<PortState>,
-    /// ntuple rule locations installed per PF iface (slice 5).
-    /// Present in the schema from day one so adopting a newer state
-    /// file layout never needs a version bump for this field.
+    /// ntuple rule locations installed per PF iface.
+    ///
+    /// The **only durable record that MCAM rules exist**. They are NIC
+    /// state, not process state, so they outlive both VPP and the
+    /// daemon; without this a restart cannot know it is steering, and
+    /// `unsteer` — which removes what its own ledger names — would
+    /// answer `Ok` over rules that are still in the NIC.
+    ///
+    /// Written through [`crate::runtime::IdentityStore::steering_changed`]
+    /// after every steer and unsteer, in both polarities. Use
+    /// [`group_steer_rules`] / [`flatten_steer_rules`] to convert, never
+    /// by hand: the shape here is grouped for the file, the shape
+    /// everything else uses is flat, and three open-coded conversions is
+    /// how the two stop agreeing.
     pub steer_rules: Vec<(String, Vec<u32>)>,
     /// VPP pid at last state write. `None` = no process was running.
     ///
@@ -303,6 +315,33 @@ fn write_str(path: &Path, value: &str) -> Result<(), String> {
 /// actually granted them — on long-uptime hosts a contiguous 512 MiB
 /// reservation can silently fall short, which must be an error here,
 /// not an EAL mystery later. Returns the verified count.
+/// Flat `(iface, loc)` pairs → the grouped shape the state file holds.
+///
+/// Order-preserving in both directions, so a round trip is the identity
+/// and a test can assert on the list it handed in. Paired with
+/// [`flatten_steer_rules`] and kept here, next to the field, because
+/// three open-coded conversions — the store's write, `bring_up`'s
+/// restore, and `bring_up`'s stale-rule rewrite — is exactly how a
+/// grouped record and a flat ledger stop describing the same rules.
+pub fn group_steer_rules(rules: &[(String, u32)]) -> Vec<(String, Vec<u32>)> {
+    let mut grouped: Vec<(String, Vec<u32>)> = Vec::new();
+    for (iface, loc) in rules {
+        match grouped.iter_mut().find(|(name, _)| name == iface) {
+            Some((_, locs)) => locs.push(*loc),
+            None => grouped.push((iface.clone(), vec![*loc])),
+        }
+    }
+    grouped
+}
+
+/// The state file's grouped shape → the flat ledger everything else uses.
+pub fn flatten_steer_rules(grouped: &[(String, Vec<u32>)]) -> Vec<(String, u32)> {
+    grouped
+        .iter()
+        .flat_map(|(iface, locs)| locs.iter().map(|l| (iface.clone(), *l)))
+        .collect()
+}
+
 pub fn reserve_hugepages_in(pool_dir: &Path, pages: u32) -> Result<u32, String> {
     let nr = pool_dir.join("nr_hugepages");
     let current: u32 = read_trim(&nr)?.parse().unwrap_or(0);

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -658,6 +658,10 @@ impl Effects for EffectsView {
         outcome
     }
 
+    fn steering_in_place(&self) -> bool {
+        !self.core.borrow().steering.installed().is_empty()
+    }
+
     fn kill(&mut self) -> Disposition {
         let mut c = self.core.borrow_mut();
         let Some(p) = c.process.as_mut() else {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1,7 +1,7 @@
 //! The runtime: [`Observe`] and [`Effects`] implemented by delegation
 //! to the real machinery — [`VppProcess`] for the process,
 //! [`ConvergenceEngine`] for everything reachable over the API socket,
-//! and a [`Steering`] seam for the MCAM rules that land in slice 5.
+//! and a [`Steering`] seam over the MCAM rules ([`crate::ntuple`]).
 //!
 //! This is the last layer of pure wiring before `Module::attach()`. It
 //! deliberately contains **no policy**: every decision lives in the
@@ -36,9 +36,9 @@
 //!   [`ResourceState`](crate::resources::ResourceState) — the same
 //!   attach wiring. A [`NullStore`] exists for tests only.
 //! - **MCAM steering.** [`Steering`] is a seam; the ETHTOOL
-//!   implementation is slice 5. The placeholder here refuses in both
-//!   directions — see [`SteeringUnavailable`] for why refusing to
-//!   *unsteer* is the load-bearing half.
+//!   implementation is [`crate::ntuple`]. [`SteeringUnavailable`] stands
+//!   in where no port steers, and refuses in both directions — see it
+//!   for why refusing to *unsteer* is the load-bearing half.
 
 use std::cell::RefCell;
 use std::path::PathBuf;
@@ -101,6 +101,23 @@ pub trait IdentityStore {
     /// Persisting them is what lets the next daemon adopt instead of
     /// blind-attaching.
     fn interfaces_attached(&mut self, indices: &[(String, u32)]) -> Result<(), String>;
+
+    /// The MCAM rules believed installed right now, as `(iface, loc)`.
+    ///
+    /// Written after every steer and unsteer, in both polarities.
+    /// MCAM rules outlive the process that installed them — they are
+    /// NIC state, not process state — so this file is the only thing
+    /// that can tell the next daemon they exist.
+    ///
+    /// Without it a restart with a steered VPP alive was doubly unsafe.
+    /// `bring_up` derives `Adopted { steered }` from the recorded rules,
+    /// so an empty record meant the supervisor believed nothing was
+    /// diverted: teardown emitted no `Unsteer` and released the VF with
+    /// MCAM still pointing traffic into it. And
+    /// [`Steering::unsteer`] removes what its own ledger names, so a
+    /// fresh ledger would have answered `Ok` — reporting rules removed
+    /// that were still in the NIC.
+    fn steering_changed(&mut self, rules: &[(String, u32)]) -> Result<(), String>;
 }
 
 /// Hands back the VF/vfio/hugepage resources attach acquired.
@@ -137,6 +154,9 @@ impl IdentityStore for NullStore {
     fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
         Ok(())
     }
+    fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// Releases nothing, and says so. Tests only, and it must keep
@@ -152,36 +172,66 @@ impl ResourceRelease for NoResources {
     }
 }
 
-/// The MCAM steering seam. Real implementation lands in slice 5
-/// (ETHTOOL_SRXCLSRLINS, ring_cookie `(vf+1)<<32`, loc budgeting).
+/// The MCAM steering seam ([`crate::ntuple::NtupleSteering`] is the
+/// real one: ETHTOOL_SRXCLSRLINS, ring_cookie `(vf+1)<<32`, loc
+/// budgeting).
+///
+/// [`Self::steer`] is a **reconcile**, not an append: it makes the NIC
+/// match the current target, whatever was there before. That is what
+/// the supervisor already assumes when it re-emits `Action::Steer` for
+/// a VPP it believes is steered (the UniFi controller wipes classifier
+/// state on provisioning, so rules may simply be gone), and it is what
+/// lets [`Self::retarget`] change the target under a live port without
+/// a second code path.
 pub trait Steering {
     /// Install the rules. `Ok` means they are confirmed in the NIC.
     fn steer(&mut self) -> Result<(), String>;
     /// Remove the rules. `Ok` means they are confirmed gone — and only
     /// then, because the supervisor releases VFs on the strength of it.
     fn unsteer(&mut self) -> Result<(), String>;
+    /// `(iface, loc)` for every rule believed to be in the NIC right
+    /// now, including any that a removal could not clear.
+    ///
+    /// Read after **every** steer and unsteer, successful or not, and
+    /// persisted — see [`IdentityStore::steering_changed`]. A rule that
+    /// would not come out is still diverting traffic, so the failure
+    /// path is the one that most needs this recorded.
+    fn installed(&self) -> Vec<(String, u32)>;
+    /// Change what steering *should* be, without touching the NIC.
+    ///
+    /// Deliberately infallible and side-effect-free: it records intent,
+    /// and the next `steer`/`unsteer` is what makes the hardware agree.
+    /// Splitting it that way keeps one routine — `steer` — responsible
+    /// for every rule that ever reaches the NIC, so a reconfigure cannot
+    /// grow its own, subtly different, installation path.
+    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet);
 }
 
-/// The placeholder until slice 5: refuses both directions.
+/// A steering seam that refuses both directions.
 ///
-/// `steer` refusing is obvious. `unsteer` refusing is the half that
-/// matters: `Ok` from unsteer becomes `Event::Unsteered`, which clears
-/// `steered` and unblocks `ReleaseResources` — so a placeholder that
-/// faked success would let the supervisor release a VF that MCAM rules
-/// from a previous run might still be pointing traffic at. Refusing
-/// keeps `steered` true and the VF withheld, which is the designed
-/// behaviour for "rules exist that we cannot manage". A config with
-/// every port `steer off` never reaches either path.
+/// Used where no port asks to steer, and by tests. `steer` refusing is
+/// obvious. `unsteer` refusing is the half that matters: `Ok` from
+/// unsteer becomes `Event::Unsteered`, which clears `steered` and
+/// unblocks `ReleaseResources` — so a stand-in that faked success would
+/// let the supervisor release a VF that MCAM rules from a previous run
+/// might still be pointing traffic at. Refusing keeps `steered` true
+/// and the VF withheld, which is the designed behaviour for "rules
+/// exist that we cannot manage". A config with every port `steer off`
+/// never reaches either path.
 #[derive(Debug, Default)]
 pub struct SteeringUnavailable;
 
 impl Steering for SteeringUnavailable {
     fn steer(&mut self) -> Result<(), String> {
-        Err("MCAM steering is not implemented until slice 5; port stays unsteered".into())
+        Err("MCAM steering is unavailable in this runtime; port stays unsteered".into())
     }
     fn unsteer(&mut self) -> Result<(), String> {
-        Err("MCAM steering is not implemented until slice 5; cannot confirm rules removed".into())
+        Err("MCAM steering is unavailable in this runtime; cannot confirm rules removed".into())
     }
+    fn installed(&self) -> Vec<(String, u32)> {
+        Vec::new()
+    }
+    fn retarget(&mut self, _ports: Vec<(String, u32)>, _plan: crate::steer::RuleSet) {}
 }
 
 /// Everything both trait views share.
@@ -291,6 +341,16 @@ impl Runtime {
         c.process = Some(p);
         c.attach_mode = crate::attach::AttachMode::Adopted;
         c.engine.set_steered(steered);
+    }
+
+    /// Point steering at a new set of ports and rules.
+    ///
+    /// Records intent only — see [`Steering::retarget`]. The caller must
+    /// follow it with the supervisor event that reconciles the NIC, and
+    /// the supervision loop is the only caller precisely so that the two
+    /// cannot be separated.
+    pub fn retarget(&self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet) {
+        self.core.borrow_mut().steering.retarget(ports, plan);
     }
 
     /// The two trait views the driver's tick takes.
@@ -452,6 +512,26 @@ impl Core {
         }
         r
     }
+
+    /// Write the steering ledger through, after any change to it.
+    ///
+    /// Called on **both** outcomes of steer and unsteer, which is the
+    /// whole point. The failure paths are the ones that matter: a
+    /// rollback that could not clear a rule, or an unsteer the NIC
+    /// refused, leaves rules diverting traffic — and those are exactly
+    /// the rules a later `detach --all` has to be able to find.
+    /// Recording only successes would persist an empty list at the
+    /// moment the record most needs to be non-empty.
+    ///
+    /// The result goes through [`Self::note_persist`], so a failure
+    /// degrades health rather than failing the steer: the rules are in
+    /// the NIC either way, and reporting the steer as failed would make
+    /// the supervisor believe traffic is not diverted when it is.
+    fn record_steering(&mut self) {
+        let rules = self.steering.installed();
+        let r = self.store.steering_changed(&rules);
+        let _ = self.note_persist(r);
+    }
 }
 
 impl Observe for ObserveView {
@@ -565,11 +645,17 @@ impl Effects for EffectsView {
     }
 
     fn unsteer(&mut self) -> Result<(), String> {
-        self.core.borrow_mut().steering.unsteer()
+        let mut c = self.core.borrow_mut();
+        let outcome = c.steering.unsteer();
+        c.record_steering();
+        outcome
     }
 
     fn steer(&mut self) -> Result<(), String> {
-        self.core.borrow_mut().steering.steer()
+        let mut c = self.core.borrow_mut();
+        let outcome = c.steering.steer();
+        c.record_steering();
+        outcome
     }
 
     fn kill(&mut self) -> Disposition {
@@ -720,6 +806,154 @@ mod tests {
         )
     }
 
+    /// Steering that reports a ledger and can be made to fail, so the
+    /// persistence wiring can be observed on both polarities.
+    #[derive(Default)]
+    struct LedgerSteering {
+        rules: Vec<(String, u32)>,
+        /// What the next call leaves behind, and whether it succeeds.
+        next: Option<(Vec<(String, u32)>, bool)>,
+    }
+
+    impl Steering for LedgerSteering {
+        fn steer(&mut self) -> Result<(), String> {
+            let (rules, ok) = self.next.take().unwrap_or_default();
+            self.rules = rules;
+            if ok {
+                Ok(())
+            } else {
+                Err("MCAM refused".into())
+            }
+        }
+        fn unsteer(&mut self) -> Result<(), String> {
+            let (rules, ok) = self.next.take().unwrap_or_default();
+            self.rules = rules;
+            if ok {
+                Ok(())
+            } else {
+                Err("a rule would not come out".into())
+            }
+        }
+        fn installed(&self) -> Vec<(String, u32)> {
+            self.rules.clone()
+        }
+        fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+    }
+
+    /// Every ledger the store was handed, in order.
+    type LedgerLog = std::rc::Rc<std::cell::RefCell<Vec<Vec<(String, u32)>>>>;
+
+    /// Records every steering ledger it is handed.
+    #[derive(Default)]
+    struct RecordingStore(LedgerLog);
+
+    impl IdentityStore for RecordingStore {
+        fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+            Ok(())
+        }
+        fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+            Ok(())
+        }
+        fn steering_changed(&mut self, rules: &[(String, u32)]) -> Result<(), String> {
+            self.0.borrow_mut().push(rules.to_vec());
+            Ok(())
+        }
+    }
+
+    /// Every steer and unsteer writes the ledger through — **including
+    /// the ones that fail**.
+    ///
+    /// The failure polarity is the whole reason this is asserted. A
+    /// rollback that could not clear a rule, or an unsteer the NIC
+    /// refused, leaves rules diverting traffic; recording only successes
+    /// would persist an empty list at exactly the moment the record has
+    /// to be non-empty, and `detach --all` would have nothing to find.
+    #[test]
+    fn every_steering_change_is_persisted_including_the_failures() {
+        let seen: LedgerLog = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        // A steer that lands two rules, then an unsteer that gets one
+        // out and leaves the other stuck.
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024), ("eth4".into(), 1025)], true)),
+            ..Default::default()
+        };
+
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(RecordingStore(std::rc::Rc::clone(&seen))),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let (_, mut fx) = rt.views();
+        fx.steer().expect("installs");
+
+        rt.core.borrow_mut().steering = Box::new(LedgerSteering {
+            rules: vec![("eth4".into(), 1024), ("eth4".into(), 1025)],
+            next: Some((vec![("eth4".into(), 1025)], false)),
+        });
+        fx.unsteer().expect_err("one rule would not come out");
+
+        let seen = seen.borrow();
+        assert_eq!(seen.len(), 2, "both changes reached the store");
+        assert_eq!(
+            seen[0],
+            vec![("eth4".to_string(), 1024), ("eth4".to_string(), 1025)],
+            "the successful steer recorded what it installed"
+        );
+        assert_eq!(
+            seen[1],
+            vec![("eth4".to_string(), 1025)],
+            "the FAILED unsteer recorded the rule still in the NIC — a record of nothing \
+             here is a VF released under live steering"
+        );
+    }
+
+    /// A store that cannot record the ledger degrades health; it does
+    /// not fail the steer.
+    ///
+    /// The rules are in the NIC either way. Reporting the steer as
+    /// failed would tell the supervisor traffic is not diverted while it
+    /// is, which is the more dangerous of the two wrong answers.
+    #[test]
+    fn an_unrecordable_steering_ledger_degrades_rather_than_failing() {
+        struct Refusing;
+        impl IdentityStore for Refusing {
+            fn process_changed(&mut self, _: Option<ProcessIdentity>) -> Result<(), String> {
+                Ok(())
+            }
+            fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Ok(())
+            }
+            fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Err("state dir is read-only".into())
+            }
+        }
+
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024)], true)),
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(Refusing),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let (_, mut fx) = rt.views();
+        fx.steer()
+            .expect("the steer itself succeeded and must say so");
+        assert!(
+            rt.status().store_error.is_some(),
+            "but the operator has to learn the record is stale — the next start cannot adopt"
+        );
+    }
+
     /// The placeholder must refuse BOTH directions. `unsteer` faking
     /// success would emit `Unsteered`, clear `steered`, and unblock the
     /// release of a VF that rules from a previous run might still be
@@ -821,6 +1055,9 @@ mod tests {
             fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
                 Ok(())
             }
+            fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Ok(())
+            }
         }
         let rt = Runtime::new(
             engine(),
@@ -853,6 +1090,9 @@ mod tests {
                 Ok(())
             }
             fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+                Ok(())
+            }
+            fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
                 Ok(())
             }
         }

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -29,7 +29,7 @@
 //! reports it). The final status is published either way, so the
 //! caller can see exactly what the shutdown left behind.
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -101,6 +101,45 @@ const MAX_EPISODE_REASONS: usize = 8;
 /// the teardown is unfinished.
 const DETACH_BUDGET: Duration = Duration::from_millis(900);
 
+/// How long [`SupervisionService::apply_steering`] waits for the loop to
+/// pick up a steering change and report what happened.
+///
+/// The alternative — post and return `Ok` — is what makes this worth a
+/// wait at all. `packetframe reconfigure` writes an OK/ERR marker the
+/// operator reads, and this is the canary lever: "the rollout step
+/// succeeded" and "the rollout step was queued" must not look the same.
+/// A refused MCAM insert has to come back as a failure at the moment
+/// the operator is watching for one.
+///
+/// Generous against the loop's own cadence (it re-checks at least every
+/// [`STOP_POLL_CAP`]) and still well inside the CLI's 5 s ack timeout,
+/// so a timeout here reaches the operator as a timeout rather than as a
+/// dropped connection.
+const STEERING_BUDGET: Duration = Duration::from_secs(2);
+
+/// Poll granularity while waiting for the loop to answer.
+const STEERING_POLL: Duration = Duration::from_millis(5);
+
+/// A steering change on its way from `Module::reconfigure` to the loop.
+///
+/// Carries the whole target rather than a delta. The loop applies it
+/// with [`crate::runtime::Runtime::retarget`] and one supervisor event,
+/// and `Action::Steer` reconciles the NIC — so there is exactly one
+/// routine that decides which rules exist, and a reconfigure cannot
+/// grow a second, subtly different one.
+#[derive(Debug, Clone)]
+pub struct SteeringRequest {
+    /// Matched against the answer so a caller cannot collect the result
+    /// of somebody else's request — or of its own previous one.
+    seq: u64,
+    /// `(PF iface, VF index)` for every port now configured `steer on`.
+    pub ports: Vec<(String, u32)>,
+    pub plan: crate::steer::RuleSet,
+    /// Whether traffic should be diverted once the target is in place.
+    /// False is the rollback landing zone, not an error.
+    pub want_steer: bool,
+}
+
 /// Builds the loop's non-`Send` pieces on the loop thread, and returns
 /// the events to inject before the first tick.
 ///
@@ -164,6 +203,16 @@ pub struct Published {
 struct Shared {
     stop: AtomicBool,
     latest: Mutex<Option<Published>>,
+    /// A steering change waiting to be applied. At most one: a second
+    /// request supersedes the first, which is right — both describe the
+    /// complete target, and the newer one is the config that is now on
+    /// disk. The superseded caller learns it was superseded rather than
+    /// waiting out its budget for an answer that will never come.
+    steering_request: Mutex<Option<SteeringRequest>>,
+    /// What the loop made of request `seq`.
+    steering_result: Mutex<Option<(u64, Result<(), String>)>>,
+    /// Hands out request sequence numbers.
+    steering_seq: AtomicU64,
 }
 
 /// The one place a shutdown that did not complete is turned into a snapshot.
@@ -336,6 +385,9 @@ impl SupervisionService {
         let shared = Arc::new(Shared {
             stop: AtomicBool::new(false),
             latest: Mutex::new(None),
+            steering_request: Mutex::new(None),
+            steering_result: Mutex::new(None),
+            steering_seq: AtomicU64::new(0),
         });
         let looped = Arc::clone(&shared);
         let (ready_tx, ready_rx) = std::sync::mpsc::channel::<Result<(), String>>();
@@ -504,6 +556,74 @@ impl SupervisionService {
     /// and — importantly — after a panic: a dead loop means nothing is
     /// supervising VPP, which the caller must surface rather than keep
     /// reporting the last published (now frozen) status as current.
+    /// Hand the loop a new steering target and wait for its verdict.
+    ///
+    /// Synchronous on purpose — see [`STEERING_BUDGET`]. Returns `Err`
+    /// when the loop refused the change (not converged, the FIB is
+    /// incomplete, an MCAM insert failed), when a newer request
+    /// superseded this one, or when the loop did not answer in time. In
+    /// every one of those cases the operator's rollout step did NOT
+    /// happen, which is what they need to know.
+    pub fn apply_steering(
+        &self,
+        ports: Vec<(String, u32)>,
+        plan: crate::steer::RuleSet,
+        want_steer: bool,
+    ) -> Result<(), String> {
+        // Sequence first, so the request that lands in the slot is
+        // always the one whose number we then wait for.
+        let seq = self.shared.steering_seq.fetch_add(1, Ordering::SeqCst) + 1;
+        *self.shared.steering_request.lock().expect("steering lock") = Some(SteeringRequest {
+            seq,
+            ports,
+            plan,
+            want_steer,
+        });
+
+        let deadline = Instant::now() + STEERING_BUDGET;
+        loop {
+            // Two ways to be done, and the second is not an error worth
+            // waiting out: if the slot now holds a HIGHER sequence, this
+            // request was replaced before the loop ever saw it, and no
+            // answer for it will ever be published.
+            if let Some((answered, outcome)) = self
+                .shared
+                .steering_result
+                .lock()
+                .expect("steering lock")
+                .clone()
+            {
+                if answered == seq {
+                    return outcome;
+                }
+            }
+            if let Some(pending) = self
+                .shared
+                .steering_request
+                .lock()
+                .expect("steering lock")
+                .as_ref()
+            {
+                if pending.seq > seq {
+                    return Err(
+                        "a newer configuration change replaced this one before it was applied; \
+                         re-run `packetframe reconfigure` to see where the newer one landed"
+                            .into(),
+                    );
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "the supervision loop did not apply the steering change within {:?}. It is \
+                     busy or wedged — the change was NOT applied, and `packetframe status` \
+                     reports what the module is doing",
+                    STEERING_BUDGET
+                ));
+            }
+            std::thread::sleep(STEERING_POLL);
+        }
+    }
+
     pub fn is_alive(&self) -> bool {
         self.thread.as_ref().is_some_and(|t| !t.is_finished())
     }
@@ -623,6 +743,80 @@ fn fmt_failures(outcome: &crate::executor::Outcome) -> Vec<String> {
         .iter()
         .map(|(action, why)| format!("{action:?}: {why}"))
         .collect()
+}
+
+/// Apply one steering change, from inside the loop.
+///
+/// Split out so the two halves of a steering change — the target and
+/// the reconcile — happen in one place and in one order. The target is
+/// recorded first, unconditionally, because `Action::Steer` reconciles
+/// against whatever the target is: swapping it after the event would
+/// install the OLD rules and leave the new ones for whenever the next
+/// verify happened to fire.
+fn apply_steering(
+    driver: &mut Driver,
+    runtime: &Runtime,
+    fx: &mut dyn crate::executor::Effects,
+    req: &SteeringRequest,
+) -> Result<(), String> {
+    let state = driver.state();
+    if !matches!(state, State::Ready | State::Steered) {
+        // Deliberately refused rather than queued. A steer request that
+        // outlives a crash and fires against the replacement is not what
+        // the operator asked for, and the replacement re-steers on its
+        // own if steering was wanted. The new config is on disk either
+        // way, so the next attach picks it up.
+        return Err(format!(
+            "vpp-offload is {state:?}, not converged — steering changes apply only from \
+             Ready or Steered. The new configuration is on disk and takes effect at the \
+             next successful convergence"
+        ));
+    }
+    runtime.retarget(req.ports.clone(), req.plan.clone());
+
+    let event = if req.want_steer {
+        // The same gate the automatic path uses, and applied on the same
+        // terms: **first steer only**. An operator turning the lever on
+        // an unsteered port is no more entitled to divert traffic into a
+        // FIB with known holes than a `VerifyPassed` is, and this is the
+        // likelier door — the canary ladder's shape is "steer once the
+        // table has converged", which is exactly when someone is
+        // impatient.
+        //
+        // A port that is ALREADY steered is deliberately not gated.
+        // `blocks_first_steer` counts `installing`, which is nonzero
+        // whenever routes are in flight — routine under a live BGP feed
+        // — so gating the reconcile would make `packetframe reconfigure`
+        // fail at random. And the failure would be the wrong way round:
+        // refusing leaves the PREVIOUS rules installed, so a prefix the
+        // operator just removed from the allowlist keeps being diverted.
+        if !driver.supervisor().is_steered() {
+            let counts = runtime.status().counts;
+            if counts.blocks_first_steer() {
+                return Err(format!(
+                    "refusing the first steer: the FIB is incomplete ({} unresolvable, {} \
+                     withheld, {} still installing). Diverting traffic into it would \
+                     blackhole exactly the prefixes that are missing. `packetframe status` \
+                     reports all three; they must be zero",
+                    counts.unresolvable, counts.withheld, counts.installing
+                ));
+            }
+        }
+        Event::SteerRequested
+    } else {
+        Event::UnsteerRequested
+    };
+
+    let tick = driver.inject(Instant::now(), event, fx);
+    // The actions ran synchronously inside `inject`, and their failures
+    // exist only in this Tick — the same reason the main loop keeps its
+    // injected outcomes. Here they are also the operator's answer.
+    let failures = fmt_failures(&tick.outcome);
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(failures.join("; "))
+    }
 }
 
 fn run_loop(
@@ -747,6 +941,35 @@ fn run_loop(
     let _ = ready.send(Ok(()));
 
     while !shared.stop.load(Ordering::SeqCst) {
+        // Steering changes first, before the tick. They are the
+        // operator's, they are synchronous on the far side, and a tick
+        // can take a while — a resync batch, a verify sample — so
+        // applying them after would spend the caller's budget waiting
+        // for work that has nothing to do with the request.
+        let request = shared
+            .steering_request
+            .lock()
+            .expect("steering lock")
+            .take();
+        if let Some(req) = request {
+            let outcome = apply_steering(&mut driver, &runtime, &mut fx, &req);
+            if let Err(e) = &outcome {
+                // Also onto the health surface. `apply_steering` answers
+                // the caller, but `packetframe reconfigure` is not the
+                // only way this is read: a refused canary step has to be
+                // visible in `packetframe status` afterwards, the same
+                // as a refused automatic steer.
+                remember_failures(&mut last_failures, vec![format!("Reconfigure: {e}")]);
+            }
+            *shared.steering_result.lock().expect("steering lock") = Some((req.seq, outcome));
+            // The engine's socket deadline keys on whether packets are
+            // on VPP, and that may have just changed. Synced here rather
+            // than left to the post-tick call for the same reason
+            // `adopt_process` takes `steered` as a parameter: the work
+            // in between runs under the wrong budget otherwise.
+            runtime.set_steered(driver.supervisor().is_steered());
+        }
+
         let now = Instant::now();
         let tick = driver.tick(now, &mut obs, &mut fx);
         let mut failures: Vec<String> = fmt_failures(&tick.outcome);

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -111,11 +111,21 @@ const DETACH_BUDGET: Duration = Duration::from_millis(900);
 /// A refused MCAM insert has to come back as a failure at the moment
 /// the operator is watching for one.
 ///
-/// Generous against the loop's own cadence (it re-checks at least every
-/// [`STOP_POLL_CAP`]) and still well inside the CLI's 5 s ack timeout,
-/// so a timeout here reaches the operator as a timeout rather than as a
-/// dropped connection.
-const STEERING_BUDGET: Duration = Duration::from_secs(2);
+/// Sized against **one tick**, not against the poll cadence. The request
+/// is picked up before the next tick, so the wait is however long the
+/// tick already in progress takes — and in `Ready`/`Steered`, the only
+/// states a steering change is accepted from, that is a liveness ping
+/// (1.5 s budget while steered) plus a delta drain. Two seconds would
+/// therefore time out on an ordinary busy tick and report a failure over
+/// a change that was about to happen.
+///
+/// Bounded above by the CLI's own 5 s ack timeout
+/// (`RECONFIGURE_TIMEOUT_MS`), which covers every module's reconfigure,
+/// so this cannot simply be made generous. 3 s leaves room for
+/// fast-path's reconcile alongside it. A timeout is not a lost change
+/// either way: the wait withdraws the request if the loop has not taken
+/// it, and says plainly which of the two happened.
+const STEERING_BUDGET: Duration = Duration::from_secs(3);
 
 /// Poll granularity while waiting for the loop to answer.
 const STEERING_POLL: Duration = Duration::from_millis(5);
@@ -641,11 +651,52 @@ impl SupervisionService {
                 }
             }
             if Instant::now() >= deadline {
+                // WITHDRAW it, if the loop has not taken it yet.
+                //
+                // Leaving it in the slot is how "the change was NOT
+                // applied" becomes a lie: the loop takes whatever is
+                // there on its next free iteration, so a rollback
+                // reported as failed would quietly take effect afterwards
+                // — and publish its verdict where this caller is no
+                // longer listening. An operator who has just been told
+                // their `steer off` failed will do something else about
+                // it; the change must not also happen.
+                let withdrawn = {
+                    let mut slot = self.shared.steering_request.lock().expect("steering lock");
+                    let ours = slot.as_ref().is_some_and(|r| r.seq == seq);
+                    if ours {
+                        *slot = None;
+                    }
+                    ours
+                };
+                if !withdrawn {
+                    // The loop has it, so it is genuinely in flight and
+                    // cannot be recalled. One last look for the verdict —
+                    // it may have landed between the poll and now, and
+                    // reporting a timeout over a published answer would
+                    // be the same lie in the other direction.
+                    if let Some((answered, outcome)) = self
+                        .shared
+                        .steering_result
+                        .lock()
+                        .expect("steering lock")
+                        .clone()
+                    {
+                        if answered == seq {
+                            return outcome;
+                        }
+                    }
+                    return Err(format!(
+                        "the supervision loop took the steering change but had not finished it \
+                         within {STEERING_BUDGET:?}, so it MAY still take effect. \
+                         `packetframe status` reports what the module is doing; re-run once it \
+                         settles."
+                    ));
+                }
                 return Err(format!(
-                    "the supervision loop did not apply the steering change within {:?}. It is \
-                     busy or wedged — the change was NOT applied, and `packetframe status` \
-                     reports what the module is doing",
-                    STEERING_BUDGET
+                    "the supervision loop did not pick up the steering change within \
+                     {STEERING_BUDGET:?} — it is busy or wedged. The change was withdrawn and \
+                     NOT applied; `packetframe status` reports what the module is doing."
                 ));
             }
             std::thread::sleep(STEERING_POLL);

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -138,6 +138,21 @@ pub struct SteeringRequest {
     /// Whether traffic should be diverted once the target is in place.
     /// False is the rollback landing zone, not an error.
     pub want_steer: bool,
+    /// Whether the `steer` flag itself moved in this reconfigure.
+    ///
+    /// The difference between "the operator just turned the lever" and
+    /// "the config still says `steer on`, and this port was deliberately
+    /// left unsteered". Without it, a SIGHUP for an unrelated reason —
+    /// an added `allow-prefix`, a changed global — would divert traffic
+    /// on every `steer on` port that had not yet been steered, because
+    /// the flag is *present*. The machine never steers a first attach on
+    /// its own precisely because that decision is the operator's, and a
+    /// side effect of editing something else is not that decision.
+    ///
+    /// A port that is already steering is reconciled either way: its
+    /// traffic is diverted now, so the rules must match the new
+    /// allowlist whether or not the lever moved.
+    pub lever_moved: bool,
 }
 
 /// Builds the loop's non-`Send` pieces on the loop thread, and returns
@@ -552,10 +567,6 @@ impl SupervisionService {
         }
     }
 
-    /// Whether the loop thread is still running. `false` after `stop`,
-    /// and — importantly — after a panic: a dead loop means nothing is
-    /// supervising VPP, which the caller must surface rather than keep
-    /// reporting the last published (now frozen) status as current.
     /// Hand the loop a new steering target and wait for its verdict.
     ///
     /// Synchronous on purpose — see [`STEERING_BUDGET`]. Returns `Err`
@@ -569,6 +580,7 @@ impl SupervisionService {
         ports: Vec<(String, u32)>,
         plan: crate::steer::RuleSet,
         want_steer: bool,
+        lever_moved: bool,
     ) -> Result<(), String> {
         // Sequence first, so the request that lands in the slot is
         // always the one whose number we then wait for.
@@ -578,6 +590,7 @@ impl SupervisionService {
             ports,
             plan,
             want_steer,
+            lever_moved,
         });
 
         let deadline = Instant::now() + STEERING_BUDGET;
@@ -624,6 +637,10 @@ impl SupervisionService {
         }
     }
 
+    /// Whether the loop thread is still running. `false` after `stop`,
+    /// and — importantly — after a panic: a dead loop means nothing is
+    /// supervising VPP, which the caller must surface rather than keep
+    /// reporting the last published (now frozen) status as current.
     pub fn is_alive(&self) -> bool {
         self.thread.as_ref().is_some_and(|t| !t.is_finished())
     }
@@ -774,7 +791,22 @@ fn apply_steering(
     }
     runtime.retarget(req.ports.clone(), req.plan.clone());
 
+    let steered = driver.supervisor().is_steered();
     let event = if req.want_steer {
+        // The config says steer, but that is not the same as the
+        // operator asking for it NOW.
+        //
+        // A `steer on` port that has never steered is in the designed
+        // staging state: the machine never steers a first attach on its
+        // own, because when traffic moves is the operator's decision and
+        // the canary ladder is paced by hand. So a SIGHUP that did not
+        // move the lever — an added `allow-prefix`, a changed global —
+        // updates the target and stops there. Diverting traffic as a side
+        // effect of editing something else is precisely the decision this
+        // module is not allowed to make.
+        if !steered && !req.lever_moved {
+            return Ok(());
+        }
         // The same gate the automatic path uses, and applied on the same
         // terms: **first steer only**. An operator turning the lever on
         // an unsteered port is no more entitled to divert traffic into a
@@ -790,7 +822,7 @@ fn apply_steering(
         // fail at random. And the failure would be the wrong way round:
         // refusing leaves the PREVIOUS rules installed, so a prefix the
         // operator just removed from the allowlist keeps being diverted.
-        if !driver.supervisor().is_steered() {
+        if !steered {
             let counts = runtime.status().counts;
             if counts.blocks_first_steer() {
                 return Err(format!(

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -585,20 +585,50 @@ impl SupervisionService {
         // Sequence first, so the request that lands in the slot is
         // always the one whose number we then wait for.
         let seq = self.shared.steering_seq.fetch_add(1, Ordering::SeqCst) + 1;
-        *self.shared.steering_request.lock().expect("steering lock") = Some(SteeringRequest {
-            seq,
-            ports,
-            plan,
-            want_steer,
-            lever_moved,
-        });
+        let displaced = self
+            .shared
+            .steering_request
+            .lock()
+            .expect("steering lock")
+            .replace(SteeringRequest {
+                seq,
+                ports,
+                plan,
+                want_steer,
+                lever_moved,
+            });
+        // A request still sitting in the slot never ran, and now never
+        // will — the slot holds one, and this call just took it. Answer
+        // it here or its caller waits out the whole budget for a verdict
+        // nobody will ever publish.
+        //
+        // Answered at the displacement rather than inferred by the
+        // waiter, which is what the first version did: it peeked at the
+        // slot and treated a higher sequence as proof of being
+        // superseded. That is wrong in the case that matters — the loop
+        // may have taken request A and be applying it right now, so a
+        // newly-arrived B makes A's waiter report "replaced before it
+        // was applied" about a change that DID happen. State recorded
+        // from a request rather than from an observation, in the
+        // machinery built to avoid exactly that.
+        //
+        // Unreachable from the loader today (SIGHUP handling is serial,
+        // and each `reconfigure` blocks for its answer), so this is
+        // about the seam being honest rather than about a live race.
+        if let Some(older) = displaced {
+            *self.shared.steering_result.lock().expect("steering lock") = Some((
+                older.seq,
+                Err(
+                    "a newer configuration change replaced this one before the supervision \
+                     loop saw it; re-run `packetframe reconfigure` to see where the newer \
+                     one landed"
+                        .into(),
+                ),
+            ));
+        }
 
         let deadline = Instant::now() + STEERING_BUDGET;
         loop {
-            // Two ways to be done, and the second is not an error worth
-            // waiting out: if the slot now holds a HIGHER sequence, this
-            // request was replaced before the loop ever saw it, and no
-            // answer for it will ever be published.
             if let Some((answered, outcome)) = self
                 .shared
                 .steering_result
@@ -608,21 +638,6 @@ impl SupervisionService {
             {
                 if answered == seq {
                     return outcome;
-                }
-            }
-            if let Some(pending) = self
-                .shared
-                .steering_request
-                .lock()
-                .expect("steering lock")
-                .as_ref()
-            {
-                if pending.seq > seq {
-                    return Err(
-                        "a newer configuration change replaced this one before it was applied; \
-                         re-run `packetframe reconfigure` to see where the newer one landed"
-                            .into(),
-                    );
                 }
             }
             if Instant::now() >= deadline {

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -1183,7 +1183,9 @@ mod tests {
     fn a_failed_steer_is_distinguishable_from_deliberate_steer_off() {
         // First attach: the operator asked, the MCAM insert failed.
         let mut first = ready_supervisor();
-        first.on(Event::SteerFailed);
+        first.on(Event::SteerFailed {
+            rules_remain: false,
+        });
         assert!(!first.is_steered());
         assert!(
             first.steer_intended(),
@@ -1199,7 +1201,9 @@ mod tests {
         sup.on(Event::SyncComplete);
         sup.on(Event::VerifyPassed);
         sup.on(Event::Unsteered); // rules torn down on the way through
-        sup.on(Event::SteerFailed);
+        sup.on(Event::SteerFailed {
+            rules_remain: false,
+        });
         assert!(!sup.is_steered());
         assert!(sup.steer_intended());
 

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -41,14 +41,11 @@
 //! family attempted that cannot work, a budget overrun leaving a port
 //! half-steered) is decided here and tested without hardware.
 //!
-//! The ioctl half is deliberately absent rather than sketched.
-//! `ethtool_rx_flow_spec` is not in `libc`, so its layout would be
-//! hand-written from a header this machine cannot read, and a field in
-//! the wrong place produces rules that install cleanly and match the
-//! wrong traffic. When it lands it must **read every rule back** with
-//! `ETHTOOL_GRXCLSRULE` and compare against what was asked for, so the
-//! layout is self-validating on the first real NIC instead of trusted —
-//! the same reasoning the FIB readback verify rests on.
+//! The ioctl half is [`crate::ntuple`], which installs what this plans
+//! and reads every rule back with `ETHTOOL_GRXCLSRULE` before believing
+//! it — `ethtool_rx_flow_spec` is not in `libc`, so its layout is
+//! hand-written, and a field in the wrong place produces rules that
+//! install cleanly and match the wrong traffic.
 
 use std::net::Ipv4Addr;
 

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -227,6 +227,36 @@ pub enum Event {
     ConvergenceStopped,
     /// Backoff elapsed.
     BackoffElapsed,
+    /// This attach inherited MCAM rules with no process behind them.
+    ///
+    /// Steering is NIC state, so a VPP that died steered leaves its
+    /// rules diverting allowlisted traffic into a VF nothing is
+    /// servicing — a blackhole that started when it died and that a
+    /// fresh spawn does not end, since reaching `Ready` takes a full
+    /// convergence and the machine never steers a first attach on its
+    /// own.
+    ///
+    /// Reported rather than cleaned up by the caller so the ordinary
+    /// teardown ordering handles it: `Unsteer` first, and if the NIC
+    /// refuses, `steered` stays true and the VF stays withheld. The
+    /// *want* is recorded too — steering was established and never
+    /// deliberately stopped — so the replacement re-steers once it
+    /// verifies, which is what closes the blackhole.
+    InheritedSteering,
+    /// The operator turned the canary lever ON: a `steer on` appeared,
+    /// or the allowlist changed under a port that is already steering.
+    ///
+    /// Distinct from `VerifyPassed`'s automatic re-steer because the
+    /// machine deliberately never steers a first attach on its own —
+    /// that decision is the operator's, and this is how they make it
+    /// without a restart. The caller must have called
+    /// [`crate::runtime::Steering::retarget`] first; `Action::Steer`
+    /// reconciles the NIC to whatever the target now is.
+    SteerRequested,
+    /// The operator turned the canary lever OFF — the rollback landing
+    /// zone. Membership stays, the FIB stays synced, traffic goes back
+    /// to the fallback tier.
+    UnsteerRequested,
     /// Operator asked for a clean stop.
     StopRequested,
 }
@@ -499,6 +529,52 @@ impl Supervisor {
                 self.steered = true;
                 self.steer_wanted = true;
                 vec![]
+            }
+
+            // Rules without a process. Believed steered on the strength
+            // of the record, because that is the only evidence there is
+            // — and believing it is what makes the teardown emit
+            // `Unsteer` and withhold the VF if the removal is refused.
+            //
+            // Only from `Stopped`: this is an attach-time fact, injected
+            // before the first `StartRequested`. Anywhere else it would
+            // be describing a process that exists.
+            (Stopped, InheritedSteering) => {
+                self.steered = true;
+                self.steer_wanted = true;
+                vec![Action::Unsteer]
+            }
+
+            // --- the canary lever, turned without a restart ---
+            //
+            // Legal only from the two converged states. Everywhere else
+            // there is either no verified FIB to divert traffic into or
+            // a teardown in progress, and both make an operator's steer
+            // request something to decline rather than to queue: a
+            // request that survives a crash and fires against the
+            // replacement is not what was asked for.
+            //
+            // From `Ready` this is the first steer. From `Steered` it is
+            // a reconcile — the target changed underneath live rules —
+            // and the state deliberately does not move, because traffic
+            // never stopped being diverted.
+            (Ready | State::Steered, SteerRequested) => {
+                self.steer_wanted = true;
+                vec![Action::Steer]
+            }
+            // Believed down only on `Unsteered`, exactly as everywhere
+            // else. The state returns to `Ready` because that is what
+            // membership-without-steering is — the designed staging
+            // state — but `steered` is left for the acknowledgement, so
+            // a refused removal keeps the VF withheld.
+            (Ready | State::Steered, UnsteerRequested) => {
+                self.steer_wanted = false;
+                self.state = Ready;
+                if self.steered {
+                    vec![Action::Unsteer]
+                } else {
+                    vec![]
+                }
             }
 
             // --- death and wedging ---
@@ -1251,5 +1327,157 @@ mod tests {
         assert!(s.on(Event::Wedged).is_empty());
         assert_eq!(s.state(), State::Stopped);
         assert_eq!(s.failures(), 0);
+    }
+
+    /// Turning the canary lever on from the staging state.
+    ///
+    /// The whole point of `reconfigure`: the rollout's first steer, and
+    /// every step after it, must not cost a VPP restart — that is ~40 s
+    /// of resync with the offload down, per step.
+    fn ready_unsteered() -> Supervisor {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::Spawned);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Ready);
+        assert!(!s.is_steered());
+        s
+    }
+
+    #[test]
+    fn an_operator_can_steer_a_ready_vpp_without_a_restart() {
+        let mut s = ready_unsteered();
+        assert_eq!(s.on(Event::SteerRequested), vec![Action::Steer]);
+        // The state does NOT move on the request. `Steered` is the
+        // acknowledgement, exactly as on the automatic path: claiming it
+        // here would report a steered dataplane whose MCAM inserts had
+        // not yet been attempted.
+        assert_eq!(s.state(), State::Ready);
+        assert!(!s.is_steered());
+
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Steered);
+        assert!(s.is_steered());
+    }
+
+    /// A refused canary step leaves the *want* recorded, so the next
+    /// verify retries it — the same rule the automatic path follows.
+    #[test]
+    fn a_refused_operator_steer_is_not_mistaken_for_steer_off() {
+        let mut s = ready_unsteered();
+        s.on(Event::SteerRequested);
+        s.on(Event::SteerFailed);
+        assert!(!s.is_steered(), "nothing was diverted");
+        assert!(
+            s.steer_intended(),
+            "a rollout that broke must be distinguishable from the designed staging state"
+        );
+    }
+
+    /// Turning it off is the rollback landing zone: membership stays,
+    /// the FIB stays synced, traffic returns to the fallback tier.
+    #[test]
+    fn unsteering_on_request_returns_to_the_staging_state() {
+        let mut s = running_and_steered();
+        assert_eq!(s.on(Event::UnsteerRequested), vec![Action::Unsteer]);
+        assert_eq!(s.state(), State::Ready);
+        assert!(
+            s.is_steered(),
+            "still believed steered until the removal is acknowledged — releasing a VF on \
+             an optimistic clear is the failure this rule exists for"
+        );
+
+        s.on(Event::Unsteered);
+        assert!(!s.is_steered());
+        assert!(
+            !s.steer_intended(),
+            "a deliberate `steer off` must not be re-steered by the next verify"
+        );
+    }
+
+    /// A removal the NIC refused keeps the VF withheld.
+    #[test]
+    fn a_refused_operator_unsteer_keeps_the_vf_withheld() {
+        let mut s = running_and_steered();
+        s.on(Event::UnsteerRequested);
+        s.on(Event::UnsteerFailed);
+        assert!(s.is_steered(), "traffic is still diverted");
+        assert!(
+            s.on(Event::StopRequested).contains(&Action::Unsteer),
+            "every later teardown must keep trying, and keep withholding the VF"
+        );
+    }
+
+    /// Rules inherited from a dead VPP are taken down first, and
+    /// withhold the VF if they will not come down.
+    ///
+    /// MCAM outlives the process. Without this the record's rules were
+    /// adopted into the ledger and then ignored: the supervisor believed
+    /// nothing was diverted, so teardown emitted no `Unsteer` and
+    /// released the VF while the NIC was still steering into it.
+    #[test]
+    fn inherited_steering_is_taken_down_before_anything_else() {
+        let mut s = Supervisor::new();
+        assert_eq!(s.on(Event::InheritedSteering), vec![Action::Unsteer]);
+        assert!(
+            s.is_steered(),
+            "the record is the only evidence there is, and believing it is what makes \
+             the teardown emit Unsteer"
+        );
+
+        // Removal refused: the VF must stay withheld, on this and every
+        // later teardown.
+        s.on(Event::UnsteerFailed);
+        assert!(s.is_steered());
+        assert!(s.on(Event::StopRequested).contains(&Action::Unsteer));
+    }
+
+    /// Inheriting steering also inherits the *want*, so the replacement
+    /// re-steers once it verifies.
+    ///
+    /// Steering was established and never deliberately stopped — and
+    /// until the replacement steers, those prefixes are diverted into a
+    /// VF with nothing behind them. Waiting for an operator would leave
+    /// the blackhole open across a restart nobody watched.
+    #[test]
+    fn a_replacement_re_steers_what_the_dead_vpp_was_steering() {
+        let mut s = Supervisor::new();
+        s.on(Event::InheritedSteering);
+        s.on(Event::Unsteered);
+        assert!(!s.is_steered(), "the stale rules are gone");
+        assert!(s.steer_intended(), "but the want survives them");
+
+        s.on(Event::StartRequested);
+        s.on(Event::Spawned);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert!(
+            s.on(Event::VerifyPassed).contains(&Action::Steer),
+            "a verified replacement must restore the offload without being asked"
+        );
+    }
+
+    /// Steering requests are refused outside the converged states rather
+    /// than queued.
+    ///
+    /// A request that survives a crash and fires against the replacement
+    /// is not what the operator asked for — and it is unnecessary: the
+    /// replacement re-steers on its own if steering was wanted.
+    #[test]
+    fn a_steer_request_while_converging_does_nothing() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::Spawned);
+        s.on(Event::ApiUp);
+        assert_eq!(s.state(), State::Syncing);
+
+        assert!(s.on(Event::SteerRequested).is_empty());
+        assert_eq!(s.state(), State::Syncing);
+        assert!(
+            !s.steer_intended(),
+            "a refused request must leave no want behind, or the next VerifyPassed acts on it"
+        );
     }
 }

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -195,9 +195,25 @@ pub enum Event {
     /// it fires.
     PhaseTimedOut,
     /// Installing the MCAM rules failed. The dataplane is verified but
-    /// traffic is NOT diverted — the safe staging state, reported
-    /// rather than papered over.
-    SteerFailed,
+    /// traffic is not going where it was asked to go.
+    ///
+    /// `rules_remain` is **observed from the steering ledger**, not
+    /// inferred: [`crate::ntuple::NtupleSteering::steer`] rolls back
+    /// all-or-nothing, so a failure may leave the NIC empty (clean
+    /// rollback) or holding rules the NIC refused to delete — and on a
+    /// *reconcile* of an already-steering port the rollback removes the
+    /// rules that were working a moment ago. Nothing in the lifecycle
+    /// state distinguishes those, so the executor reads the ledger and
+    /// says which.
+    ///
+    /// Guessing either way is wrong in a way that matters. Assuming
+    /// rules remain reports a steered, healthy offload over an empty NIC
+    /// — traffic is on the eBPF tier and every surface says otherwise.
+    /// Assuming they are gone suppresses the `Unsteer` teardown owes and
+    /// releases a VF that MCAM may still target.
+    SteerFailed {
+        rules_remain: bool,
+    },
     /// MCAM rules are confirmed removed.
     ///
     /// Steering is only believed *down* on this acknowledgement, for
@@ -619,8 +635,20 @@ impl Supervisor {
             // on the next `VerifyPassed`, and every health surface reads
             // it as the designed staging state. Same defect shape as the
             // rest of this file: an attempt that failed left no trace.
-            (Ready, SteerFailed) => {
+            //
+            // Reachable from `State::Steered` too, since a reconfigure
+            // re-steers a live port — and that is the case where leaving
+            // `steered` alone was actively wrong: the rollback empties
+            // the NIC, so the machine would sit in `Steered`, report the
+            // steering subsystem Healthy with no message, and publish
+            // `packetframe_vpp_state{state="steered"}` while every
+            // steered packet was in fact on the eBPF tier. `state`
+            // returns to `Ready` because that is where "verified, not
+            // diverting what we asked" belongs.
+            (Ready | State::Steered, SteerFailed { rules_remain }) => {
                 self.steer_wanted = true;
+                self.steered = rules_remain;
+                self.state = Ready;
                 vec![]
             }
 
@@ -1067,7 +1095,7 @@ mod tests {
         assert_eq!(s.state(), State::Ready);
 
         // Rules could not be installed.
-        assert_eq!(s.on(Event::SteerFailed), vec![]);
+        assert_eq!(s.on(Event::SteerFailed { rules_remain: true }), vec![]);
         assert_eq!(
             s.state(),
             State::Ready,
@@ -1100,7 +1128,9 @@ mod tests {
         assert!(!s.steer_intended(), "nothing has asked for steering yet");
 
         // The operator's canary fires and the MCAM insert fails.
-        s.on(Event::SteerFailed);
+        s.on(Event::SteerFailed {
+            rules_remain: false,
+        });
         assert!(!s.is_steered());
         assert!(
             s.steer_intended(),
@@ -1368,7 +1398,9 @@ mod tests {
     fn a_refused_operator_steer_is_not_mistaken_for_steer_off() {
         let mut s = ready_unsteered();
         s.on(Event::SteerRequested);
-        s.on(Event::SteerFailed);
+        s.on(Event::SteerFailed {
+            rules_remain: false,
+        });
         assert!(!s.is_steered(), "nothing was diverted");
         assert!(
             s.steer_intended(),
@@ -1478,6 +1510,63 @@ mod tests {
         assert!(
             !s.steer_intended(),
             "a refused request must leave no want behind, or the next VerifyPassed acts on it"
+        );
+    }
+
+    /// A failed reconcile of a LIVE steered port must not leave the
+    /// machine claiming it is steering.
+    ///
+    /// `steer` rolls back all-or-nothing, and on a reconcile that
+    /// rollback removes the rules that were working a moment ago — so a
+    /// clean rollback empties the NIC. With `SteerFailed` falling through
+    /// to the catch-all from `State::Steered`, the machine stayed
+    /// `Steered` with `steered == true`: `steering_health()` reports
+    /// Healthy with no message and the state gauge publishes
+    /// `state="steered"`, while every steered packet is in fact on the
+    /// eBPF tier.
+    ///
+    /// So the observed ledger decides, and the assertion is on
+    /// `is_steered()` rather than on the state name — that is the field
+    /// health and teardown both read.
+    #[test]
+    fn a_failed_reconcile_of_a_live_port_stops_claiming_to_steer() {
+        let mut s = running_and_steered();
+        s.on(Event::SteerRequested);
+        s.on(Event::SteerFailed {
+            rules_remain: false,
+        });
+
+        assert!(
+            !s.is_steered(),
+            "the rollback emptied the NIC, so nothing is diverted and nothing may say it is"
+        );
+        assert_eq!(s.state(), State::Ready, "verified, but not diverting");
+        assert!(
+            s.steer_intended(),
+            "the want survives, so the next verify restores the offload"
+        );
+        assert!(
+            !s.on(Event::StopRequested).contains(&Action::Unsteer),
+            "and no Unsteer is owed for rules that are confirmed gone"
+        );
+    }
+
+    /// The same failure with rules left behind keeps the VF withheld.
+    ///
+    /// The other polarity, and the reason this is observed rather than
+    /// assumed: a rollback that could not delete leaves rules diverting
+    /// traffic, so `steered` must stay true or `ReleaseResources` unbinds
+    /// a VF that MCAM still targets.
+    #[test]
+    fn a_failed_reconcile_that_left_rules_keeps_the_vf_withheld() {
+        let mut s = running_and_steered();
+        s.on(Event::SteerRequested);
+        s.on(Event::SteerFailed { rules_remain: true });
+
+        assert!(s.is_steered(), "rules are still in the NIC");
+        assert!(
+            s.on(Event::StopRequested).contains(&Action::Unsteer),
+            "so every teardown must try again and keep withholding the VF"
         );
     }
 }

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -529,3 +529,123 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
         "the rollback must be suppressed: {e}"
     );
 }
+
+/// MCAM rules recorded by a VPP that is no longer running must be
+/// cleared before a fresh one is spawned.
+///
+/// They are NIC state, so they survive both the process and the daemon —
+/// and with nothing behind the VF they have been blackholing the steered
+/// prefixes since that VPP died. A fresh spawn does not fix it: reaching
+/// `Ready` takes a full convergence, and the supervisor never steers a
+/// first attach on its own. So the rules would keep diverting traffic
+/// into a hole under a daemon that reports Healthy.
+///
+/// Clearing them hands those prefixes back to the eBPF fast-path, which
+/// is the entire premise of it being the permanent failover tier.
+///
+/// The assertion is on the RECORD rather than on the NIC, because these
+/// tests have no NIC: on this host the removal fails and the rules stay
+/// in the ledger, which is itself the invariant that matters — a rule
+/// that would not come out must remain findable by `detach --all`.
+#[test]
+fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
+    let fake = fake_vpp::Fake::start("bringup-stale-steer");
+    let host = Host::new(
+        "stale-steer",
+        &[("eth4", "0002:07:00.0")],
+        fake.path.clone(),
+    );
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("first attach");
+    drop(attached);
+
+    // Play the kernel's part: a real bind creates the `driver` symlink
+    // adoption verifies against.
+    let link = host
+        .paths
+        .sys
+        .pci_devices
+        .join("0002:07:00.0")
+        .join("driver");
+    if !link.exists() {
+        std::os::unix::fs::symlink(host.paths.sys.pci_drivers.join("vfio-pci"), &link).unwrap();
+    }
+
+    // What a steered VPP leaves behind when it dies: rules on the
+    // record, no live process.
+    let mut state = host.state().expect("state file");
+    state.steer_rules = vec![("eth4".into(), vec![1024, 1025])];
+    state.vpp_pid = None;
+    state.vpp_start_ticks = None;
+    state.vpp_boot_id = None;
+    state.save(&host.paths.sys.state_dir).unwrap();
+
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("second attach");
+    drop(attached);
+
+    let after = host.state().expect("state file");
+    let residual = packetframe_vpp_offload::resources::flatten_steer_rules(&after.steer_rules);
+    assert_eq!(
+        residual,
+        vec![("eth4".to_string(), 1024), ("eth4".to_string(), 1025)],
+        "a rule the removal could not clear must stay on the record — dropping it is how \
+         a live MCAM rule becomes invisible to every later teardown"
+    );
+}
+
+/// A recorded ledger is what `unsteer` acts on after a restart.
+///
+/// Both halves of this shipped in #127 and nothing connected them:
+/// `steer_rules` was read by `bring_up` and written by nobody, and
+/// `NtupleSteering::adopt_installed` had no production caller. So a
+/// daemon restart over a steered VPP believed nothing was diverted,
+/// emitted no `Unsteer` on teardown, and released the VF with MCAM
+/// still pointing traffic into it.
+///
+/// Asserted through the teardown that the ledger governs: with rules on
+/// the record, the release must be REFUSED, because on this host they
+/// cannot be confirmed gone.
+#[test]
+fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
+    let fake = fake_vpp::Fake::start("bringup-ledger");
+    let host = Host::new("ledger", &[("eth4", "0002:07:00.0")], fake.path.clone());
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("first attach");
+    drop(attached);
+
+    // Play the kernel's part: a real bind creates the `driver` symlink
+    // adoption verifies against.
+    let link = host
+        .paths
+        .sys
+        .pci_devices
+        .join("0002:07:00.0")
+        .join("driver");
+    if !link.exists() {
+        std::os::unix::fs::symlink(host.paths.sys.pci_drivers.join("vfio-pci"), &link).unwrap();
+    }
+
+    let mut state = host.state().expect("state file");
+    state.steer_rules = vec![("eth4".into(), vec![1024])];
+    state.save(&host.paths.sys.state_dir).unwrap();
+
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("attach");
+    let report = attached.service.stop();
+    let published = report
+        .published
+        .or_else(|| report.pending.map(|p| p.settle()))
+        .expect("a final snapshot");
+
+    assert!(
+        published.resources_leaked,
+        "an unconfirmed steering removal must withhold the VF; releasing it while MCAM \
+         may still target it is the blackhole this ledger exists to prevent. Report: {:?}",
+        published.report
+    );
+    assert!(
+        host.state().is_some(),
+        "and the state file must survive, or nothing can find the rules later"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -267,6 +267,9 @@ fn a_persist_that_recovers_clears_the_recorded_failure() {
                 Ok(())
             }
         }
+        fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     let fake = Fake::start("store-recover");
@@ -350,6 +353,9 @@ fn a_successful_spawn_persist_clears_an_earlier_store_failure() {
             }
         }
         fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+            Ok(())
+        }
+        fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
             Ok(())
         }
     }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1190,7 +1190,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true)
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
         .expect("the canary lever must turn without a restart");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1200,7 +1200,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
 
     // Rollback: membership stays, the FIB stays synced, traffic returns
     // to the fallback tier.
-    svc.apply_steering(Vec::new(), plan_for(2), false)
+    svc.apply_steering(Vec::new(), plan_for(2), false, true)
         .expect("rollback");
     assert_eq!(svc.status().expect("published").state, State::Ready);
 
@@ -1267,7 +1267,7 @@ fn a_steering_change_before_convergence_is_refused() {
     .expect("service starts");
 
     let e = svc
-        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true)
+        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
         .expect_err("must refuse before convergence");
     assert!(
         e.contains("not converged"),
@@ -1277,6 +1277,188 @@ fn a_steering_change_before_convergence_is_refused() {
     assert!(
         e.contains("takes effect at the next successful convergence"),
         "and it must say what happens to the config the operator just wrote: {e}"
+    );
+
+    svc.stop();
+}
+
+/// A SIGHUP that did not move the lever must not divert traffic.
+///
+/// `steer on` in the config is not the same as the operator asking to
+/// steer NOW. A port configured `steer on` that has never steered is in
+/// the designed staging state — the machine never steers a first attach
+/// on its own, because the canary ladder is paced by hand — so a
+/// reconfigure for an unrelated reason (an added `allow-prefix`, a
+/// changed global) must update the target and stop.
+///
+/// The assertion is that the SPY saw no steer, not merely that the call
+/// returned Ok: returning Ok while quietly diverting traffic is exactly
+/// the outcome under test.
+#[test]
+fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
+    let fake = Fake::start("svc-no-lever");
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SpySteering(spy)),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Ready: {:?}",
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // `steer on` is in the config (ports is non-empty, want_steer true)
+    // but the flag did not move in this reconfigure.
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+        .expect("a target update is not an error");
+
+    assert_eq!(
+        svc.status().expect("published").state,
+        State::Ready,
+        "traffic must still be on the fallback tier"
+    );
+    let seen = log.lock().unwrap().clone();
+    assert_eq!(
+        seen,
+        vec!["retarget 1 ports, 4 rules".to_string()],
+        "the target is updated and nothing else — a steer here would divert traffic as a \
+         side effect of editing something unrelated"
+    );
+
+    // And the operator turning the lever on the very next reconfigure
+    // still works, so this withholds rather than latches.
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .expect("the lever still turns");
+    assert_eq!(svc.status().expect("published").state, State::Steered);
+
+    svc.stop();
+}
+
+/// An allowlist change under a port that IS steering is reconciled,
+/// lever or no lever.
+///
+/// Its traffic is diverted right now, so the rules must match the new
+/// allowlist — withholding here would leave a prefix the operator just
+/// removed from the allowlist still being diverted, which is the failure
+/// inverted.
+#[test]
+fn an_allowlist_change_under_live_steering_is_always_reconciled() {
+    let fake = Fake::start("svc-live-reconcile");
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SpySteering(spy)),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            // Adopted ALREADY steered: rules are in the NIC and traffic
+            // is diverted while it converges, which is the case whose
+            // reconcile must not be withheld.
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: true }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Steered {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Steered: {:?}",
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // The lever did NOT move — only the allowlist did.
+    log.lock().unwrap().clear();
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(1), true, false)
+        .expect("a live port must be reconciled");
+
+    let seen = log.lock().unwrap().clone();
+    assert!(
+        seen.contains(&"steer".to_string()),
+        "a steering port must be reconciled to the new allowlist even when the lever did \
+         not move, or a withdrawn prefix keeps being diverted: {seen:?}"
     );
 
     svc.stop();

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -248,6 +248,9 @@ impl IdentityStore for RefusingStore {
     fn interfaces_attached(&mut self, _: &[(String, u32)]) -> Result<(), String> {
         Err("state dir is read-only".into())
     }
+    fn steering_changed(&mut self, _: &[(String, u32)]) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 /// An unpersisted interface identity must DEGRADE health, not pass
@@ -682,6 +685,10 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
         fn unsteer(&mut self) -> Result<(), String> {
             Ok(())
         }
+        fn installed(&self) -> Vec<(String, u32)> {
+            Vec::new()
+        }
+        fn retarget(&mut self, _: Vec<(String, u32)>, _: packetframe_vpp_offload::steer::RuleSet) {}
     }
 
     let fake = Fake::start("svc-panic");
@@ -1074,4 +1081,203 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
         std::thread::sleep(Duration::from_millis(10));
     }
     assert!(pending.is_finished(), "the teardown never settled");
+}
+
+/// Steering that records what it was asked to do, so the request path
+/// can be observed without a NIC. The ioctl half has its own tests
+/// against an in-memory NIC inside the crate.
+#[derive(Default)]
+struct SpySteering(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
+
+impl packetframe_vpp_offload::runtime::Steering for SpySteering {
+    fn steer(&mut self) -> Result<(), String> {
+        self.0.lock().unwrap().push("steer".into());
+        Ok(())
+    }
+    fn unsteer(&mut self) -> Result<(), String> {
+        self.0.lock().unwrap().push("unsteer".into());
+        Ok(())
+    }
+    fn installed(&self) -> Vec<(String, u32)> {
+        Vec::new()
+    }
+    fn retarget(
+        &mut self,
+        ports: Vec<(String, u32)>,
+        plan: packetframe_vpp_offload::steer::RuleSet,
+    ) {
+        self.0.lock().unwrap().push(format!(
+            "retarget {} ports, {} rules",
+            ports.len(),
+            plan.rules.len()
+        ));
+    }
+}
+
+fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {
+    let allow: Vec<IpPrefix> = (0..count).map(|i| fake_vpp::v4(0, i)).collect();
+    packetframe_vpp_offload::steer::RuleSet::plan(
+        &allow,
+        packetframe_vpp_offload::steer::McamBudget::default(),
+    )
+    .expect("fits")
+}
+
+/// The canary lever, turned through the running service.
+///
+/// This is `Module::reconfigure`'s whole path: post a target, the loop
+/// retargets and injects the event, the supervisor emits `Steer`, and
+/// the answer comes back to the caller SYNCHRONOUSLY — because
+/// `packetframe reconfigure` writes an OK/ERR marker an operator reads,
+/// and "the rollout step succeeded" must not look like "the rollout step
+/// was queued".
+#[test]
+fn an_operator_can_steer_and_unsteer_a_converged_service() {
+    let fake = Fake::start("svc-steer");
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SpySteering(spy)),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Ready: {:?}",
+            s.state
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true)
+        .expect("the canary lever must turn without a restart");
+    assert_eq!(
+        svc.status().expect("published").state,
+        State::Steered,
+        "and the change is visible before the call returns, not eventually"
+    );
+
+    // Rollback: membership stays, the FIB stays synced, traffic returns
+    // to the fallback tier.
+    svc.apply_steering(Vec::new(), plan_for(2), false)
+        .expect("rollback");
+    assert_eq!(svc.status().expect("published").state, State::Ready);
+
+    let seen = log.lock().unwrap().clone();
+    assert_eq!(
+        seen,
+        vec![
+            "retarget 1 ports, 4 rules".to_string(),
+            "steer".into(),
+            "retarget 0 ports, 4 rules".into(),
+            "unsteer".into(),
+        ],
+        "the target is recorded BEFORE the reconcile, or Steer installs the old rules"
+    );
+
+    svc.stop();
+}
+
+/// A steering change before convergence is refused, not queued.
+///
+/// A request that outlives a crash and fires against the replacement is
+/// not what the operator asked for — and it is unnecessary, since a
+/// replacement re-steers on its own when steering was wanted. The
+/// refusal has to reach the caller, because their rollout step did not
+/// happen.
+#[test]
+fn a_steering_change_before_convergence_is_refused() {
+    let fake = Fake::start("svc-steer-early");
+    let sock = fake.path.clone();
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+            );
+            let runtime = Runtime::new(
+                engine,
+                // Large enough that the drain spans ticks, so the
+                // request lands while the machine is still converging.
+                Box::new(Mirror(
+                    (0..=255u8)
+                        .flat_map(|a| (0..=255u8).map(move |b| fake_vpp::v4(a, b)))
+                        .collect(),
+                )),
+                Box::new(SteeringUnavailable),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            Ok((Driver::new(), runtime, vec![Event::StartRequested]))
+        }),
+    )
+    .expect("service starts");
+
+    let e = svc
+        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true)
+        .expect_err("must refuse before convergence");
+    assert!(
+        e.contains("not converged"),
+        "must be the refusal, not the wait timing out — a timeout here would make this \
+         test pass without the refusal ever running: {e}"
+    );
+    assert!(
+        e.contains("takes effect at the next successful convergence"),
+        "and it must say what happens to the config the operator just wrote: {e}"
+    );
+
+    svc.stop();
 }


### PR DESCRIPTION
`reconfigure` was the last of slice 5's code. Allowlist changes and per-port `steer on|off` now become MCAM deltas under a running VPP.

That lever is what the rollout turns port by port. Making it restart-only would put ~40 s of resync with the offload down between an operator and every step — including the rollback step, whose whole purpose is to get traffic off a misbehaving VPP quickly.

Everything else in the section is refused **by name**: `port`/`cores` are VF and thread topology, `expected-routes` sizes the main heap and stats segment, and VPP fixes all of it at start. Applying a raised ceiling to a VPP running on the old segments is the mid-resync OOM abort gate 0b found.

## Four commits, and why there are four

Writing this surfaced four defects — three in #127, one in this PR's own first commit. **All of them are one shape: acting on a value's presence rather than on an observation of change.** Every one was found by mechanically running a written-down check over the diff, not by reading it again.

### `0a197b9` — `reconfigure`, plus three defects in #127

**`ResourceState::steer_rules` had no writer.** Read in one place — to decide whether an adopted VPP is diverting traffic — and `IdentityStore` had no method that could set it. `NtupleSteering::adopt_installed` likewise had no production caller. A daemon restart over a steered VPP therefore believed nothing was steered: teardown emitted no `Unsteer` and released the VF with MCAM still pointing traffic into it. Had it known, `unsteer` removes what its own ledger names — a fresh ledger would have answered `Ok` over rules still in the NIC.

**`steer` appended to that ledger rather than treating it as a set.** The supervisor deliberately re-emits `Action::Steer` for a VPP it believes steered (the controller wipes classifier state on provisioning), so the second pass recorded every slot twice, `unsteer` deleted each twice, and a teardown that had removed every rule reported failures and withheld the VF.

**Rules with no process behind them were adopted and then ignored.** MCAM outlives the process, so a VPP that died steered leaves its rules diverting into a VF nothing is servicing — blackholing from the moment it died, and a fresh spawn does not end it. `Event::InheritedSteering` hands that to the supervisor's own teardown ordering: `Unsteer` first, VF withheld if the NIC refuses, and the *want* inherited so the replacement re-steers once it verifies.

*My first fix for that third one grew a second removal path inside `bring_up`. The test caught it, because it asserted the invariant — an unconfirmed removal withholds the VF — and withholding is the supervisor's behaviour, which an inline path bypasses.*

### `0cc34af` — `detach --all` clears steering instead of refusing over it

Found by running the grep-for-a-caller gate on the **reader/writer axis**: `steer_rules` had gained a writer, so every reader's assumptions needed re-checking.

The standalone teardown refused whenever the state file recorded MCAM rules, with a comment noting the field was always empty so the guard was hypothetical. This PR made it real — and refusing is the wrong answer, because `packetframe detach --all` is the remedy every error in this subsystem points an operator at. One that refuses whenever a steered VPP had been running would strand the box. It can do the removal, so it does, first, before the kill. Through `NtupleSteering`, so it shares the removal routine including the half that matters: a rule the NIC will not delete stays on the record.

### `aa2e2e4` — a SIGHUP that did not move the lever must not steer

`want_steer` was derived from the `steer on` flag being *present*, so any SIGHUP — an added `allow-prefix`, a changed global — would have diverted traffic on every `steer on` port not yet steered. That breaks the invariant the canary ladder rests on: such a port is in the *designed* staging state, because when traffic moves is the operator's call.

The request now carries whether the flag itself moved. A port already steering is reconciled either way (its traffic is diverted now, so the rules must match the new allowlist); a port not steering is steered only when the lever actually moved. Verified by reverting the check and watching the test fail.

### `0a2e400` — answer a displaced request where it is displaced

The supersede check inferred its verdict instead of observing one: the waiter read a higher sequence in the slot as proof of having been replaced before running. Wrong when the loop has taken request A and is applying it — a newly-arrived B then makes A's caller report "replaced before it was applied" about a change that happened. Displacing an unapplied request now publishes its verdict. Net less code, and unreachable from the loader either way (SIGHUP handling is serial).

## Structural changes

- **`steer` is a reconcile**, clearing what the target no longer contains before installing. That is the semantics the supervisor already assumed, and it lets `retarget` change the target under a live port without a second installation path. A retarget that cannot clear a stale rule installs nothing — the new set may reuse its slot.
- **The allowlist is a shared handle, not a copy.** `reconfigure` is handed only its own module's section and the allowlist lives in fast-path's, so a module holding a `Vec` would have compared against the startup allowlist, found no change, and reported OK for the one thing SIGHUP was raised to do.
- **`apply_steering` waits for the loop's verdict.** `packetframe reconfigure` writes an OK/ERR marker an operator reads; "the rollout step succeeded" must not look like "the rollout step was queued".
- `group_steer_rules`/`flatten_steer_rules` — three open-coded conversions between the grouped record and the flat ledger is how the two stop describing the same rules.
- Dropped `NtupleSteering::installed()`, the inherent method: tests-only callers, and it shadowed the trait method of the same name with a different return type.

## Testing

Nothing in `steer`/`unsteer` had ever executed. Every ethtool call fails on a dev host, so both routines could only be tested along their failure paths — precisely where the sequencing they encode is invisible. There is now an in-memory NIC at the ioctl boundary.

It substitutes for a NIC's **behaviour, not its layout**: it stores whatever `flow_spec` produced and hands the same bytes back, so a field at the wrong offset round-trips perfectly. That check still has exactly one venue — the `GRXCLSRULE` readback against real hardware — and it is still unrun.

Gates: `fmt`, host clippy, `cargo test --workspace --all-features`, and per-target `--workspace --all-targets` clippy on all four published triples. The last one caught three Linux-gated test impls that no host gate compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)