### PR TITLE
fix: three defects found turning on the first steer

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -709,6 +709,28 @@ fn reconfigure_from_signal(
         }
     };
 
+    // The membership invariant, on THIS path as well as at startup.
+    //
+    // `run` validates before attaching, and that used to be the only
+    // check — which left the guard enforced on the path nobody uses to
+    // turn steering on, and absent from the one the rollout actually
+    // follows. The canary ladder is `steer off` everywhere, then flip
+    // one port and SIGHUP. Without this, that flip diverts traffic while
+    // other egress ports have no `port` line, and every destination
+    // whose best path leaves through one of them is blackholed: exactly
+    // the failure the rule was written for, reached through the
+    // documented procedure.
+    //
+    // A refusal here changes nothing. The daemon keeps running the
+    // configuration it already had, and the operator gets the reason
+    // from `packetframe reconfigure` — which is the right outcome for a
+    // config that would have diverted traffic into a hole.
+    if let Err(e) = new_config.validate_vpp_offload() {
+        tracing::error!(error = %e, "SIGHUP config is unsafe to apply; keeping current config");
+        write_reconfigure_marker(&marker_path, &format!("ERR validate: {e}"));
+        return;
+    }
+
     // Before the module loop, and for the WHOLE config rather than per
     // module. vpp-offload's steering target is derived from fast-path's
     // `allow-prefix` lines, which its own `ModuleConfig` does not

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -987,7 +987,19 @@ fn parse_reconfigure_marker(body: &str) -> Result<(), ReconfigureError> {
         let _ = rest;
         Ok(())
     } else if let Some(rest) = trimmed.strip_prefix("ERR ") {
-        Err(ReconfigureError::DaemonRejected(rest.to_string()))
+        // Drop the trailing nanosecond stamp the writer appends. Without
+        // this every rejection an operator reads ends in a 19-digit
+        // number glued to the last word of the sentence, which reads as
+        // part of the diagnostic — observed on the first real reconfigure
+        // refusal. Only stripped when the tail actually is a number, so a
+        // truncated or hand-edited marker still shows what it holds.
+        let message = match rest.rsplit_once(' ') {
+            Some((head, tail)) if !head.is_empty() && tail.chars().all(|c| c.is_ascii_digit()) => {
+                head
+            }
+            _ => rest,
+        };
+        Err(ReconfigureError::DaemonRejected(message.to_string()))
     } else {
         // Marker exists but doesn't match the expected format.
         Err(ReconfigureError::Io(format!(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -212,7 +212,51 @@ fn parse_mode(s: &str) -> Result<packetframe_probe::AttachMode, String> {
     }
 }
 
+/// Put SIGPIPE back to the kernel default before anything prints.
+///
+/// Rust ignores SIGPIPE at startup, so a write to a closed pipe returns
+/// EPIPE and `println!` panics on it. That turns `packetframe status |
+/// head` — an entirely ordinary thing for an operator to type — into:
+///
+/// ```text
+/// thread 'main' panicked at library/std/src/io/stdio.rs:
+/// failed printing to stdout: Broken pipe (os error 32)
+/// ```
+///
+/// which reads like packetframe broke rather than like `head` having
+/// seen enough. Observed on the shadow during the first bring-up, on a
+/// command whose output an operator was trying to trim.
+///
+/// The default disposition kills the process silently, which is what
+/// every other Unix tool does and what the shell expects. `run` inherits
+/// the same behaviour: a daemon whose stdout reader goes away now exits
+/// on the signal instead of panicking, which is the better of the two —
+/// and it cannot fire spuriously, since SIGPIPE needs the read end
+/// actually closed. Under systemd stdout is the journal socket and the
+/// case does not arise at all.
+///
+/// Not unit-tested: the behaviour is a process-level signal disposition,
+/// and any test that could observe it would be re-testing libc. It is
+/// verified the way it was found — by piping the output into `head`.
+///
+/// Gated on Linux rather than on `unix` because that is where `libc` is
+/// a dependency of this crate, and where the daemon runs. A macOS dev
+/// build keeps the panic; nobody operates a router from one.
+#[cfg(target_os = "linux")]
+fn restore_default_sigpipe() {
+    // SAFETY: `signal` with SIG_DFL on SIGPIPE is async-signal-safe and
+    // runs before any thread is spawned.
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn restore_default_sigpipe() {}
+
 fn main() -> ExitCode {
+    restore_default_sigpipe();
+
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         // Default: info from our crates, plus suppress one upstream
         // noise source. `bgpkit_parser::parser::bgp::messages`

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -4287,4 +4287,47 @@ module fast-path
         let v = extract_mss_clamps(&m);
         assert_eq!(v[0].2, 65495);
     }
+
+    /// The membership rule must hold for a config arriving by SIGHUP,
+    /// not only one arriving at startup.
+    ///
+    /// This is the shape the rollout actually takes: start with every
+    /// port `steer off` (always valid, membership-only), then flip one
+    /// port on and reload. If only startup validates, that flip is
+    /// unchecked — and it is the exact moment traffic starts being
+    /// diverted, with other egress ports possibly having no `port` line
+    /// at all.
+    ///
+    /// Asserted on the *config* rather than through the signal handler
+    /// because the handler needs a live daemon; what has to be true is
+    /// that the same predicate rejects the same file, whichever door it
+    /// comes through.
+    #[test]
+    fn the_membership_rule_rejects_a_steer_on_reload_too() {
+        // The staging state the ladder starts from: two attached ports,
+        // both members, neither steering.
+        let staged = "module fast-path\n  attach eth4 generic\n  attach eth5 generic\n  \
+                      forwarding-mode custom-fib\n\n\
+                      module vpp-offload\n  port eth4 cores 1 steer off\n  \
+                      port eth5 cores 1 steer off\n  expected-routes 100\n";
+        Config::parse(staged)
+            .unwrap()
+            .validate_vpp_offload()
+            .expect("all-steer-off is the designed staging state");
+
+        // The rollout's first rung, with one member quietly missing.
+        // Startup would refuse this; so must a reload.
+        let rung_one = "module fast-path\n  attach eth4 generic\n  attach eth5 generic\n  \
+                        forwarding-mode custom-fib\n\n\
+                        module vpp-offload\n  port eth5 cores 1 steer on\n  \
+                        expected-routes 100\n";
+        let e = Config::parse(rung_one)
+            .unwrap()
+            .validate_vpp_offload()
+            .expect_err("eth4 has no port line while eth5 steers");
+        assert!(
+            format!("{e}").contains("eth4"),
+            "the refusal must name the uncovered port: {e}"
+        );
+    }
 }

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -211,6 +211,16 @@ pub enum Completeness {
         authority: u64,
         mirror: u64,
     },
+    /// The mirror holds substantially MORE than the authority claims.
+    ///
+    /// Not a loading state, and not a drift figure worth printing — it
+    /// means the thing being asked is not the thing feeding us. Seen on
+    /// first contact: the box had a local `birdc` answering for its own
+    /// near-empty bird while the table arrived from a different router,
+    /// and the "% short" arithmetic reported 6852510%. Steering is still
+    /// refused — an authority we cannot trust is no basis for diverting
+    /// traffic — but the reason has to say which problem it is.
+    AuthorityMismatch { authority: u64, mirror: u64 },
     /// There is a report, but it is too old to act on.
     Stale { age: std::time::Duration },
     /// No report at all, or none that supports a judgement.
@@ -244,6 +254,12 @@ impl Completeness {
                 "the route mirror holds {mirror} of the authority's {authority} routes \
                  ({:.2}% short) — it is probably still loading",
                 drift * 100.0
+            ),
+            Completeness::AuthorityMismatch { authority, mirror } => format!(
+                "the route mirror holds {mirror} routes but the authority reports only \
+                 {authority} — that is not the authority feeding this mirror. Check which \
+                 bird `birdc` is talking to; on a box whose routes come from elsewhere, \
+                 `require-table-complete off` is the right answer"
             ),
             Completeness::Stale { age } => format!(
                 "the last completeness check was {}s ago, too old to act on",
@@ -280,13 +296,23 @@ pub fn assess(
         };
     };
     if drift <= max_drift {
-        Completeness::Converged { drift }
-    } else {
-        Completeness::Incomplete {
-            drift,
+        return Completeness::Converged { drift };
+    }
+    // Which side is short decides which problem this is, and they lead
+    // somewhere different. Short of the authority is a mirror still
+    // loading — wait. Larger than the authority cannot be a loading
+    // state at all; it means the authority is not the one feeding this
+    // mirror, and no amount of waiting fixes it.
+    if r.mirror_routes > r.authority_routes {
+        return Completeness::AuthorityMismatch {
             authority: r.authority_routes,
             mirror: r.mirror_routes,
-        }
+        };
+    }
+    Completeness::Incomplete {
+        drift,
+        authority: r.authority_routes,
+        mirror: r.mirror_routes,
     }
 }
 
@@ -681,6 +707,41 @@ mod tests {
                 !h.verdict().permits_steering(),
                 "the newest report is the verdict"
             );
+        }
+
+        /// A mirror LARGER than the authority is not a loading state.
+        ///
+        /// This is what the shadow produced on first contact: a local
+        /// `birdc` answering for a near-empty bird while the table
+        /// arrived from a different router. The old arithmetic called it
+        /// "6852510% short — probably still loading", which is the exact
+        /// opposite of what was wrong and sends an operator to wait for
+        /// something that will never happen.
+        #[test]
+        fn a_mirror_larger_than_the_authority_names_the_right_problem() {
+            let v = verdict(Some(report(19, 1_301_996, Duration::ZERO)));
+            assert!(!v.permits_steering());
+            assert!(matches!(v, Completeness::AuthorityMismatch { .. }), "{v:?}");
+            let msg = v.describe();
+            assert!(
+                msg.contains("not the authority feeding this mirror"),
+                "the operator must be told it is the wrong authority, not a slow one: {msg}"
+            );
+            assert!(
+                !msg.contains("short") && !msg.contains("loading"),
+                "and must NOT be told to wait: {msg}"
+            );
+        }
+
+        /// A mirror trivially ahead of the authority is still converged.
+        ///
+        /// Routes arrive between the two counts, so the mirror leading by
+        /// a hair is ordinary churn. Only a gap past the drift threshold
+        /// means the authority is wrong.
+        #[test]
+        fn a_mirror_a_hair_ahead_is_still_converged() {
+            let v = verdict(Some(report(1_000_000, 1_000_500, Duration::ZERO)));
+            assert!(v.permits_steering(), "{v:?}");
         }
     }
 }

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -102,6 +102,23 @@ pub struct Attached {
     pub adopted_process: bool,
 }
 
+/// Which completeness handle the runtime should actually gate on.
+///
+/// A named function rather than an inline `if` because the bug it fixes
+/// was an inline nothing: the directive was parsed, refused against, and
+/// never consulted where it decided anything. One place, one rule,
+/// testable without a NIC.
+fn completeness_gate(
+    cfg: &VppOffloadConfig,
+    handle: Option<Arc<packetframe_common::fib::TableCompleteness>>,
+) -> Option<Arc<packetframe_common::fib::TableCompleteness>> {
+    if cfg.require_table_complete {
+        handle
+    } else {
+        None
+    }
+}
+
 /// Acquire, render, adopt-or-arm, and start supervising.
 ///
 /// On any failure after acquisition, everything acquired is released
@@ -129,6 +146,17 @@ pub fn bring_up(
                 .into(),
         );
     }
+    // `off` means off.
+    //
+    // The loader builds a completeness handle whenever both modules are
+    // configured and hands it over unconditionally — it has no view of
+    // this directive. So dropping it HERE is the only thing that makes
+    // `require-table-complete off` mean anything. Without this the
+    // directive was read, validated against above, and then ignored: the
+    // gate ran on every deployment, including the ones that set it off
+    // precisely because they have no authority worth comparing to.
+    let completeness = completeness_gate(cfg, completeness);
+
     // --- Everything pure first. A config that cannot work must cost no
     // sysfs writes; the alternative is a rollback path exercised by
     // ordinary operator typos.
@@ -593,4 +621,44 @@ fn finish(
         acquired,
         adopted_process,
     })
+}
+
+/// `require-table-complete off` must actually turn the gate off.
+///
+/// The loader hands over a completeness handle whenever both modules are
+/// configured — it has no view of this directive — so the module is the
+/// only thing that can honour it. Before this, the directive was parsed,
+/// refused against when no publisher existed, and then ignored: the gate
+/// ran on every deployment, including the ones that set it off precisely
+/// because their `birdc` answers for the wrong bird. Found on the shadow,
+/// where `off` was set and the steer was refused anyway.
+#[cfg(test)]
+mod completeness_gate_tests {
+    use super::*;
+
+    fn cfg(require: bool) -> VppOffloadConfig {
+        VppOffloadConfig {
+            ports: vec![("eth1".into(), 1, false)],
+            vpp_binary: None,
+            expected_routes: 1_600_000,
+            hugepages: None,
+            require_table_complete: require,
+        }
+    }
+
+    #[test]
+    fn off_drops_the_handle_and_on_keeps_it() {
+        let handle = Arc::new(packetframe_common::fib::TableCompleteness::new());
+
+        assert!(
+            completeness_gate(&cfg(false), Some(handle.clone())).is_none(),
+            "`off` must drop the handle, or the directive decides nothing"
+        );
+        assert!(
+            completeness_gate(&cfg(true), Some(handle)).is_some(),
+            "`on` must keep it"
+        );
+        // And nothing invents a gate that was never handed over.
+        assert!(completeness_gate(&cfg(true), None).is_none());
+    }
 }


### PR DESCRIPTION
All three surfaced on the shadow, from one refusal:

```
Steer: refusing to steer: the route mirror holds 1301996 of the authority's 19
routes (6852510.53% short) — it is probably still loading [...] 1785970084356950720
```

## 1. SIGHUP never enforced the membership rule

`validate_vpp_offload` ran in `run` and nowhere else. The rule it enforces — no ingress is steered until every possible egress port is a VPP member — was checked on the path nobody uses to turn steering on, and absent from the one the rollout follows.

The canary ladder is: bring everything up `steer off` (always valid, membership-only is legal), then flip one port and reload. Step two was unchecked, so an operator following the documented procedure could divert traffic while other egress ports had no `port` line, blackholing every destination whose best path leaves through one of them.

Now validated before anything is applied. A refusal costs nothing — the daemon keeps the config it had, and the reason comes back through `packetframe reconfigure`.

`validate_interfaces` is deliberately not added: attach-set changes are restart-only and already skipped on this path, so failing a reload over an absent interface would reject a config whose interface changes were never going to apply.

## 2. `require-table-complete off` was ignored

The shadow's config had it off. The gate fired anyway.

The loader builds a completeness handle whenever both modules are configured — it has no view of the directive — and `bring_up` wired that handle into the runtime unconditionally. So the flag was parsed, refused against when no publisher existed, and then never consulted where it decided anything.

That only bites the `off` case, which is exactly the deployments that set it because their local `birdc` answers for the wrong bird. The decision now lives in one named function with a test, because the bug it fixes was an inline nothing.

## 3. A mirror *larger* than the authority reported as "still loading"

The drift arithmetic divides by the authority's count, so 19 against 1,301,996 came out as 6852510% short. It isn't short, it isn't loading, and waiting will never fix it — the box was asking its own near-empty bird while the table arrived from a different router.

That is now its own verdict with its own message, pointing at which bird `birdc` is talking to. A mirror a hair ahead is still converged: routes arrive between the two counts and that's ordinary churn.

## Also

The reconfigure marker is written `"{status} {nanos}"` and the ERR branch returned everything after `ERR `, so every rejection an operator reads ended in a 19-digit number glued to the last word. Stripped only when the tail really is digits.

## Testing

Five new tests. The membership rule as the two rungs of the ladder; the gate honouring `off` and `on`; the wrong-authority verdict naming the right problem and *not* telling the operator to wait; a mirror slightly ahead still converging.

Gates: fmt, host clippy, `cargo test --workspace --all-features`, per-target clippy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)