### PR TITLE
fix(vpp-offload): two defects the first steer against a NIC found

### DIFF
--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -130,6 +130,7 @@ pub fn bring_up(
     source: Box<dyn RouteSource + Send + Sync>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
+    budget: &McamBudget,
 ) -> Result<Attached, String> {
     // `require-table-complete on` with nothing publishing completeness
     // is refused at attach rather than discovered at the first canary
@@ -177,17 +178,38 @@ pub fn bring_up(
     // that overruns the MCAM budget rather than truncating it: a
     // partially steered port divides traffic between the two forwarding
     // tiers along a line nobody chose.
-    let steer_plan = RuleSet::plan(allowlist, McamBudget::default())?;
+    //
+    // Built only when something steers, for the same reason
+    // `steering_target` does it that way: `plan` refuses an allowlist
+    // that overruns the budget, and the budget is now the NIC's real 16
+    // slots rather than an imagined 512. Planning unconditionally would
+    // make an allowlist of more than eight v4 prefixes refuse to *attach*
+    // — on a config whose ports are all `steer off`, where no rule would
+    // ever be installed and the refusal decides nothing.
     let wants_steer = cfg.ports.iter().any(|(_, _, steer)| *steer);
-    if wants_steer && steer_plan.rules.is_empty() {
-        return Err(format!(
-            "port(s) are configured `steer on`, but the allowlist produces no steerable \
-             rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected by this NIC). \
-             Steering would divert nothing while reporting Healthy; set the ports \
-             `steer off` or give fast-path a v4 `allow-prefix`",
-            steer_plan.skipped_v6
-        ));
-    }
+    let steer_plan = if wants_steer {
+        // An allowlist with nothing steerable in it is a config error,
+        // and settling that needs no NIC — so it is settled BEFORE the
+        // table query. Otherwise the operator's answer is whatever the
+        // ioctl said (on a down port, `EOPNOTSUPP`), which names the
+        // wrong problem entirely.
+        let steerable = allowlist
+            .iter()
+            .filter(|p| matches!(p, packetframe_common::fib::IpPrefix::V4 { .. }))
+            .count();
+        if steerable == 0 {
+            return Err(format!(
+                "port(s) are configured `steer on`, but the allowlist produces no steerable \
+                 rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected by this NIC). \
+                 Steering would divert nothing while reporting Healthy; set the ports \
+                 `steer off` or give fast-path a v4 `allow-prefix`",
+                allowlist.len() - steerable
+            ));
+        }
+        RuleSet::plan(allowlist, budget.clone())?
+    } else {
+        RuleSet::default()
+    };
 
     // Only the ports the operator asked to steer. `steer off` is the
     // designed staging state and the rollback landing zone, so a port

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -193,10 +193,7 @@ pub fn bring_up(
         // table query. Otherwise the operator's answer is whatever the
         // ioctl said (on a down port, `EOPNOTSUPP`), which names the
         // wrong problem entirely.
-        let steerable = allowlist
-            .iter()
-            .filter(|p| matches!(p, packetframe_common::fib::IpPrefix::V4 { .. }))
-            .count();
+        let steerable = crate::steer::steerable_count(allowlist);
         if steerable == 0 {
             return Err(format!(
                 "port(s) are configured `steer on`, but the allowlist produces no steerable \

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -240,6 +240,36 @@ impl SharedAllowlist {
     }
 }
 
+/// Which interfaces `attach` should ask for their ntuple table.
+///
+/// Every steering port — unless the allowlist holds nothing this NIC can
+/// steer, in which case: none.
+///
+/// The exception is the whole point. `bring_up` refuses an unsteerable
+/// allowlist on the config alone, deliberately *before* any ioctl, so an
+/// operator who wrote `steer on` against a v6-only allowlist reads about
+/// their allowlist. Querying every steering port here regardless moved
+/// the NIC read one layer out and back in front of that refusal, so on
+/// an administratively-down port the answer became `EOPNOTSUPP` — a true
+/// statement about the wrong problem. Found in review on #132; the
+/// ordering `bring_up`'s own comment promises is only real if this
+/// function honours it.
+///
+/// A named function, so the rule is testable without a NIC.
+fn ifaces_to_query<'a>(
+    cfg: &'a VppOffloadConfig,
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Vec<&'a str> {
+    if steer::steerable_count(allowlist) == 0 {
+        return Vec::new();
+    }
+    cfg.ports
+        .iter()
+        .filter(|(_, _, steer)| *steer)
+        .map(|(iface, _, _)| iface.as_str())
+        .collect()
+}
+
 /// What steering should look like for a config + allowlist.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SteeringTarget {
@@ -666,13 +696,8 @@ impl Module for VppOffloadModule {
         // keeps its pure phase pure: planning slots is arithmetic, and
         // which slots exist is an environment read like every other one
         // this function performs before delegating.
-        let budget = match steer::McamBudget::for_ifaces(
-            self.cfg
-                .ports
-                .iter()
-                .filter(|(_, _, steer)| *steer)
-                .map(|(iface, _, _)| iface.as_str()),
-        ) {
+        let allowlist = self.allowlist.get();
+        let budget = match steer::McamBudget::for_ifaces(ifaces_to_query(&self.cfg, &allowlist)) {
             Ok(b) => b,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
         };
@@ -680,7 +705,7 @@ impl Module for VppOffloadModule {
             &self.cfg,
             &paths,
             source,
-            &self.allowlist.get(),
+            &allowlist,
             self.completeness.clone(),
             &budget,
         ) {
@@ -959,6 +984,44 @@ mod tests {
             last_failures: Vec::new(),
             store_error: None,
         }
+    }
+
+    /// `attach` asks no NIC when the allowlist has nothing steerable.
+    ///
+    /// The ordering is the assertion. `bring_up` refuses an unsteerable
+    /// allowlist on the config alone, deliberately ahead of any ioctl, so
+    /// that an operator who wrote `steer on` against a v6-only allowlist
+    /// reads about their allowlist rather than about `EOPNOTSUPP` from a
+    /// port that happens to be down. Querying unconditionally here put
+    /// the NIC read back in front of that refusal — found in review, and
+    /// invisible to every other test because both paths still refuse.
+    #[test]
+    fn nothing_steerable_means_no_nic_is_asked() {
+        let cfg = VppOffloadConfig {
+            ports: vec![("eth4".into(), 1, true), ("eth5".into(), 1, false)],
+            ..VppOffloadConfig::default()
+        };
+        let v6_only = [packetframe_common::fib::IpPrefix::V6 {
+            addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            prefix_len: 32,
+        }];
+        assert!(
+            ifaces_to_query(&cfg, &v6_only).is_empty(),
+            "a v6-only allowlist is a config error; asking a NIC first answers the wrong question"
+        );
+        assert!(
+            ifaces_to_query(&cfg, &[]).is_empty(),
+            "and so is an empty one"
+        );
+
+        // With something steerable, only the steering ports are asked —
+        // `steer off` is the staging state and installs nothing, so its
+        // table is not a constraint on the plan.
+        let v4 = [packetframe_common::fib::IpPrefix::V4 {
+            addr: [10, 88, 1, 0],
+            prefix_len: 24,
+        }];
+        assert_eq!(ifaces_to_query(&cfg, &v4), vec!["eth4"]);
     }
 
     /// An unattached module orchestrates nothing, and says so honestly

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -286,7 +286,8 @@ fn steering_target(
             want_steer: false,
         });
     }
-    let plan = steer::RuleSet::plan(allowlist, steer::McamBudget::default())?;
+    let budget = steer::McamBudget::for_ifaces(ports.iter().map(|(iface, _)| iface.as_str()))?;
+    let plan = steer::RuleSet::plan(allowlist, budget)?;
     // `steer on` with nothing steerable is refused for the same reason
     // `bring_up` refuses it: steering would divert nothing while every
     // surface reported it on.
@@ -661,12 +662,27 @@ impl Module for VppOffloadModule {
             ));
         }
         let paths = bringup::AttachPaths::live(&self.state_dir, default_hugepage_bytes());
+        // The NIC is asked here rather than inside `bring_up`, which
+        // keeps its pure phase pure: planning slots is arithmetic, and
+        // which slots exist is an environment read like every other one
+        // this function performs before delegating.
+        let budget = match steer::McamBudget::for_ifaces(
+            self.cfg
+                .ports
+                .iter()
+                .filter(|(_, _, steer)| *steer)
+                .map(|(iface, _, _)| iface.as_str()),
+        ) {
+            Ok(b) => b,
+            Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
+        };
         let attached = match bringup::bring_up(
             &self.cfg,
             &paths,
             source,
             &self.allowlist.get(),
             self.completeness.clone(),
+            &budget,
         ) {
             Ok(a) => a,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -45,6 +45,35 @@ const ETHTOOL_GRXCLSRULE: u32 = 0x0000_002f;
 /// not mention protocols at all.
 const IP_USER_FLOW: u32 = 0x0d;
 
+/// The table size assumed where there is no interface to ask.
+///
+/// Measured on the EFG's `rvu-nicpf` on 2026-08-05: locations 0..=15 are
+/// accepted and 16 upward are rejected. Reached only by
+/// [`crate::steer::McamBudget::default`] — tests and the non-Linux stub.
+/// Production goes through [`rule_table`], because a constant is exactly
+/// what put `base: 1024` in this file.
+pub const FALLBACK_TABLE_SIZE: u32 = 16;
+
+/// The `loc` space one interface actually offers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuleTable {
+    /// Locations run `0..size`. From the driver, not from us.
+    pub size: u32,
+    /// Locations already holding a rule — anyone's, not just ours.
+    pub occupied: Vec<u32>,
+}
+
+/// Ask `iface` how big its ntuple table is and what already sits in it.
+///
+/// The one number that governs a `loc`, read from the thing that
+/// enforces it. Note the failure mode this replaces is not a wrong
+/// answer but a plausible one: `npc/mcam_info` reports a real, correct,
+/// entirely different quantity, and nothing about reading it feels like
+/// a guess.
+pub fn rule_table(iface: &str) -> Result<RuleTable, String> {
+    sys::rule_table(iface)
+}
+
 /// `union ethtool_flow_union` — sized by its `hdata[52]` member.
 #[repr(C)]
 #[derive(Clone, Copy)]
@@ -88,10 +117,14 @@ const _: () = assert!(core::mem::size_of::<RxFlowSpec>() == 168);
 
 /// `struct ethtool_rxnfc`, up to and including `rule_cnt`.
 ///
-/// The trailing `rule_locs[0]` is only read by `GRXCLSRLALL`, which this
-/// module does not use — it tracks the locations it installed rather
-/// than asking the NIC to enumerate them, because a location we did not
-/// choose is one teardown cannot account for.
+/// Enough for every command that names a single rule. `GRXCLSRLALL`
+/// needs the trailing `rule_locs[]` as well and uses its own struct in
+/// `sys`, because appending an array to this one lands it four bytes
+/// past where the kernel writes.
+///
+/// Teardown still removes only the locations the ledger records — a slot
+/// this module did not choose is one it cannot account for — so the
+/// enumeration feeds slot *selection*, never removal.
 #[repr(C)]
 #[derive(Clone, Copy, Default)]
 struct Rxnfc {
@@ -136,18 +169,39 @@ pub fn mask_for(prefix_len: u8) -> u32 {
 /// Build the flow spec for one rule. Split out so the encoding is
 /// testable without a NIC — every field the NIC matches on is decided
 /// here.
+///
+/// **A set bit in `m_u` means IGNORE**, which is the opposite of the
+/// reading this function was first written to. Two consequences, and the
+/// first is the one that made every insert fail:
+///
+/// - `m_u` must start all-ones. Left zeroed — the obvious "I only set
+///   what I match" default — it asks the NIC to match every field in the
+///   union exactly against `h_u`, which is all zeros: source address
+///   `0.0.0.0`, protocol 0, TOS 0, `l4_4_bytes` 0. The driver rejects
+///   that outright, which is how this surfaced.
+/// - The address mask is the **complement** of the netmask. A /24 is
+///   `0.0.0.255` — ignore the host bits — not `255.255.255.0`, which
+///   ignores the network and matches the host.
+///
+/// Both were confirmed against the NIC on 2026-08-05 by inserting via
+/// `ethtool -N` and reading the rule back: a rule naming only a
+/// destination reports `Src IP addr: 0.0.0.0 mask: 255.255.255.255`,
+/// `Protocol: 0 mask: 0xff`, and its own `Dest IP addr: 10.88.1.0 mask:
+/// 0.0.0.255`.
 fn flow_spec(rule: &SteerRule, vf_index: u32) -> RxFlowSpec {
     let mut fs = RxFlowSpec {
         flow_type: IP_USER_FLOW,
         ring_cookie: ring_cookie(vf_index),
         location: rule.location,
+        // Ignore everything, then un-ignore the bits this rule matches.
+        m_u: FlowUnion { hdata: [0xff; 52] },
         ..RxFlowSpec::default()
     };
     // `ethtool_usrip4_spec` lays out as ip4src, ip4dst, l4_4_bytes, tos,
     // ip_ver, proto — so the two addresses are the first eight bytes of
     // the union, in network order.
     let addr = rule.prefix.octets();
-    let mask = mask_for(rule.prefix_len).to_be_bytes();
+    let mask = (!mask_for(rule.prefix_len)).to_be_bytes();
     let (addr_off, mask_off) = match rule.side {
         Side::Src => (0, 0),
         Side::Dst => (4, 4),
@@ -174,7 +228,69 @@ fn matches(asked: &RxFlowSpec, got: &RxFlowSpec) -> bool {
 
 #[cfg(all(target_os = "linux", not(test)))]
 mod sys {
-    use super::Rxnfc;
+    use super::{RuleTable, RxFlowSpec, Rxnfc};
+
+    /// `ETHTOOL_GRXCLSRLALL` — enumerate installed locations, and report
+    /// how many the table holds. Lives here rather than beside the other
+    /// command codes because it is the only one whose buffer is
+    /// variable-length, and `RxnfcAll` below is why.
+    const ETHTOOL_GRXCLSRLALL: u32 = 0x0000_0030;
+
+    /// The most locations one query will enumerate.
+    ///
+    /// Four times the measured table, so a NIC with a larger one still
+    /// answers rather than failing with `EMSGSIZE`; if a driver ever
+    /// holds more rules than this the query fails loudly rather than
+    /// returning a short list, which would make occupied slots look
+    /// free.
+    const MAX_ENUMERATED_RULES: usize = 64;
+
+    /// `struct ethtool_rxnfc` **with its trailing `rule_locs[]`**.
+    ///
+    /// Written flat rather than as `{ Rxnfc, [u32; N] }` because that
+    /// nesting is wrong in a way that compiles: `Rxnfc` ends on a `u32`
+    /// at offset 184 but carries 8-byte alignment from its `data` field,
+    /// so `size_of` rounds it to 192 and the array would start four
+    /// bytes past where the kernel writes. The offset assertion below is
+    /// the check, not the layout comment.
+    #[repr(C)]
+    struct RxnfcAll {
+        cmd: u32,
+        flow_type: u32,
+        data: u64,
+        fs: RxFlowSpec,
+        rule_cnt: u32,
+        rule_locs: [u32; MAX_ENUMERATED_RULES],
+    }
+
+    const _: () = assert!(core::mem::offset_of!(RxnfcAll, rule_locs) == 188);
+
+    pub(in crate::ntuple) fn rule_table(iface: &str) -> Result<RuleTable, String> {
+        let mut all = RxnfcAll {
+            cmd: ETHTOOL_GRXCLSRLALL,
+            flow_type: 0,
+            data: 0,
+            fs: RxFlowSpec::default(),
+            // The capacity of `rule_locs`, which the kernel uses to size
+            // its own buffer and to bound what it copies back.
+            rule_cnt: MAX_ENUMERATED_RULES as u32,
+            rule_locs: [0; MAX_ENUMERATED_RULES],
+        };
+        // SAFETY: the pointer covers the whole `RxnfcAll`, which is what
+        // the kernel writes through for `GRXCLSRLALL`.
+        unsafe { ethtool_raw(iface, (&mut all as *mut RxnfcAll).cast()) }.map_err(|e| {
+            format!(
+                "reading the ntuple rule table of {iface}: {e}. A port that is administratively \
+                 down answers EOPNOTSUPP here — `otx2_get_rxnfc` gates on `netif_running` — which \
+                 reads like the NIC lacks the feature rather than like the link being down"
+            )
+        })?;
+        let count = (all.rule_cnt as usize).min(MAX_ENUMERATED_RULES);
+        Ok(RuleTable {
+            size: all.data as u32,
+            occupied: all.rule_locs[..count].to_vec(),
+        })
+    }
 
     /// `SIOCETHTOOL`, the ioctl every ethtool command rides. Lives here
     /// rather than beside the `ETHTOOL_*` command codes because it is the
@@ -189,6 +305,16 @@ mod sys {
     /// operation; the kernel reads and writes through the pointer for
     /// the lifetime of the call only.
     pub(super) fn ethtool(iface: &str, req: &mut Rxnfc) -> Result<(), String> {
+        // SAFETY: the pointer covers a fully initialised `Rxnfc`, which
+        // is the whole buffer for every command except `GRXCLSRLALL`.
+        unsafe { ethtool_raw(iface, (req as *mut Rxnfc).cast()) }
+    }
+
+    /// # Safety
+    /// `req` must point at a fully initialised `ethtool_rxnfc`-shaped
+    /// buffer large enough for whatever its `cmd` makes the kernel write
+    /// — for `GRXCLSRLALL` that includes the trailing `rule_locs[]`.
+    unsafe fn ethtool_raw(iface: &str, req: *mut core::ffi::c_void) -> Result<(), String> {
         let name = iface.as_bytes();
         let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
         if name.len() >= ifr.ifr_name.len() {
@@ -197,7 +323,7 @@ mod sys {
         for (dst, src) in ifr.ifr_name.iter_mut().zip(name) {
             *dst = *src as libc::c_char;
         }
-        ifr.ifr_ifru.ifru_data = req as *mut Rxnfc as *mut libc::c_char;
+        ifr.ifr_ifru.ifru_data = req as *mut libc::c_char;
 
         let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
         if sock < 0 {
@@ -224,8 +350,11 @@ mod sys {
 
 #[cfg(all(not(target_os = "linux"), not(test)))]
 mod sys {
-    use super::Rxnfc;
+    use super::{RuleTable, Rxnfc};
     pub(super) fn ethtool(_iface: &str, _req: &mut Rxnfc) -> Result<(), String> {
+        Err("ntuple steering is Linux-only".into())
+    }
+    pub(in crate::ntuple) fn rule_table(_iface: &str) -> Result<RuleTable, String> {
         Err("ntuple steering is Linux-only".into())
     }
 }
@@ -253,7 +382,6 @@ pub(super) mod sys {
     use std::cell::RefCell;
     use std::collections::HashMap;
 
-    #[derive(Default)]
     pub(crate) struct FakeNic {
         rules: HashMap<(String, u32), super::RxFlowSpec>,
         /// Locations whose delete must fail, modelling the rule that
@@ -262,6 +390,21 @@ pub(super) mod sys {
         /// Locations whose insert must fail, modelling a full or
         /// otherwise refusing MCAM.
         uninsertable: Vec<u32>,
+        /// How many locations this fake offers. Defaults to the measured
+        /// hardware size rather than to zero, so a test that forgets to
+        /// set it gets a plausible NIC instead of one with no table.
+        table_size: u32,
+    }
+
+    impl Default for FakeNic {
+        fn default() -> Self {
+            Self {
+                rules: HashMap::new(),
+                undeletable: Vec::new(),
+                uninsertable: Vec::new(),
+                table_size: super::FALLBACK_TABLE_SIZE,
+            }
+        }
     }
 
     thread_local! {
@@ -281,6 +424,33 @@ pub(super) mod sys {
 
     pub(crate) fn wedge_insert(locations: &[u32]) {
         NIC.with(|n| n.borrow_mut().uninsertable = locations.to_vec());
+    }
+
+    pub(crate) fn set_table_size(size: u32) {
+        NIC.with(|n| n.borrow_mut().table_size = size);
+    }
+
+    /// The fake's answer to `GRXCLSRLALL`.
+    ///
+    /// Note what this cannot stand in for: the real one reads a size the
+    /// *driver* chose, and the whole defect it exists to prevent was a
+    /// number this codebase chose for itself. A test using this proves
+    /// the budget arithmetic, never the size.
+    pub(in crate::ntuple) fn rule_table(iface: &str) -> Result<super::RuleTable, String> {
+        NIC.with(|n| {
+            let nic = n.borrow();
+            let mut occupied: Vec<u32> = nic
+                .rules
+                .keys()
+                .filter(|(i, _)| i == iface)
+                .map(|(_, loc)| *loc)
+                .collect();
+            occupied.sort_unstable();
+            Ok(super::RuleTable {
+                size: nic.table_size,
+                occupied,
+            })
+        })
     }
 
     /// Every `(iface, loc)` the NIC currently holds, sorted — the
@@ -627,9 +797,34 @@ mod tests {
         );
 
         // And the mask follows the address, or the rule matches a
-        // different width than intended.
-        assert_eq!(&src.m_u.hdata[0..4], &[255, 255, 255, 0]);
-        assert_eq!(&dst.m_u.hdata[4..8], &[255, 255, 255, 0]);
+        // different width than intended. A SET bit means ignore, so a
+        // /24 is the complement of the netmask — asserted as the literal
+        // the NIC reports rather than as `!mask_for(24)`, which would
+        // pass against either polarity.
+        assert_eq!(&src.m_u.hdata[0..4], &[0, 0, 0, 255], "ip4src /24");
+        assert_eq!(&dst.m_u.hdata[4..8], &[0, 0, 0, 255], "ip4dst /24");
+
+        // Everything this rule does NOT match must be ignored, which is
+        // all-ones. Left at the struct default of zero it reads as
+        // "match exactly", and the driver refuses the whole rule — the
+        // defect that made every insert fail with EINVAL. Checked across
+        // the rest of the union, not just the sibling address, because
+        // `usr_ip4_spec` also carries tos, proto and l4_4_bytes.
+        assert_eq!(
+            &src.m_u.hdata[4..],
+            &[0xff; 48][..],
+            "a src rule ignores ip4dst and every other field"
+        );
+        assert_eq!(
+            &dst.m_u.hdata[0..4],
+            &[0xff, 0xff, 0xff, 0xff],
+            "a dst rule ignores ip4src"
+        );
+        assert_eq!(
+            &dst.m_u.hdata[8..],
+            &[0xff; 44][..],
+            "a dst rule ignores tos, proto and l4_4_bytes"
+        );
     }
 
     /// The readback comparison must reject the differences that change
@@ -650,7 +845,7 @@ mod tests {
             |f: &mut RxFlowSpec| f.location = 99,
             |f: &mut RxFlowSpec| f.flow_type = 0x01,
             |f: &mut RxFlowSpec| f.h_u.hdata[0] = 24,
-            |f: &mut RxFlowSpec| f.m_u.hdata[3] = 0xff,
+            |f: &mut RxFlowSpec| f.m_u.hdata[3] = 0x00,
         ] {
             let mut got = asked;
             mutate(&mut got);
@@ -659,6 +854,71 @@ mod tests {
                 "a difference that changes forwarding must be caught"
             );
         }
+    }
+
+    /// Slots come from the NIC's table, and occupied ones are not slots.
+    ///
+    /// The defect this replaces was a budget that named locations the
+    /// driver would never accept, so the assertions are about the budget
+    /// *tracking the table* rather than about any particular number: a
+    /// test pinning 16 would pass just as well against a second
+    /// hardcoded constant.
+    #[test]
+    fn the_budget_follows_the_nic_rather_than_a_constant() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+
+        let empty = McamBudget::for_ifaces(["eth0"]).expect("fake NIC answers");
+        assert_eq!(
+            empty.free.len(),
+            FALLBACK_TABLE_SIZE as usize,
+            "an untouched table offers every location"
+        );
+        assert_eq!(
+            empty.free.first(),
+            Some(&(FALLBACK_TABLE_SIZE - 1)),
+            "highest first, to stay clear of whatever the vendor installs low"
+        );
+
+        // A smaller table yields a smaller budget, with no code change.
+        sys::set_table_size(4);
+        let small = McamBudget::for_ifaces(["eth0"]).expect("fake NIC answers");
+        assert_eq!(small.free, vec![3, 2, 1, 0]);
+
+        // And an allowlist that no longer fits is refused whole rather
+        // than truncated into a half-steered port.
+        let e = RuleSet::plan(
+            &[
+                IpPrefix::V4 {
+                    addr: [10, 0, 0, 0],
+                    prefix_len: 24,
+                },
+                IpPrefix::V4 {
+                    addr: [10, 1, 0, 0],
+                    prefix_len: 24,
+                },
+                IpPrefix::V4 {
+                    addr: [10, 2, 0, 0],
+                    prefix_len: 24,
+                },
+            ],
+            small,
+        )
+        .expect_err("six rules cannot fit four slots");
+        assert!(e.contains("only 4 slot(s) are free"), "{e}");
+
+        // Rules already in the table are excluded, not overwritten —
+        // including ones this module did not install.
+        sys::set_table_size(FALLBACK_TABLE_SIZE);
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        s.steer().expect("installs at 15 and 14");
+        let after = McamBudget::for_ifaces(["eth0"]).expect("fake NIC answers");
+        assert!(
+            !after.free.contains(&15) && !after.free.contains(&14),
+            "occupied slots must not be offered again: {:?}",
+            after.free
+        );
+        assert_eq!(after.free.first(), Some(&13), "the next free one is next");
     }
 
     /// A plan with no rules refuses rather than reporting success.
@@ -765,14 +1025,17 @@ mod tests {
         s.steer().expect("installs");
         assert_eq!(
             sys::rules(),
-            vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
+            vec![("eth0".to_string(), 14), ("eth0".to_string(), 15)],
             "both directions, in the planned slots"
         );
-        assert_eq!(
-            s.installed(),
-            sys::rules(),
-            "the ledger names what the NIC holds"
-        );
+        // Sorted on both sides: the ledger is a SET (that is #127's
+        // fix), so it holds no order worth asserting, and slots are now
+        // taken highest-first — comparing raw would test the direction
+        // the budget hands out locations rather than the property that
+        // matters, which is that the two name the same rules.
+        let mut ledger = s.installed();
+        ledger.sort();
+        assert_eq!(ledger, sys::rules(), "the ledger names what the NIC holds");
 
         s.unsteer().expect("removes");
         assert!(sys::rules().is_empty(), "nothing left in the NIC");
@@ -829,16 +1092,18 @@ mod tests {
         s.steer().expect("installs four");
         assert_eq!(sys::rules().len(), 4);
 
-        // Down to one prefix: slots 1026/1027 are no longer wanted.
+        // Down to one prefix: slots 13/12 are no longer wanted.
         s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
         s.steer().expect("reconciles");
 
         assert_eq!(
             sys::rules(),
-            vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
+            vec![("eth0".to_string(), 14), ("eth0".to_string(), 15)],
             "the withdrawn prefix's rules are gone from the NIC, not merely unrecorded"
         );
-        assert_eq!(s.installed(), sys::rules());
+        let mut ledger = s.installed();
+        ledger.sort();
+        assert_eq!(ledger, sys::rules());
     }
 
     /// A retarget that cannot clear a stale rule installs NOTHING.
@@ -858,7 +1123,7 @@ mod tests {
         );
         s.steer().expect("installs four");
 
-        sys::wedge_delete(&[1026]);
+        sys::wedge_delete(&[13]);
         s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
         let e = s.steer().expect_err("must refuse");
 
@@ -867,7 +1132,7 @@ mod tests {
             "the operator has to learn both halves: what stayed, and that nothing new landed: {e}"
         );
         assert!(
-            s.installed().contains(&("eth0".to_string(), 1026)),
+            s.installed().contains(&("eth0".to_string(), 13)),
             "the rule that would not come out must stay in the ledger, or detach cannot find it"
         );
     }
@@ -877,14 +1142,14 @@ mod tests {
     ///
     /// All-or-nothing is the point: a port holding half its rules
     /// forwards some allowlisted traffic through VPP and the rest
-    /// through the kernel. Slot 1027 — the last of four — is made to
+    /// through the kernel. Slot 12 — the last of four — is made to
     /// refuse, so three rules are already in the NIC when the failure
     /// lands.
     #[test]
     fn a_failed_insert_leaves_the_port_unsteered() {
         use crate::runtime::Steering as _;
         sys::reset();
-        sys::wedge_insert(&[1027]);
+        sys::wedge_insert(&[12]);
         let mut s = NtupleSteering::new(
             vec![("eth0".into(), 0)],
             plan_for(&[[10, 0, 0, 0], [10, 1, 0, 0]]),

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -29,7 +29,7 @@ pub(crate) fn run(
     for iface in ports {
         caps.push(probe_sriov(iface));
     }
-    caps.push(probe_steering_budget(allowlist));
+    caps.push(probe_steering_budget(ports, allowlist));
     caps
 }
 
@@ -47,10 +47,24 @@ pub(crate) fn run(
 ///
 /// Read-only and non-required, like every probe here: it computes the
 /// plan the module would install, and installs nothing.
-fn probe_steering_budget(allowlist: &[packetframe_common::fib::IpPrefix]) -> Capability {
+///
+/// **The budget comes from the NIC.** This used to plan against
+/// `McamBudget::default()` and report whether the arithmetic held — a
+/// constant checked against itself, which passed while every insert the
+/// module would issue was rejected, because the constant named a slot
+/// 1008 past the end of the table. A probe whose answer cannot disagree
+/// with the code it is probing is not a probe.
+fn probe_steering_budget(
+    ports: &[String],
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Capability {
     use crate::steer::{McamBudget, RuleSet};
 
-    let budget = McamBudget::default();
+    let budget = match McamBudget::for_ifaces(ports.iter().map(String::as_str)) {
+        Ok(b) => b,
+        Err(e) => return Capability::fail("vpp.steering.budget", e, false),
+    };
+    let free = budget.free.len();
     match RuleSet::plan(allowlist, budget) {
         // Nothing to steer is a FAIL however it arose. The two ways there
         // read very differently to an operator, so they are named
@@ -76,11 +90,10 @@ fn probe_steering_budget(allowlist: &[packetframe_common::fib::IpPrefix]) -> Cap
         ),
         Ok(set) => {
             let detail = format!(
-                "{} rule(s) for {} steerable prefix(es), budget {} from slot {}{}",
+                "{} rule(s) for {} steerable prefix(es); the NIC reports {} free slot(s){}",
                 set.rules.len(),
                 set.rules.len() / 2,
-                budget.count,
-                budget.base,
+                free,
                 if set.skipped_v6 > 0 {
                     format!(
                         "; {} IPv6 prefix(es) NOT steerable on this NIC and left on the \
@@ -255,7 +268,10 @@ mod steering_probe_tests {
     /// to declare an allowlist when a port asks to steer.
     #[test]
     fn an_allowlist_that_steers_nothing_never_passes() {
-        let empty = probe_steering_budget(&[]);
+        // No ports: `for_ifaces` asks no NIC and yields the fallback
+        // budget, so these stay tests of the ALLOWLIST logic — which is
+        // what they were always about — on a host that has no rvu NIC.
+        let empty = probe_steering_budget(&[], &[]);
         assert_eq!(empty.status, CapabilityStatus::Fail, "{empty:?}");
         assert!(
             empty.detail.contains("allowlist is empty"),
@@ -263,10 +279,13 @@ mod steering_probe_tests {
             empty.detail
         );
 
-        let v6_only = probe_steering_budget(&[IpPrefix::V6 {
-            addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            prefix_len: 32,
-        }]);
+        let v6_only = probe_steering_budget(
+            &[],
+            &[IpPrefix::V6 {
+                addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                prefix_len: 32,
+            }],
+        );
         assert_eq!(v6_only.status, CapabilityStatus::Fail, "{v6_only:?}");
         assert!(
             v6_only.detail.contains("IPv6"),
@@ -276,7 +295,7 @@ mod steering_probe_tests {
 
         // A steerable prefix passes, so the failures above are about
         // having nothing to steer rather than the probe always failing.
-        let ok = probe_steering_budget(&[v4(0, 24)]);
+        let ok = probe_steering_budget(&[], &[v4(0, 24)]);
         assert_eq!(ok.status, CapabilityStatus::Pass, "{ok:?}");
     }
 }

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -177,6 +177,22 @@ impl Default for McamBudget {
 /// Source and destination — see [`RuleSet::plan`] for why both.
 const RULES_PER_PREFIX: usize = 2;
 
+/// How many prefixes in `allowlist` this NIC could steer at all.
+///
+/// v4 only: `ip6` ntuple is rejected by this NIC's AF, so a v6 prefix
+/// consumes no slot and cannot be diverted.
+///
+/// A named function because two callers need the answer and one of them
+/// needs it *before* touching a NIC: whether there is anything to steer
+/// is a property of the config, and settling it first is what keeps an
+/// unsteerable allowlist from being reported as an ioctl failure.
+pub fn steerable_count(allowlist: &[IpPrefix]) -> usize {
+    allowlist
+        .iter()
+        .filter(|p| matches!(p, IpPrefix::V4 { .. }))
+        .count()
+}
+
 impl RuleSet {
     /// Decide the rules for one port.
     ///

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -18,11 +18,18 @@
 //! reading back what the NIC actually stored. Nothing about the uapi
 //! documents it.
 //!
-//! **`loc` must be an allocated slot.** The driver rejects an
-//! out-of-range location rather than assigning one, so this module
-//! tracks the locations it owns and hands back exactly those. The
-//! reference NIC has 2048 MCAM entries with ~1689 free, so the budget
-//! is real but not tight at allowlist scale.
+//! **`loc` must be an allocated slot, and there are sixteen.** The
+//! driver rejects an out-of-range location rather than assigning one, so
+//! this module tracks the locations it owns and hands back exactly
+//! those. The size comes from the NIC via `ETHTOOL_GRXCLSRLALL` — see
+//! [`McamBudget::for_ifaces`] — because this file previously asserted it
+//! instead, from `npc/mcam_info`'s "2048 entries, 1689 available". Those
+//! figures are real and describe the NPC block across all six PFs; they
+//! have never governed an ethtool `loc`, which on this hardware runs
+//! `0..=15` per port. At two rules per prefix that is a ceiling of
+//! **eight steerable IPv4 prefixes per port**, which is tight at
+//! allowlist scale and is the opposite of what this paragraph used to
+//! say.
 //!
 //! ## v4 only, by probe rather than by choice
 //!
@@ -85,7 +92,7 @@ pub struct RuleSet {
     pub skipped_v6: u32,
 }
 
-/// How many MCAM slots a port may use.
+/// Which MCAM slots a port may use, in the order they should be taken.
 ///
 /// A budget rather than a constant because the NIC's table is shared —
 /// UniFi's own rules live in it too — and overrunning it fails the
@@ -93,23 +100,76 @@ pub struct RuleSet {
 /// steered port: some allowlisted traffic diverted to VPP, the rest on
 /// the kernel path. That is not a degraded version of steering, it is a
 /// different forwarding policy than either tier was configured for.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+///
+/// **A list of locations rather than a base and a count**, because the
+/// previous shape could not express the two things that actually govern
+/// it: which slots exist, and which are already taken. It carried
+/// `base: 1024, count: 512`, reasoned from `npc/mcam_info` reporting
+/// 2048 entries with 1689 available — figures that describe the NPC
+/// block across all six PFs and have never governed an ethtool `loc`.
+/// The real per-port space on this NIC is **0..=15**, so the first rule
+/// the module ever tried to install was 1008 slots past the end and the
+/// driver rejected it with `EINVAL`. See [`McamBudget::from_table`],
+/// which asks the NIC instead of asserting.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct McamBudget {
-    /// First slot this module may use.
-    pub base: u32,
-    /// How many consecutive slots from `base`.
-    pub count: u32,
+    /// Locations this module may use, most-preferred first.
+    pub free: Vec<u32>,
+}
+
+impl McamBudget {
+    /// Take the free locations, highest first.
+    ///
+    /// Highest-first preserves the intent behind the old `base: 1024` —
+    /// keep clear of whatever the vendor installs, without enumerating
+    /// it, since the UniFi controller rewrites classifier state on every
+    /// push. That reasoning was sound; only its arithmetic was wrong.
+    /// Occupied slots are excluded outright rather than merely avoided,
+    /// so a vendor rule appearing between `feasibility` and a steer
+    /// costs a refusal instead of an overwrite.
+    pub fn from_table(table: &crate::ntuple::RuleTable) -> Self {
+        let free = (0..table.size)
+            .rev()
+            .filter(|loc| !table.occupied.contains(loc))
+            .collect();
+        Self { free }
+    }
+
+    /// The slots usable across *every* port that will steer.
+    ///
+    /// The intersection, not the first port's answer. One plan is
+    /// installed on all of them at the same locations, so a slot free on
+    /// eth4 and taken on eth5 is not a slot — and finding that out at
+    /// insert time would leave a partially steered port, which is the
+    /// one outcome [`RuleSet::plan`] exists to prevent.
+    pub fn for_ifaces<'a>(ifaces: impl IntoIterator<Item = &'a str>) -> Result<Self, String> {
+        let mut budget: Option<Self> = None;
+        for iface in ifaces {
+            let next = Self::from_table(&crate::ntuple::rule_table(iface)?);
+            budget = Some(match budget {
+                None => next,
+                Some(prev) => Self {
+                    free: prev
+                        .free
+                        .into_iter()
+                        .filter(|loc| next.free.contains(loc))
+                        .collect(),
+                },
+            });
+        }
+        // No steering ports means no NIC was asked and none will be
+        // written; the caller is building a plan it will not install.
+        Ok(budget.unwrap_or_default())
+    }
 }
 
 impl Default for McamBudget {
     fn default() -> Self {
-        // Measured on the reference NIC: 2048 entries, ~1689 free, and
-        // UniFi's own rules sit low. Starting at 1024 keeps this module
-        // clear of them without needing to enumerate what the vendor
-        // installed — which changes under us on every controller push.
+        // The measured size of an empty table on this NIC, used only
+        // where there is no interface to ask — tests, and the non-Linux
+        // stub. Every production path goes through `from_table`.
         Self {
-            base: 1024,
-            count: 512,
+            free: (0..crate::ntuple::FALLBACK_TABLE_SIZE).rev().collect(),
         }
     }
 }
@@ -146,13 +206,16 @@ impl RuleSet {
         let skipped_v6 = (allowlist.len() - steerable.len()) as u32;
         let needed = steerable.len() * RULES_PER_PREFIX;
 
-        if needed > budget.count as usize {
+        if needed > budget.free.len() {
             return Err(format!(
-                "the allowlist needs {needed} MCAM rule(s) ({} steerable prefix(es) × {}                  directions) but the budget allows {} from slot {}; steering part of the                  allowlist would split it across both forwarding tiers, so none is installed",
+                "the allowlist needs {needed} MCAM rule(s) ({} steerable prefix(es) × {} \
+                 directions) but only {} slot(s) are free on this NIC; steering part of the \
+                 allowlist would split it across both forwarding tiers, so none is installed. \
+                 The per-port ntuple table on this hardware holds 16 rules, so at two rules \
+                 per prefix the allowlist can carry at most 8 IPv4 prefixes",
                 steerable.len(),
                 RULES_PER_PREFIX,
-                budget.count,
-                budget.base
+                budget.free.len()
             ));
         }
 
@@ -163,7 +226,7 @@ impl RuleSet {
                     prefix: addr,
                     prefix_len,
                     side,
-                    location: budget.base + (i * RULES_PER_PREFIX + j) as u32,
+                    location: budget.free[i * RULES_PER_PREFIX + j],
                 });
             }
         }
@@ -211,8 +274,8 @@ mod tests {
         );
         assert_eq!(
             set.locations(),
-            vec![1024, 1025, 1026, 1027],
-            "consecutive slots from the budget's base, so teardown can find them"
+            vec![15, 14, 13, 12],
+            "the highest free slots on a 16-entry table, consecutive so teardown can find them"
         );
     }
 
@@ -232,7 +295,9 @@ mod tests {
     #[test]
     fn an_allowlist_that_exceeds_the_budget_is_refused_whole() {
         let allow: Vec<IpPrefix> = (0..4).map(|i| v4(10, i, 0, 0, 16)).collect();
-        let budget = McamBudget { base: 0, count: 5 };
+        let budget = McamBudget {
+            free: (0..5).rev().collect(),
+        };
         let e = RuleSet::plan(&allow, budget).expect_err("must refuse");
 
         assert!(
@@ -250,7 +315,13 @@ mod tests {
 
         // One more slot and the same allowlist fits, so the refusal is
         // about the budget and not about the allowlist's shape.
-        let ok = RuleSet::plan(&allow, McamBudget { base: 0, count: 8 }).expect("fits exactly");
+        let ok = RuleSet::plan(
+            &allow,
+            McamBudget {
+                free: (0..8).rev().collect(),
+            },
+        )
+        .expect("fits exactly");
         assert_eq!(ok.rules.len(), 8);
     }
 
@@ -271,7 +342,13 @@ mod tests {
                 prefix_len: 32,
             },
         ];
-        let e = RuleSet::plan(&allow, McamBudget { base: 0, count: 3 }).expect_err("must refuse");
+        let e = RuleSet::plan(
+            &allow,
+            McamBudget {
+                free: (0..3).rev().collect(),
+            },
+        )
+        .expect_err("must refuse");
         assert!(
             e.contains("needs 4 MCAM rule(s)") && e.contains("2 steerable prefix(es)"),
             "the v6 prefix is not steerable and must not inflate either number: {e}"

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -35,6 +35,7 @@ use packetframe_vpp_offload::acquire::SysPaths;
 use packetframe_vpp_offload::bringup::{bring_up, AttachPaths};
 use packetframe_vpp_offload::engine::RouteSource;
 use packetframe_vpp_offload::resources::ResourceState;
+use packetframe_vpp_offload::steer::McamBudget;
 use packetframe_vpp_offload::VppOffloadConfig;
 
 /// The allowlist steering would divert. Non-empty so the `steer on`
@@ -166,7 +167,15 @@ fn a_fresh_attach_acquires_renders_and_supervises() {
     );
     let cfg = host.cfg(&[("eth4", 1, false), ("eth5", 1, false)]);
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("bring-up");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("bring-up");
 
     // --- The core map: workers off the top, main below them, cpu0 and
     // the isolated cpu12 untouched.
@@ -277,17 +286,31 @@ fn a_config_that_cannot_work_touches_nothing() {
     // More workers than there are usable CPUs (18 online, cpu0 and cpu12
     // excluded ⇒ 16 usable, so 16 workers plus a main thread cannot fit).
     let mut cfg = host.cfg(&[("eth4", 16, false)]);
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("must fail");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must fail");
     assert!(e.contains("usable CPU"), "{e}");
 
     // A VPP binary that is not there.
     cfg = host.cfg(&[("eth4", 1, false)]);
     cfg.vpp_binary = Some(host.base.join("no-such-vpp").to_string_lossy().into_owned());
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("must fail");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must fail");
     assert!(e.contains("does not exist"), "{e}");
 
     // A VPP binary that is there but cannot be executed. Distinct from
@@ -298,9 +321,16 @@ fn a_config_that_cannot_work_touches_nothing() {
     fs::write(&unexecutable, "not really vpp").unwrap();
     fs::set_permissions(&unexecutable, fs::Permissions::from_mode(0o644)).unwrap();
     cfg.vpp_binary = Some(unexecutable.to_string_lossy().into_owned());
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("must fail");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must fail");
     assert!(e.contains("is not executable"), "{e}");
 
     // No attempt may have created a VF, a reservation, or a record.
@@ -345,9 +375,16 @@ fn a_failure_after_acquisition_releases_what_it_took() {
     fs::create_dir_all(&host.paths.startup_conf).unwrap();
 
     let cfg = host.cfg(&[("eth4", 1, false)]);
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("must fail");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must fail");
     assert!(e.contains("conf-is-a-dir"), "{e}");
     assert!(
         e.contains("was released"),
@@ -447,9 +484,16 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         addr: [0x26, 0x02, 0xf7, 0xd8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         prefix_len: 48,
     }];
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &v6_only, None)
-        .err()
-        .expect("steer on with nothing steerable must be refused");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &v6_only,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("steer on with nothing steerable must be refused");
     assert!(e.contains("no steerable"), "{e}");
     assert!(e.contains("steer off"), "and the remedy stated: {e}");
 
@@ -466,7 +510,14 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
     // And the SAME config with a steerable allowlist is accepted, so the
     // refusal is about having nothing to steer rather than about `steer
     // on` still being unimplemented.
-    let ok = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None);
+    let ok = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    );
     assert!(
         ok.is_ok(),
         "a steerable allowlist must now be accepted: {:?}",
@@ -495,8 +546,15 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
     // releases and removes the state file, and dropping deliberately does not
     // tear down (that is preserve-on-exit, §8.5), so the record survives —
     // which is exactly the situation a daemon restart finds.
-    let attached =
-        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink that
@@ -518,9 +576,16 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
     state.vpp_boot_id = None; // the third leg is missing
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("an unverifiable identity must refuse");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("an unverifiable identity must refuse");
     assert!(e.contains("4242"), "the pid must be named: {e}");
     assert!(e.contains("boot id"), "and the missing leg: {e}");
     assert!(
@@ -562,8 +627,15 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
     );
     let cfg = host.cfg(&[("eth4", 1, false)]);
 
-    let attached =
-        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink
@@ -587,8 +659,15 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
     state.vpp_boot_id = None;
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let attached =
-        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("second attach");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("second attach");
     drop(attached);
 
     let after = host.state().expect("state file");
@@ -619,8 +698,15 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
     let host = Host::new("ledger", &[("eth4", "0002:07:00.0")], fake.path.clone());
     let cfg = host.cfg(&[("eth4", 1, false)]);
 
-    let attached =
-        bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("first attach");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("first attach");
     drop(attached);
 
     // Play the kernel's part: a real bind creates the `driver` symlink
@@ -639,7 +725,15 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
     state.steer_rules = vec![("eth4".into(), vec![1024])];
     state.save(&host.paths.sys.state_dir).unwrap();
 
-    let attached = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None).expect("attach");
+    let attached = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .expect("attach");
     let report = attached.service.stop();
     let published = report
         .published
@@ -672,9 +766,16 @@ fn requiring_completeness_with_no_publisher_is_refused_at_attach() {
     let mut cfg = host.cfg(&[("eth4", 1, false)]);
     cfg.require_table_complete = true;
 
-    let e = bring_up(&cfg, &host.paths, Box::new(Mirror), &ALLOW, None)
-        .err()
-        .expect("must refuse");
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must refuse");
     assert!(e.contains("require-table-complete"), "{e}");
     assert!(
         e.contains("refused forever"),

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -18,7 +18,14 @@ running badly.
 > composition has never executed on hardware. Neither has any of the
 > three published failover numbers.
 >
-> **No part of the MCAM ioctl path has ever met a NIC.** Every rule
+> **The MCAM ioctl path has now met a NIC, and it took two rounds.**
+> First contact on 2026-08-05 found the `loc` space sized from the wrong
+> figure and `m_u` written with inverted polarity; both are fixed and
+> both failed loudly, as designed — nothing was installed, and the
+> all-or-nothing unwind left the port with zero rules. What is *still*
+> unproven is everything past installation: no steered packet has ever
+> reached VPP, because the only port available to test on carries
+> nothing the allowlist matches. Every rule
 > insert is followed by an `ETHTOOL_GRXCLSRULE` readback and compared
 > field by field, precisely so a wrong `ethtool_rx_flow_spec` offset
 > fails loudly on first contact instead of installing a rule that
@@ -382,7 +389,8 @@ Be precise about this when reasoning about an incident.
 | Stats segment | 97 B/route | **at two threads** — counter vectors are per-thread, so every per-route figure is a two-thread figure |
 | Live table | 1,053,360 v4 (1,301,000 v4+v6) | 2026-08-02 |
 | Nexthop spread | eth3 1,248,508 / eth2 52,492 | the full-table decision rests on this |
-| MCAM capacity | 2048 entries, ~1689 free | budget is base 1024, count 512 → **256 v4 prefixes** at 2 rules each |
+| ntuple `loc` space | **16 per port** (0..=15) | measured on the shadow's eth1 2026-08-05, by insert-and-read-back. At 2 rules per prefix → **8 steerable IPv4 prefixes per port**. Production's allowlist is 2. |
+| NPC MCAM block | 2048 entries, ~1689 free, 31 allocated per PF | from `npc/mcam_info`. **This is not the `loc` space** and must never be used to size one — doing so is what produced `base: 1024`, an out-of-range slot that failed the first steer this module ever attempted. |
 
 **Published but never measured:**
 
@@ -462,9 +470,25 @@ refused rather than adopted.
 - **Restart ordering is stop → detach --all → start.** This bit
   production twice. A plain `systemctl restart` leaves the previous
   attachment's pins in place and the next start refuses them.
-- **MCAM slots must be pre-allocated.** The driver rejects an
-  out-of-range `loc` rather than assigning one, which is why this module
-  tracks the locations it owns (base 1024) and hands back exactly those.
+- **The ntuple table holds 16 rules per port, and `npc/mcam_info` will
+  not tell you that.** The driver rejects an out-of-range `loc` with
+  `EINVAL` rather than assigning one. The module asks the NIC via
+  `ETHTOOL_GRXCLSRLALL` and takes the highest free slots; the debugfs
+  figures (2048 entries, 1689 available) describe the NPC block across
+  all six PFs and govern nothing here. Ceiling: **8 IPv4 prefixes per
+  steered port**, and `packetframe feasibility` reports the real free
+  count under `vpp.steering.budget`.
+- **A port must be administratively UP before it can be steered.**
+  `otx2_get_rxnfc` gates on `netif_running`, so a down port answers
+  `EOPNOTSUPP` to both the insert and the rule-count query — which reads
+  like the NIC lacks ntuple rather than like the link being down.
+  `ethtool -k <if> | grep ntuple` says `on` either way and will not
+  disambiguate it.
+- **`ethtool -N` exits 0 when the insert fails.** It prints
+  `rmgr: Cannot insert RX class rule: ...` to stderr and returns success,
+  so any check shaped like `if ethtool -N ... >/dev/null 2>&1` reports
+  every location as working. Confirm with `ethtool -n <if>` and look for
+  the `Filter: <loc>` block.
 - **The first steer is guarded against an incomplete table — but only
   where there is a bird.** Verification samples what the *ledger* holds,
   so a table that is merely missing prefixes verifies clean. That is why


### PR DESCRIPTION
First contact between the MCAM ioctl path and a real NIC, on the shadow. Two defects, both in values rather than in structure, and both failed loudly — nothing was installed and the all-or-nothing unwind left the port with zero rules.

## The `loc` was sized from the wrong number

`McamBudget::default()` carried `base: 1024, count: 512`, reasoned from `npc/mcam_info` reporting 2048 MCAM entries with 1689 available. Those figures are real and describe the NPC block across all six PFs; they have never governed an ethtool `loc`, which on this hardware runs **0..=15 per port**. The first rule the module ever attempted was 1008 slots past the end, and the driver rejected it with `EINVAL`.

The budget is now a list of free locations read from the NIC via `ETHTOOL_GRXCLSRLALL`, highest first — preserving the "stay clear of whatever the vendor installs low" intent, which was sound, inside a space the driver sizes. Occupied slots are excluded outright rather than avoided, so a vendor rule appearing between `feasibility` and a steer costs a refusal instead of an overwrite.

## `m_u` had inverted polarity, and a wrong default

A set mask bit means **ignore**. Confirmed by readback: a rule naming only a destination reports `Src IP addr: 0.0.0.0 mask: 255.255.255.255`, `Protocol: 0 mask: 0xff`, and its own `Dest IP addr: 10.88.1.0 mask: 0.0.0.255`.

So the struct default of zero asked the NIC to match every field in the union exactly against an all-zero `h_u` — source `0.0.0.0`, protocol 0, TOS 0, `l4_4_bytes` 0 — and the address mask written on top of it ignored the network bits and matched the host. Now: `m_u` starts all-ones, and the address mask is the complement of the netmask.

The test asserts the literal bytes the NIC reports rather than `!mask_for(24)`, which would pass under either polarity. The in-memory fake NIC stores whatever `flow_spec` produced and hands the same bytes back, so it cannot catch this class — that caveat was already in its docs and it held.

## The probe was checking a constant against itself

`vpp.steering.budget` planned against the same `McamBudget::default()` it was validating and reported **pass**, with "budget 512 from slot 1024", while every insert the module would issue was rejected. It reads the NIC now and reports the real free count. Same shape as the completeness gate in #131 — a check whose answer cannot disagree with the code it checks — one level further out.

## Two consequences worth stating

- **The allowlist is bounded by hardware**: 16 rules per port at 2 per prefix (source and destination, so a flow's halves don't split across tiers) is **8 IPv4 prefixes per steered port**. Production runs 2. `RuleSet::plan`'s refusal and the runbook both say so now.
- **`bring_up` takes the budget as an argument** rather than reading a constant, which keeps its pure phase actually pure. The NIC read moved up to `attach`, beside the other environment reads.

Also fixed in passing: `bring_up` planned unconditionally, so with the ceiling dropping from 512 to 16 an allowlist of more than eight prefixes would have refused to *attach* on a config whose ports were all `steer off` — a refusal deciding nothing. It now plans only when something steers, matching `steering_target`.

## What this does not prove

The rule installs and reads back. No steered packet has reached VPP: the only port available to test on carries the interconnect, and the allowlist prefixes never appear there. Gate 0b item 1's steered half and item 7 (PMTUD) still need a traffic peer.

## Verification

`fmt`, `test`, host `clippy`, and `clippy --workspace --all-targets --all-features` against all four published triples. The Linux-target run is what caught the stale `probe_linux.rs` tests, which macOS never compiles — and it was silently resolving to a Homebrew rustc with no Linux std until `~/.cargo/bin` was put first in `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)