### PR TITLE
feat(tc): split err_parse_tc by which bounds check produced it

### DIFF
--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -212,12 +212,42 @@ pub enum StatIdx {
     /// excess unattributable without flipping datapaths. During any
     /// mixed rollout, `err_parse - err_parse_tc` is the XDP share.
     ErrParseTc = 45,
+    // --- v0.2.10: which bounds check produced `ErrParseTc`. Append-only.
+    //
+    // All four producers are the same statement — the bytes I need are
+    // not in front of me — and under `cls_bpf` that does NOT mean a
+    // runt: `data`..`data_end` spans only the LINEAR part of the skb, so
+    // a GRO-coalesced or page-fragmented frame can carry its L3 header
+    // outside the window while being perfectly well formed. Splitting
+    // them is what turns "0.18% unexplained" into a specific claim, and
+    // the split is diagnostic ONLY: no remedy is applied until these
+    // say which site fires. See docs/runbooks/tc-datapath.md.
+    //
+    // Each is bumped IN ADDITION to `ErrParse` and `ErrParseTc`, so the
+    // existing two keep their meaning and dashboards keyed on them do
+    // not move. The four must sum to `err_parse_tc`.
+    /// Shorter than an Ethernet header.
+    ErrParseTcL2 = 46,
+    /// 802.1Q/ad frame shorter than `EthHdr + VLAN_HDR_LEN`. Only the
+    /// INLINE-tag path can reach this; a tag lifted into `vlan_tci` by
+    /// the driver never parses bytes.
+    ErrParseTcVlan = 47,
+    /// Shorter than the IPv4 header at its offset. The arm the
+    /// non-linear-skb hypothesis predicts, since L3 sits furthest into
+    /// the frame.
+    ErrParseTcL3V4 = 48,
+    /// Shorter than the IPv6 header at its offset. Separate from the v4
+    /// arm because the headers differ in size (40 vs 20), so a linear
+    /// window that truncates one may not truncate the other — and if the
+    /// counts split by family rather than by depth, the hypothesis is
+    /// wrong.
+    ErrParseTcL3V6 = 49,
 }
 
 /// Total counter count. Sizes the `[u64; N]` value of the single-entry
 /// `STATS` per-CPU map. New counters bump this; dashboards keying on
 /// indices keep working.
-pub const STATS_COUNT: u32 = 46;
+pub const STATS_COUNT: u32 = 50;
 
 /// `STATS_COUNT` as usize, for the array-of-counters value type.
 pub const STATS_COUNT_USIZE: usize = STATS_COUNT as usize;

--- a/crates/modules/fast-path/bpf/src/tc.rs
+++ b/crates/modules/fast-path/bpf/src/tc.rs
@@ -113,6 +113,7 @@ fn tc_try_fast_path(
     let start = ctx.data();
     let end = ctx.data_end();
     if start + EthHdr::LEN > end {
+        bump(stats, StatIdx::ErrParseTcL2);
         return Err(());
     }
     let eth = start as *mut EthHdr;
@@ -135,6 +136,7 @@ fn tc_try_fast_path(
         // Inline-tag fallback; mirrors main.rs's parse (one tag, QinQ
         // out of scope, VID 0 treated as absent).
         if start + EthHdr::LEN + VLAN_HDR_LEN > end {
+            bump(stats, StatIdx::ErrParseTcVlan);
             return Err(());
         }
         let tci_hi = unsafe { *((start + EthHdr::LEN) as *const u8) };
@@ -189,6 +191,7 @@ fn tc_handle_ipv4(
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv4Hdr::LEN > end {
+        bump(stats, StatIdx::ErrParseTcL3V4);
         return Err(());
     }
     let ip = (start + ip_offset) as *mut Ipv4Hdr;
@@ -273,6 +276,7 @@ fn tc_handle_ipv6(
     let start = ctx.data();
     let end = ctx.data_end();
     if start + ip_offset + Ipv6Hdr::LEN > end {
+        bump(stats, StatIdx::ErrParseTcL3V6);
         return Err(());
     }
     let ip = (start + ip_offset) as *mut Ipv6Hdr;

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -31,7 +31,7 @@ use std::fmt::Write as _;
 /// operators (19 hid `err_head_shift`; 33 hid the mss-clamp and
 /// tail-call diagnostics from the Prometheus export; a separate
 /// hardcoded 37 hid `pass_ndp` from `packetframe status`).
-pub const COUNTER_NAMES: [&str; 46] = [
+pub const COUNTER_NAMES: [&str; 50] = [
     "rx_total",
     "matched_v4",
     "matched_v6",
@@ -87,6 +87,14 @@ pub const COUNTER_NAMES: [&str; 46] = [
     "fib_cache_stale",
     // --- v0.2.9: per-hook parse-error attribution ---
     "err_parse_tc",
+    // --- v0.2.10: which bounds check produced `err_parse_tc`.
+    // These four must sum to `err_parse_tc`; all of them mean "the bytes
+    // I need are not in front of me", which under cls_bpf is a statement
+    // about the skb's LINEAR window rather than about the packet.
+    "err_parse_tc_l2",
+    "err_parse_tc_vlan",
+    "err_parse_tc_l3_v4",
+    "err_parse_tc_l3_v6",
 ];
 
 /// `COUNTER_NAMES.len()` as a named const. Sizes the `[u64; N]` value
@@ -238,7 +246,7 @@ mod tests {
         // Mirror of `STATS_COUNT` from `bpf/src/maps.rs`. If these
         // drift, the zip() in render_textfile silently truncates
         // this test catches that at unit-test time.
-        assert_eq!(COUNTER_NAMES.len(), 46);
+        assert_eq!(COUNTER_NAMES.len(), 50);
         assert_eq!(COUNTER_NAMES.len(), COUNTER_COUNT);
         // The newest counters, as a canary that the tail of the list
         // stayed aligned with the `StatIdx` discriminants.
@@ -248,6 +256,10 @@ mod tests {
         assert_eq!(COUNTER_NAMES[43], "fib_cache_miss");
         assert_eq!(COUNTER_NAMES[44], "fib_cache_stale");
         assert_eq!(COUNTER_NAMES[45], "err_parse_tc");
+        assert_eq!(COUNTER_NAMES[46], "err_parse_tc_l2");
+        assert_eq!(COUNTER_NAMES[47], "err_parse_tc_vlan");
+        assert_eq!(COUNTER_NAMES[48], "err_parse_tc_l3_v4");
+        assert_eq!(COUNTER_NAMES[49], "err_parse_tc_l3_v6");
     }
 
     #[test]

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -55,7 +55,29 @@ pub struct FpCfg {
 unsafe impl Pod for FpCfg {}
 
 pub const FP_CFG_VERSION_V2: u32 = 1;
-pub const STATS_COUNT: u32 = 46;
+pub const STATS_COUNT: u32 = 50;
+
+/// This mirror cannot drift from the library's count again.
+///
+/// It did: the four `err_parse_tc_*` counters were appended to
+/// `bpf/src/maps.rs` and to `metrics::COUNTER_NAMES`, and this constant
+/// beside them was missed. Nothing on a dev host noticed, because the
+/// macOS BPF build falls back to a stub and no real map is ever loaded
+/// to disagree — it surfaced only in CI's sudo-gated attach step, as
+/// `InvalidValueSize { size: 368, expected: 400 }`, which is 46 vs 50
+/// counters and reads like nothing of the sort.
+///
+/// A `const` assertion fails at compile time instead — though note
+/// *where*: these test files are `#![cfg(target_os = "linux")]`, so this
+/// module does not compile on a macOS host at all and the assertion is
+/// invisible there too. It fires under the per-target check
+/// (`--target x86_64-unknown-linux-gnu --all-targets`), which is the
+/// local gate that sees Linux-only test code — verified by setting this
+/// to 46 and watching it fail.
+const _: () = assert!(
+    STATS_COUNT as usize == packetframe_fast_path::metrics::COUNTER_COUNT,
+    "STATS_COUNT must equal metrics::COUNTER_COUNT — append to both, or the      harness types a map value size the BPF program did not write"
+);
 
 /// Flag bit constants mirrored from `bpf/src/maps.rs`. Test harness
 /// uses these to flip forwarding modes on the live BPF program.

--- a/crates/modules/fast-path/tests/common/mod.rs
+++ b/crates/modules/fast-path/tests/common/mod.rs
@@ -121,6 +121,10 @@ pub enum StatIdx {
     FibCacheMiss = 43,
     FibCacheStale = 44,
     ErrParseTc = 45,
+    ErrParseTcL2 = 46,
+    ErrParseTcVlan = 47,
+    ErrParseTcL3V4 = 48,
+    ErrParseTcL3V6 = 49,
 }
 
 /// Minimum XDP verdict constants. Pulled in locally to avoid a

--- a/crates/modules/fast-path/tests/tc_fixtures.rs
+++ b/crates/modules/fast-path/tests/tc_fixtures.rs
@@ -193,6 +193,7 @@ fn tc_parse_error_bumps_both_shared_and_tc_counter() {
 
     let parse_before = h.stat(StatIdx::ErrParse);
     let parse_tc_before = h.stat(StatIdx::ErrParseTc);
+    let breakdown_before = tc_parse_breakdown(&h);
 
     let (verdict, out) = h.run_tc(&runt);
     assert_eq!(verdict, tc_action::TC_ACT_OK);
@@ -204,12 +205,59 @@ fn tc_parse_error_bumps_both_shared_and_tc_counter() {
         "tc parse failure must be attributable per-hook"
     );
 
+    // And attributable to a SITE, which is the point of the breakdown:
+    // this frame clears the L2 check and dies on the v4 header, so the
+    // v4 arm must move and no other. Asserted as "which one moved"
+    // rather than on an absolute value, because a counter that only has
+    // to be non-zero is satisfied by every site bumping at once — which
+    // is exactly the bug a breakdown exists to rule out.
+    let breakdown_after = tc_parse_breakdown(&h);
+    assert_eq!(
+        moved(&breakdown_before, &breakdown_after),
+        vec!["err_parse_tc_l3_v4"],
+        "before={breakdown_before:?} after={breakdown_after:?}"
+    );
+
     // The same runt through the XDP hook bumps only the shared
     // counter: `err_parse - err_parse_tc` must stay the XDP share.
     let (verdict, _) = h.run(&runt);
     assert_eq!(verdict, xdp_action::XDP_PASS);
     assert_eq!(h.stat(StatIdx::ErrParse), parse_before + 2);
     assert_eq!(h.stat(StatIdx::ErrParseTc), parse_tc_before + 1);
+    assert_eq!(
+        tc_parse_breakdown(&h),
+        breakdown_after,
+        "the XDP hook must not touch the tc breakdown"
+    );
+
+    // The invariant the four exist to satisfy: they partition
+    // `err_parse_tc`. A site added later that forgets its counter
+    // breaks this rather than silently shrinking the total.
+    let total: u64 = breakdown_after.iter().map(|(_, v)| v).sum();
+    assert_eq!(
+        total,
+        h.stat(StatIdx::ErrParseTc),
+        "the breakdown must account for every tc parse failure"
+    );
+}
+
+/// The four sites, named, so a failure says which one moved.
+fn tc_parse_breakdown(h: &Harness) -> Vec<(&'static str, u64)> {
+    vec![
+        ("err_parse_tc_l2", h.stat(StatIdx::ErrParseTcL2)),
+        ("err_parse_tc_vlan", h.stat(StatIdx::ErrParseTcVlan)),
+        ("err_parse_tc_l3_v4", h.stat(StatIdx::ErrParseTcL3V4)),
+        ("err_parse_tc_l3_v6", h.stat(StatIdx::ErrParseTcL3V6)),
+    ]
+}
+
+fn moved(before: &[(&'static str, u64)], after: &[(&'static str, u64)]) -> Vec<&'static str> {
+    before
+        .iter()
+        .zip(after)
+        .filter(|((_, b), (_, a))| a > b)
+        .map(|((n, _), _)| *n)
+        .collect()
 }
 
 #[test]

--- a/docs/runbooks/tc-datapath.md
+++ b/docs/runbooks/tc-datapath.md
@@ -87,8 +87,9 @@ future tc use beyond debugging.
 
 ## The tc-only `err_parse`
 
-**Status: analysed, not confirmed. Nothing here has been measured — the
-confirming change is unwritten on purpose (see the end).**
+**Status: analysed, instrumented, not yet measured.** The counters that
+would confirm it now exist; no tc canary has been run since they were
+added, so the hypothesis below is still a hypothesis.
 
 `err_parse_tc` has exactly four producers, all in `tc.rs`, and they are
 all the same shape — a bounds check against `ctx.data_end()`:
@@ -125,26 +126,55 @@ The remedy, if confirmed, is `bpf_skb_pull_data(skb, needed)` before the
 parse, with `data`/`data_end` re-read afterwards — the pointers are
 invalidated by the call. It is not free: a pull can copy.
 
-### What would confirm it
+### The breakdown, and how to read it
 
-Two appended `StatIdx` entries splitting the four sites — at minimum
-"too short for L2" versus "too short for L3" — and a `bpf_skb_pull_data`
-retry on the L3 arm counting how often the pull succeeds. If the pull
-turns the failures into forwards, the hypothesis is proven and the fix
-is already in hand.
+Four appended counters now split the sites, bumped **in addition to**
+`err_parse` and `err_parse_tc` so both keep their meaning:
 
-**Deliberately not written yet, and the reason is worth recording.** It
-is a BPF datapath change, and BPF changes cannot be compiled on the
-macOS dev host at all — the build falls back to a stub, so the code
-would appear to build and its tests would pass having executed nothing.
-The only gates that see BPF are CI and the qemu verifier. Writing
-verifier-sensitive code for a 5.15 vendor kernel with no compiler and no
-verifier in the loop is how a day gets lost; this waits for both.
+| counter | site |
+|---|---|
+| `err_parse_tc_l2` | shorter than `EthHdr` |
+| `err_parse_tc_vlan` | inline-tagged frame shorter than `EthHdr + VLAN_HDR_LEN` |
+| `err_parse_tc_l3_v4` | shorter than the IPv4 header at its offset |
+| `err_parse_tc_l3_v6` | shorter than the IPv6 header at its offset |
 
-It is also worth being honest about priority: the tc datapath is a
-**measured dead end** on this fleet (+70% ns/pkt, see above) and is
-reserved for temporary tcpdump visibility. This matters if tc is ever
-reconsidered, and not before.
+They partition `err_parse_tc` — the four must sum to it, and a test
+asserts that so a site added later cannot quietly shrink the total.
+
+What each outcome would mean, decided now rather than after seeing the
+numbers:
+
+- **Concentrated in the L3 arms** → the non-linear-skb hypothesis holds.
+  L3 sits furthest into the frame, so it is what a short linear window
+  truncates first. Proceed to `bpf_skb_pull_data`.
+- **Concentrated in `l2`** → genuine runts, and the hypothesis is wrong.
+  A frame too short for 14 bytes is malformed however it is stored.
+- **Split by FAMILY rather than by depth** (v4 and v6 arms differing by
+  much more than their traffic ratio) → also wrong, or at least
+  incomplete: the two headers differ in size, so a depth explanation
+  predicts they track traffic share while a family explanation does not.
+- **`vlan` non-zero at all** → notable on its own. That arm is reachable
+  only when the tag is still in-band, which on this fleet should be
+  rare, since the driver lifts it into `vlan_tci`.
+
+### The remedy is deliberately NOT applied yet
+
+If the L3 arms dominate, the fix is `bpf_skb_pull_data(skb, needed)`
+before the parse, with `data`/`data_end` re-read afterwards — the call
+invalidates them — and it is not free, since a pull can copy.
+
+It is not in this change on purpose. Applying a remedy before the
+diagnosis confirms the disease is how a correct piece of code gets
+"fixed" into a broken one; that happened twice in this repo in one week
+(see `docs/runbooks/vpp-offload.md` on the ntuple mask). The counters
+cost nothing on the fast path — they are bumps on an already-failing
+branch — and they answer the question. Wire them up, run a tc canary on
+one interface, read the split, then write the fix the numbers ask for.
+
+Priority, honestly: the tc datapath is a **measured dead end** on this
+fleet (+70% ns/pkt, see above) and is reserved for temporary tcpdump
+visibility. This matters if tc is ever reconsidered, and not before —
+which is why the diagnosis ships and the datapath change waits.
 
 ## Prerequisites
 


### PR DESCRIPTION
Closes the diagnosis half of #16. Now that Actions is back, BPF can be compiled and verified, which is what this needed.

## What changed

Four appended `StatIdx` entries, one per producer, bumped **in addition to** `err_parse` and `err_parse_tc` so both keep their existing meaning:

| counter | site |
|---|---|
| `err_parse_tc_l2` | shorter than `EthHdr` |
| `err_parse_tc_vlan` | inline-tagged frame shorter than `EthHdr + VLAN_HDR_LEN` |
| `err_parse_tc_l3_v4` | shorter than the IPv4 header at its offset |
| `err_parse_tc_l3_v6` | shorter than the IPv6 header at its offset |

Append-only, per the counter-index rule — indices 46–49, `STATS_COUNT` 46 → 50.

## Why this is diagnosis and not a fix

Under XDP, `data`..`data_end` is the whole frame, so these checks mean "runt". Under `cls_bpf` the window is only the **linear** part of the skb, so a GRO-coalesced or page-fragmented frame can fail them while being perfectly well-formed. That would explain everything we observe — tc-only, small but non-zero, fail-safe — and the remedy would be `bpf_skb_pull_data` before the parse.

**It is a hypothesis, so the remedy is not in this PR.** Applying a fix before the diagnosis confirms the disease is how correct code gets "fixed" into broken code, which happened twice in this repo in one week — the ntuple mask being the expensive one. The counters cost a bump on an already-failing branch and they answer the question directly.

The runbook records what each outcome would *mean* before the numbers exist, so the reading can't be fitted to the result: L3-dominant confirms it, L2-dominant refutes it, a split by family rather than by depth refutes it too, and any `vlan` count at all is independently interesting since the driver should be lifting tags into `vlan_tci`.

## Test

The existing tc fixture asserted `err_parse_tc` incremented. It now also asserts **which** arm moved — `["err_parse_tc_l3_v4"]` and nothing else — and that the four **partition** `err_parse_tc`. A breakdown satisfied by every arm bumping at once isn't a breakdown, and a total that silently shrinks when someone adds a fifth site is worse than no breakdown at all.

Also asserts the XDP hook leaves the tc breakdown untouched, preserving the `err_parse - err_parse_tc` = XDP-share property.

## Verification

`fmt`, `test`, host `clippy`, and all four target triples locally. **The BPF program itself can only be built by CI and only be verified by the qemu job** — this Mac's BPF build falls back to a stub — so the meaningful gates here are the cross-builds and the 5.15/6.6 qemu runs, which exercise `tc_fixtures`.

## Remaining after this

Everything left needs the traffic peer: drills (a)/(b)/(c), the `<1 s` detach measurement, gate 0b item 1's steered half, and PMTUD. Stats-segment gauges stay deferred — a parser for VPP's internal shared-memory layout is worth building when something reads it and can be validated on hardware, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)