### PR TITLE
feat: don't steer into a route mirror that is still loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **eBPF/XDP fast-path for Linux packet forwarding.** Pure Rust, pluggable, attaches per-interface. Forwards allowlisted traffic directly between NICs at the driver level (bypassing iptables, conntrack, and the kernel routing stack), and falls back to normal kernel forwarding for everything else.
 
-Production-tested on edge routers with full-table BGP feeds. **~98% of allowlisted flows fast-path** in measured deployments, with conntrack table size and customer-facing latency both reduced significantly versus stock kernel forwarding.
+Running in production on edge routers with full-table BGP feeds. About 98% of allowlisted flows take the fast path there; conntrack entries and customer-facing latency both dropped substantially, with numbers below.
 
 GPL-3.0-or-later. Linux ≥ 5.15. Single static binary; no separate libbpf, bpftool, or runtime nightly toolchain.
 
@@ -75,8 +75,8 @@ PacketFrame complements existing routing daemons rather than replacing them. The
 | `packetframe reconfigure` / `systemctl reload packetframe` | Production (v0.2.4+) |
 | Two-stage BPF datapath (`fast_path` + `finalize` via `bpf_tail_call`) | Production (v0.2.5+); see [docs/runbooks/tail-call-architecture.md](docs/runbooks/tail-call-architecture.md) |
 | `probe` module (diagnostic XDP) | Production |
-| tc-ingress datapath (`attach <iface> tc`, custom-fib only) | Experimental (Phase T); see [docs/runbooks/tc-datapath.md](docs/runbooks/tc-datapath.md) |
-| Module health + metrics surface (`packetframe status`, `packetframe_vpp_*`) | Production |
+| tc-ingress datapath (`attach <iface> tc`, custom-fib only) | Built and measured slower: +70% CPU per packet on the reference hardware. Kept for reference, not recommended; see [docs/runbooks/tc-datapath.md](docs/runbooks/tc-datapath.md) |
+| Per-module health + metrics, read by `packetframe status` and the Prometheus textfile | Production (v0.2.7+) |
 | `vpp-offload` module (VPP-on-VF forwarding vector) | **Code-complete, hardware-unproven** — never run against a real VPP; see [docs/runbooks/vpp-offload.md](docs/runbooks/vpp-offload.md) |
 | `ddos` module (XDP-time SYN-flood + amplification filter) | Future; sketched in SPEC §5.2 (priority 0–999, security/admission) |
 | `sampler` module (per-flow ringbuf observability) | Future; sketched in SPEC §5.3 (priority 2000–2999, observation) |
@@ -90,7 +90,7 @@ Releases are published on the [GitHub releases page](https://github.com/unredact
 ### Debian / Ubuntu (.deb)
 
 ```sh
-VERSION=v0.2.6
+VERSION=v0.2.7
 ARCH=$(dpkg --print-architecture)   # amd64 or arm64
 
 curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/packetframe_${VERSION#v}_${ARCH}.deb"
@@ -107,7 +107,7 @@ Installs `/usr/bin/packetframe`, the systemd unit at `/lib/systemd/system/packet
 For musl-static deployments, non-Debian distros, or anything else:
 
 ```sh
-VERSION=v0.2.6
+VERSION=v0.2.7
 TARGET=aarch64-unknown-linux-gnu     # or: x86_64-unknown-linux-{gnu,musl}, aarch64-unknown-linux-musl
 
 curl -LO "https://github.com/unredacted/packetframe/releases/download/${VERSION}/packetframe-${VERSION}-${TARGET}.tar.gz"
@@ -214,32 +214,27 @@ route-source bmp 127.0.0.1:6543 require-loc-rib
 
 See [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md) for the full operational guide: cutover sequence, rollback, integrity checking, troubleshooting.
 
-## Forwarding vectors
+## Second forwarding path (vpp-offload)
 
-`forwarding-mode` chooses how a route is *resolved*. A **vector** is what
-actually moves the packet, and PacketFrame is built to carry more than
-one at a time.
+The XDP fast-path is how PacketFrame forwards packets today. The
+`vpp-offload` module adds a second option for the same traffic: the NIC's
+hardware classifier sends allowlisted packets straight to an SR-IOV
+virtual function, where a VPP process that PacketFrame starts and
+supervises forwards them. VPP gets its routes from the same BGP feed the
+fast-path uses, so both paths make the same forwarding decisions.
 
-- **eBPF fast-path** (XDP on the PFs) is the vector today, and stays the
-  permanent failover tier. It is at its structural floor under generic
-  XDP — native XDP panics the reference vendor kernel, so there is no
-  cheap headroom left here.
-- **`vpp-offload`** (phase 4) adds a second: MCAM hardware bifurcation
-  steers allowlisted traffic to an SR-IOV VF owned by a
-  packetframe-supervised VPP, which forwards it from a full-table FIB fed
-  by the same resolved best-paths the eBPF tier uses. Anything not
-  steered — and everything, if VPP dies — stays on the tier above.
+Traffic that isn't steered stays on the XDP path, and so does all of it
+if VPP stops running.
 
-The split is what makes the second vector safe to adopt incrementally:
-membership is provisioned everywhere first, then steering is turned on
-one port at a time, and turning it off is a config edit rather than a
-restart. **No dataplane code for the second vector lives in this repo** —
-VPP is unmodified upstream, built and shipped on its own release tag.
+Steering is per-interface and off by default. You turn it on one
+interface at a time and turn it back off with a config reload, without
+restarting VPP. No VPP source lives in this repo: PacketFrame builds
+unmodified upstream VPP and publishes it under its own release tag.
 
-`vpp-offload` is code-complete and **hardware-unproven**: it has never
-run against a real VPP process, and its MCAM ioctl path has never met a
-NIC. Read [`docs/runbooks/vpp-offload.md`](docs/runbooks/vpp-offload.md)
-before enabling it anywhere that carries traffic.
+The code is finished but has never run against a real VPP process or a
+real NIC. Read
+[`docs/runbooks/vpp-offload.md`](docs/runbooks/vpp-offload.md) before
+turning it on anywhere carrying traffic.
 
 ## Attach modes
 
@@ -317,14 +312,24 @@ sudo packetframe fib dump-v4           # walk FIB_V4 LPM trie
 sudo packetframe detach --all          # remove all pins, detach XDP
 ```
 
-Counters export as Prometheus textfile every 15 s when `metrics-textfile` is set. Metrics include per-counter gauges, custom-FIB occupancy by nexthop state, and the active forwarding mode.
+Counters export as a Prometheus textfile every 15 s when `metrics-textfile` is set: per-counter gauges, custom-FIB occupancy by nexthop state, the active forwarding mode, and whatever each loaded module publishes.
 
 ## Documentation
 
 - [`conf/example.conf`](conf/example.conf): annotated reference config
-- [`docs/runbooks/custom-fib.md`](docs/runbooks/custom-fib.md): operational runbook for custom-FIB mode (cutover, rollback, integrity checks, triage by symptom)
-- [`docs/runbooks/vpp-offload.md`](docs/runbooks/vpp-offload.md): operational runbook for the VPP-on-VF vector (canary ladder, rollback, triage, and which published numbers are measured)
-- [`docs/runbooks/vpp-offload-spike.md`](docs/runbooks/vpp-offload-spike.md): the gate-0b bring-up procedure and its results, including what failed
+
+Runbooks, in `docs/runbooks/`:
+
+| File | Covers |
+|---|---|
+| [`custom-fib.md`](docs/runbooks/custom-fib.md) | Custom-FIB mode: cutover, rollback, integrity checks, triage by symptom |
+| [`reconfigure.md`](docs/runbooks/reconfigure.md) | What SIGHUP applies and what needs a restart |
+| [`mss-clamp.md`](docs/runbooks/mss-clamp.md) | MSS clamping and the iptables-bypass gap it closes |
+| [`tail-call-architecture.md`](docs/runbooks/tail-call-architecture.md) | The two-stage BPF datapath and why it is split |
+| [`generic-mode-performance.md`](docs/runbooks/generic-mode-performance.md) | Measured cost of generic vs native XDP, and host tuning |
+| [`tc-datapath.md`](docs/runbooks/tc-datapath.md) | The tc-ingress variant, and why it measured slower |
+| [`vpp-offload.md`](docs/runbooks/vpp-offload.md) | Running vpp-offload: rollout, rollback, triage, which numbers are measured |
+| [`vpp-offload-spike.md`](docs/runbooks/vpp-offload-spike.md) | How vpp-offload was brought up on test hardware, and what failed |
 
 ## Build from source
 
@@ -348,13 +353,16 @@ packetframe/
 ├── crates/
 │   ├── common/                       # config parser, Module trait, capability probes
 │   ├── cli/                          # the `packetframe` binary
-│   └── modules/
-│       ├── fast-path/                # main forwarding module
-│       │   └── bpf/                  # XDP program (nightly toolchain)
-│       └── probe/                    # diagnostic XDP probe
-│           └── bpf/                  # probe BPF program
+│   ├── modules/
+│   │   ├── fast-path/                # main forwarding module
+│   │   │   └── bpf/                  # XDP program (nightly toolchain)
+│   │   ├── probe/                    # diagnostic XDP probe
+│   │   │   └── bpf/                  # probe BPF program
+│   │   └── vpp-offload/              # second forwarding path (supervises VPP)
+│   └── tools/vpp-api-codegen/        # generates VPP binary-API structs from its .api.json
 ├── conf/example.conf                 # annotated reference config
 ├── docs/runbooks/                    # operational runbooks
+├── vpp/pin.toml                      # which upstream VPP we build and ship
 └── .github/workflows/                # CI (fmt/clippy/test, cross-build, qemu-verifier, release)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PacketFrame
 
-**eBPF/XDP fast-path for Linux packet forwarding.** Pure Rust, pluggable, attaches per-interface. Forwards allowlisted traffic directly between NICs at the driver level (bypassing iptables, conntrack, and the kernel routing stack), and falls back to normal kernel forwarding for everything else.
+**Forwarding data plane for Linux edge routers.** PacketFrame takes the traffic you allowlist off the kernel's conntrack and netfilter path and forwards it straight between NICs, leaving everything else to normal kernel forwarding. It can build its own routing table from a BGP feed, so it neither depends on netlink nor competes with the routing daemon for it. Written in Rust, attached one interface at a time, and removable the same way.
 
 Running in production on edge routers with full-table BGP feeds. About 98% of allowlisted flows take the fast path there; conntrack entries and customer-facing latency both dropped substantially, with numbers below.
 
@@ -8,21 +8,27 @@ GPL-3.0-or-later. Linux ≥ 5.15. Single static binary; no separate libbpf, bpft
 
 ## What it does
 
-For each interface you attach it to, PacketFrame runs an eBPF program at XDP ingress that:
+One daemon, one config file, and a set of modules. There are three parts.
+
+**The fast path.** For each interface you attach it to, PacketFrame runs an eBPF program at XDP ingress that:
 
 1. **Filters** by your declared `allow-prefix` / `allow-prefix6` lists. Non-matching packets fall through to the kernel unchanged.
 2. **Forwards** matched packets directly to the egress NIC via `bpf_redirect_map`: no `nf_hook_slow`, no conntrack, no iptables walk, no kernel skb allocation in native XDP mode.
-3. **Resolves the egress** via either the kernel FIB (`bpf_fib_lookup`) or PacketFrame's own LPM trie populated from a BGP feed (your choice via `forwarding-mode`).
+3. **Resolves the egress** via either the kernel FIB (`bpf_fib_lookup`) or PacketFrame's own routing table (your choice via `forwarding-mode`).
 
-Optional layered features:
+**The route side.** In custom-FIB mode PacketFrame reads BGP itself — iBGP from `bird` today, or BMP (RFC 7854/9069) — and builds an LPM trie from it, resolving next-hop MACs over netlink. The kernel route table is not involved, so daemons that read it are unaffected and there is no race over BGP attribute updates.
+
+**A second way to forward.** The `vpp-offload` module can hand allowlisted traffic to a VPP process on an SR-IOV virtual function instead, using the same routes. It is written but has not run on real hardware yet; see [below](#second-forwarding-path-vpp-offload).
+
+Other things the fast path can do:
 
 - **VLAN push/pop/rewrite** for tagged forwarding
-- **Custom-FIB mode**: ingest BGP routes directly via iBGP (production today, with `bird`) or BMP (RFC 7854/9069). No netlink dependency, no race with other daemons subscribed to kernel routes.
 - **Per-host fast-path for connected destinations** via `local-prefix` directives + ARP scavenging
 - **XDP-time bogon block** (`block-prefix`) for dropping traffic to unrouteable destinations before kernel processing
 - **Default-route synthesis** in custom-FIB mode (`fallback-default`) for catching destinations the BGP feed doesn't cover
+- **MSS clamping** for fast-pathed TCP, which iptables no longer sees
 
-## Benefits
+## What changes
 
 | Concern | Stock kernel forwarding | PacketFrame fast-path |
 |---|---|---|
@@ -57,7 +63,9 @@ Actual results depend on workload mix, NIC, kernel version, and deployment topol
 | Memory model | kernel-managed BPF maps | hugepages | kernel | kernel |
 | Deploy disruption | per-iface attach, opt-in | replaces network stack | runs alongside | default |
 
-PacketFrame complements existing routing daemons rather than replacing them. The intended pairing is `bird` (BGP) + `pathvector` (config generator) + PacketFrame (fast-path). FRR works similarly via its BMP support.
+The PacketFrame column describes the fast path, which is what runs in production. `vpp-offload` sits between the first two columns: it puts VPP on a virtual function under PacketFrame's supervision, so for steered traffic it does bypass the kernel fully and does need dedicated cores. The fast path stays underneath as the fallback.
+
+PacketFrame does not replace a routing daemon. The intended pairing is `bird` (BGP) + `pathvector` (config generator) + PacketFrame. FRR works too, via its BMP support.
 
 ## Status
 
@@ -300,12 +308,18 @@ Quick directive index:
 **Module fast-path: driver opt-ins**
 - `driver-workaround rvu-nicpf-head-shift {auto|on|off}`
 
-`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, and forwarding-mode bits. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, or editing `local-prefix`/`local-prefix6` requires a restart.
+**Module vpp-offload** (see [the runbook](docs/runbooks/vpp-offload.md) before using)
+- `port <iface> cores <n> steer {on|off}`: one line per interface VPP takes part in; `steer` is the per-interface switch
+- `expected-routes <n>`: sizes VPP's memory, fixed when it starts
+- `hugepages <n>`, `vpp-binary <path>`
+- `require-table-complete {on|off}`: wait for the routing table to finish loading before steering (default on)
+
+`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, forwarding-mode bits, and vpp-offload's `steer` switches. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, editing `local-prefix`/`local-prefix6`, or changing any vpp-offload directive other than `steer` requires a restart.
 
 ## Operator tools
 
 ```sh
-sudo packetframe status                # live counters from pinned STATS map
+sudo packetframe status                # live counters, plus each module's health
 sudo packetframe fib stats             # custom-FIB occupancy / hash mode
 sudo packetframe fib lookup <ip>       # "what would XDP do for this dst?"
 sudo packetframe fib dump-v4           # walk FIB_V4 LPM trie

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PacketFrame
 
-**Forwarding data plane for Linux edge routers.** PacketFrame takes the traffic you allowlist off the kernel's conntrack and netfilter path and forwards it straight between NICs, leaving everything else to normal kernel forwarding. It can build its own routing table from a BGP feed, so it neither depends on netlink nor competes with the routing daemon for it. Written in Rust, attached one interface at a time, and removable the same way.
+**Forwarding data plane for Linux edge routers.** PacketFrame takes the traffic you allowlist off the kernel's conntrack and netfilter path and forwards it straight between NICs, leaving everything else to normal kernel forwarding. It can build its own routing table from a BGP feed instead of reading the kernel's, so it doesn't compete with the routing daemon over it. Written in Rust, and opt-in per interface: it only touches the ones you name.
 
 Running in production on edge routers with full-table BGP feeds. About 98% of allowlisted flows take the fast path there; conntrack entries and customer-facing latency both dropped substantially, with numbers below.
 
@@ -35,7 +35,7 @@ Other things the fast path can do:
 | Per-packet conntrack lookup | yes, every packet | bypassed for allowlisted flows |
 | iptables FORWARD chain walk | yes, every packet, every rule | bypassed |
 | skb allocation cost (native XDP) | yes | bypassed |
-| BGP route source | netlink from a routing daemon | direct iBGP/BMP, no netlink coupling |
+| BGP route source | netlink from a routing daemon | direct iBGP/BMP; netlink is used only for next-hop MACs |
 | Kernel features still work | yes | yes (slow path is unchanged) |
 | Fallback path | n/a | always: non-matching traffic uses kernel |
 

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -348,6 +348,20 @@ module fast-path
 #                                 # restart, and reconfigure says so.
 #   hugepages 10                  # >= derived minimum (checked at startup)
 #   # vpp-binary /usr/bin/vpp
+#   # require-table-complete on   # default. A first steer waits until the
+#                                 # route mirror is confirmed converged
+#                                 # against bird, because bird's initial
+#                                 # dump takes time and steering into a
+#                                 # half-loaded table blackholes whatever
+#                                 # has not arrived — a steered miss is
+#                                 # DROPPED, where an unsteered one falls
+#                                 # to the kernel path. Set `off` only
+#                                 # where there is no bird to compare
+#                                 # against (the shadow); it means you own
+#                                 # that judgement instead. Attach REFUSES
+#                                 # `on` when nothing publishes
+#                                 # completeness, rather than declining
+#                                 # every steer forever.
 #
 # One sizing note that is easy to miss: the MCAM budget is 512 slots at
 # two rules per prefix (source and destination), so at most 256 v4

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -254,6 +254,17 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         crate::feasibility::allowlist_from_config(&config),
     ));
 
+    // How complete the route mirror is, published by the fast-path's
+    // integrity checker and read by vpp-offload before it diverts
+    // traffic. One object, both tiers, same wiring as the feed and the
+    // allowlist — and only built when BOTH modules are present, because
+    // an unpublished handle is what `require-table-complete on` refuses
+    // at attach rather than silently treating as permission.
+    #[cfg(feature = "vpp-offload")]
+    let completeness = feed
+        .as_ref()
+        .map(|_| std::sync::Arc::new(packetframe_common::fib::TableCompleteness::new()));
+
     let mut modules: Vec<(String, Box<dyn Module>)> = Vec::new();
     for section in &config.modules {
         match section.name.as_str() {
@@ -263,6 +274,10 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 #[cfg(feature = "vpp-offload")]
                 if let Some(f) = &feed {
                     m.set_route_sink(f.clone());
+                }
+                #[cfg(feature = "vpp-offload")]
+                if let Some(c) = &completeness {
+                    m.set_completeness(c.clone());
                 }
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }
@@ -278,6 +293,9 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 // from that section. The loader is the only place that
                 // sees both.
                 m.set_allowlist(allowlist.clone());
+                if let Some(c) = &completeness {
+                    m.set_completeness(c.clone());
+                }
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }
             other => {

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -166,6 +166,13 @@ pub enum ModuleDirective {
     /// Must be ≥ the minimum derived from `expected-routes`; the
     /// renderer errors at load otherwise.
     VppHugepages(u32),
+    /// `require-table-complete on|off` — whether a first steer waits
+    /// for the route mirror to be confirmed converged against bird.
+    ///
+    /// Default `on`. `off` is for deployments with no authority to
+    /// compare against — the shadow has no bird of its own — and it
+    /// means the operator owns the completeness judgement instead.
+    VppRequireTableComplete(bool),
     AllowPrefix4(Ipv4Prefix),
     AllowPrefix6(Ipv6Prefix),
     /// Connected/local prefix the operator wants packetframe to
@@ -1811,6 +1818,13 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             }
             Ok(ModuleDirective::ExpectedRoutes(n))
         }),
+        "require-table-complete" => {
+            parse_single_arg(line, rest, "require-table-complete", |t| match t {
+                "on" => Ok(ModuleDirective::VppRequireTableComplete(true)),
+                "off" => Ok(ModuleDirective::VppRequireTableComplete(false)),
+                _ => Err("require-table-complete expects on|off".to_string()),
+            })
+        }
         "hugepages" => parse_single_arg(line, rest, "hugepages", |t| {
             let n: u32 = t
                 .parse()

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -140,6 +140,195 @@ impl PeerId {
     }
 }
 
+// --- Table completeness ----------------------------------------------
+
+/// Drift at or below which the mirror counts as converged, for the
+/// purpose of **letting traffic be steered into it**.
+///
+/// A separate constant from the integrity checker's own warn threshold
+/// even though both start at 1%, because they answer different
+/// questions and will drift apart the moment either is tuned. The
+/// checker asks "should an operator look at this?"; this asks "may we
+/// divert packets into it?".
+///
+/// What it is actually separating is **"bird's initial dump is still
+/// arriving"** — where the mirror holds a fraction of the table — from
+/// an ordinary converged state with BGP churn on top. That is a gap of
+/// tens of percent, so a modest threshold does the job while tolerating
+/// the churn a tighter one would trip over. A gate that refuses during
+/// normal operation is a gate operators turn off.
+///
+/// The residual is deliberate and bounded: both tiers mirror the same
+/// table, so a prefix missing here is missing from the eBPF tier too.
+/// Steering makes it worse rather than new — an unsteered miss falls to
+/// the kernel path, a steered one is dropped by VPP — which is why the
+/// gate exists at all, and why it is sized to catch the large case.
+pub const STEER_MAX_DRIFT: f64 = 0.01;
+
+/// How old a completeness report may be and still be acted on.
+///
+/// The publisher's cadence is ~5 minutes, so this tolerates two missed
+/// runs rather than blocking a rollout step on one slow `birdc`. It is
+/// generous because of what the report says: "the table had converged".
+/// A table does not un-converge while nobody is looking — and the case
+/// that would matter, a daemon restart mid-dump, cannot produce a stale
+/// report at all, since the handle lives in memory and a fresh process
+/// starts with none.
+pub const STEER_MAX_REPORT_AGE: std::time::Duration = std::time::Duration::from_secs(900);
+
+/// One comparison of the mirror against its authority.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct CompletenessReport {
+    /// What the authority (bird) says it has.
+    pub authority_routes: u64,
+    /// What our mirror holds.
+    pub mirror_routes: u64,
+    /// When the comparison was made.
+    pub at: std::time::Instant,
+}
+
+impl CompletenessReport {
+    /// How far the mirror is from the authority, as a fraction of the
+    /// authority's count. `None` when the authority reports zero, which
+    /// is not a 100%-complete mirror — it is no basis for a judgement.
+    pub fn drift(&self) -> Option<f64> {
+        if self.authority_routes == 0 {
+            return None;
+        }
+        let a = self.authority_routes as f64;
+        Some((a - self.mirror_routes as f64).abs() / a)
+    }
+}
+
+/// The verdict a steering decision acts on.
+#[derive(Debug, Clone, PartialEq)]
+pub enum Completeness {
+    /// Safe to divert traffic into.
+    Converged { drift: f64 },
+    /// The mirror is measurably short of the authority.
+    Incomplete {
+        drift: f64,
+        authority: u64,
+        mirror: u64,
+    },
+    /// There is a report, but it is too old to act on.
+    Stale { age: std::time::Duration },
+    /// No report at all, or none that supports a judgement.
+    Unknown { why: &'static str },
+}
+
+impl Completeness {
+    /// Whether traffic may be steered on the strength of this.
+    ///
+    /// Only `Converged` says yes. `Unknown` deliberately does **not** —
+    /// "I could not establish this" is not the same as "there is no
+    /// constraint", and reading it as permission is the exact shape that
+    /// has produced the worst bugs in this subsystem. Deployments with
+    /// no authority to compare against say so in config rather than
+    /// arriving here.
+    pub fn permits_steering(&self) -> bool {
+        matches!(self, Completeness::Converged { .. })
+    }
+
+    /// Operator-facing reason, for the refusal message.
+    pub fn describe(&self) -> String {
+        match self {
+            Completeness::Converged { drift } => {
+                format!("converged ({:.3}% drift)", drift * 100.0)
+            }
+            Completeness::Incomplete {
+                drift,
+                authority,
+                mirror,
+            } => format!(
+                "the route mirror holds {mirror} of the authority's {authority} routes \
+                 ({:.2}% short) — it is probably still loading",
+                drift * 100.0
+            ),
+            Completeness::Stale { age } => format!(
+                "the last completeness check was {}s ago, too old to act on",
+                age.as_secs()
+            ),
+            Completeness::Unknown { why } => format!("completeness is unknown: {why}"),
+        }
+    }
+}
+
+/// Turn a report into a verdict. Pure, so the rule is testable without
+/// a bird, a VPP or a NIC.
+pub fn assess(
+    report: Option<CompletenessReport>,
+    now: std::time::Instant,
+    max_drift: f64,
+    max_age: std::time::Duration,
+) -> Completeness {
+    let Some(r) = report else {
+        return Completeness::Unknown {
+            why: "no check has run yet",
+        };
+    };
+    // Age first. A report whose drift looks fine but which predates
+    // anything we care about is not evidence, and reporting its drift
+    // would invite acting on it.
+    let age = now.saturating_duration_since(r.at);
+    if age > max_age {
+        return Completeness::Stale { age };
+    }
+    let Some(drift) = r.drift() else {
+        return Completeness::Unknown {
+            why: "the authority reports zero routes",
+        };
+    };
+    if drift <= max_drift {
+        Completeness::Converged { drift }
+    } else {
+        Completeness::Incomplete {
+            drift,
+            authority: r.authority_routes,
+            mirror: r.mirror_routes,
+        }
+    }
+}
+
+/// Where the route mirror publishes how complete it is, for the second
+/// forwarding tier to read before diverting traffic.
+///
+/// A shared handle rather than a copy, and a `std` lock rather than
+/// tokio's, because the two ends live in different worlds: the publisher
+/// is the fast-path's async integrity checker, the reader is
+/// vpp-offload's synchronous supervision loop. Neither should have to
+/// adopt the other's runtime to answer one question.
+///
+/// The loader owns it and hands the same object to both, exactly as it
+/// does for the route feed and the allowlist.
+#[derive(Debug, Default)]
+pub struct TableCompleteness(std::sync::RwLock<Option<CompletenessReport>>);
+
+impl TableCompleteness {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Record a comparison. The integrity checker is the only writer.
+    pub fn publish(&self, report: CompletenessReport) {
+        *self.0.write().expect("completeness lock") = Some(report);
+    }
+
+    pub fn latest(&self) -> Option<CompletenessReport> {
+        *self.0.read().expect("completeness lock")
+    }
+
+    /// The verdict now, under the steering policy.
+    pub fn verdict(&self) -> Completeness {
+        assess(
+            self.latest(),
+            std::time::Instant::now(),
+            STEER_MAX_DRIFT,
+            STEER_MAX_REPORT_AGE,
+        )
+    }
+}
+
 #[cfg(test)]
 mod peer_id_tests {
     use super::*;
@@ -386,5 +575,112 @@ mod tests {
         let f = RouteSourceError::fatal("listener bind");
         assert!(!f.recoverable);
         assert!(format!("{f}").contains("fatal"));
+    }
+
+    mod completeness {
+        use super::super::*;
+        use std::time::{Duration, Instant};
+
+        fn report(authority: u64, mirror: u64, age: Duration) -> CompletenessReport {
+            CompletenessReport {
+                authority_routes: authority,
+                mirror_routes: mirror,
+                at: Instant::now() - age,
+            }
+        }
+
+        fn verdict(r: Option<CompletenessReport>) -> Completeness {
+            assess(r, Instant::now(), STEER_MAX_DRIFT, STEER_MAX_REPORT_AGE)
+        }
+
+        /// The case the gate exists for: bird's initial dump is still
+        /// arriving, so the mirror holds a fraction of the table.
+        /// Steering into it blackholes everything not yet loaded, and —
+        /// unlike an unsteered miss, which falls to the kernel path —
+        /// a steered one is dropped.
+        #[test]
+        fn a_mirror_still_loading_does_not_permit_steering() {
+            let v = verdict(Some(report(1_053_360, 400_000, Duration::ZERO)));
+            assert!(!v.permits_steering());
+            assert!(matches!(v, Completeness::Incomplete { .. }), "{v:?}");
+            let msg = v.describe();
+            assert!(
+                msg.contains("1053360") && msg.contains("400000"),
+                "the operator needs both numbers to judge it: {msg}"
+            );
+        }
+
+        /// Ordinary churn must not refuse a rollout step. A gate that
+        /// fires during normal operation is a gate operators disable.
+        #[test]
+        fn ordinary_churn_still_permits_steering() {
+            // 0.5% short — well inside the noise BGP produces.
+            let v = verdict(Some(report(1_000_000, 995_000, Duration::ZERO)));
+            assert!(v.permits_steering(), "{v:?}");
+        }
+
+        /// No report is NOT permission.
+        ///
+        /// "I could not establish this" read as "there is no
+        /// constraint" is the shape that has produced the worst bugs in
+        /// this subsystem. A deployment with no authority to compare
+        /// against says so in config rather than arriving here.
+        #[test]
+        fn an_absent_report_is_not_permission() {
+            let v = verdict(None);
+            assert!(!v.permits_steering());
+            assert!(matches!(v, Completeness::Unknown { .. }), "{v:?}");
+        }
+
+        /// An authority reporting zero routes is not a complete mirror.
+        ///
+        /// The arithmetic would divide by zero; the honest reading is
+        /// that bird has nothing to compare against, which is no basis
+        /// for diverting traffic.
+        #[test]
+        fn a_zero_route_authority_is_unknown_not_converged() {
+            let v = verdict(Some(report(0, 0, Duration::ZERO)));
+            assert!(!v.permits_steering(), "{v:?}");
+            assert!(matches!(v, Completeness::Unknown { .. }), "{v:?}");
+        }
+
+        /// Age is judged BEFORE drift.
+        ///
+        /// A report that looks converged but predates anything we care
+        /// about is not evidence, and reporting its drift would invite
+        /// acting on it.
+        #[test]
+        fn a_stale_report_is_refused_even_when_it_looks_converged() {
+            let old = report(
+                1_000_000,
+                1_000_000,
+                STEER_MAX_REPORT_AGE + Duration::from_secs(1),
+            );
+            let v = verdict(Some(old));
+            assert!(!v.permits_steering());
+            assert!(matches!(v, Completeness::Stale { .. }), "{v:?}");
+        }
+
+        /// The handle is a window, not a copy: a publish is visible to
+        /// the reader without anything being handed over.
+        #[test]
+        fn a_published_report_is_visible_through_the_handle() {
+            let h = TableCompleteness::new();
+            assert!(
+                !h.verdict().permits_steering(),
+                "empty handle permits nothing"
+            );
+
+            h.publish(report(1_000_000, 999_000, Duration::ZERO));
+            assert!(h.verdict().permits_steering());
+
+            // And a later, worse report replaces it rather than being
+            // merged with the good one.
+            h.publish(report(1_000_000, 100_000, Duration::ZERO));
+            assert!(
+                !h.verdict().permits_steering(),
+                "the newest report is the verdict"
+            );
+        }
     }
 }

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -133,6 +133,7 @@ impl RouteController {
         fallback_default: Option<FallbackDefaultSpec>,
         fdb_pin_chains: std::collections::HashMap<u32, (u32, u16)>,
         route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
+        completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
     ) -> Result<Self, ControllerError> {
         // Dedicated runtime. `worker_threads(2)` keeps task count to
         // what Phase 3 actually needs; the resolver, programmer, and
@@ -225,12 +226,17 @@ impl RouteController {
                 peer_acl,
             }) => {
                 let snapshot = shared_snapshot();
-                let checker = IntegrityChecker::new(
+                let mut checker = IntegrityChecker::new(
                     IntegrityConfig::default(),
                     snapshot.clone(),
                     prog_handle.clone(),
                     shutdown_token.clone(),
                 );
+                // The second tier's steering gate reads what this
+                // publishes; see `TableCompleteness`.
+                if let Some(h) = completeness.clone() {
+                    checker = checker.with_completeness(h);
+                }
                 tasks.push(runtime.spawn(async move { checker.run().await }));
 
                 // v0.2.2: spawn under a retry-with-backoff loop. Pre-fix,
@@ -291,12 +297,17 @@ impl RouteController {
                 expected_peer_ip,
             }) => {
                 let snapshot = shared_snapshot();
-                let checker = IntegrityChecker::new(
+                let mut checker = IntegrityChecker::new(
                     IntegrityConfig::default(),
                     snapshot.clone(),
                     prog_handle.clone(),
                     shutdown_token.clone(),
                 );
+                // The second tier's steering gate reads what this
+                // publishes; see `TableCompleteness`.
+                if let Some(h) = completeness.clone() {
+                    checker = checker.with_completeness(h);
+                }
                 tasks.push(runtime.spawn(async move { checker.run().await }));
 
                 // v0.2.2: same retry-with-backoff pattern as BmpStation

--- a/crates/modules/fast-path/src/fib/integrity.rs
+++ b/crates/modules/fast-path/src/fib/integrity.rs
@@ -93,6 +93,20 @@ pub struct IntegrityChecker {
     snapshot: SharedSnapshot,
     prog: FibProgrammerHandle,
     shutdown: CancellationToken,
+    /// Where the same comparison is republished for the **second
+    /// forwarding tier** to read before it diverts traffic.
+    ///
+    /// Same numbers, different consumer and a different question. This
+    /// checker asks "should an operator look at this?" on a 5-minute
+    /// drift-catch cadence; vpp-offload asks "may I steer packets into
+    /// this mirror yet?", where the case that matters is bird's initial
+    /// dump still arriving. Publishing rather than having vpp-offload
+    /// run its own `birdc` keeps one process shelling out to bird and
+    /// one place parsing its output.
+    ///
+    /// `None` when nothing is consuming it, which is every
+    /// single-module deployment.
+    completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
 }
 
 impl IntegrityChecker {
@@ -107,7 +121,20 @@ impl IntegrityChecker {
             snapshot,
             prog,
             shutdown,
+            completeness: None,
         }
+    }
+
+    /// Publish each comparison to the second forwarding tier as well.
+    ///
+    /// Set by the loader, which is the only place that sees both
+    /// modules — the same wiring the route feed and the allowlist use.
+    pub fn with_completeness(
+        mut self,
+        handle: Arc<packetframe_common::fib::TableCompleteness>,
+    ) -> Self {
+        self.completeness = Some(handle);
+        self
     }
 
     /// Main loop. Sleeps `config.interval`, runs one check, repeats.
@@ -136,6 +163,18 @@ impl IntegrityChecker {
         let bird_route = run_birdc_count(&self.config.birdc_path).await;
         let bird_peers = run_birdc_protocols(&self.config.birdc_path).await;
         let pf_route = self.prog.mirror_counts().await;
+
+        // Captured from THIS run's results, before they are folded into
+        // the snapshot.
+        //
+        // The snapshot's count fields are sticky — a failed `birdc` or a
+        // failed `mirror_counts` leaves the previous run's number in
+        // place, which is right for a drift-catch display and wrong as
+        // the basis of a steering decision. Reading them back below
+        // would publish a report built from one fresh number and one
+        // five minutes old, and the reader acts on it.
+        let fresh_bird = bird_route.as_ref().ok().copied();
+        let fresh_mirror = pf_route.as_ref().ok().map(|(v4, v6)| v4 + v6);
 
         let mut snap = self.snapshot.write().await;
         snap.last_run = Some(Instant::now());
@@ -166,6 +205,24 @@ impl IntegrityChecker {
                 snap.last_error = Some(format!("programmer mirror_counts: {e}"));
                 warn!(error = %e, "integrity check: mirror_counts failed");
             }
+        }
+
+        // Republished for the steering gate, and only when BOTH counts
+        // came from THIS run.
+        //
+        // A partial run publishes nothing rather than a mixed report:
+        // the reader treats an absent report as "refuse to steer", which
+        // is the safe reading, while a fabricated one would be acted on.
+        // Leaving the previous report in place is correct — it ages out
+        // on its own, and its own timestamp says how far behind it is.
+        if let (Some(handle), Some(bird), Some(pf)) =
+            (self.completeness.as_ref(), fresh_bird, fresh_mirror)
+        {
+            handle.publish(packetframe_common::fib::CompletenessReport {
+                authority_routes: bird as u64,
+                mirror_routes: pf as u64,
+                at: Instant::now(),
+            });
         }
 
         if let (Some(bird), Some(pf)) = (snap.bird_route_count, snap.packetframe_route_count) {

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -81,6 +81,8 @@ pub struct FastPathModule {
     /// have missed every route resolved in the meantime.
     #[cfg(target_os = "linux")]
     route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
+    #[cfg(target_os = "linux")]
+    completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
 }
 
 impl FastPathModule {
@@ -99,6 +101,20 @@ impl FastPathModule {
         sink: std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>,
     ) {
         self.route_sink = Some(sink);
+    }
+
+    /// Publish how complete the route mirror is, for a second tier to
+    /// consult before it diverts traffic.
+    ///
+    /// Same constraint and same reason as [`Self::set_route_sink`]: the
+    /// loader is the only caller, and it must land before
+    /// [`Module::attach`] spawns the integrity checker.
+    #[cfg(target_os = "linux")]
+    pub fn set_completeness(
+        &mut self,
+        handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
+    ) {
+        self.completeness = Some(handle);
     }
 
     /// Snapshot of the current attach set for status reporting.
@@ -167,7 +183,12 @@ impl Module for FastPathModule {
             .state
             .as_mut()
             .ok_or_else(|| ModuleError::other(MODULE_NAME, "attach called before load"))?;
-        linux_impl::attach(state, cfg, self.route_sink.clone())
+        linux_impl::attach(
+            state,
+            cfg,
+            self.route_sink.clone(),
+            self.completeness.clone(),
+        )
     }
 
     #[cfg(not(target_os = "linux"))]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1180,6 +1180,7 @@ pub fn attach(
     state: &mut ActiveState,
     cfg: &ModuleConfig<'_>,
     route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
+    completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
 ) -> ModuleResult<Vec<Attachment>> {
     // v0.2.5: load `finalize` first so its FD is available for the
     // MUTATION_PROGS[0] population below. Order matters: fast_path's
@@ -1635,6 +1636,7 @@ pub fn attach(
             fallback_default,
             fdb_pin_chains,
             route_sink,
+            completeness,
         )
         .map_err(|e| {
             ModuleError::other(MODULE_NAME, format!("RouteController start failed: {e}"))

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -35,6 +35,7 @@
 //! tear its steering down first.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use crate::acquire::{self, Acquired, ResourceOwner, SharedOwner, SysPaths};
 use crate::attach::PortAttach;
@@ -111,7 +112,23 @@ pub fn bring_up(
     paths: &AttachPaths,
     source: Box<dyn RouteSource + Send + Sync>,
     allowlist: &[packetframe_common::fib::IpPrefix],
+    completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
 ) -> Result<Attached, String> {
+    // `require-table-complete on` with nothing publishing completeness
+    // is refused at attach rather than discovered at the first canary
+    // step. The gate would never pass — every steer would be declined
+    // with "no check has run yet" — and the operator would be debugging
+    // a rollout that cannot proceed instead of reading this once.
+    if cfg.require_table_complete && completeness.is_none() {
+        return Err(
+            "`require-table-complete on` (the default), but nothing is publishing route \
+             completeness — the fast-path integrity checker needs `birdc` and a bird to \
+             ask. Steering would be refused forever. Either give this box a bird, or set \
+             `require-table-complete off` and own the judgement yourself (see the canary \
+             ladder in docs/runbooks/vpp-offload.md)"
+                .into(),
+        );
+    }
     // --- Everything pure first. A config that cannot work must cost no
     // sysfs writes; the alternative is a rollback path exercised by
     // ordinary operator typos.
@@ -241,6 +258,7 @@ pub fn bring_up(
         acquired,
         &vpp_binary,
         steering,
+        completeness,
     ) {
         Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
@@ -309,6 +327,7 @@ fn finish(
     acquired: Acquired,
     vpp_binary: &Path,
     steering: NtupleSteering,
+    completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
     // rewritten on every attach: it is a pure function of config, and
@@ -469,6 +488,9 @@ fn finish(
             vpp_binary,
             startup_conf_path,
         );
+        if let Some(handle) = completeness {
+            runtime.require_table_complete(handle);
+        }
         let initial = match adopted {
             Some(p) => {
                 // The API handshake MUST happen before the adoption is

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -95,6 +95,10 @@ pub struct VppOffloadConfig {
     pub vpp_binary: Option<String>,
     pub expected_routes: u64,
     pub hugepages: Option<u32>,
+    /// Whether a first steer waits for the route mirror to be confirmed
+    /// converged against bird. See
+    /// [`packetframe_common::fib::TableCompleteness`].
+    pub require_table_complete: bool,
 }
 
 /// Default sizing input when `expected-routes` is absent.
@@ -111,6 +115,9 @@ impl VppOffloadConfig {
     pub fn from_directives(directives: &[ModuleDirective]) -> Self {
         let mut out = Self {
             expected_routes: DEFAULT_EXPECTED_ROUTES,
+            // Safe by default: absent config must not mean "divert
+            // traffic into whatever the mirror happens to hold".
+            require_table_complete: true,
             ..Self::default()
         };
         for d in directives {
@@ -124,6 +131,7 @@ impl VppOffloadConfig {
                 ModuleDirective::VppBinary(p) => out.vpp_binary = Some(p.clone()),
                 ModuleDirective::ExpectedRoutes(n) => out.expected_routes = *n,
                 ModuleDirective::VppHugepages(n) => out.hugepages = Some(*n),
+                ModuleDirective::VppRequireTableComplete(v) => out.require_table_complete = *v,
                 _ => {}
             }
         }
@@ -133,7 +141,8 @@ impl VppOffloadConfig {
     /// What in `new` cannot be applied without a restart.
     ///
     /// `Ok(())` means the only differences are ones `reconfigure` can
-    /// act on: the per-port `steer` flag. Everything else is fixed at
+    /// act on: the per-port `steer` flag and `require-table-complete`,
+    /// neither of which VPP knows about. Everything else is fixed at
     /// VPP's start or at VF acquisition, so the honest answer is to
     /// refuse and say so — the alternative is a daemon whose running
     /// configuration silently differs from the file an operator just
@@ -306,6 +315,10 @@ pub struct VppOffloadModule {
     /// Prefixes steering diverts, inherited from fast-path's allowlist.
     /// Empty until the loader sets it; see [`Self::set_allowlist`].
     allowlist: std::sync::Arc<SharedAllowlist>,
+    /// Where the route mirror says how complete it is. `None` until the
+    /// loader wires it, which it does only when a route authority
+    /// exists; see [`Self::set_completeness`].
+    completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
     /// `Some` once supervision is running.
     attached: Option<bringup::Attached>,
     /// A teardown still running in the background after `detach` returned.
@@ -332,6 +345,7 @@ impl VppOffloadModule {
     pub fn new() -> Self {
         Self {
             allowlist: std::sync::Arc::new(SharedAllowlist::default()),
+            completeness: None,
             cfg: VppOffloadConfig::default(),
             state_dir: std::path::PathBuf::new(),
             source: None,
@@ -372,6 +386,20 @@ impl VppOffloadModule {
     /// for why a snapshot is wrong on exactly the SIGHUP path.
     pub fn set_allowlist(&mut self, allowlist: std::sync::Arc<SharedAllowlist>) {
         self.allowlist = allowlist;
+    }
+
+    /// Hand the module the route mirror's completeness handle.
+    ///
+    /// The loader sets this when the fast-path has a route authority to
+    /// compare against; without it, `require-table-complete on` refuses
+    /// at attach rather than refusing every steer forever. Same wiring
+    /// as the route feed and the allowlist — the loader is the only
+    /// place that sees both modules.
+    pub fn set_completeness(
+        &mut self,
+        handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
+    ) {
+        self.completeness = Some(handle);
     }
 
     /// Settle a finished background teardown and replace the provisional
@@ -633,7 +661,13 @@ impl Module for VppOffloadModule {
             ));
         }
         let paths = bringup::AttachPaths::live(&self.state_dir, default_hugepage_bytes());
-        let attached = match bringup::bring_up(&self.cfg, &paths, source, &self.allowlist.get()) {
+        let attached = match bringup::bring_up(
+            &self.cfg,
+            &paths,
+            source,
+            &self.allowlist.get(),
+            self.completeness.clone(),
+        ) {
             Ok(a) => a,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
         };
@@ -1183,6 +1217,7 @@ mod tests {
             vpp_binary: None,
             expected_routes: routes,
             hugepages: None,
+            require_table_complete: true,
         }
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -207,17 +207,20 @@ pub trait Steering {
     fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet);
 }
 
-/// A steering seam that refuses both directions.
+/// A steering seam that refuses both directions. **Tests only.**
 ///
-/// Used where no port asks to steer, and by tests. `steer` refusing is
-/// obvious. `unsteer` refusing is the half that matters: `Ok` from
-/// unsteer becomes `Event::Unsteered`, which clears `steered` and
-/// unblocks `ReleaseResources` — so a stand-in that faked success would
-/// let the supervisor release a VF that MCAM rules from a previous run
-/// might still be pointing traffic at. Refusing keeps `steered` true
-/// and the VF withheld, which is the designed behaviour for "rules
-/// exist that we cannot manage". A config with every port `steer off`
-/// never reaches either path.
+/// `bring_up` constructs a [`crate::ntuple::NtupleSteering`]
+/// unconditionally — a config with every port `steer off` gets one with
+/// an empty port list, not this — so nothing in production reaches it.
+/// It is kept because it encodes the rule every stand-in must follow,
+/// and a test double that got this wrong would prove the opposite of
+/// what it claims: `steer` refusing is obvious, but `unsteer` refusing
+/// is the half that matters. `Ok` from unsteer becomes
+/// `Event::Unsteered`, which clears `steered` and unblocks
+/// `ReleaseResources` — so faking success releases a VF that MCAM rules
+/// from a previous run might still be pointing traffic at. Refusing
+/// keeps `steered` true and the VF withheld, which is the designed
+/// behaviour for "rules exist that we cannot manage".
 #[derive(Debug, Default)]
 pub struct SteeringUnavailable;
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -263,6 +263,13 @@ struct Core {
     /// (an observed exit is a fact whether or not it can be recorded).
     /// Surfaced for status; never blocks the loop.
     last_store_error: Option<String>,
+    /// The completeness gate: may traffic be diverted into the mirror
+    /// yet?
+    ///
+    /// `None` when `require-table-complete off` — the deployment has no
+    /// authority to compare against (the shadow has no bird of its own)
+    /// and the operator owns the judgement instead.
+    completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
     /// Why the last drain failed, or `None` if the last one succeeded.
     ///
     /// Recorded here rather than left to the caller because the caller
@@ -302,6 +309,7 @@ impl Runtime {
     ) -> Self {
         Self {
             core: Rc::new(RefCell::new(Core {
+                completeness: None,
                 engine,
                 process: None,
                 source,
@@ -341,6 +349,21 @@ impl Runtime {
         c.process = Some(p);
         c.attach_mode = crate::attach::AttachMode::Adopted;
         c.engine.set_steered(steered);
+    }
+
+    /// Require the route mirror to be confirmed converged before any
+    /// steer installs rules.
+    ///
+    /// Set by the attach wiring when `require-table-complete on` (the
+    /// default). Left unset, [`Effects::steer`] does not consult
+    /// completeness at all — which is the honest shape for a deployment
+    /// with no authority to compare against, and is a config decision
+    /// rather than an inference.
+    pub fn require_table_complete(
+        &self,
+        handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
+    ) {
+        self.core.borrow_mut().completeness = Some(handle);
     }
 
     /// Point steering at a new set of ports and rules.
@@ -653,6 +676,34 @@ impl Effects for EffectsView {
 
     fn steer(&mut self) -> Result<(), String> {
         let mut c = self.core.borrow_mut();
+        // The completeness gate, HERE rather than at either caller.
+        //
+        // Two paths reach a steer: the operator's `reconfigure`, and the
+        // supervisor's automatic re-steer once a replacement verifies.
+        // The second is the one that would have been missed — the
+        // fast-path's mirror rebuilds from bird after a daemon restart,
+        // so a VPP that comes back up while the dump is still arriving
+        // re-steers into a table missing most of its prefixes. Gating
+        // the operator path alone would leave exactly that door open, so
+        // the check sits at the single point both go through.
+        //
+        // Refusing is cheap and self-correcting: it becomes
+        // `SteerFailed`, which leaves `steer_wanted` set, so the next
+        // verify retries — and by then the dump has usually finished. No
+        // rules are installed, so `rules_remain` is unaffected.
+        if let Some(handle) = &c.completeness {
+            let verdict = handle.verdict();
+            if !verdict.permits_steering() {
+                return Err(format!(
+                    "refusing to steer: {}. Traffic would be diverted into a table that \
+                     cannot forward it, and a steered miss is dropped rather than falling \
+                     back to the kernel path. This retries on its own once the mirror \
+                     converges; `require-table-complete off` opts out where there is no \
+                     bird to compare against",
+                    verdict.describe()
+                ));
+            }
+        }
         let outcome = c.steering.steer();
         c.record_steering();
         outcome
@@ -1138,5 +1189,94 @@ mod tests {
         );
         // And only once.
         assert_eq!(obs.poll_exit(), None);
+    }
+
+    /// A steer into a mirror that is still loading is refused.
+    ///
+    /// The gate sits in `steer()` rather than at either caller, and this
+    /// is why: the operator's `reconfigure` is the obvious path, but the
+    /// supervisor also re-steers automatically once a replacement
+    /// verifies — and after a daemon restart the fast-path's mirror is
+    /// rebuilding from bird, so that automatic path can divert traffic
+    /// into a table missing most of its prefixes. One check, both paths.
+    #[test]
+    fn a_steer_into_a_loading_mirror_is_refused() {
+        use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024)], true)),
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let handle = std::sync::Arc::new(TableCompleteness::new());
+        rt.require_table_complete(handle.clone());
+
+        let (_, mut fx) = rt.views();
+        // Nothing published yet: unknown is not permission.
+        let e = fx.steer().expect_err("must refuse without a verdict");
+        assert!(e.contains("refusing to steer"), "{e}");
+        assert!(
+            e.contains("require-table-complete off"),
+            "the message must name the way out, or an operator with no bird is stuck: {e}"
+        );
+
+        // Still loading.
+        handle.publish(CompletenessReport {
+            authority_routes: 1_000_000,
+            mirror_routes: 300_000,
+            at: std::time::Instant::now(),
+        });
+        let e = fx.steer().expect_err("must refuse a partial mirror");
+        assert!(e.contains("300000") && e.contains("1000000"), "{e}");
+
+        // And NOTHING was installed on either refusal — the refusal is
+        // before the NIC, so a later retry starts clean.
+        assert!(
+            rt.core.borrow().steering.installed().is_empty(),
+            "a refused steer must not have touched the NIC"
+        );
+
+        // Converged: the same call now goes through.
+        handle.publish(CompletenessReport {
+            authority_routes: 1_000_000,
+            mirror_routes: 999_000,
+            at: std::time::Instant::now(),
+        });
+        fx.steer().expect("a converged mirror permits steering");
+        assert_eq!(rt.core.borrow().steering.installed().len(), 1);
+    }
+
+    /// Without the handle the gate does not exist at all.
+    ///
+    /// `require-table-complete off` is a deployment with no authority to
+    /// compare against — the shadow has no bird of its own. That is a
+    /// config decision, not an inference: `bring_up` refuses `on` with
+    /// nothing publishing, so this state is only ever reached
+    /// deliberately.
+    #[test]
+    fn an_unset_gate_does_not_block_steering() {
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024)], true)),
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let (_, mut fx) = rt.views();
+        fx.steer().expect("no gate configured, no gate applied");
     }
 }

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -136,6 +136,10 @@ impl Host {
             vpp_binary: Some(self.vpp_binary.to_string_lossy().into_owned()),
             expected_routes: 1_600_000,
             hugepages: None,
+            // These fixtures have no route authority to compare
+            // against, and none of them steers; the gate is exercised
+            // where it lives, in `runtime`.
+            require_table_complete: false,
         }
     }
 
@@ -162,7 +166,7 @@ fn a_fresh_attach_acquires_renders_and_supervises() {
     );
     let cfg = host.cfg(&[("eth4", 1, false), ("eth5", 1, false)]);
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("bring-up");
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("bring-up");
 
     // --- The core map: workers off the top, main below them, cpu0 and
     // the isolated cpu12 untouched.
@@ -273,7 +277,7 @@ fn a_config_that_cannot_work_touches_nothing() {
     // More workers than there are usable CPUs (18 online, cpu0 and cpu12
     // excluded ⇒ 16 usable, so 16 workers plus a main thread cannot fit).
     let mut cfg = host.cfg(&[("eth4", 16, false)]);
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
         .err()
         .expect("must fail");
     assert!(e.contains("usable CPU"), "{e}");
@@ -281,7 +285,7 @@ fn a_config_that_cannot_work_touches_nothing() {
     // A VPP binary that is not there.
     cfg = host.cfg(&[("eth4", 1, false)]);
     cfg.vpp_binary = Some(host.base.join("no-such-vpp").to_string_lossy().into_owned());
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
         .err()
         .expect("must fail");
     assert!(e.contains("does not exist"), "{e}");
@@ -294,7 +298,7 @@ fn a_config_that_cannot_work_touches_nothing() {
     fs::write(&unexecutable, "not really vpp").unwrap();
     fs::set_permissions(&unexecutable, fs::Permissions::from_mode(0o644)).unwrap();
     cfg.vpp_binary = Some(unexecutable.to_string_lossy().into_owned());
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
         .err()
         .expect("must fail");
     assert!(e.contains("is not executable"), "{e}");
@@ -341,7 +345,7 @@ fn a_failure_after_acquisition_releases_what_it_took() {
     fs::create_dir_all(&host.paths.startup_conf).unwrap();
 
     let cfg = host.cfg(&[("eth4", 1, false)]);
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
         .err()
         .expect("must fail");
     assert!(e.contains("conf-is-a-dir"), "{e}");
@@ -443,7 +447,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         addr: [0x26, 0x02, 0xf7, 0xd8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         prefix_len: 48,
     }];
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &v6_only)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &v6_only, None)
         .err()
         .expect("steer on with nothing steerable must be refused");
     assert!(e.contains("no steerable"), "{e}");
@@ -462,7 +466,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
     // And the SAME config with a steerable allowlist is accepted, so the
     // refusal is about having nothing to steer rather than about `steer
     // on` still being unimplemented.
-    let ok = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW);
+    let ok = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None);
     assert!(
         ok.is_ok(),
         "a steerable allowlist must now be accepted: {:?}",
@@ -491,7 +495,8 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
     // releases and removes the state file, and dropping deliberately does not
     // tear down (that is preserve-on-exit, §8.5), so the record survives —
     // which is exactly the situation a daemon restart finds.
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("first attach");
+    let attached =
+        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink that
@@ -513,7 +518,7 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
     state.vpp_boot_id = None; // the third leg is missing
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW)
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
         .err()
         .expect("an unverifiable identity must refuse");
     assert!(e.contains("4242"), "the pid must be named: {e}");
@@ -557,7 +562,8 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
     );
     let cfg = host.cfg(&[("eth4", 1, false)]);
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("first attach");
+    let attached =
+        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink
@@ -581,7 +587,8 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
     state.vpp_boot_id = None;
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("second attach");
+    let attached =
+        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("second attach");
     drop(attached);
 
     let after = host.state().expect("state file");
@@ -612,7 +619,8 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
     let host = Host::new("ledger", &[("eth4", "0002:07:00.0")], fake.path.clone());
     let cfg = host.cfg(&[("eth4", 1, false)]);
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("first attach");
+    let attached =
+        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink
@@ -631,7 +639,7 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
     state.steer_rules = vec![("eth4".into(), vec![1024])];
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW).expect("attach");
+    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("attach");
     let report = attached.service.stop();
     let published = report
         .published
@@ -647,5 +655,39 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
     assert!(
         host.state().is_some(),
         "and the state file must survive, or nothing can find the rules later"
+    );
+}
+
+/// `require-table-complete on` with nothing publishing completeness is
+/// refused at attach.
+///
+/// The gate would never pass — every steer declined with "no check has
+/// run yet" — so the operator would be debugging a rollout that cannot
+/// proceed. Better to say it once, at the point the configuration is
+/// read, and name both ways out.
+#[test]
+fn requiring_completeness_with_no_publisher_is_refused_at_attach() {
+    let fake = fake_vpp::Fake::start("bringup-complete");
+    let host = Host::new("complete", &[("eth4", "0002:07:00.0")], fake.path.clone());
+    let mut cfg = host.cfg(&[("eth4", 1, false)]);
+    cfg.require_table_complete = true;
+
+    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
+        .err()
+        .expect("must refuse");
+    assert!(e.contains("require-table-complete"), "{e}");
+    assert!(
+        e.contains("refused forever"),
+        "the consequence has to be stated, not just the condition: {e}"
+    );
+    assert!(
+        e.contains("bird") && e.contains("off"),
+        "and both ways out named: {e}"
+    );
+    // Nothing was acquired: this is a pure-phase refusal, so a config
+    // typo costs no sysfs writes.
+    assert!(
+        host.state().is_none(),
+        "a config refusal must not have touched the box"
     );
 }

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -250,8 +250,8 @@ Traffic returns to the eBPF fast-path. Membership stays, the FIB stays
 synced, VPP keeps running — you land on rung 0, which is a state you
 have already soaked.
 
-This path is deliberately robust in one specific way: an allowlist that
-has outgrown the MCAM budget **does not block it**. The budget check
+One thing about this path is deliberate: an allowlist that has outgrown
+the MCAM budget does not block it. The budget check
 only applies when rules are about to be installed, because `unsteer`
 removes what the ledger names and never consults the plan. An allowlist
 growing past the budget is a plausible route to wanting exactly this

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -197,6 +197,13 @@ including the step whose purpose is to get traffic *off* a bad VPP.
 **Rung 0 — membership, everything off.** Every fast-path attach port
 gets a `port` line; every one is `steer off`.
 
+Before anything else, know which side of `require-table-complete` you are
+on. On a box with its own bird, leave it `on` (the default) and the first
+steer waits until the mirror is confirmed converged. On a box without one
+— the shadow — attach will **refuse to start** with `on`, because the gate
+could never pass; set `off` there and the completeness judgement is yours,
+which in practice means reading the route counts before you turn a lever.
+
 ```bash
 packetframe reconfigure /etc/packetframe/packetframe.conf
 ```
@@ -286,6 +293,30 @@ If the NIC *has* the rules and traffic still is not arriving, suspect
 keyword mis-encodes it on the rvu driver, so a rule installed by hand
 with that keyword lands somewhere else. Gate 0a established this by
 inserting both forms and reading back what the NIC stored.
+
+### A steer is refused with "the route mirror holds N of M routes"
+
+The completeness gate. bird's initial dump has not finished, so the
+mirror is short of the table and steering into it would blackhole
+whatever has not arrived — and a steered miss is dropped, where an
+unsteered one falls through to the kernel path.
+
+Nothing to do: it retries on its own. The refusal leaves the *want* set,
+so the next verify attempts the steer again, and by then the dump has
+usually finished. Watch the two counts converge:
+
+```bash
+birdc show route count
+packetframe status /etc/packetframe/packetframe.conf | grep -A6 'module health'
+```
+
+If it persists, the mirror is genuinely not keeping up and that is a
+fast-path problem, not a steering one — check the integrity checker's
+drift warnings in the log.
+
+Refusals reading **"completeness is unknown"** or **"too old to act on"**
+mean something different: no check has run, or the last one is over 15
+minutes old. That is `birdc` failing, not the table being incomplete.
 
 ### `packetframe_vpp_routes{state="unresolvable"} > 0`
 
@@ -428,11 +459,13 @@ refused rather than adopted.
 - **MCAM slots must be pre-allocated.** The driver rejects an
   out-of-range `loc` rather than assigning one, which is why this module
   tracks the locations it owns (base 1024) and hands back exactly those.
-- **The first steer is not guarded against an *incomplete* table.**
-  Verification samples what the ledger holds, so a table that is merely
-  missing prefixes verifies clean. the `unresolvable`, `withheld` and
-  `installing` route counts must all read zero before you turn the first lever —
-  which is what rung 0's soak is for. Closing this in code needs a
-  completeness signal the module does not have; bird's own route count,
-  which the fast-path integrity checker already fetches, is the
-  candidate.
+- **The first steer is guarded against an incomplete table — but only
+  where there is a bird.** Verification samples what the *ledger* holds,
+  so a table that is merely missing prefixes verifies clean. That is why
+  the guard is a separate comparison against bird's own route count,
+  published by the fast-path integrity checker and consulted by every
+  steer, not by the verify. Where no publisher exists,
+  `require-table-complete off` hands the judgement back to you, and rung
+  0's soak is what discharges it: the `unresolvable`, `withheld` and
+  `installing` counts must all read zero before you turn the first
+  lever.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -184,34 +184,36 @@ vppctl -s /run/packetframe/vpp/api.sock show threads
 
 ## The canary ladder
 
-Traffic moves when *you* say so. The module never steers a first attach
-on its own, and — since #128 — a `reconfigure` that did not move the
-`steer` flag will not either, so editing an unrelated line cannot divert
-traffic as a side effect.
+Traffic moves only when you say so. The module never steers on a first
+attach, and a reconfigure that did not change a `steer` flag will not
+either, so editing an unrelated line cannot divert traffic by accident.
 
-Each rung is a `steer` edit plus a SIGHUP. **No restart, no resync**:
-that is the whole point of `reconfigure` handling this, because a
-restart would cost ~40 s of resync with the offload down at every step —
-including the step whose purpose is to get traffic *off* a bad VPP.
+Each rung is a `steer` edit plus a SIGHUP. There is no restart and no
+resync: a restart would cost about 40 seconds with the offload down at
+every step, including the step meant to get traffic off a bad VPP
+quickly.
 
 **Rung 0 — membership, everything off.** Every fast-path attach port
 gets a `port` line; every one is `steer off`.
 
-Before anything else, know which side of `require-table-complete` you are
-on. On a box with its own bird, leave it `on` (the default) and the first
-steer waits until the mirror is confirmed converged. On a box without one
-— the shadow — attach will **refuse to start** with `on`, because the gate
-could never pass; set `off` there and the completeness judgement is yours,
-which in practice means reading the route counts before you turn a lever.
+Decide `require-table-complete` first. On a box running its own bird,
+leave it `on` (the default); the first steer then waits until the route
+mirror matches bird's route count. On a box without a local bird, attach
+refuses to start with `on`, because the check could never pass. Set it
+`off` there and compare the counts yourself before turning a lever:
+`packetframe status` reports how many routes are installed, and
+`birdc show route count` on the box running bird says how many there
+should be.
 
 ```bash
 packetframe reconfigure /etc/packetframe/packetframe.conf
 ```
 
-Wait for `fib-synced healthy` and `routes_unresolvable 0`. Soak here —
+Wait for `fib-synced healthy` and for
+`packetframe_vpp_routes{state="unresolvable"}` to read 0. Soak here for
 at least an hour, and through a udapi provision cycle if one is due.
-This state is safe by construction: VPP is up, its FIB is synced and
-verified, and not one packet is diverted.
+Nothing is diverted in this state: VPP is up, its FIB is synced and
+verified, and every packet is still on the XDP path.
 
 **Rung 1 — one port.** Flip the least important port to `steer on`,
 SIGHUP, and confirm:
@@ -445,8 +447,8 @@ refused rather than adopted.
 
 - **`packetframe feasibility` does not attach anything.** It used to,
   via `--config`, on every configured port — including the native-XDP
-  attach that panics this fleet. Fixed in #124; if you are on an older
-  build, do not run it against a live config.
+  attach that panics this fleet. Fixed in v0.2.7; on an older build, do
+  not run it against a live config.
 - **`reconfigure` accepts only the `steer` flag.** `port`, `cores`,
   `expected-routes`, `hugepages` and `vpp-binary` are all fixed at VPP's
   start or at VF acquisition, and each is refused **by name** with what


### PR DESCRIPTION
The last hole the canary ladder was papering over, and the only code item left before shadow testing.

## The problem

Readback verification samples what the **ledger** holds, so a table that is merely *missing prefixes* verifies clean. Steering into it blackholes whatever hasn't arrived — and that's worse than not steering, because an unsteered miss falls through to the kernel path while a steered one is dropped by VPP.

The case is bird's initial dump. Until now the only guard was a line in the runbook.

## The signal already existed

The fast-path's integrity checker compares its mirror against `birdc show route count` every five minutes for drift warnings. The number was there; it just had no second consumer. It now republishes each comparison into a shared `TableCompleteness` handle that the loader gives to both tiers — same wiring as the route feed and the allowlist.

## Where the gate sits

**In `Effects::steer`, not at either caller.** Two paths reach a steer: the operator's `reconfigure`, and the supervisor's automatic re-steer once a replacement verifies. The second is the one that would have been missed — after a daemon restart the mirror rebuilds from bird, so a VPP coming back up mid-dump re-steers into a table missing most of its prefixes. Gating the operator path alone leaves that door open.

Refusing is cheap and self-correcting: it becomes `SteerFailed`, which leaves `steer_wanted` set, so the next verify retries. No rules are installed, so `rules_remain` is unaffected.

## Two judgements

**The threshold is its own constant**, not the integrity checker's warn threshold, even though both start at 1%. They answer different questions and will diverge the moment either is tuned. What this one separates is "the dump is still arriving" (tens of percent) from converged-with-churn — so a modest value does the job. A gate that fires during normal operation is a gate operators turn off.

**Absent is not permission.** No report, a zero-route authority, or a report older than 15 minutes all refuse. "I could not establish this" read as "there is no constraint" is the shape that produced this subsystem's worst bugs.

## The escape hatch, and why it's config

`require-table-complete off` is for deployments with no authority to compare against — **the shadow has no bird of its own**, so it needs this to test at all. It's a config decision rather than an inference: `on` (the default) with nothing publishing is refused **at attach**, because the gate could never pass and the operator would otherwise be debugging a rollout that cannot proceed.

## One bug caught while writing it

The integrity snapshot's count fields are **sticky** — a failed `birdc` or `mirror_counts` leaves the previous run's number in place. That's right for a drift display and wrong as the basis of a steering decision: publishing from them would mix one fresh number with one five minutes old. The report is built from this run's results or not published at all.

## Testing

9 new tests. The rule (`assess`) is a pure function in `common`, so the whole policy — still-loading, ordinary churn, absent, zero-authority, stale — is tested without a bird, a VPP or a NIC. The gate itself is tested in `runtime`, including that a refusal never touches the NIC, and the attach-time refusal in `vpp_bringup`. Verified by reverting the gate and watching the test fail.

Gates: fmt, host clippy, `cargo test --workspace --all-features`, per-target `--workspace --all-targets` clippy on all four published triples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)