### PR TITLE
feat(vpp-offload): say which staging state this is, and stop implying verify is live

### DIFF
--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -696,6 +696,10 @@ impl NtupleSteering {
 }
 
 impl crate::runtime::Steering for NtupleSteering {
+    fn configured_ports(&self) -> usize {
+        self.ports.len()
+    }
+
     fn steer(&mut self) -> Result<(), String> {
         if self.plan.rules.is_empty() {
             return Err(

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -205,6 +205,18 @@ pub trait Steering {
     /// for every rule that ever reaches the NIC, so a reconfigure cannot
     /// grow its own, subtly different, installation path.
     fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet);
+    /// How many ports the CONFIG asks to steer, whether or not any rule
+    /// is installed.
+    ///
+    /// Distinct from everything else here, which reports what the NIC
+    /// holds. The supervisor deliberately never steers a first attach on
+    /// its own — `steer on` in the file is the designed staging state
+    /// until an operator moves the lever — so without this the health
+    /// surface cannot tell "configured off" from "configured on and
+    /// waiting", and reports the identical line for both. An operator
+    /// who wrote `steer on`, restarted, and read `steer off (staging
+    /// state)` has no way to know the config was seen.
+    fn configured_ports(&self) -> usize;
 }
 
 /// A steering seam that refuses both directions. **Tests only.**
@@ -225,6 +237,10 @@ pub trait Steering {
 pub struct SteeringUnavailable;
 
 impl Steering for SteeringUnavailable {
+    fn configured_ports(&self) -> usize {
+        0
+    }
+
     fn steer(&mut self) -> Result<(), String> {
         Err("MCAM steering is unavailable in this runtime; port stays unsteered".into())
     }
@@ -426,6 +442,7 @@ impl Runtime {
             store_error: c.last_store_error.clone(),
             drain_error: c.last_drain_error.clone(),
             source_backlog: c.source.backlog(),
+            steer_configured_ports: c.steering.configured_ports(),
         }
     }
 }
@@ -443,6 +460,9 @@ pub struct RuntimeStatus {
     pub store_error: Option<String>,
     /// Why the last drain failed. See `Core::last_drain_error`.
     pub drain_error: Option<String>,
+    /// How many ports the config asks to steer. See
+    /// [`Steering::configured_ports`].
+    pub steer_configured_ports: usize,
     /// Changes the source is holding that the engine has not pulled yet.
     ///
     /// Distinct from `pending_ops`, which is what the engine has pulled
@@ -871,9 +891,18 @@ mod tests {
         rules: Vec<(String, u32)>,
         /// What the next call leaves behind, and whether it succeeds.
         next: Option<(Vec<(String, u32)>, bool)>,
+        /// Ports the config asks to steer. Its own field rather than
+        /// derived from `rules`, because the whole point of
+        /// `configured_ports` is being answerable when nothing is
+        /// installed.
+        configured: usize,
     }
 
     impl Steering for LedgerSteering {
+        fn configured_ports(&self) -> usize {
+            self.configured
+        }
+
         fn steer(&mut self) -> Result<(), String> {
             let (rules, ok) = self.next.take().unwrap_or_default();
             self.rules = rules;
@@ -951,6 +980,7 @@ mod tests {
         rt.core.borrow_mut().steering = Box::new(LedgerSteering {
             rules: vec![("eth4".into(), 1024), ("eth4".into(), 1025)],
             next: Some((vec![("eth4".into(), 1025)], false)),
+            configured: 1,
         });
         fx.unsteer().expect_err("one rule would not come out");
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1005,6 +1005,7 @@ fn run_loop(
             rs.store_error.clone(),
             rs.drain_error.clone(),
             rs.source_backlog,
+            rs.steer_configured_ports > 0,
         );
         let report = snap.report();
         let overall = report.overall;

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -154,6 +154,22 @@ impl ApiHealth {
 /// verification**, never the fact that a resync finished — a drained
 /// pending map means we sent everything, which is exactly the kind of
 /// requested-not-observed claim that has bitten this module repeatedly.
+///
+/// **Verification is a convergence-time gate, not a heartbeat**, and the
+/// `age` here is how an operator sees that. It runs on first attach and
+/// after every resync, and then not again: a periodic verify would have
+/// to sample the ledger and probe VPP while deltas are in flight, and a
+/// withdrawal landing between sample and probe reads as a mismatch —
+/// which is why `drain_batch` is excluded during `Verifying` in the
+/// first place. Steady-state divergence is meant to surface as drain
+/// errors and a rising outstanding count instead.
+///
+/// The consequence is real and worth knowing before reading a
+/// dashboard: on a long-lived steered daemon this can legitimately say
+/// `last ok 18966s ago` (measured, 2026-08-06), and nothing would notice
+/// VPP's FIB drifting for a reason other than our own deltas. Making it
+/// a heartbeat is a design change, not a tweak — it needs an answer for
+/// the in-flight-delta race first.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FibSync {
     /// No verify has completed for the current process.
@@ -229,6 +245,18 @@ pub struct StatusSnapshot {
     /// state, which is the designed rollback landing zone rather than a
     /// fault.
     pub steer_intended: bool,
+    /// The config asks at least one port to steer.
+    ///
+    /// Separate from `steer_intended`, which is the supervisor's belief
+    /// about whether traffic is or should be diverted *right now*. The
+    /// machine never steers a first attach on its own — when traffic
+    /// moves is an operator decision, paced by hand up the canary ladder
+    /// — so a port configured `steer on` that has never steered sits in
+    /// the designed staging state. Without this the surface reported the
+    /// identical line for that and for `steer off`, and an operator who
+    /// had just written `steer on` could not tell the config had been
+    /// read at all.
+    pub steer_configured: bool,
     pub undead: bool,
     pub failures: u32,
     pub counts: SinkCounts,
@@ -281,6 +309,7 @@ impl StatusSnapshot {
         api: ApiHealth,
         fib: FibSync,
         ports: Vec<PortLink>,
+        steer_configured: bool,
     ) -> Self {
         Self::observe_parts(
             sup,
@@ -293,6 +322,7 @@ impl StatusSnapshot {
             None,
             None,
             0,
+            steer_configured,
         )
     }
 
@@ -313,11 +343,13 @@ impl StatusSnapshot {
         store_error: Option<String>,
         drain_error: Option<String>,
         source_backlog: u64,
+        steer_configured: bool,
     ) -> Self {
         Self {
             state: sup.state(),
             steered: sup.is_steered(),
             steer_intended: sup.steer_intended(),
+            steer_configured,
             undead: sup.is_undead(),
             failures: sup.failures(),
             counts,
@@ -553,10 +585,13 @@ impl StatusSnapshot {
                         )),
                     )
                 } else {
+                    // "verified AT" rather than "verified", because
+                    // nothing re-runs verification in steady state and
+                    // this line is read hours later. See `FibSync`.
                     (
                         HealthState::Healthy,
                         Some(format!(
-                            "{} routes installed, verified on {sampled} probes",
+                            "{} routes installed; last verified on {sampled} probes",
                             c.installed
                         )),
                     )
@@ -583,6 +618,19 @@ impl StatusSnapshot {
             // The deliberate staging state: all members up, FIB synced
             // and verified, nothing diverted. Every canary's waypoint
             // and every rollback's landing zone, so it is not a fault.
+            //
+            // Split by what the CONFIG says, because the two ways to be
+            // here read very differently to whoever is holding the
+            // rollout. Both are Healthy — waiting for a lever is not a
+            // fault — but "I asked for this" and "the machine is waiting
+            // for me" must not print the same line.
+            (false, false) if self.steer_configured => (
+                HealthState::Healthy,
+                Some(
+                    "configured `steer on`, awaiting an operator lever move; traffic is on                      the eBPF tier. A first attach never steers by itself — set the port                      `steer off`, `packetframe reconfigure`, then back to `steer on` and                      reconfigure again (canary ladder, docs/runbooks/vpp-offload.md)"
+                        .into(),
+                ),
+            ),
             (false, false) => (
                 HealthState::Healthy,
                 Some("steer off (staging state); traffic is on the eBPF tier".into()),
@@ -994,7 +1042,15 @@ mod tests {
         fib: FibSync,
         ports: Vec<PortLink>,
     ) -> StatusSnapshot {
-        StatusSnapshot::observe(sup, led.counts(), &PendingMap::new(), api, fib, ports)
+        StatusSnapshot::observe(
+            sup,
+            led.counts(),
+            &PendingMap::new(),
+            api,
+            fib,
+            ports,
+            false,
+        )
     }
 
     #[test]
@@ -1224,6 +1280,64 @@ mod tests {
             .find(|x| x.name == SUBSYS_STEERING)
             .unwrap();
         assert_eq!(steer.state, HealthState::Degraded);
+    }
+
+    /// The two ways to be unsteered must not print the same line.
+    ///
+    /// Both are Healthy — a first attach never steers by itself, so
+    /// `steer on` waiting for a lever is the designed staging state, not
+    /// a fault. But an operator who has just written `steer on` and
+    /// restarted needs to see that the config was read. Reporting
+    /// `steer off (staging state)` at them says the opposite, and this
+    /// bit us directly on the shadow: the first steer needed a lever
+    /// round-trip that nothing in the output suggested.
+    ///
+    /// Asserts the DISTINCTION rather than either message's wording — a
+    /// test pinning one string passes just as well when both arms print
+    /// it.
+    #[test]
+    fn configured_steer_on_reads_differently_from_steer_off() {
+        let led = ledger_with(10, 0, 0);
+        let sup = ready_supervisor();
+        assert!(!sup.is_steered() && !sup.steer_intended());
+
+        let msg = |configured: bool| {
+            StatusSnapshot::observe(
+                &sup,
+                led.counts(),
+                &PendingMap::new(),
+                ApiHealth::Answering {
+                    silent_for: Duration::ZERO,
+                },
+                verified(1),
+                ports_up(),
+                configured,
+            )
+            .report()
+            .subsystems
+            .into_iter()
+            .find(|x| x.name == SUBSYS_STEERING)
+            .map(|x| (x.state, x.message.unwrap_or_default()))
+            .unwrap()
+        };
+
+        let (off_state, off_msg) = msg(false);
+        let (on_state, on_msg) = msg(true);
+
+        assert_eq!(off_state, HealthState::Healthy, "steer off is not a fault");
+        assert_eq!(
+            on_state,
+            HealthState::Healthy,
+            "and neither is waiting for the lever"
+        );
+        assert_ne!(
+            off_msg, on_msg,
+            "a config asking to steer must not report as one that is not"
+        );
+        assert!(
+            on_msg.contains("lever"),
+            "the waiting case must say what unblocks it: {on_msg}"
+        );
     }
 
     /// Undead outranks everything: the VF cannot be released and no

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -679,6 +679,10 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
 fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
     struct PanicOnSteer;
     impl packetframe_vpp_offload::runtime::Steering for PanicOnSteer {
+        fn configured_ports(&self) -> usize {
+            1
+        }
+
         fn steer(&mut self) -> Result<(), String> {
             panic!("supervision loop panic, on purpose");
         }
@@ -1090,6 +1094,10 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
 struct SpySteering(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
 
 impl packetframe_vpp_offload::runtime::Steering for SpySteering {
+    fn configured_ports(&self) -> usize {
+        1
+    }
+
     fn steer(&mut self) -> Result<(), String> {
         self.0.lock().unwrap().push("steer".into());
         Ok(())

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -207,6 +207,17 @@ resync: a restart would cost about 40 seconds with the offload down at
 every step, including the step meant to get traffic off a bad VPP
 quickly.
 
+**The lever has to travel.** What triggers a steer is the `steer` flag
+*changing*, not its value — so a daemon that started with `steer on`
+already in the file is sitting in the staging state and a reconfigure
+against that same file does nothing. `packetframe status` names this
+case: `configured "steer on", awaiting an operator lever move`. To move
+it, set the port `steer off`, `packetframe reconfigure`, set it back to
+`steer on`, and reconfigure again. This costs one round trip after any
+restart of an already-steered deployment, and it is deliberate: a SIGHUP
+raised for an unrelated edit must never divert traffic as a side
+effect.
+
 **Rung 0 — membership, everything off.** Every fast-path attach port
 gets a `port` line; every one is `steer off`.
 
@@ -394,6 +405,10 @@ Be precise about this when reasoning about an incident.
 | Nexthop spread | eth3 1,248,508 / eth2 52,492 | the full-table decision rests on this |
 | ntuple `loc` space | **16 per port** (0..=15) | measured on the shadow's eth1 2026-08-05, by insert-and-read-back. At 2 rules per prefix → **8 steerable IPv4 prefixes per port**. Production's allowlist is 2. |
 | NPC MCAM block | 2048 entries, ~1689 free, 31 allocated per PF | from `npc/mcam_info`. **This is not the `loc` space** and must never be used to size one — doing so is what produced `base: 1024`, an out-of-range slot that failed the first steer this module ever attempted. |
+| First steer | **4 rules installed and readback-verified** | 2026-08-06, shadow eth1, locs 15/14/13/12, src+dst × 2 prefixes → VF 0. Installation only: eth1 carries the interconnect, so zero packets match. |
+| Steered-idle soak | **5 h 17 m**, rules intact, no restarts | 2026-08-06 overnight. Proves nothing wiped them; does **not** prove they survive a UniFi provisioning push — the re-assert path is still untested. |
+| Drill (d) adopt-while-steered | **PASS** | restart under a steered VPP; MCAM rule count sampled at 5 Hz never left 4, VPP never restarted, adoption took `Adopted {{ steered: true }}`. Loss unmeasured (no traffic peer). |
+| Restart Unhealthy window | **~10 s** | between adoption and the first verify. See the warning below — it is correct behaviour. |
 
 **Published but never measured:**
 
@@ -403,6 +418,51 @@ Be precise about this when reasoning about an incident.
 | Wedge detection ≤ 2 s | UNMEASURED |
 | Recovery ≤ 90 s | UNMEASURED |
 | `detach` < 1 s across N VFs | UNMEASURED — needs real VFs; relaxes to a documented best-effort bound if hardware says so |
+| Steered packets actually reaching VPP | UNMEASURED — gate 0b item 1's second half; needs a traffic peer |
+| PMTUD through a steered path | UNMEASURED — gate 0b item 7, unskippable |
+
+### A planned restart looks Unhealthy for ~10 seconds. Do not page on it.
+
+Restarting packetframe over a **steered** VPP reports:
+
+```
+vpp-offload: UNHEALTHY
+  fib-synced   UNHEALTHY — traffic steered into an unverified FIB
+```
+
+for roughly ten seconds, then clears to `fib-synced healthy` on its own.
+
+This is correct and deliberate. An adopted VPP is presumed
+good-until-proven-stale: the module resyncs and verifies but does **not**
+unsteer first, because unsteering a correctly-forwarding VPP would create
+the blackhole the design exists to avoid. So between adoption and the
+first completed verify, traffic genuinely is diverted into a FIB this
+process has not yet checked — and the health surface refuses to call that
+healthy rather than papering over it.
+
+Consequence for alerting: anything paging on `packetframe_vpp_health`
+will fire on every planned restart. Either alert on a sustained
+Unhealthy (30 s or more) or exclude the window explicitly. Measured
+2026-08-06 on the shadow during drill (d).
+
+### Verification does not re-run in steady state
+
+`fib-synced` reports the **last completed** readback verify, and the
+`last ok Ns ago` beside it is not decoration — on a long-lived steered
+daemon it legitimately reads hours. Measured: `last ok 18966s ago` after
+a 5 h uptime.
+
+Verify runs on first attach and after every resync, then not again. A
+periodic verify would have to sample the ledger and probe VPP while
+deltas are in flight, and a withdrawal landing between sample and probe
+reads as a mismatch — which is why delta draining is excluded during
+`Verifying` in the first place. Steady-state divergence is meant to
+surface as drain errors and a rising outstanding count instead.
+
+What this means when you are reading a dashboard: a green `fib-synced`
+says the FIB was verified *at some point*, not that it is being watched.
+Nothing here would notice VPP's FIB drifting for a reason other than this
+module's own deltas.
 
 **Failed, and shaping the design:**
 


### PR DESCRIPTION
Everything here came out of the shadow this morning: the first steer, drill (d), and an overnight soak. No speculative changes.

## `steer on` and `steer off` printed the same line

The supervisor deliberately never steers a first attach — traffic moves when an operator says so, paced up the canary ladder. So a port configured `steer on` that has never steered sits in the designed staging state, and `status` reported it identically to a port configured off:

```
steering  healthy — steer off (staging state); traffic is on the eBPF tier
```

`steer_intended` is the supervisor's belief about *now*; nothing carried the config's intent, so the surface could not tell the two apart. Someone who has just written `steer on` and restarted reads that and reasonably concludes the config was ignored. It cost a confused round on the shadow — the first steer needed a lever round-trip that nothing in the output hinted at.

`Steering::configured_ports` carries it through `RuntimeStatus` to the snapshot, and the waiting case now names what unblocks it. Both stay Healthy; waiting for a lever is not a fault.

The test asserts the two messages **differ** and that the waiting one mentions the lever — not either exact string. A test pinning one wording passes just as well when both arms print it, which is the failure mode that let this ship.

## `verified on N probes` read present-tense about an hours-old fact

Measured on the shadow: `fib-synced healthy — 1053641 routes installed, verified on 64 probes (last ok 18966s ago)` — a 5h16m-old verify under a 5h17m uptime, steered, and entirely as designed.

Verify is a convergence-time gate, not a heartbeat. It runs on attach and after every resync and then stops, because a periodic verify would sample the ledger and probe VPP while deltas are in flight, and a withdrawal landing between sample and probe reads as a mismatch — which is exactly why delta draining is already excluded during `Verifying`.

So: "last verified", and the policy plus its consequence written where `FibSync` is defined. **Nothing would notice VPP's FIB drifting for a reason other than this module's own deltas.** That is a real gap and a design change to close (it needs an answer for the in-flight-delta race first), not something to paper over with a staleness threshold — which on a check that never re-runs would just mean permanent Degraded, the "fine line operators learn to ignore" this runbook already warns about.

## A planned restart looks Unhealthy for ~10 seconds

Drill (d) surfaced it. Adoption resyncs and verifies **without** unsteering first — unsteering a correctly-forwarding VPP is the blackhole the design exists to avoid — so between adoption and the first verify, traffic genuinely is diverted into a FIB this process has not checked, and health says so.

Correct behaviour that will page anyone alerting on `packetframe_vpp_health` at every planned restart. Documented with the measurement and an alerting suggestion.

## Measured results recorded

- **First steer**: 4 rules, locs 15/14/13/12, readback-verified. Installation only — eth1 carries the interconnect, zero packets match.
- **Steered-idle soak**: 5h17m, rules intact, no restarts. Explicitly noted as *not* proving survival of a UniFi provisioning push; the re-assert path is still untested.
- **Drill (d)**: PASS. Rule count sampled at 5 Hz never left 4 across a full daemon restart; `Adopted { steered: true }` executed for the first time anywhere.
- Added the two traffic-peer-blocked items to the unmeasured table, so the list of what is still owed is complete.

## Verification

`fmt`, `test`, host `clippy`, and `clippy --workspace --all-targets --all-features` against all four published triples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)