### PR TITLE
feat: the module health surface, and slice 6's docs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,7 @@ dependencies = [
  "packetframe-fast-path",
  "packetframe-probe",
  "packetframe-vpp-offload",
+ "serde",
  "serde_json",
  "signal-hook",
  "thiserror 2.0.19",

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 | Two-stage BPF datapath (`fast_path` + `finalize` via `bpf_tail_call`) | Production (v0.2.5+); see [docs/runbooks/tail-call-architecture.md](docs/runbooks/tail-call-architecture.md) |
 | `probe` module (diagnostic XDP) | Production |
 | tc-ingress datapath (`attach <iface> tc`, custom-fib only) | Experimental (Phase T); see [docs/runbooks/tc-datapath.md](docs/runbooks/tc-datapath.md) |
+| Module health + metrics surface (`packetframe status`, `packetframe_vpp_*`) | Production |
+| `vpp-offload` module (VPP-on-VF forwarding vector) | **Code-complete, hardware-unproven** — never run against a real VPP; see [docs/runbooks/vpp-offload.md](docs/runbooks/vpp-offload.md) |
 | `ddos` module (XDP-time SYN-flood + amplification filter) | Future; sketched in SPEC §5.2 (priority 0–999, security/admission) |
 | `sampler` module (per-flow ringbuf observability) | Future; sketched in SPEC §5.3 (priority 2000–2999, observation) |
 | `randomizer` module (TC egress jitter for NoiseNet anti-correlation) | Future; sketched in SPEC §5.1 (priority ~3000, egress) |
@@ -212,6 +214,33 @@ route-source bmp 127.0.0.1:6543 require-loc-rib
 
 See [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md) for the full operational guide: cutover sequence, rollback, integrity checking, troubleshooting.
 
+## Forwarding vectors
+
+`forwarding-mode` chooses how a route is *resolved*. A **vector** is what
+actually moves the packet, and PacketFrame is built to carry more than
+one at a time.
+
+- **eBPF fast-path** (XDP on the PFs) is the vector today, and stays the
+  permanent failover tier. It is at its structural floor under generic
+  XDP — native XDP panics the reference vendor kernel, so there is no
+  cheap headroom left here.
+- **`vpp-offload`** (phase 4) adds a second: MCAM hardware bifurcation
+  steers allowlisted traffic to an SR-IOV VF owned by a
+  packetframe-supervised VPP, which forwards it from a full-table FIB fed
+  by the same resolved best-paths the eBPF tier uses. Anything not
+  steered — and everything, if VPP dies — stays on the tier above.
+
+The split is what makes the second vector safe to adopt incrementally:
+membership is provisioned everywhere first, then steering is turned on
+one port at a time, and turning it off is a config edit rather than a
+restart. **No dataplane code for the second vector lives in this repo** —
+VPP is unmodified upstream, built and shipped on its own release tag.
+
+`vpp-offload` is code-complete and **hardware-unproven**: it has never
+run against a real VPP process, and its MCAM ioctl path has never met a
+NIC. Read [`docs/runbooks/vpp-offload.md`](docs/runbooks/vpp-offload.md)
+before enabling it anywhere that carries traffic.
+
 ## Attach modes
 
 Each `attach <iface> <mode>` directive picks how XDP binds to the interface:
@@ -294,6 +323,8 @@ Counters export as Prometheus textfile every 15 s when `metrics-textfile` is set
 
 - [`conf/example.conf`](conf/example.conf): annotated reference config
 - [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md): operational runbook for custom-FIB mode (cutover, rollback, integrity checks, triage by symptom)
+- [`docs/runbooks/vpp-offload.md`](docs/runbooks/vpp-offload.md): operational runbook for the VPP-on-VF vector (canary ladder, rollback, triage, and which published numbers are measured)
+- [`docs/runbooks/vpp-offload-spike.md`](docs/runbooks/vpp-offload-spike.md): the gate-0b bring-up procedure and its results, including what failed
 
 ## Build from source
 

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -308,17 +308,29 @@ module fast-path
   # block-prefix 198.51.100.0/24  # TEST-NET-2
   # block-prefix 203.0.113.0/24   # TEST-NET-3
 
-# --- vpp-offload (phase 4, EXPERIMENTAL scaffold) --------------------------
+# --- vpp-offload (phase 4) -------------------------------------------------
 # The VPP-on-VF forwarding vector: hardware-bifurcated allowlist traffic
 # forwarded by a packetframe-supervised VPP on SR-IOV VFs, with the eBPF
-# fast-path above as the permanent failover tier. Requires the fast-path
-# section (steered prefixes inherit its allowlist, which must mean pure
-# stateless L3 transit) and `forwarding-mode custom-fib` before any port
-# steers. MEMBERSHIP IS ALL-OR-NOTHING: every fast-path attach port needs
-# a `port` line before any `steer on` (a steered packet's best path may
-# egress any port; missing members blackhole those destinations). `steer`
-# is the per-port canary lever; all-members + all-steer-off is the safe
-# staging state. See the phase-4 plan / vpp-offload runbook.
+# fast-path above as the permanent failover tier.
+#
+# STATUS: code-complete, HARDWARE-UNPROVEN. No part of this has run
+# against a real VPP process, and no part of the MCAM ioctl path has met
+# a NIC. Do not enable on a production router without walking the canary
+# ladder in docs/runbooks/vpp-offload.md.
+#
+# Requires the fast-path section (steered prefixes inherit its allowlist,
+# which must mean pure stateless L3 transit) and `forwarding-mode
+# custom-fib` before any port steers.
+#
+# MEMBERSHIP IS ALL-OR-NOTHING: every fast-path attach port needs a
+# `port` line before any `steer on` (a steered packet's best path may
+# egress any port; missing members blackhole those destinations).
+#
+# `steer` is the per-port canary lever and the ONLY directive here that
+# can change under a running VPP — a SIGHUP applies it as an MCAM delta,
+# with no restart and no resync. Everything else is fixed when VPP starts
+# and is refused by name on reconfigure. All-members + all-steer-off is
+# the safe staging state, and the landing zone for every rollback.
 #
 # module vpp-offload
 #   port eth0 cores 1 steer off   # a member because the fast-path attaches
@@ -331,5 +343,20 @@ module fast-path
 #   expected-routes 1600000       # v4+v6 DFZ + growth; drives memory sizing.
 #                                 # Live table measured ~1.30M (2026-08-02);
 #                                 # DFZ grows ~100k/yr, so this is ~3 years.
+#                                 # Sizes VPP's main heap AND stats segment,
+#                                 # both fixed at start: changing it needs a
+#                                 # restart, and reconfigure says so.
 #   hugepages 10                  # >= derived minimum (checked at startup)
 #   # vpp-binary /usr/bin/vpp
+#
+# One sizing note that is easy to miss: the MCAM budget is 512 slots at
+# two rules per prefix (source and destination), so at most 256 v4
+# `allow-prefix` entries can be steered. An allowlist that overruns it is
+# refused WHOLE rather than truncated — a partially steered port splits
+# traffic between the tiers along a line nobody chose. `packetframe
+# feasibility` reports this as capability `vpp.steering.budget`.
+#
+# IPv6 cannot be steered at all: `ip6` ntuple is rejected by this NIC's
+# AF (error 710, no v6 extraction in the vendor NPC profile), so v6 stays
+# on the XDP custom-FIB path. v6 `allow-prefix6` entries are counted and
+# skipped, not attempted.

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -20,6 +20,7 @@ packetframe-probe = { workspace = true, optional = true }
 anyhow.workspace = true
 clap.workspace = true
 thiserror.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/crates/cli/src/atomic.rs
+++ b/crates/cli/src/atomic.rs
@@ -1,0 +1,62 @@
+//! Write-then-rename, for every file a *reader outside this process*
+//! polls.
+//!
+//! Two of those now — the Prometheus textfile and the module health
+//! snapshot — which is why this is its own module rather than a helper
+//! inside one of them. Both readers poll on their own schedule and
+//! neither takes a lock, so a partially written file is not a rare race
+//! but the ordinary outcome of overlapping a read with a write.
+//!
+//! The temp path is opened `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` (see
+//! [`crate::loader::create_excl_no_follow`]) so a pre-existing symlink
+//! at the temp path cannot redirect the privileged write — the May 2026
+//! audit Slice 4 finding.
+
+use std::io::Write as _;
+use std::path::Path;
+
+/// Write `contents` to `path` atomically.
+///
+/// The rename is atomic on POSIX when source and dest are on the same
+/// filesystem, which is what node_exporter's textfile collector relies
+/// on to never read a half-written file.
+//
+// Reachable in production only from the Linux daemon paths (the metrics
+// exporter and the health publisher), so a non-Linux build sees no
+// caller. The lint is cfg'd rather than the code, so the macOS dev loop
+// still compiles and still runs the tests that use it.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    // The same filename with `.tmp` appended, so the temp file stays on
+    // the same filesystem as the target. `with_extension("tmp")` would
+    // drop the `.prom` and stop a second writer distinguishing ours.
+    let tmp = path.with_file_name(format!(
+        "{}.tmp",
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("packetframe.out"),
+    ));
+    {
+        #[cfg(target_os = "linux")]
+        let mut f = crate::loader::create_excl_no_follow(&tmp).or_else(|e| {
+            // Symmetry with the loader helper's retry path. On a crashed
+            // predecessor the `.tmp` leftover is a regular file: unlink
+            // and retry once. A symlink (attacker pre-creation) trips
+            // O_NOFOLLOW on the retry too.
+            if e.kind() == std::io::ErrorKind::AlreadyExists {
+                let meta = std::fs::symlink_metadata(&tmp)?;
+                if meta.file_type().is_file() {
+                    std::fs::remove_file(&tmp)?;
+                    return crate::loader::create_excl_no_follow(&tmp);
+                }
+            }
+            Err(e)
+        })?;
+        #[cfg(not(target_os = "linux"))]
+        let mut f = std::fs::File::create(&tmp)?;
+        f.write_all(contents)?;
+        f.sync_all()?;
+    }
+    std::fs::rename(&tmp, path)?;
+    Ok(())
+}

--- a/crates/cli/src/health.rs
+++ b/crates/cli/src/health.rs
@@ -1,0 +1,481 @@
+//! The module health snapshot, published to disk so `packetframe
+//! status` can read it.
+//!
+//! ## Why a file
+//!
+//! `Module::health_check` is an in-process call on a live module, and
+//! the modules live inside `packetframe run`'s own `Vec<Box<dyn
+//! Module>>`. `packetframe status` is a *different process*, and it
+//! deliberately works with no daemon running at all — it reads the pin
+//! registry and the pinned maps, because the dataplane survives a daemon
+//! exit (SPEC.md §8.5). There is no way for it to call into the daemon.
+//!
+//! So the daemon publishes, on a cadence, and `status` reads. Same shape
+//! as the reconfigure ack marker, and the same write-then-rename, for
+//! the same reason: a reader must never see a half-written file.
+//!
+//! ## Why the snapshot carries a pid
+//!
+//! A file outlives the process that wrote it. Age alone cannot tell a
+//! snapshot from a *stale* snapshot — the wall clock can jump, and "30
+//! seconds old" means something completely different for a running
+//! daemon than for one that died 30 seconds in. The pid is the
+//! liveness question answered directly: if that process is gone, this
+//! file describes a daemon that no longer exists, and `status` must say
+//! so rather than presenting `Healthy` from history.
+//!
+//! Both are recorded. The pid answers "is this live", the timestamp
+//! answers "how far behind is it", and neither substitutes for the
+//! other.
+
+#![cfg(feature = "fast-path")]
+
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use packetframe_common::module::{HealthCtx, HealthReport, MetricsWriter, Module};
+use serde::{Deserialize, Serialize};
+
+/// Sub-path under `state-dir`.
+pub const HEALTH_FILE_NAME: &str = "module-health.json";
+
+/// One module's last health check.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleEntry {
+    pub module: String,
+    /// `None` when the check itself failed — which is not the same as
+    /// an unhealthy report and must not be rendered as one.
+    pub report: Option<HealthReport>,
+    /// Why the check could not be performed.
+    pub error: Option<String>,
+}
+
+/// What the daemon publishes each cycle.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Snapshot {
+    /// The publishing daemon's pid. See the module docs: this is the
+    /// liveness question, not a diagnostic.
+    pub pid: i32,
+    /// Unix seconds at write time, for the age.
+    pub written_at: u64,
+    pub modules: Vec<ModuleEntry>,
+}
+
+impl Snapshot {
+    pub fn path_in(state_dir: &Path) -> PathBuf {
+        state_dir.join(HEALTH_FILE_NAME)
+    }
+}
+
+/// Ask every module how it is and what it wants published.
+///
+/// The call site that was missing: nothing in the CLI invoked
+/// `Module::health_check` or `Module::sample_metrics` for **any** module,
+/// so everything they produced — vpp-offload's `HealthReport` and its
+/// `packetframe_vpp_*` gauges, fast-path's subsystem health — was
+/// unreachable.
+///
+/// Deliberately portable rather than living in the Linux-only loop that
+/// calls it. Nothing here touches Linux, and a `#[cfg(target_os =
+/// "linux")]` test is invisible to every host gate — it compiles under a
+/// per-target clippy and only ever *runs* in CI, which is how a
+/// signature change here would first be discovered by a red pipeline.
+///
+/// Nothing in it can fail the daemon: a module that cannot answer is
+/// recorded as unable to answer, and a snapshot that cannot be written is
+/// logged and dropped. A health surface that could take the dataplane
+/// down would be worse than one that goes quiet.
+// Only the Linux daemon loop calls this, so a non-Linux build has no
+// production caller — the tests below are the only ones. Same treatment
+// as `RunError::Runtime` in `loader.rs`: cfg the lint, not the code, so
+// the macOS dev loop keeps compiling AND keeps running the tests. The
+// alternative (gating the whole module to Linux) would make these tests
+// invisible to every host gate, which is the trap this project has hit
+// twice.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn poll(state_dir: &Path, modules: &[(String, Box<dyn Module>)], gauges: &Mutex<String>) {
+    let ctx = HealthCtx::new();
+    let mut entries = Vec::with_capacity(modules.len());
+    let mut rendered = String::new();
+
+    for (name, module) in modules {
+        entries.push(match module.health_check(&ctx) {
+            Ok(report) => ModuleEntry {
+                module: name.clone(),
+                report: Some(report),
+                error: None,
+            },
+            // A check that could not run is NOT an unhealthy module. The
+            // two are different facts that lead somewhere different —
+            // "the dataplane is unwell" versus "we do not know" — and
+            // collapsing them pages on the wrong thing.
+            Err(e) => ModuleEntry {
+                module: name.clone(),
+                report: None,
+                error: Some(e.to_string()),
+            },
+        });
+
+        // Rendered into a per-module buffer and appended only on success.
+        // The textfile is parsed as a whole, so half a line from a module
+        // that failed partway through writing would take out every other
+        // module's gauges and the BPF counters in the same file.
+        let mut buf = String::new();
+        match module.sample_metrics(&mut MetricsWriter::new(&mut buf, name)) {
+            Ok(()) => rendered.push_str(&buf),
+            Err(e) => tracing::warn!(module = %name, error = %e, "sample_metrics failed"),
+        }
+    }
+
+    match gauges.lock() {
+        Ok(mut slot) => *slot = rendered,
+        Err(e) => tracing::warn!(error = %e, "module gauge slot is poisoned"),
+    }
+    if let Err(e) = publish(state_dir, entries) {
+        tracing::warn!(error = %e, "could not publish the module health snapshot");
+    }
+}
+
+/// Write the snapshot, atomically.
+///
+/// Failures are the caller's to log and swallow: a health surface that
+/// could take the daemon down would be worse than one that goes quiet.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn publish(state_dir: &Path, modules: Vec<ModuleEntry>) -> Result<(), String> {
+    let snapshot = Snapshot {
+        pid: std::process::id() as i32,
+        written_at: unix_now(),
+        modules,
+    };
+    let body = serde_json::to_vec_pretty(&snapshot).map_err(|e| format!("serialise: {e}"))?;
+    std::fs::create_dir_all(state_dir).map_err(|e| format!("create state dir: {e}"))?;
+    crate::atomic::write(&Snapshot::path_in(state_dir), &body)
+        .map_err(|e| format!("write {}: {e}", Snapshot::path_in(state_dir).display()))
+}
+
+/// Remove it. Called on a clean exit, so `status` does not present a
+/// departed daemon's last report as the current one.
+#[cfg_attr(not(target_os = "linux"), allow(dead_code))]
+pub fn remove(state_dir: &Path) {
+    let path = Snapshot::path_in(state_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "could not remove health snapshot")
+        }
+    }
+}
+
+/// Read it back. `Ok(None)` means no daemon has ever published one.
+pub fn load(state_dir: &Path) -> Result<Option<Snapshot>, String> {
+    let path = Snapshot::path_in(state_dir);
+    let body = match std::fs::read(&path) {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(format!("read {}: {e}", path.display())),
+    };
+    serde_json::from_slice(&body)
+        .map(Some)
+        .map_err(|e| format!("parse {}: {e}", path.display()))
+}
+
+/// How old the snapshot is, in seconds, or `None` if the clock has moved
+/// backwards since it was written.
+///
+/// `None` rather than a saturating `0`: a negative age means the clock
+/// jumped, and reporting "0 seconds old" would present the most
+/// suspicious snapshot as the freshest possible one.
+pub fn age_seconds(snapshot: &Snapshot) -> Option<u64> {
+    unix_now().checked_sub(snapshot.written_at)
+}
+
+fn unix_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use packetframe_common::module::{HealthState, SubsystemHealth};
+
+    fn tmpdir(tag: &str) -> PathBuf {
+        let d = std::env::temp_dir().join(format!("pf-health-{tag}-{}", std::process::id()));
+        std::fs::create_dir_all(&d).unwrap();
+        d
+    }
+
+    /// A published report survives the round trip with its structure
+    /// intact.
+    ///
+    /// The subsystem list is what an operator reads to tell "the offload
+    /// is staged" from "the offload is broken", so a snapshot that kept
+    /// only `overall` would be a summary of the one thing they cannot
+    /// act on.
+    #[test]
+    fn a_report_round_trips_with_its_subsystems() {
+        let dir = tmpdir("roundtrip");
+        publish(
+            &dir,
+            vec![ModuleEntry {
+                module: "vpp-offload".into(),
+                report: Some(HealthReport {
+                    overall: HealthState::Degraded,
+                    subsystems: vec![SubsystemHealth {
+                        name: "steering".into(),
+                        state: HealthState::Degraded,
+                        message: Some("steer off (staging state)".into()),
+                        last_success_age_seconds: Some(4),
+                    }],
+                }),
+                error: None,
+            }],
+        )
+        .unwrap();
+
+        let got = load(&dir).unwrap().expect("published");
+        assert_eq!(got.pid, std::process::id() as i32);
+        assert_eq!(got.modules.len(), 1);
+        let m = &got.modules[0];
+        assert_eq!(m.module, "vpp-offload");
+        let r = m.report.as_ref().expect("a report");
+        assert_eq!(r.overall, HealthState::Degraded);
+        assert_eq!(r.subsystems.len(), 1);
+        assert_eq!(r.subsystems[0].name, "steering");
+        assert_eq!(
+            r.subsystems[0].message.as_deref(),
+            Some("steer off (staging state)")
+        );
+        assert_eq!(r.subsystems[0].last_success_age_seconds, Some(4));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A failed check is recorded as a failed check, not as an unhealthy
+    /// module.
+    ///
+    /// The two are different facts and lead somewhere different: one
+    /// says the dataplane is unwell, the other says we do not know. A
+    /// snapshot that collapsed them would page on the wrong thing.
+    #[test]
+    fn a_failed_check_is_not_an_unhealthy_report() {
+        let dir = tmpdir("failed");
+        publish(
+            &dir,
+            vec![ModuleEntry {
+                module: "vpp-offload".into(),
+                report: None,
+                error: Some("module `vpp-offload`: supervision loop is gone".into()),
+            }],
+        )
+        .unwrap();
+
+        let got = load(&dir).unwrap().expect("published");
+        assert!(got.modules[0].report.is_none());
+        assert!(got.modules[0]
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("supervision loop is gone")));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Nothing published reads as nothing published, not as an error.
+    #[test]
+    fn a_missing_snapshot_is_not_a_failure() {
+        let dir = tmpdir("missing");
+        assert!(load(&dir).unwrap().is_none());
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A clock that moved backwards yields no age rather than a
+    /// flattering one.
+    ///
+    /// Saturating to `0` would present the most suspicious snapshot —
+    /// one apparently written in the future — as the freshest possible,
+    /// which is the direction that hides a problem.
+    #[test]
+    fn a_snapshot_from_the_future_reports_no_age() {
+        let s = Snapshot {
+            pid: 1,
+            written_at: unix_now() + 3600,
+            modules: Vec::new(),
+        };
+        assert!(age_seconds(&s).is_none());
+    }
+
+    use packetframe_common::module::{
+        Attachment, HookUse, LoaderCtx, ModuleConfig, ModuleError, ModuleResult,
+    };
+
+    /// A module that reports whatever the test tells it to.
+    struct Fake {
+        name: &'static str,
+        health: Option<HealthReport>,
+        gauges: Option<&'static str>,
+    }
+
+    impl Module for Fake {
+        fn name(&self) -> &'static str {
+            self.name
+        }
+        fn hook_spec(&self) -> Vec<HookUse> {
+            Vec::new()
+        }
+        fn load(&mut self, _: &ModuleConfig<'_>, _: &LoaderCtx<'_>) -> ModuleResult<()> {
+            Ok(())
+        }
+        fn attach(&mut self, _: &ModuleConfig<'_>) -> ModuleResult<Vec<Attachment>> {
+            Ok(Vec::new())
+        }
+        fn reconfigure(&mut self, _: &ModuleConfig<'_>) -> ModuleResult<()> {
+            Ok(())
+        }
+        fn detach(&mut self) -> ModuleResult<()> {
+            Ok(())
+        }
+        fn sample_metrics(&self, out: &mut MetricsWriter<'_>) -> ModuleResult<()> {
+            // Writes FIRST, then fails, which is the case that matters:
+            // the partial output must be discarded rather than appended.
+            out.out.push_str("packetframe_partial_line_no_newl");
+            match self.gauges {
+                Some(text) => {
+                    out.out.clear();
+                    out.out.push_str(text);
+                    Ok(())
+                }
+                None => Err(ModuleError::other(self.name, "cannot sample")),
+            }
+        }
+        fn health_check(&self, _: &HealthCtx) -> ModuleResult<HealthReport> {
+            match &self.health {
+                Some(r) => Ok(r.clone()),
+                None => Err(ModuleError::other(self.name, "supervision loop is gone")),
+            }
+        }
+    }
+
+    /// The poll reaches BOTH destinations an operator reads.
+    ///
+    /// Before it, nothing in the CLI called `health_check` or
+    /// `sample_metrics` for any module, so everything they produced was
+    /// unreachable. Asserting only that the call happened would pass with
+    /// the results dropped at either boundary — the shape this project
+    /// keeps producing — so this checks the gauge slot and the snapshot.
+    #[test]
+    fn the_poll_reaches_both_the_gauge_slot_and_the_snapshot() {
+        let dir = tmpdir("both");
+        let modules: Vec<(String, Box<dyn Module>)> = vec![(
+            "vpp-offload".into(),
+            Box::new(Fake {
+                name: "vpp-offload",
+                health: Some(HealthReport {
+                    overall: HealthState::Degraded,
+                    subsystems: vec![SubsystemHealth {
+                        name: "steering".into(),
+                        state: HealthState::Healthy,
+                        message: Some("steer off (staging state)".into()),
+                        last_success_age_seconds: None,
+                    }],
+                }),
+                gauges: Some("packetframe_vpp_health 1\n"),
+            }),
+        )];
+        let slot = Mutex::new(String::new());
+
+        poll(&dir, &modules, &slot);
+
+        assert_eq!(
+            slot.lock().unwrap().as_str(),
+            "packetframe_vpp_health 1\n",
+            "the module's gauges must reach the slot the exporter appends"
+        );
+        let snap = load(&dir).unwrap().expect("published");
+        let r = snap.modules[0].report.as_ref().expect("a report");
+        assert_eq!(r.overall, HealthState::Degraded);
+        assert_eq!(r.subsystems[0].name, "steering");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// One module's failure must not cost another module its gauges.
+    ///
+    /// The textfile is parsed as a whole, so a partial line from a module
+    /// that failed partway through writing would take out every other
+    /// module's gauges AND the BPF counters in the same file. Each module
+    /// renders into its own buffer; only a successful one is appended.
+    #[test]
+    fn a_failing_module_does_not_corrupt_the_others_gauges() {
+        let dir = tmpdir("partial");
+        let modules: Vec<(String, Box<dyn Module>)> = vec![
+            (
+                "broken".into(),
+                Box::new(Fake {
+                    name: "broken",
+                    health: None,
+                    gauges: None,
+                }),
+            ),
+            (
+                "fast-path".into(),
+                Box::new(Fake {
+                    name: "fast-path",
+                    health: Some(HealthReport::healthy()),
+                    gauges: Some("packetframe_fp_ok 1\n"),
+                }),
+            ),
+        ];
+        let slot = Mutex::new(String::new());
+
+        poll(&dir, &modules, &slot);
+
+        assert_eq!(
+            slot.lock().unwrap().as_str(),
+            "packetframe_fp_ok 1\n",
+            "the healthy module's gauges survive, and the broken module's partial line is \
+             nowhere in the output"
+        );
+
+        let snap = load(&dir).unwrap().expect("published");
+        let broken = snap
+            .modules
+            .iter()
+            .find(|m| m.module == "broken")
+            .expect("recorded");
+        assert!(broken.report.is_none(), "no verdict was obtained");
+        assert!(broken
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("supervision loop is gone")));
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// A poll replaces the previous fragment rather than appending to it.
+    ///
+    /// Appending would grow the textfile without bound and publish every
+    /// gauge many times over, which Prometheus reads as a duplicate-metric
+    /// error for the whole file.
+    #[test]
+    fn a_second_poll_replaces_the_first_fragment() {
+        let dir = tmpdir("replace");
+        let modules: Vec<(String, Box<dyn Module>)> = vec![(
+            "fast-path".into(),
+            Box::new(Fake {
+                name: "fast-path",
+                health: Some(HealthReport::healthy()),
+                gauges: Some("packetframe_fp_ok 1\n"),
+            }),
+        )];
+        let slot = Mutex::new(String::new());
+
+        poll(&dir, &modules, &slot);
+        poll(&dir, &modules, &slot);
+
+        assert_eq!(
+            slot.lock().unwrap().as_str(),
+            "packetframe_fp_ok 1\n",
+            "one copy, however many polls have run"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -739,7 +739,11 @@ fn reconfigure_from_signal(
 /// (config text, BGP/BMP error text propagated up); a stray ANSI
 /// escape sequence in the marker would corrupt the operator's TTY
 /// when they run `packetframe reconfigure`. Audit Slice 5 hardening.
-#[cfg(all(target_os = "linux", feature = "fast-path"))]
+///
+/// Gated on the feature rather than on Linux because the health surface
+/// prints the same class of text on every platform — see
+/// [`scrub_for_terminal`].
+#[cfg(feature = "fast-path")]
 fn scrub_control_chars(s: &str) -> String {
     s.chars()
         .map(|c| {
@@ -750,6 +754,22 @@ fn scrub_control_chars(s: &str) -> String {
             }
         })
         .collect()
+}
+
+/// The same scrub, for text going **straight to a terminal** rather than
+/// into a line-oriented file.
+///
+/// Built on [`scrub_control_chars`] rather than beside it, so what counts
+/// as a control character is decided in exactly one place. What differs
+/// is tab and newline: the marker file keeps them because lines are its
+/// record separator, and a terminal must not, because a `\n` inside a
+/// subsystem message can **forge a row** — a message ending
+/// `"\n  vpp-offload: healthy"` would print an extra module line that no
+/// module reported. The strings involved carry VPP, ethtool and ntuple
+/// error text from outside this process, so that is not hypothetical.
+#[cfg(feature = "fast-path")]
+fn scrub_for_terminal(s: &str) -> String {
+    scrub_control_chars(s).replace(['\n', '\t'], " ")
 }
 
 /// Append a timestamp + status line to the reconfigure marker file.
@@ -1423,19 +1443,31 @@ fn print_module_health(state_dir: &Path) {
         match (&m.report, &m.error) {
             // A check that could not run is not a verdict about the
             // module, and must not be rendered as one.
-            (_, Some(e)) => println!("  {}: health check FAILED — {e}", m.module),
+            (_, Some(e)) => println!(
+                "  {}: health check FAILED — {}",
+                scrub_for_terminal(&m.module),
+                scrub_for_terminal(e)
+            ),
             (Some(r), None) => {
-                println!("  {}: {}", m.module, health_word(r.overall));
+                println!(
+                    "  {}: {}",
+                    scrub_for_terminal(&m.module),
+                    health_word(r.overall)
+                );
                 for sub in &r.subsystems {
                     let age = match sub.last_success_age_seconds {
                         Some(a) => format!(" (last ok {a}s ago)"),
                         None => String::new(),
                     };
-                    let msg = sub.message.as_deref().unwrap_or("");
+                    let msg = sub
+                        .message
+                        .as_deref()
+                        .map(scrub_for_terminal)
+                        .unwrap_or_default();
                     let sep = if msg.is_empty() { "" } else { " — " };
                     println!(
                         "    {:<14} {}{sep}{msg}{age}",
-                        sub.name,
+                        scrub_for_terminal(&sub.name),
                         health_word(sub.state)
                     );
                 }
@@ -1445,7 +1477,7 @@ fn print_module_health(state_dir: &Path) {
             // the file was written by something else or hand-edited.
             (None, None) => println!(
                 "  {}: no report and no error recorded (malformed snapshot)",
-                m.module
+                scrub_for_terminal(&m.module)
             ),
         }
     }
@@ -1737,5 +1769,53 @@ mod vpp_detach_tests {
         std::fs::create_dir_all(&dir).unwrap();
         assert!(detach_vpp_offload(&dir).is_ok());
         std::fs::remove_dir_all(&dir).unwrap();
+    }
+}
+
+/// The terminal scrub. Host-runnable on purpose: this is the rule that
+/// existed on one path to an operator's TTY and not on the other, which
+/// is exactly the shape that gets missed.
+#[cfg(all(test, feature = "fast-path"))]
+mod terminal_scrub_tests {
+    use super::*;
+
+    /// An ANSI escape in module-supplied text must not reach the
+    /// terminal. `scrub_control_chars` has said so since the May 2026
+    /// audit; the health surface is a second path to the same TTY and
+    /// was not using it.
+    #[test]
+    fn an_escape_sequence_cannot_reach_the_terminal() {
+        let hostile = "ntuple insert failed: \x1b[2J\x1b[1;1Hgotcha";
+        let clean = scrub_for_terminal(hostile);
+        assert!(!clean.contains('\x1b'), "{clean:?}");
+        assert!(
+            clean.contains("gotcha") && clean.contains("ntuple insert failed"),
+            "the actual message must survive, or the scrub costs the operator the diagnosis: \
+             {clean:?}"
+        );
+    }
+
+    /// A newline must not survive either — on a terminal it FORGES A ROW.
+    ///
+    /// This is what makes the display scrub stricter than the marker
+    /// scrub rather than the same function reused: the marker file keeps
+    /// newlines because lines are its record separator. Here a subsystem
+    /// message ending in a fake health line would print a module verdict
+    /// no module reported, and the strings carry VPP/ethtool text from
+    /// outside this process.
+    #[test]
+    fn a_newline_cannot_forge_a_health_row() {
+        let forged = "cannot reach VPP\n  vpp-offload: healthy";
+        let clean = scrub_for_terminal(forged);
+        assert!(!clean.contains('\n'), "{clean:?}");
+        assert_eq!(clean, "cannot reach VPP   vpp-offload: healthy");
+    }
+
+    /// And the marker path keeps its newlines, so this did not quietly
+    /// change the file format underneath `packetframe reconfigure`.
+    #[test]
+    fn the_marker_scrub_still_keeps_its_record_separator() {
+        assert_eq!(scrub_control_chars("a\nb\tc"), "a\nb\tc");
+        assert_eq!(scrub_control_chars("a\x1bb"), "a?b");
     }
 }

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1405,7 +1405,13 @@ fn print_module_health(state_dir: &Path) {
             return;
         }
         Err(e) => {
-            eprintln!("note: module health unavailable ({e})");
+            // Scrubbed too: this carries a serde parse error, which can
+            // quote bytes from the snapshot file. Ours to write, but a
+            // corrupt or hand-edited one is exactly when this branch runs.
+            eprintln!(
+                "note: module health unavailable ({})",
+                scrub_for_terminal(&e)
+            );
             return;
         }
     };

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -10,6 +10,8 @@
 //!   alone.
 
 use std::path::{Path, PathBuf};
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+use std::time::{Duration, Instant};
 
 use packetframe_common::{config::Config, probe::run_probes};
 
@@ -364,8 +366,18 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 
     // Start the metrics exporter once STATS is pinned (which happens
     // in the attach loop above).
+    // Shared with the exporter so the modules' gauges reach the same
+    // textfile as the BPF counters, without a second writer. Created even
+    // when no textfile is configured, because the health poll publishes
+    // into it unconditionally and a slot nobody reads costs one
+    // allocation.
+    let module_gauges: crate::metrics::ModuleGauges = Default::default();
     let metrics_exporter = config.global.metrics_textfile.as_ref().map(|path| {
-        crate::metrics::MetricsExporter::start(path.clone(), config.global.bpffs_root.clone())
+        crate::metrics::MetricsExporter::start(
+            path.clone(),
+            config.global.bpffs_root.clone(),
+            module_gauges.clone(),
+        )
     });
 
     // Start circuit-breaker sampler(s) for each module that declared
@@ -402,6 +414,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         config_path,
         &config.global.state_dir,
         &mut modules,
+        &module_gauges,
         #[cfg(feature = "vpp-offload")]
         &allowlist,
     )
@@ -438,6 +451,15 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
             drop(modules);
         }
     }
+    // The health snapshot describes a *daemon*, and this one is
+    // leaving. Unlike the pins — which deliberately outlive the process
+    // (§8.5) — a report kept past its writer is only misleading:
+    // `packetframe status` would render the last `Healthy` from a
+    // process that no longer exists. Removed here on the clean paths;
+    // for a crash, `status` falls back to the recorded pid, which is the
+    // check that cannot be forgotten.
+    crate::health::remove(&config.global.state_dir);
+
     // Best-effort PID file cleanup. Non-fatal, the file is harmless
     // if left behind (PID will be unrecognized on re-validate).
     if let Err(e) = std::fs::remove_file(&pid_file_path) {
@@ -545,19 +567,54 @@ enum Termination {
     BreakerTrip,
 }
 
-/// Drive the signal loop. Returns the termination reason the caller
-/// uses to decide whether to detach or preserve pins on exit.
+/// How often the loop samples `health_check` and `sample_metrics`.
+///
+/// Deliberately shorter than the exporter's 15 s write interval. The
+/// exporter appends whatever fragment it finds, and the two run on
+/// independent phases — at equal cadences a fragment could be a whole
+/// write period old, so the file would routinely pair fresh BPF counters
+/// with module gauges from the previous cycle. At 5 s the pairing is off
+/// by at most a third of a write.
+///
+/// It is also the health snapshot's cadence, which sets how stale
+/// `packetframe status` can be while the daemon is healthy.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+const MODULE_POLL_INTERVAL: Duration = Duration::from_secs(5);
+
+/// How long the loop sleeps between checks for a pending signal.
+///
+/// The cost of not blocking on the signal fd: one wakeup per interval,
+/// each a non-blocking drain plus two `Instant` comparisons. The same
+/// 250 ms the metrics exporter already uses for its shutdown check, and
+/// it bounds SIGTERM latency the same way.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+const SIGNAL_POLL: Duration = Duration::from_millis(250);
+
+/// Drive the daemon's main loop: signals, plus the module health and
+/// metrics cadence. Returns the termination reason the caller uses to
+/// decide whether to detach or preserve pins on exit.
 ///
 /// - SIGHUP → re-parse config + reconfigure each loaded module.
 /// - SIGTERM/SIGINT → `Termination::ExitPreserveAttach` (keep pins).
 /// - SIGUSR1 → `Termination::BreakerTrip` (breaker fired; caller
 ///   detaches). SIGUSR1 is raised by the breaker sampler thread on
 ///   trip.
+/// - every [`MODULE_POLL_INTERVAL`] → sample the modules.
+///
+/// **This loop is where the module polling has to live**, and that is
+/// what turned a blocking `signals.forever()` into a poll. `health_check`
+/// and `sample_metrics` need the modules, the modules are owned here
+/// alongside the `&mut` uses (reconfigure, detach), and sharing them with
+/// the exporter thread would mean an `Arc<Mutex<_>>` that serialises a
+/// metrics read against a reconfigure. Polling here keeps single
+/// ownership and keeps the textfile single-writer; the cost is one
+/// wakeup per [`SIGNAL_POLL`].
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 fn drive_signal_loop(
     config_path: &Path,
     state_dir: &Path,
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+    module_gauges: &crate::metrics::ModuleGauges,
     #[cfg(feature = "vpp-offload")] allowlist: &packetframe_vpp_offload::SharedAllowlist,
 ) -> Result<Termination, String> {
     use signal_hook::{
@@ -568,27 +625,42 @@ fn drive_signal_loop(
     let mut signals = Signals::new([SIGTERM, SIGINT, SIGHUP, SIGUSR1])
         .map_err(|e| format!("signal registration: {e}"))?;
 
-    for sig in signals.forever() {
-        match sig {
-            SIGHUP => reconfigure_from_signal(
-                config_path,
-                state_dir,
-                modules,
-                #[cfg(feature = "vpp-offload")]
-                allowlist,
-            ),
-            SIGTERM | SIGINT => {
-                tracing::info!(signal = sig, "termination requested");
-                return Ok(Termination::ExitPreserveAttach);
+    // Sample once immediately. Waiting a full interval would leave
+    // `packetframe status` reporting "no snapshot" for the first 5 s of
+    // every daemon's life — which is exactly when an operator who just
+    // started it is looking.
+    let mut next_poll = Instant::now();
+
+    loop {
+        for sig in signals.pending() {
+            match sig {
+                SIGHUP => reconfigure_from_signal(
+                    config_path,
+                    state_dir,
+                    modules,
+                    #[cfg(feature = "vpp-offload")]
+                    allowlist,
+                ),
+                SIGTERM | SIGINT => {
+                    tracing::info!(signal = sig, "termination requested");
+                    return Ok(Termination::ExitPreserveAttach);
+                }
+                SIGUSR1 => {
+                    tracing::warn!("SIGUSR1 received, breaker-triggered shutdown");
+                    return Ok(Termination::BreakerTrip);
+                }
+                _ => {}
             }
-            SIGUSR1 => {
-                tracing::warn!("SIGUSR1 received, breaker-triggered shutdown");
-                return Ok(Termination::BreakerTrip);
-            }
-            _ => {}
         }
+
+        let now = Instant::now();
+        if now >= next_poll {
+            crate::health::poll(state_dir, modules, module_gauges);
+            next_poll = now + MODULE_POLL_INTERVAL;
+        }
+
+        std::thread::sleep(SIGNAL_POLL);
     }
-    Ok(Termination::ExitPreserveAttach)
 }
 
 /// SIGHUP handler. Re-parses the config from `config_path` and calls
@@ -1282,9 +1354,109 @@ pub fn status(config_path: &Path) -> Result<(), String> {
         // process exit (§8.5).
         #[cfg(target_os = "linux")]
         print_stats(&config.global.bpffs_root);
+
+        print_module_health(&config.global.state_dir);
     }
 
     Ok(())
+}
+
+/// Render the daemon's last published module health.
+///
+/// Everything else `status` prints is read from the kernel or from a pin
+/// and is therefore *current by construction*. This is not: it is a file
+/// a daemon wrote, and the daemon may be gone. So the liveness question
+/// is answered first and separately — from the recorded pid, the same
+/// cross-check `reconfigure` uses — and the age second. A report is only
+/// presented as current when the process that wrote it still exists.
+#[cfg(feature = "fast-path")]
+fn print_module_health(state_dir: &Path) {
+    use packetframe_common::module::HealthState;
+
+    let snapshot = match crate::health::load(state_dir) {
+        Ok(Some(s)) => s,
+        Ok(None) => {
+            println!();
+            println!(
+                "module health: no snapshot at {} — no daemon has published one (module \
+                 health needs a running `packetframe run`; the counters above do not)",
+                crate::health::Snapshot::path_in(state_dir).display()
+            );
+            return;
+        }
+        Err(e) => {
+            eprintln!("note: module health unavailable ({e})");
+            return;
+        }
+    };
+
+    println!();
+    // Liveness BEFORE the contents. An operator who reads "Healthy" and
+    // only then learns the daemon is dead has already drawn the
+    // conclusion, and it was the wrong one.
+    #[cfg(target_os = "linux")]
+    let live = proc_exe_matches_current(snapshot.pid);
+    // No /proc to cross-check against, so liveness is unknown rather
+    // than assumed either way.
+    #[cfg(not(target_os = "linux"))]
+    let live = false;
+
+    let age = match crate::health::age_seconds(&snapshot) {
+        Some(a) => format!("{a}s old"),
+        // The clock moved backwards since the write; saying so beats
+        // printing a flattering number derived from it.
+        None => "written in the future (clock skew)".to_string(),
+    };
+
+    if live {
+        println!("module health (pid {}, {age}):", snapshot.pid);
+    } else {
+        println!(
+            "module health: STALE — the daemon that wrote this (pid {}) is gone. The report \
+             below is history, {age}; the dataplane may still be forwarding via its pins \
+             (§8.5).",
+            snapshot.pid
+        );
+    }
+
+    for m in &snapshot.modules {
+        match (&m.report, &m.error) {
+            // A check that could not run is not a verdict about the
+            // module, and must not be rendered as one.
+            (_, Some(e)) => println!("  {}: health check FAILED — {e}", m.module),
+            (Some(r), None) => {
+                println!("  {}: {}", m.module, health_word(r.overall));
+                for sub in &r.subsystems {
+                    let age = match sub.last_success_age_seconds {
+                        Some(a) => format!(" (last ok {a}s ago)"),
+                        None => String::new(),
+                    };
+                    let msg = sub.message.as_deref().unwrap_or("");
+                    let sep = if msg.is_empty() { "" } else { " — " };
+                    println!(
+                        "    {:<14} {}{sep}{msg}{age}",
+                        sub.name,
+                        health_word(sub.state)
+                    );
+                }
+            }
+            // Neither a report nor a reason. Unreachable from
+            // `health::poll`, which always sets exactly one, so it means
+            // the file was written by something else or hand-edited.
+            (None, None) => println!(
+                "  {}: no report and no error recorded (malformed snapshot)",
+                m.module
+            ),
+        }
+    }
+
+    fn health_word(s: HealthState) -> &'static str {
+        match s {
+            HealthState::Healthy => "healthy",
+            HealthState::Degraded => "DEGRADED",
+            HealthState::Unhealthy => "UNHEALTHY",
+        }
+    }
 }
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,11 +8,14 @@
 //! detaching. `fib` (Option F, Phase 3.8, see SPEC.md §4.11) opens
 //! the pinned custom-FIB maps directly for inspection.
 
+mod atomic;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod breaker;
 mod feasibility;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod fib_cli;
+#[cfg(feature = "fast-path")]
+mod health;
 mod loader;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod metrics;

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -8,10 +8,9 @@
 
 #![cfg(all(target_os = "linux", feature = "fast-path"))]
 
-use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -20,18 +19,36 @@ const INTERVAL: Duration = Duration::from_secs(15);
 /// for the exporter to wake.
 const POLL: Duration = Duration::from_millis(250);
 
+/// Where the loader leaves the modules' rendered gauges for the
+/// exporter to include.
+///
+/// A slot rather than a second writer, because the textfile has exactly
+/// one writer and that is what makes its atomic rename mean anything.
+/// `Module::sample_metrics` needs `&dyn Module`, and the modules live in
+/// `run_linux`'s vector alongside the `&mut` uses (reconfigure, detach)
+/// — so the loader samples on its own cadence and publishes the text
+/// here, and the exporter appends whatever it finds.
+///
+/// Consequence, deliberate: the fragment can be up to one loader poll
+/// interval stale relative to the BPF counters in the same file. That is
+/// the price of not sharing the modules across threads, and it is why
+/// the poll interval is shorter than the write interval rather than
+/// equal to it — equal cadences with independent phase would have made
+/// the staleness a whole write period.
+pub type ModuleGauges = Arc<Mutex<String>>;
+
 pub struct MetricsExporter {
     shutdown: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
 
 impl MetricsExporter {
-    pub fn start(textfile_path: PathBuf, bpffs_root: PathBuf) -> Self {
+    pub fn start(textfile_path: PathBuf, bpffs_root: PathBuf, modules: ModuleGauges) -> Self {
         let shutdown = Arc::new(AtomicBool::new(false));
         let shutdown_clone = shutdown.clone();
         let handle = std::thread::Builder::new()
             .name("pf-metrics".into())
-            .spawn(move || exporter_loop(textfile_path, bpffs_root, shutdown_clone))
+            .spawn(move || exporter_loop(textfile_path, bpffs_root, modules, shutdown_clone))
             .expect("spawn metrics thread");
         tracing::info!("metrics exporter started; 15s cadence");
         Self {
@@ -48,7 +65,12 @@ impl MetricsExporter {
     }
 }
 
-fn exporter_loop(textfile_path: PathBuf, bpffs_root: PathBuf, shutdown: Arc<AtomicBool>) {
+fn exporter_loop(
+    textfile_path: PathBuf,
+    bpffs_root: PathBuf,
+    modules: ModuleGauges,
+    shutdown: Arc<AtomicBool>,
+) {
     let start = Instant::now();
     let mut next_write = Instant::now();
 
@@ -56,7 +78,7 @@ fn exporter_loop(textfile_path: PathBuf, bpffs_root: PathBuf, shutdown: Arc<Atom
         let now = Instant::now();
         if now >= next_write {
             let uptime = start.elapsed().as_secs();
-            if let Err(e) = write_once(&textfile_path, &bpffs_root, uptime) {
+            if let Err(e) = write_once(&textfile_path, &bpffs_root, &modules, uptime) {
                 tracing::warn!(error = %e, "metrics write failed; will retry at next tick");
             }
             next_write = now + INTERVAL;
@@ -66,7 +88,7 @@ fn exporter_loop(textfile_path: PathBuf, bpffs_root: PathBuf, shutdown: Arc<Atom
             // One final write so external collectors see the last
             // state before this process exits.
             let uptime = start.elapsed().as_secs();
-            let _ = write_once(&textfile_path, &bpffs_root, uptime);
+            let _ = write_once(&textfile_path, &bpffs_root, &modules, uptime);
             return;
         }
 
@@ -74,7 +96,12 @@ fn exporter_loop(textfile_path: PathBuf, bpffs_root: PathBuf, shutdown: Arc<Atom
     }
 }
 
-fn write_once(textfile_path: &Path, bpffs_root: &Path, uptime_seconds: u64) -> Result<(), String> {
+fn write_once(
+    textfile_path: &Path,
+    bpffs_root: &Path,
+    modules: &ModuleGauges,
+    uptime_seconds: u64,
+) -> Result<(), String> {
     let stats = packetframe_fast_path::stats_from_pin(bpffs_root)
         .map_err(|e| format!("read STATS pin: {e}"))?;
     let mut body = packetframe_fast_path::metrics::render_textfile(&stats, uptime_seconds);
@@ -84,51 +111,23 @@ fn write_once(textfile_path: &Path, bpffs_root: &Path, uptime_seconds: u64) -> R
     // handles that by emitting zeros + a `mode=\"kernel-fib\"` one-hot.
     let fib = packetframe_fast_path::fib_status_from_pin(bpffs_root);
     body.push_str(&packetframe_fast_path::metrics::render_fib_gauges(&fib));
-    atomic_write(textfile_path, body.as_bytes())
-        .map_err(|e| format!("atomic write {}: {e}", textfile_path.display()))?;
-    Ok(())
-}
-
-/// Write-then-rename. The rename is atomic on POSIX when source and
-/// dest are on the same filesystem, node_exporter's textfile
-/// collector relies on this to never read a half-written file.
-///
-/// The `.tmp` open uses `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` (see
-/// [`crate::loader::create_excl_no_follow`]) so a pre-existing
-/// symlink at the temp path cannot redirect the privileged write.
-/// This was the May 2026 audit Slice 4 finding.
-fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
-    // Use the same filename with `.tmp` appended so we stay on the
-    // same filesystem as the target (`with_extension("tmp")` would
-    // drop the `.prom` and prevent a second writer from
-    // distinguishing ours).
-    let tmp = path.with_file_name(format!(
-        "{}.tmp",
-        path.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("packetframe.prom"),
-    ));
-    {
-        #[cfg(target_os = "linux")]
-        let mut f = crate::loader::create_excl_no_follow(&tmp).or_else(|e| {
-            // Symmetry with the loader helper's retry path. On a
-            // crashed predecessor, the .tmp leftover is a regular
-            // file, unlink and retry once. A symlink (attacker
-            // pre-creation) trips O_NOFOLLOW on the retry too.
-            if e.kind() == std::io::ErrorKind::AlreadyExists {
-                let meta = std::fs::symlink_metadata(&tmp)?;
-                if meta.file_type().is_file() {
-                    std::fs::remove_file(&tmp)?;
-                    return crate::loader::create_excl_no_follow(&tmp);
-                }
-            }
-            Err(e)
-        })?;
-        #[cfg(not(target_os = "linux"))]
-        let mut f = std::fs::File::create(&tmp)?;
-        f.write_all(contents)?;
-        f.sync_all()?;
+    // Whatever the loader last sampled from the modules. Appended rather
+    // than merged: each module namespaces its own gauges
+    // (`packetframe_vpp_*`), so there is nothing to reconcile — and a
+    // renderer here would be a second place that decides what a module's
+    // metrics look like.
+    //
+    // An empty fragment is the honest output before the loader's first
+    // poll, and after a module whose `sample_metrics` is a no-op.
+    match modules.lock() {
+        Ok(fragment) => body.push_str(&fragment),
+        // A poisoned lock means the loader panicked while holding it.
+        // The BPF gauges are still true and still worth writing; losing
+        // the module fragment is the smaller loss, and the panic itself
+        // is already on its way to the log.
+        Err(e) => tracing::warn!(error = %e, "module gauges unavailable this tick"),
     }
-    std::fs::rename(&tmp, path)?;
+    crate::atomic::write(textfile_path, body.as_bytes())
+        .map_err(|e| format!("atomic write {}: {e}", textfile_path.display()))?;
     Ok(())
 }

--- a/crates/common/src/module.rs
+++ b/crates/common/src/module.rs
@@ -6,6 +6,7 @@
 
 use std::path::{Path, PathBuf};
 
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::config::{GlobalConfig, ModuleSection};
@@ -105,7 +106,13 @@ impl HealthCtx {
 }
 
 /// Overall health of a subsystem.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+///
+/// `Serialize`/`Deserialize` because the loader publishes a health
+/// snapshot to disk for `packetframe status` to read — module health
+/// needs a live daemon, and `status` runs without one. Derived here
+/// rather than mirrored in the CLI: a hand-copied enum is how the
+/// counter-name list drifted (see `metrics::COUNTER_NAMES`).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HealthState {
     /// Subsystem is operating normally; all checks pass.
     #[default]
@@ -147,7 +154,7 @@ impl HealthState {
 /// Per-subsystem health entry within a [`HealthReport`]. `name` is
 /// stable for dashboards; changing it breaks operator tooling that
 /// keys on the string.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubsystemHealth {
     /// Stable identifier, e.g. `"bmp-station"`, `"netlink-neigh"`,
     /// `"fib-programmer"`. Append-safe (new subsystems can land);
@@ -175,7 +182,7 @@ pub struct SubsystemHealth {
 /// Added during the Option F custom-FIB rollout because the prior
 /// `ModuleResult<()>` surface couldn't express partial-degraded
 /// states across multiple control-plane subsystems.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HealthReport {
     pub overall: HealthState,
     pub subsystems: Vec<SubsystemHealth>,

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1,0 +1,438 @@
+# vpp-offload operations runbook
+
+The VPP-on-VF forwarding vector: MCAM-bifurcated allowlist traffic
+forwarded by a packetframe-supervised VPP on SR-IOV VFs, with the eBPF
+fast-path on the PFs as the permanent failover tier.
+
+Companion to [`vpp-offload-spike.md`](vpp-offload-spike.md), which is the
+**gate-0b bring-up procedure** — what was measured, how, and what
+failed. This document is what you read when it is running, or when it is
+running badly.
+
+> ## Read this before the first bring-up
+>
+> **No part of this module has ever run against a real VPP process.**
+> Every layer is unit-tested, `Module::attach` runs end to end against a
+> fixture sysfs and a fake VPP on a unix socket, and the convergence
+> budget was measured by a bench driving the same engine — but the
+> composition has never executed on hardware. Neither has any of the
+> three published failover numbers.
+>
+> **No part of the MCAM ioctl path has ever met a NIC.** Every rule
+> insert is followed by an `ETHTOOL_GRXCLSRULE` readback and compared
+> field by field, precisely so a wrong `ethtool_rx_flow_spec` offset
+> fails loudly on first contact instead of installing a rule that
+> matches the wrong traffic while both tiers report healthy. Expect that
+> check to be the thing that fires first, and treat it as the module
+> working, not failing.
+>
+> **Native XDP attach panics this vendor kernel.** Not a queue-leak
+> question, not something to re-test on an idle port. The version gate
+> that forces `auto` to generic is load-bearing safety.
+
+## Contents
+
+- [Architecture at a glance](#architecture-at-a-glance)
+- [Healthy state](#healthy-state)
+- [Everyday inspection commands](#everyday-inspection-commands)
+- [The canary ladder](#the-canary-ladder)
+- [Rollback](#rollback)
+- [Triage by symptom](#triage-by-symptom)
+- [Numbers: measured vs published-on-faith](#numbers-measured-vs-published-on-faith)
+- [Install and upgrade on the router](#install-and-upgrade-on-the-router)
+- [Constraints worth knowing before you debug](#constraints-worth-knowing-before-you-debug)
+
+## Architecture at a glance
+
+```text
+ bird ──iBGP──→ BgpListener ──RouteEvent──→ FibProgrammer ──→ BPF maps   (failover tier)
+                NeighborResolver                  │
+                                                  └─ResolvedRouteSink──→ RouteFeed
+                                                                           │
+                                                        vpp-offload engine ─┴─binary API─→ VPP FIB
+                                                                                           + static neighbours
+ eth4 PF ── MCAM steer (allowlist × {src,dst}) ──→ VF ──→ VPP workers ──→ VF tx (src MAC = MAC-PF)
+    └─ everything else ──→ kernel path, eBPF fast-path in front
+```
+
+Three things about that picture are load-bearing and easy to get
+backwards:
+
+**The second tier hangs off the *programmer*, not off the route
+events.** A `RouteEvent::Add` carries one advertisement (`peer_id`,
+`path_id`, `local_pref`); turning a prefix's advertisements into the set
+that forwards is the programmer's local-pref tiering and ADD-PATH
+aggregation. So vpp-offload consumes the programmer's resolved
+best-paths. **Consequence: VPP's FIB mirrors what the fast-path
+resolved, including its refusals** — which is worth more than mirroring
+bird, because it means a failover cannot change forwarding.
+
+**Membership and steering are different things.** A VPP FIB path
+resolves through an adjacency on a VPP-owned interface, so VPP must own
+a VF on *every possible egress port* before *any* ingress is steered — a
+packet steered on eth5 whose best path exits eth4 dies otherwise.
+Membership (a `port` line) is all-or-nothing across the forwarding
+domain and is validated at config load. Steering (`steer on|off`) is
+per-port and is the canary lever.
+
+**VPP never ARPs.** Neighbours are static, from the resolver. ARP
+suppression holds by construction rather than by knob: MCAM rules match
+IPv4 fields, so ARP frames (0x0806) can never be steered — VPP
+physically cannot receive an ARP request.
+
+## Healthy state
+
+Two ports of call. `packetframe status` for the structured view:
+
+```bash
+packetframe status /etc/packetframe/packetframe.conf
+```
+
+Under a healthy, fully steered offload the module-health section reads:
+
+```text
+module health (pid 12345, 3s old):
+  vpp-offload: healthy
+    vpp-process    healthy
+    api-ping       healthy (last ok 0s ago)
+    fib-synced     healthy — 1053360 routes installed, verified on 64 probes (last ok 41s ago)
+    steering       healthy
+    ports          healthy
+```
+
+Five rows, always. Two more — `route-feed` and `state-file` — appear
+**only when they have failed**, deliberately, so the list carries no
+permanent "fine" line for an operator to learn to ignore. Seeing either
+of them at all is the signal.
+
+Two of the five rows are worth understanding rather than glancing at.
+
+**`module health: STALE`** means the daemon that wrote the snapshot is
+gone. The report below it is history. The dataplane may well still be
+forwarding — bpffs pins outlive the process by design (SPEC.md §8.5) —
+but nothing is supervising VPP.
+
+**`steering healthy — steer off (staging state); traffic is on the eBPF
+tier`** is *not* a fault. All
+members up, FIB synced and verified, nothing diverted: that is every
+canary's waypoint and every rollback's landing zone. Distinguish it from
+`steering DEGRADED — steering intended but not in place — traffic is on
+the eBPF tier`, which means a steer was attempted and failed, or was torn
+down by trouble and not yet restored.
+
+And the overall verdict is deliberately **not** the maximum of the
+subsystems. Health tracks whether packets are forwarded correctly, not
+whether the offload is working — so a crash-looping *unsteered* VPP is
+`Degraded` (the eBPF tier has the traffic) while a *steered* VPP that
+cannot forward is `Unhealthy`.
+
+For the Prometheus surface, the `packetframe_vpp_*` gauges land in the
+same textfile as the fast-path counters:
+
+```bash
+grep packetframe_vpp_ /var/lib/node_exporter/textfile/packetframe.prom
+```
+
+Both `state` and `health` are emitted **one-hot** — one series per
+possible value, exactly one of them `1` — so a dashboard reads the
+current value without a mapping table:
+
+| series | alarm when |
+|---|---|
+| `packetframe_vpp_health{state="healthy"}` | drops to `0` and stays there |
+| `packetframe_vpp_state{state="steered"}` | drops to `0` unexpectedly |
+| `packetframe_vpp_routes{state="unresolvable"}` | `> 0` at all — steady state is exactly zero |
+| `packetframe_vpp_routes{state="withheld"}` | `> 0` — the table outgrew its heap |
+| `packetframe_vpp_fib_verified` | `0` while steered |
+| `packetframe_vpp_source_backlog` | sustained non-zero — deltas are not draining |
+| `packetframe_vpp_drain_failing` | `1` — the steady-state delta apply is retrying |
+| `packetframe_vpp_undead` | `1` — a killed VPP survived and blocks the restart |
+| `packetframe_vpp_api_silent_seconds` | approaching the wedge budget (1.5 s steered) |
+
+Every series also carries `module="vpp-offload"`.
+
+`unresolvable` and `withheld` are reported separately on purpose. They
+page differently: the first is a misconfigured nexthop-device mapping,
+the second is the table having outgrown the box.
+
+## Everyday inspection commands
+
+```bash
+# Is VPP the process we think it is?
+cat /var/lib/packetframe/state/vpp-offload.json | jq '{vpp_pid, vpp_start_ticks, steer_rules}'
+```
+
+```bash
+# What MCAM rules does the NIC actually hold? (ground truth, not our ledger)
+ethtool -n eth5
+```
+
+```bash
+# What does VPP think its FIB looks like? Legitimate non-bulk vppctl.
+vppctl -s /run/packetframe/vpp/api.sock show ip fib summary
+```
+
+```bash
+# The interfaces VPP created, and their link state.
+vppctl -s /run/packetframe/vpp/api.sock show interface
+```
+
+```bash
+# Worker placement — one hot core per worker, permanently. See the heat note.
+vppctl -s /run/packetframe/vpp/api.sock show threads
+```
+
+## The canary ladder
+
+Traffic moves when *you* say so. The module never steers a first attach
+on its own, and — since #128 — a `reconfigure` that did not move the
+`steer` flag will not either, so editing an unrelated line cannot divert
+traffic as a side effect.
+
+Each rung is a `steer` edit plus a SIGHUP. **No restart, no resync**:
+that is the whole point of `reconfigure` handling this, because a
+restart would cost ~40 s of resync with the offload down at every step —
+including the step whose purpose is to get traffic *off* a bad VPP.
+
+**Rung 0 — membership, everything off.** Every fast-path attach port
+gets a `port` line; every one is `steer off`.
+
+```bash
+packetframe reconfigure /etc/packetframe/packetframe.conf
+```
+
+Wait for `fib-synced healthy` and `routes_unresolvable 0`. Soak here —
+at least an hour, and through a udapi provision cycle if one is due.
+This state is safe by construction: VPP is up, its FIB is synced and
+verified, and not one packet is diverted.
+
+**Rung 1 — one port.** Flip the least important port to `steer on`,
+SIGHUP, and confirm:
+
+```bash
+ethtool -n eth5 | head          # rules exist, at loc >= 1024
+packetframe status /etc/packetframe/packetframe.conf | grep -A6 'module health'
+```
+
+`packetframe reconfigure` reports the outcome synchronously. If it says
+the change was refused or withdrawn, **it did not happen** — that is
+deliberate, so "the rollout step succeeded" and "the rollout step was
+queued" cannot look the same.
+
+Then watch actual traffic, not counters: PMTUD in particular. A DF
+packet larger than the MTU through a steered path must come back as a
+correctly-sourced frag-needed. A silent PMTUD blackhole is a week of
+customer debugging.
+
+**Rung 2..N — one port at a time**, with a soak between each. There is
+no prize for going faster; the failure you are looking for is the one
+that only shows up under real traffic.
+
+## Rollback
+
+Any rung, at any time:
+
+```bash
+# Edit the port back to `steer off`, then:
+packetframe reconfigure /etc/packetframe/packetframe.conf
+```
+
+Traffic returns to the eBPF fast-path. Membership stays, the FIB stays
+synced, VPP keeps running — you land on rung 0, which is a state you
+have already soaked.
+
+This path is deliberately robust in one specific way: an allowlist that
+has outgrown the MCAM budget **does not block it**. The budget check
+only applies when rules are about to be installed, because `unsteer`
+removes what the ledger names and never consults the plan. An allowlist
+growing past the budget is a plausible route to wanting exactly this
+rollback, and it must not be the thing that prevents it.
+
+If you need the whole vector gone:
+
+```bash
+systemctl stop packetframe
+packetframe detach --all /etc/packetframe/packetframe.conf
+```
+
+`detach --all` takes steering down **first**, then kills VPP, then
+unbinds the VFs and restores hugepages. If it refuses, read the message:
+a rule the NIC would not delete leaves traffic diverted at a VF the
+teardown is about to unbind, so it stops rather than blackholing. The
+state file names exactly which rules remain; clear them by hand
+(`ethtool -N <iface> delete <loc>`) and re-run.
+
+## Triage by symptom
+
+### `packetframe status` says STALE
+
+The daemon is gone; VPP is not being supervised. Check whether VPP is
+still running (`pgrep -a vpp`) and whether MCAM still points at its VF
+(`ethtool -n <iface>`). If both are true, traffic is still being
+forwarded by an unsupervised process — restart packetframe, which will
+**adopt** it rather than restarting it.
+
+### Steering is on but traffic is not arriving at VPP
+
+Check the NIC's ledger against ours. Ours is
+`vpp-offload.json:steer_rules`; the NIC's is `ethtool -n <iface>`. If
+the NIC has no rules but we believe we are steering, the UniFi
+controller has wiped classifier state — a provisioning push does this.
+The supervisor re-asserts on every `Ready`, so a `packetframe
+reconfigure` (or the next verify) restores them.
+
+If the NIC *has* the rules and traffic still is not arriving, suspect
+`ring_cookie`. It must be `(vf + 1) << 32`; `ethtool`'s own `vf N`
+keyword mis-encodes it on the rvu driver, so a rule installed by hand
+with that keyword lands somewhere else. Gate 0a established this by
+inserting both forms and reading back what the NIC stored.
+
+### `packetframe_vpp_routes{state="unresolvable"} > 0`
+
+A route whose nexthop device this module cannot map. Steady state is
+exactly zero — the live table has only two egress devices, no VLAN
+nexthops, no tunnels — so any non-zero value means either a new egress
+device appeared in the table or a member port is missing. Check the
+`port` lines against every `dev` appearing as a FIB nexthop in bird.
+
+This also **blocks the first steer** on an unsteered port, by design:
+if the table cannot be installed, traffic must not be diverted into it.
+
+### `packetframe_vpp_routes{state="withheld"} > 0`
+
+The table outgrew the heap VPP started with. `expected-routes` sizes
+both the main heap and the stats segment, and VPP fixes both **at
+start** — so this cannot be fixed by a reconfigure, and `reconfigure`
+will refuse the change rather than apply a new ceiling to a VPP running
+on the old segments. That refusal is not pedantry: applying it anyway is
+the mid-resync OOM abort gate 0b found. Raise `expected-routes`, then
+restart.
+
+### The offload restarts repeatedly
+
+`packetframe status` carries the reason on the failing subsystem, and it
+is **sticky** — retained across the empty backoff ticks that follow a
+failure, so a slow poll cannot miss it. Read it before touching
+anything; the counter of failures is not the reason.
+
+If the reason mentions a CRC or version mismatch, supervision has
+*ended* rather than looping: the binary API is permanently incompatible
+and no retry can fix it. The installed VPP is not the pinned one.
+
+### A steer or unsteer that "cannot be confirmed"
+
+Both directions refuse rather than guess. `Ok` from unsteer is what
+releases the VF, so a removal that could not be confirmed keeps the VF
+withheld and keeps every later teardown trying.
+
+Where you see it is `detach`, not `status`: the teardown returns
+`teardown did not complete; VF/hugepage resources are still held`, and
+retries keep returning it until the removal is confirmed. That is the
+module declining to unbind a VF that MCAM may still target, which is the
+correct choice — a leaked VF is a line in the state file and a reboot's
+inconvenience; unbinding under live DMA is memory corruption.
+
+## Numbers: measured vs published-on-faith
+
+Be precise about this when reasoning about an incident.
+
+**Measured, on the shadow:**
+
+| number | value | conditions |
+|---|---|---|
+| Full v4 table convergence | **40.32 s** (budget ≤ 60 s) | 1,053,360 prefixes, drain 38.42 s at 27,418 routes/s, verify PASS. 2026-08-03, **one VF, fresh attach**. |
+| Main heap | 463 B/route over a 337.86 MiB floor | gate 0b item 10 |
+| Stats segment | 97 B/route | **at two threads** — counter vectors are per-thread, so every per-route figure is a two-thread figure |
+| Live table | 1,053,360 v4 (1,301,000 v4+v6) | 2026-08-02 |
+| Nexthop spread | eth3 1,248,508 / eth2 52,492 | the full-table decision rests on this |
+| MCAM capacity | 2048 entries, ~1689 free | budget is base 1024, count 512 → **256 v4 prefixes** at 2 rules each |
+
+**Published but never measured:**
+
+| number | status |
+|---|---|
+| Crash blackhole ≤ 50 ms | UNMEASURED — needs a constant-rate flow |
+| Wedge detection ≤ 2 s | UNMEASURED |
+| Recovery ≤ 90 s | UNMEASURED |
+| `detach` < 1 s across N VFs | UNMEASURED — needs real VFs; relaxes to a documented best-effort bound if hardware says so |
+
+**Failed, and shaping the design:**
+
+- **`ip6` ntuple is rejected by the AF** (error 710) while the v4
+  control inserts cleanly — the vendor NPC profile has no v6
+  extraction. No IPv6 packet can be MCAM-steered into VPP, so v6 stays
+  on the XDP custom-FIB path. Retest at every UniFi kernel bump; the
+  MKEX profile ships with the AF driver.
+- **`rx-mode adaptive` is unsupported** by the native octeon driver.
+  The heat goal is dead: **one hot core per VPP worker, 24/7**, as a
+  permanent recorded cost. Budget power and thermals for it.
+
+## Install and upgrade on the router
+
+VPP is **not** bundled in packetframe's .deb — 100 MB against 1.3 MB,
+mismatched cadence, and independent rollback, which the failover design
+wants anyway. It ships on its own release tag, built from *unmodified*
+upstream source (no fd.io bullseye+arm64 package exists at any version).
+
+Pin: **v26.06**, `platform = "octeon9"`, tag
+`vpp-v26.06-octeon9-bullseye-arm64`. The platform is mandatory rather
+than tuned — it is the only shape that builds the native octeon driver,
+and DPDK PMDs inside VPP are measured-dead on this NIC at every version.
+
+Four traps, each of which has cost real time:
+
+```bash
+# 1. Mask the service BEFORE install: the deb's postinst starts VPP.
+systemctl mask vpp.service
+# (on a re-run, stop it first)
+systemctl stop vpp.service; systemctl mask vpp.service
+```
+
+```bash
+# 2. VPP_INSTALL_SKIP_SYSCTL=1 is MANDATORY on routers. The deb writes
+#    vm.nr_hugepages=1024 assuming 2 MB pages; on this 64K-page kernel
+#    the default pool is 512 MB, so that is a 512 GiB request.
+VPP_INSTALL_SKIP_SYSCTL=1 dpkg -i vpp_*.deb
+```
+
+```bash
+# 3. Extract to /root, never /tmp — /tmp is noexec on UniFi OS, and a
+#    binary there fails at execve with EACCES.
+```
+
+```bash
+# 4. Removing the vpp package UNBINDS the VF from vfio-pci. Re-bind
+#    after every purge or upgrade, or the next attach finds the VF on
+#    the kernel driver and refuses.
+```
+
+Upgrade is `detach → install → attach`. There is no cross-version
+adoption: the state file records the VPP version, and a mismatch is
+refused rather than adopted.
+
+## Constraints worth knowing before you debug
+
+- **`packetframe feasibility` does not attach anything.** It used to,
+  via `--config`, on every configured port — including the native-XDP
+  attach that panics this fleet. Fixed in #124; if you are on an older
+  build, do not run it against a live config.
+- **`reconfigure` accepts only the `steer` flag.** `port`, `cores`,
+  `expected-routes`, `hugepages` and `vpp-binary` are all fixed at VPP's
+  start or at VF acquisition, and each is refused **by name** with what
+  to do about it. A daemon whose running config silently differed from
+  the file you just edited is how the wrong thing gets debugged for an
+  hour.
+- **Restart ordering is stop → detach --all → start.** This bit
+  production twice. A plain `systemctl restart` leaves the previous
+  attachment's pins in place and the next start refuses them.
+- **MCAM slots must be pre-allocated.** The driver rejects an
+  out-of-range `loc` rather than assigning one, which is why this module
+  tracks the locations it owns (base 1024) and hands back exactly those.
+- **The first steer is not guarded against an *incomplete* table.**
+  Verification samples what the ledger holds, so a table that is merely
+  missing prefixes verifies clean. the `unresolvable`, `withheld` and
+  `installing` route counts must all read zero before you turn the first lever —
+  which is what rung 0's soak is for. Closing this in code needs a
+  completeness signal the module does not have; bird's own route count,
+  which the fast-path integrity checker already fetches, is the
+  candidate.


### PR DESCRIPTION
Two things that had no consumer, and the documentation for what they surface.

## #27 — module health and metrics actually reach an operator

Nothing in the CLI called `Module::health_check` or `Module::sample_metrics` — **for any module**, not just vpp-offload. So everything the modules publish was unreachable: vpp-offload's `HealthReport` and its `packetframe_vpp_*` gauges, fast-path's subsystem health. That predates the phase-4 work, and it is why the entire steering health surface built over the last three PRs had nobody reading it.

The loader now polls both every 5 s, from the loop that owns the modules. That is what turned `signals.forever()` into a poll: the calls need the modules, the modules are owned there alongside the `&mut` uses (reconfigure, detach), and sharing them with the exporter thread would mean a mutex serialising a metrics read against a reconfigure. Cost is one wakeup per 250 ms — the same granularity the exporter already used, and it bounds SIGTERM latency the same way.

**Metrics** go into a slot the exporter appends, keeping the textfile single-writer, which is what makes its atomic rename mean anything. The 5 s poll is deliberately shorter than the 15 s write: at equal cadences with independent phase the file would routinely pair fresh BPF counters with module gauges a whole write period old.

**Health** goes to `<state-dir>/module-health.json`, because `packetframe status` is a different process and deliberately works with no daemon at all. The snapshot carries the writing daemon's **pid**, not just a timestamp — a file outlives its writer, and "30 s old" means something completely different for a live daemon than for one that died. `status` answers liveness first, from the same `/proc/<pid>/exe` cross-check `reconfigure` uses.

Two distinctions the surface refuses to collapse:

- A health check that **could not run** is recorded as unable to answer, never as an unhealthy module. Those page differently.
- Each module's gauges render into their own buffer, appended only on success. The textfile is parsed as a whole, so a partial line from a module that failed mid-write would take out every other module's gauges *and* the BPF counters. The test for this fails with the fix reverted, producing exactly the splice: `packetframe_partial_line_no_newlpacketframe_fp_ok 1`.

`atomic_write` moved out of the Linux-gated metrics module into `atomic.rs` — there are two of these files now and both want one implementation. And `health::poll` is deliberately portable rather than living inside the Linux-only loop, so its tests run on a dev host: a `#[cfg(target_os = "linux")]` test is invisible to every host gate and only ever runs in CI.

## #29 — slice 6 docs

`docs/runbooks/vpp-offload.md` (432 lines): the operations runbook, distinct from the gate-0b spike procedure. Canary ladder, rollback, triage by symptom, the MCAM/`ring_cookie` traps, the four install traps on this router, and a section separating **measured** numbers from **published-on-faith** ones — a runbook that presents both in one voice is how an unmeasured number gets quoted during an incident.

Every claim was checked against the source rather than written from recall, which caught four wrong ones: the route counters are `packetframe_vpp_routes{state="..."}` not four flat gauges; `state`/`health` are one-hot series; `route-feed` and `state-file` appear only when they have *failed*, so a healthy sample listing them was fiction; the state dir is `/var/lib/packetframe/state`; and an unconfirmed unsteer surfaces through `detach`, not `status`.

`example.conf` drops "EXPERIMENTAL scaffold" for "code-complete, hardware-unproven", and gains the two limits an operator would otherwise find by hitting them (MCAM caps steering at 256 v4 prefixes and refuses an over-budget allowlist whole; IPv6 cannot be steered on this NIC at all). README gains the forwarding-vectors framing and the doc pointers.

## Testing

7 new tests in `health.rs`, all running on the dev host. Gates: fmt, host clippy, `cargo test --workspace --all-features`, per-target `--workspace --all-targets` clippy on all four published triples, and a link-anchor check on the new runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)