### PR TITLE
chore: one scrub for every terminal, one wire format for every fake

### DIFF
--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -4,6 +4,7 @@
 //! config; it graduates the per-iface attach feasibility from Deferred
 //! to a real pass/fail check.
 
+use crate::scrub::scrub_for_terminal;
 use std::path::Path;
 
 use packetframe_common::{
@@ -280,11 +281,22 @@ fn print_human(report: &FeasibilityReport) {
             if failing.len() == 1 { "y" } else { "ies" },
         );
         for f in failing {
-            println!("  - {} ({})", f.name, f.detail);
+            println!(
+                "  - {} ({})",
+                scrub_for_terminal(&f.name),
+                scrub_for_terminal(&f.detail)
+            );
         }
     }
 }
 
+/// Both `name` and `detail` are scrubbed, and `detail` is the reason.
+///
+/// A capability's detail is assembled from whatever the probe found:
+/// `strerror` text from an ioctl, a VPP version string, a path out of
+/// the config, an ethtool refusal. `vpp.steering.budget` alone now
+/// carries the raw `io::Error` from `ETHTOOL_GRXCLSRLALL`. None of that
+/// originated here, and this prints straight to a TTY.
 fn print_row(cap: &Capability, name_w: usize) {
     let status = match cap.status {
         CapabilityStatus::Pass => "PASS",
@@ -295,6 +307,9 @@ fn print_row(cap: &Capability, name_w: usize) {
     let req = if cap.required { "yes" } else { "no" };
     println!(
         "{:<8} {:<4} {:<name_w$} {}",
-        status, req, cap.name, cap.detail
+        status,
+        req,
+        scrub_for_terminal(&cap.name),
+        scrub_for_terminal(&cap.detail)
     );
 }

--- a/crates/cli/src/fib_cli.rs
+++ b/crates/cli/src/fib_cli.rs
@@ -108,7 +108,13 @@ where
     let cfg = match Config::from_file(&path) {
         Ok(c) => c,
         Err(e) => {
-            eprintln!("config parse {}: {e}", path.display());
+            // The parse error quotes the config file it failed on, so
+            // it carries bytes this process did not author.
+            eprintln!(
+                "config parse {}: {}",
+                path.display(),
+                crate::scrub::scrub_for_terminal(&e.to_string())
+            );
             return ExitCode::from(EXIT_RUNTIME_ERROR);
         }
     };

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -10,6 +10,8 @@
 //!   alone.
 
 use std::path::{Path, PathBuf};
+
+use crate::scrub::scrub_for_terminal;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 use std::time::{Duration, Instant};
 
@@ -770,48 +772,6 @@ fn reconfigure_from_signal(
     }
 }
 
-/// Scrub ASCII control bytes (< 0x20) other than tab/newline from a
-/// string that's about to be written to the reconfigure marker file
-/// (and from there read back by `packetframe reconfigure` and
-/// echoed via `tracing::error!` to an operator's terminal). The
-/// failure-side `status` ultimately includes per-module error
-/// messages that can carry parser bytes from external sources
-/// (config text, BGP/BMP error text propagated up); a stray ANSI
-/// escape sequence in the marker would corrupt the operator's TTY
-/// when they run `packetframe reconfigure`. Audit Slice 5 hardening.
-///
-/// Gated on the feature rather than on Linux because the health surface
-/// prints the same class of text on every platform — see
-/// [`scrub_for_terminal`].
-#[cfg(feature = "fast-path")]
-fn scrub_control_chars(s: &str) -> String {
-    s.chars()
-        .map(|c| {
-            if c == '\t' || c == '\n' || !c.is_control() {
-                c
-            } else {
-                '?'
-            }
-        })
-        .collect()
-}
-
-/// The same scrub, for text going **straight to a terminal** rather than
-/// into a line-oriented file.
-///
-/// Built on [`scrub_control_chars`] rather than beside it, so what counts
-/// as a control character is decided in exactly one place. What differs
-/// is tab and newline: the marker file keeps them because lines are its
-/// record separator, and a terminal must not, because a `\n` inside a
-/// subsystem message can **forge a row** — a message ending
-/// `"\n  vpp-offload: healthy"` would print an extra module line that no
-/// module reported. The strings involved carry VPP, ethtool and ntuple
-/// error text from outside this process, so that is not hypothetical.
-#[cfg(feature = "fast-path")]
-fn scrub_for_terminal(s: &str) -> String {
-    scrub_control_chars(s).replace(['\n', '\t'], " ")
-}
-
 /// Append a timestamp + status line to the reconfigure marker file.
 /// Non-fatal on I/O error, the SIGHUP handler still completed its
 /// real work; the marker is just a hint to the CLI ack-poller.
@@ -828,7 +788,7 @@ fn write_reconfigure_marker(path: &Path, status: &str) {
         return;
     }
     let tmp = path.with_extension("timestamp.tmp");
-    let body = format!("{} {}\n", scrub_control_chars(status), now_ns);
+    let body = format!("{} {}\n", crate::scrub::scrub_control_chars(status), now_ns);
     let r = (|| -> std::io::Result<()> {
         let mut f = create_excl_no_follow_with_retry(&tmp)?;
         f.write_all(body.as_bytes())?;
@@ -1389,7 +1349,7 @@ pub fn status(config_path: &Path) -> Result<(), String> {
         use packetframe_fast_path::registry::load as registry_load;
         match registry_load(&config.global.state_dir) {
             Ok(Some(file)) => {
-                println!("module: {}", file.module);
+                println!("module: {}", scrub_for_terminal(&file.module));
                 println!("attachments ({}):", file.attachments.len());
                 for a in &file.attachments {
                     let hook_name = match a.hook {
@@ -1873,7 +1833,7 @@ mod terminal_scrub_tests {
     /// change the file format underneath `packetframe reconfigure`.
     #[test]
     fn the_marker_scrub_still_keeps_its_record_separator() {
-        assert_eq!(scrub_control_chars("a\nb\tc"), "a\nb\tc");
-        assert_eq!(scrub_control_chars("a\x1bb"), "a?b");
+        assert_eq!(crate::scrub::scrub_control_chars("a\nb\tc"), "a\nb\tc");
+        assert_eq!(crate::scrub::scrub_control_chars("a\x1bb"), "a?b");
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -21,6 +21,7 @@ mod loader;
 mod metrics;
 #[cfg(feature = "probe")]
 mod probe;
+mod scrub;
 
 use std::path::PathBuf;
 use std::process::ExitCode;

--- a/crates/cli/src/scrub.rs
+++ b/crates/cli/src/scrub.rs
@@ -1,0 +1,87 @@
+//! Making text safe to print at an operator's terminal.
+//!
+//! Every string this CLI prints that did not originate in this process
+//! is untrusted for terminal purposes. Not because anything here is
+//! adversarial, but because the sources are: `strerror` text from ioctls,
+//! VPP and ethtool error strings, module names read back out of on-disk
+//! JSON, config parse errors quoting the file they failed on. An ANSI
+//! escape reaching a TTY through any of those corrupts the display of a
+//! command an operator ran to find out what is wrong.
+//!
+//! **One place decides what a control character is.** This started as a
+//! pair of private helpers in `loader.rs` covering the health surface
+//! only; the reconfigure marker had its own copy first. Two copies of
+//! this rule is exactly how one of them ends up not being applied.
+
+/// Replace control characters, keeping tab and newline.
+///
+/// For text going into a **line-oriented file** — the reconfigure marker
+/// — where the newline is the record separator and removing it would
+/// corrupt the format this is protecting.
+pub fn scrub_control_chars(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c == '\t' || c == '\n' || !c.is_control() {
+                c
+            } else {
+                '?'
+            }
+        })
+        .collect()
+}
+
+/// The same scrub, for text going **straight to a terminal**.
+///
+/// Built on [`scrub_control_chars`] rather than beside it, so what counts
+/// as a control character is decided once. What differs is tab and
+/// newline: a terminal must not keep them, because a `\n` inside a
+/// message can **forge a row**. A subsystem message ending
+/// `"\n  vpp-offload: healthy"` prints an extra module line that no
+/// module reported, and an operator has no way to tell it apart from a
+/// real one.
+pub fn scrub_for_terminal(s: &str) -> String {
+    scrub_control_chars(s).replace(['\n', '\t'], " ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escapes_do_not_survive_either_scrub() {
+        let hostile = "vpp said \x1b[2J\x1b[1;31mBOOM\x07";
+        assert!(!scrub_control_chars(hostile).contains('\x1b'));
+        assert!(!scrub_for_terminal(hostile).contains('\x1b'));
+        assert!(!scrub_for_terminal(hostile).contains('\x07'));
+    }
+
+    /// The whole reason the terminal variant exists.
+    #[test]
+    fn a_newline_cannot_forge_a_row_at_a_terminal() {
+        let forged = "ok\n  vpp-offload: healthy";
+        assert!(
+            scrub_control_chars(forged).contains('\n'),
+            "the marker file keeps newlines — they are its record separator"
+        );
+        assert!(
+            !scrub_for_terminal(forged).contains('\n'),
+            "a terminal must not, or a message can print a line no module reported"
+        );
+    }
+
+    /// Ordinary text — including non-ASCII — passes through untouched.
+    /// A scrub that mangles a legitimate error message makes the output
+    /// it protects less usable, which is its own kind of failure.
+    #[test]
+    fn ordinary_text_is_unchanged() {
+        for s in [
+            "Operation not supported (os error 95)",
+            "inserting ntuple rule at loc 15",
+            "/run/packetframe/vpp/api.sock",
+            "café — ünïcode is not a control character",
+        ] {
+            assert_eq!(scrub_for_terminal(s), s);
+            assert_eq!(scrub_control_chars(s), s);
+        }
+    }
+}

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -2,14 +2,18 @@
 //! format, built from the same generated types the client encodes with.
 //!
 //! Extracted from `vpp_engine.rs` so new integration tests do not grow a
-//! fourth divergent copy (loopback and attach_verify predate it and
-//! still carry their own — migrating them is recorded follow-up work).
+//! divergent copy. `vpp_api_loopback.rs` and `vpp_attach_verify.rs` keep
+//! their own **servers** deliberately — they script handshake failures,
+//! CRC mismatches and device attach, and folding that into a fake built
+//! to model success would complicate the shared one in service of tests
+//! whose job is to break the protocol. What all three now share is
+//! `wire.rs`: frame geometry, reply headers, context extraction.
+//!
 //! Reply headers come from `MESSAGE_META` because header geometry is
 //! per-message; a hand-assumed prefix here would quietly match a
 //! hand-assumed prefix in the client and prove nothing.
 #![allow(dead_code)]
 
-use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -19,9 +23,12 @@ use packetframe_common::fib::IpPrefix;
 use std::net::{IpAddr, Ipv4Addr};
 
 use packetframe_vpp_offload::vpp_api::codec::{
-    parse_frame_header, peek_msg_id, write_frame_header, Decode, Decoder, Encode, MSG_HEADER_LEN,
-    SOCKCLNT_CREATE_MSG_ID,
+    peek_msg_id, Decode, Decoder, Encode, SOCKCLNT_CREATE_MSG_ID,
 };
+#[path = "wire.rs"]
+mod wire;
+use wire::{name_for, read_frame, reply_head, request_context, write_frame};
+
 use packetframe_vpp_offload::vpp_api::generated::{
     Address, AddressUnion, ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath,
     FibPathNh, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply,
@@ -36,48 +43,6 @@ pub const ASSIGNED_INDEX: u32 = 3;
 
 /// Link-layer address the fake mirror hands out for its one neighbour.
 pub const MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
-
-fn id_for(name: &str) -> u16 {
-    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
-}
-
-fn name_for(id: u16) -> &'static str {
-    MESSAGE_META[(id - 100) as usize].name
-}
-
-fn reply_head(name: &str) -> Vec<u8> {
-    let meta = MESSAGE_META
-        .iter()
-        .find(|m| m.name == name)
-        .expect("known reply");
-    let mut out = Vec::new();
-    out.extend_from_slice(&id_for(name).to_be_bytes());
-    if meta.client_index_prefix {
-        out.extend_from_slice(&7u32.to_be_bytes());
-    }
-    out
-}
-
-fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
-    let mut hdr = [0u8; MSG_HEADER_LEN];
-    s.read_exact(&mut hdr).ok()?;
-    let len = parse_frame_header(&hdr) as usize;
-    let mut payload = vec![0u8; len];
-    s.read_exact(&mut payload).ok()?;
-    Some(payload)
-}
-
-fn write_frame(s: &mut UnixStream, payload: &[u8]) {
-    let mut framed = Vec::new();
-    write_frame_header(&mut framed, payload.len());
-    framed.extend_from_slice(payload);
-    let _ = s.write_all(&framed);
-    let _ = s.flush();
-}
-
-fn request_context(payload: &[u8]) -> u32 {
-    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
-}
 
 mod tempdir {
     use std::path::{Path, PathBuf};

--- a/crates/modules/vpp-offload/tests/common/wire.rs
+++ b/crates/modules/vpp-offload/tests/common/wire.rs
@@ -1,0 +1,86 @@
+//! Frame and header geometry for every fake VPP in this test suite.
+//!
+//! Three fakes exist and they are **not** duplicates of each other:
+//! `fake_vpp.rs` models a working VPP for the engine and runtime tests,
+//! `vpp_api_loopback.rs` scripts handshake and CRC-mismatch failures,
+//! and `vpp_attach_verify.rs` drives device attach and readback. Their
+//! *servers* differ on purpose — pushing failure injection into a fake
+//! built to model success would make the shared one harder to reason
+//! about in service of tests whose whole job is to break the protocol.
+//!
+//! What they had no business each owning is this: how a frame is read,
+//! how one is written, where the context lives, and how a reply header
+//! is laid out. Three copies of the wire format is three places for it
+//! to drift, in a suite whose entire purpose is catching wire-format
+//! mistakes — and the header geometry comes from `MESSAGE_META` rather
+//! than being hardcoded precisely so it cannot be got wrong once, let
+//! alone three times.
+//!
+//! Included by `#[path]` into several test binaries, each of which uses
+//! a different subset — a loopback test that never builds a reply header
+//! still needs the frame reader.
+#![allow(dead_code)]
+
+use std::io::{Read as _, Write as _};
+use std::os::unix::net::UnixStream;
+
+use packetframe_vpp_offload::vpp_api::codec::{
+    parse_frame_header, write_frame_header, MSG_HEADER_LEN,
+};
+use packetframe_vpp_offload::vpp_api::generated::MESSAGE_META;
+
+/// The client index every fake hands out at handshake.
+pub const CLIENT_INDEX: u32 = 7;
+
+/// Message ids are assigned from 100 upward, in `MESSAGE_META` order —
+/// the same mapping every fake's handshake advertises.
+pub fn id_for(name: &str) -> u16 {
+    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
+}
+
+pub fn name_for(id: u16) -> &'static str {
+    MESSAGE_META[(id - 100) as usize].name
+}
+
+/// A reply's leading bytes: id, then the client index **only for the
+/// messages whose meta says so**.
+///
+/// Driven off `MESSAGE_META.client_index_prefix` rather than hardcoded
+/// as `[id][context]`, because that prefix is exactly the field a
+/// hand-written header gets wrong — and a fake with the wrong geometry
+/// validates a client with the same wrong geometry, which is worse than
+/// no test at all.
+pub fn reply_head(name: &str) -> Vec<u8> {
+    let meta = MESSAGE_META
+        .iter()
+        .find(|m| m.name == name)
+        .expect("known reply");
+    let mut out = Vec::new();
+    out.extend_from_slice(&id_for(name).to_be_bytes());
+    if meta.client_index_prefix {
+        out.extend_from_slice(&CLIENT_INDEX.to_be_bytes());
+    }
+    out
+}
+
+pub fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
+    let mut hdr = [0u8; MSG_HEADER_LEN];
+    s.read_exact(&mut hdr).ok()?;
+    let len = parse_frame_header(&hdr) as usize;
+    let mut payload = vec![0u8; len];
+    s.read_exact(&mut payload).ok()?;
+    Some(payload)
+}
+
+pub fn write_frame(s: &mut UnixStream, payload: &[u8]) {
+    let mut framed = Vec::new();
+    write_frame_header(&mut framed, payload.len());
+    framed.extend_from_slice(payload);
+    let _ = s.write_all(&framed);
+    let _ = s.flush();
+}
+
+/// The request's context, which every reply must echo back.
+pub fn request_context(payload: &[u8]) -> u32 {
+    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
+}

--- a/crates/modules/vpp-offload/tests/vpp_api_loopback.rs
+++ b/crates/modules/vpp-offload/tests/vpp_api_loopback.rs
@@ -10,9 +10,8 @@
 //! too. What it deliberately does NOT model is VPP's forwarding
 //! behaviour — that is gate 0b's job on hardware.
 
-use std::io::{Read, Write};
 use std::net::IpAddr;
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
@@ -22,9 +21,11 @@ use std::time::Duration;
 use packetframe_common::fib::IpPrefix;
 use packetframe_vpp_offload::fib_sync::{Drainer, FamilyPolicy, PortIndex, ResolvedPath};
 use packetframe_vpp_offload::sink::{Capacity, NexthopMap, PendingMap, RouteLedger};
-use packetframe_vpp_offload::vpp_api::codec::{
-    parse_frame_header, write_frame_header, Encode, MSG_HEADER_LEN, SOCKCLNT_CREATE_MSG_ID,
-};
+use packetframe_vpp_offload::vpp_api::codec::{Encode, SOCKCLNT_CREATE_MSG_ID};
+#[path = "common/wire.rs"]
+mod wire;
+use wire::{id_for, read_frame, request_context, write_frame};
+
 use packetframe_vpp_offload::vpp_api::generated::{
     IpRouteAddDelReply, MessageTableEntry, SockclntCreateReply, MESSAGE_META,
 };
@@ -33,33 +34,6 @@ use packetframe_vpp_offload::vpp_api::Transport;
 /// Message id we hand out for `ip_route_add_del_reply`.
 fn reply_id() -> u16 {
     id_for("ip_route_add_del_reply")
-}
-
-fn id_for(name: &str) -> u16 {
-    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
-}
-
-fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
-    let mut hdr = [0u8; MSG_HEADER_LEN];
-    s.read_exact(&mut hdr).ok()?;
-    let len = parse_frame_header(&hdr) as usize;
-    let mut payload = vec![0u8; len];
-    s.read_exact(&mut payload).ok()?;
-    Some(payload)
-}
-
-fn write_frame(s: &mut UnixStream, payload: &[u8]) {
-    let mut framed = Vec::new();
-    write_frame_header(&mut framed, payload.len());
-    framed.extend_from_slice(payload);
-    let _ = s.write_all(&framed);
-    let _ = s.flush();
-}
-
-/// `context` from a request payload that carries a client_index
-/// prefix (every request the drainer sends does).
-fn request_context(payload: &[u8]) -> u32 {
-    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
 }
 
 /// How the fake answers each route request, in order.

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -10,8 +10,7 @@
 //! The fake dispatches on message id, so a request sent out of order
 //! shows up as a wrong-message failure rather than passing by accident.
 
-use std::io::{Read, Write};
-use std::os::unix::net::{UnixListener, UnixStream};
+use std::os::unix::net::UnixListener;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::thread;
@@ -22,69 +21,17 @@ use packetframe_vpp_offload::attach::{attach_ports, AttachError, AttachMode, Por
 use packetframe_vpp_offload::fib_sync::{to_prefix, PortIndex};
 use packetframe_vpp_offload::sink::{Capacity, RouteLedger};
 use packetframe_vpp_offload::verify::{verify, Mismatch};
-use packetframe_vpp_offload::vpp_api::codec::{
-    parse_frame_header, peek_msg_id, write_frame_header, Encode, MSG_HEADER_LEN,
-    SOCKCLNT_CREATE_MSG_ID,
-};
+use packetframe_vpp_offload::vpp_api::codec::{peek_msg_id, Encode, SOCKCLNT_CREATE_MSG_ID};
+#[path = "common/wire.rs"]
+mod wire;
+use wire::{name_for, read_frame, reply_head, request_context, write_frame};
+
 use packetframe_vpp_offload::vpp_api::generated::{
     ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteLookupReply,
     MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
     MESSAGE_META,
 };
 use packetframe_vpp_offload::vpp_api::Transport;
-
-fn id_for(name: &str) -> u16 {
-    100 + MESSAGE_META.iter().position(|m| m.name == name).unwrap() as u16
-}
-
-fn name_for(id: u16) -> &'static str {
-    MESSAGE_META[(id - 100) as usize].name
-}
-
-/// Start a reply payload for `name`.
-///
-/// **The header geometry is per-message, not uniform**, and this fake
-/// has to honour that or it tests nothing. `dev_create_port_if_reply`
-/// carries a `client_index` between the id and the context; its own
-/// sibling `dev_attach_reply` does not. Reading the layout out of
-/// `MESSAGE_META` rather than hardcoding `[id][context]` is what makes
-/// the fake speak the same wire the real VPP does — a hand-assumed
-/// prefix here would have quietly matched a hand-assumed prefix in the
-/// client and proved nothing.
-fn reply_head(name: &str) -> Vec<u8> {
-    let meta = MESSAGE_META
-        .iter()
-        .find(|m| m.name == name)
-        .expect("known reply");
-    let mut out = Vec::new();
-    out.extend_from_slice(&id_for(name).to_be_bytes());
-    if meta.client_index_prefix {
-        out.extend_from_slice(&7u32.to_be_bytes());
-    }
-    out
-}
-
-fn read_frame(s: &mut UnixStream) -> Option<Vec<u8>> {
-    let mut hdr = [0u8; MSG_HEADER_LEN];
-    s.read_exact(&mut hdr).ok()?;
-    let len = parse_frame_header(&hdr) as usize;
-    let mut payload = vec![0u8; len];
-    s.read_exact(&mut payload).ok()?;
-    Some(payload)
-}
-
-fn write_frame(s: &mut UnixStream, payload: &[u8]) {
-    let mut framed = Vec::new();
-    write_frame_header(&mut framed, payload.len());
-    framed.extend_from_slice(payload);
-    let _ = s.write_all(&framed);
-    let _ = s.flush();
-}
-
-/// Requests carry `[msg_id][client_index][context]`.
-fn request_context(payload: &[u8]) -> u32 {
-    u32::from_be_bytes([payload[6], payload[7], payload[8], payload[9]])
-}
 
 mod tempdir {
     use std::path::{Path, PathBuf};


### PR DESCRIPTION
Two audits finished. Both turned out to be "extract the thing three copies agree on", and neither changes behaviour.

## The terminal scrub covered one of four paths to the same TTY

`scrub_control_chars` was written for the reconfigure marker. `status` grew `scrub_for_terminal` later, when the health surface turned out to be a *second* path to the same terminal. Both stayed private to `loader.rs` behind a `fast-path` feature gate — so the audit that produced them never reached the other printers.

Now scrubbed:

- **`feasibility`** — a capability's `detail` goes straight to stdout, and it is assembled from whatever the probe found: `strerror` from an ioctl, a VPP version string, a path from config, an ethtool refusal. `vpp.steering.budget` alone now carries the raw `io::Error` from `ETHTOOL_GRXCLSRLALL`.
- **`status`** — the module name read back out of on-disk JSON.
- **`fib`** — the config parse error, which quotes the file it failed to parse.

One module now, ungated, with the rule stated once: a `\n` reaching a terminal can **forge a row**, so the display scrub strips it, while the marker file keeps newlines because they are its record separator. Two copies of that distinction is exactly how one of them ends up not being applied.

## Three fake VPPs each owned the wire format

The recorded follow-up said to migrate `vpp_api_loopback` and `vpp_attach_verify` onto `fake_vpp`. **Having read them, that is the wrong shape and I didn't do it.** Their servers differ on purpose — one scripts handshake failures and CRC mismatches, one drives device attach and readback, and `fake_vpp` models a working VPP for the engine tests. Folding failure injection into a fake built to model success would complicate the shared one in service of tests whose entire job is to break the protocol.

The real duplication was `id_for`, `name_for`, `reply_head`, `read_frame`, `write_frame`, `request_context` — three copies each. Of the wire format. In the test suite whose purpose is catching wire-format mistakes. `tests/common/wire.rs` owns them now, so "reply header geometry comes from `MESSAGE_META`, never hand-assumed" holds in one place rather than three that can drift apart.

`fake_vpp`'s header comment claiming the migration was still owed is corrected to describe what was actually done and why.

## Verification

`fmt`, `test`, host `clippy`, and `clippy --workspace --all-targets --all-features` against all four published triples. No behaviour change on either half — the scrub is a no-op for text without control characters (asserted), and the extracted helpers are byte-identical to the copies they replace.

Note: GitHub Actions was in a `major_outage` while this was written, so CI had not run at the time of opening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)