### PR TITLE
feat(vpp-offload): make a member port able to forward, not just be up

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -333,6 +333,20 @@ module fast-path
 # the safe staging state, and the landing zone for every rollback.
 #
 # module vpp-offload
+#   loopback-address 198.51.100.1/32
+#                                 # MANDATORY. VPP creates one loopback with
+#                                 # this address and every member port is
+#                                 # unnumbered to it. Without it a member is
+#                                 # admin-up and forwards NOTHING: the FIB is
+#                                 # correct, readback verification passes,
+#                                 # health says `fib-synced healthy`, and every
+#                                 # packet dies at `ip4-not-enabled` (observed
+#                                 # 2026-08-07 with 1,053,960 routes verified,
+#                                 # forwarding zero). It is also what sources
+#                                 # ICMP, so PMTUD's frag-needed is only
+#                                 # correct if this is an address the far end
+#                                 # can route back to — pick one this router
+#                                 # owns, not a placeholder.
 #   port eth0 cores 1 steer off   # a member because the fast-path attaches
 #   port eth2 cores 1 steer off   # it — NOT because BGP best-paths egress
 #   port eth3 cores 1 steer off   # here. The measured table egresses via

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -166,6 +166,19 @@ pub enum ModuleDirective {
     /// Must be ≥ the minimum derived from `expected-routes`; the
     /// renderer errors at load otherwise.
     VppHugepages(u32),
+    /// `loopback-address <ip>/<len>` — the address VPP's loopback holds,
+    /// which every member port is unnumbered to.
+    ///
+    /// Not derivable, which is why it is configuration. A member port
+    /// forwards nothing until IPv4 is enabled on it (traced on hardware
+    /// 2026-08-07: frames reach `ip4-not-enabled` and are dropped), and
+    /// the scheme that works is one loopback carrying the router address
+    /// with the members unnumbered to it. Which address that should be
+    /// is a per-box decision — the reference primary has a different
+    /// address on each of four member ports and only one loopback — and
+    /// it is also what sources ICMP, so PMTUD's frag-needed is only
+    /// correct if an operator chose it deliberately.
+    VppLoopbackAddress(Ipv4Prefix),
     /// `require-table-complete on|off` — whether a first steer waits
     /// for the route mirror to be confirmed converged against bird.
     ///
@@ -987,6 +1000,28 @@ impl Config {
                 0,
                 "module vpp-offload declares no `port` lines; remove the section or give it \
                  at least one port (membership must cover every possible egress port)",
+            ));
+        }
+
+        // A member port that is not IP-enabled forwards NOTHING, and
+        // says nothing about it: the FIB is correct, readback
+        // verification passes on it, health reports `fib-synced
+        // healthy`, and every packet dies at `ip4-not-enabled`. Observed
+        // on hardware 2026-08-07 with 1,053,960 routes installed and
+        // verified on 64 probes, forwarding zero. So the address that
+        // makes forwarding possible is mandatory the moment a port
+        // exists, refused here rather than discovered by a canary.
+        if !vpp
+            .directives
+            .iter()
+            .any(|d| matches!(d, ModuleDirective::VppLoopbackAddress(_)))
+        {
+            return Err(ConfigError::parse(
+                0,
+                "module vpp-offload has `port` lines but no `loopback-address`; member ports \
+                 are unnumbered to a loopback and forward nothing without it — and do so \
+                 while reporting healthy. Add e.g. `loopback-address 198.51.100.1/32` \
+                 (an address this router owns; it also sources ICMP, so PMTUD depends on it)",
             ));
         }
 
@@ -1817,6 +1852,12 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 return Err("expected-routes must be >= 1".to_string());
             }
             Ok(ModuleDirective::ExpectedRoutes(n))
+        }),
+        "loopback-address" => parse_single_arg(line, rest, "loopback-address", |t| {
+            let p: Ipv4Prefix = t
+                .parse()
+                .map_err(|e: String| format!("loopback-address: {e}"))?;
+            Ok(ModuleDirective::VppLoopbackAddress(p))
         }),
         "require-table-complete" => {
             parse_single_arg(line, rest, "require-table-complete", |t| match t {
@@ -2753,44 +2794,44 @@ module fast-path
     #[test]
     fn vpp_offload_cross_validation() {
         // Membership-only (no steer) with a fast-path section: valid.
-        let staging = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  port eth4 cores 1 steer off\n";
+        let staging = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer off\n";
         Config::parse(staging)
             .unwrap()
             .validate_vpp_offload()
             .unwrap();
 
         // vpp-offload without fast-path: rejected.
-        let orphan = "module vpp-offload\n  port eth4 cores 1 steer off\n";
+        let orphan = "module vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer off\n";
         assert!(Config::parse(orphan)
             .unwrap()
             .validate_vpp_offload()
             .is_err());
 
         // Steering without custom-fib: rejected.
-        let no_cfib = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  port eth4 cores 1 steer on\n";
+        let no_cfib = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer on\n";
         assert!(Config::parse(no_cfib)
             .unwrap()
             .validate_vpp_offload()
             .is_err());
 
         // Steering with a fast-path attach port missing membership: rejected.
-        let missing_member = "module fast-path\n  forwarding-mode custom-fib\n  attach eth4 generic\n  attach eth5 generic\n\nmodule vpp-offload\n  port eth5 cores 1 steer on\n";
+        let missing_member = "module fast-path\n  forwarding-mode custom-fib\n  attach eth4 generic\n  attach eth5 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth5 cores 1 steer on\n";
         assert!(Config::parse(missing_member)
             .unwrap()
             .validate_vpp_offload()
             .is_err());
 
         // Full membership + steering + custom-fib: valid.
-        let good = "module fast-path\n  forwarding-mode custom-fib\n  attach eth4 generic\n  attach eth5 generic\n\nmodule vpp-offload\n  port eth4 cores 1 steer off\n  port eth5 cores 1 steer on\n";
+        let good = "module fast-path\n  forwarding-mode custom-fib\n  attach eth4 generic\n  attach eth5 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer off\n  port eth5 cores 1 steer on\n";
         Config::parse(good).unwrap().validate_vpp_offload().unwrap();
 
         // Duplicate port line: rejected.
-        let dup = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  port eth4 cores 1 steer off\n  port eth4 cores 2 steer off\n";
+        let dup = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer off\n  port eth4 cores 2 steer off\n";
         assert!(Config::parse(dup).unwrap().validate_vpp_offload().is_err());
 
         // Empty section: rejected here, so `feasibility` and `run`
         // reach the same verdict on the same file.
-        let empty = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  expected-routes 100\n";
+        let empty = "module fast-path\n  attach eth4 generic\n\nmodule vpp-offload\n  loopback-address 198.51.100.1/32\n  expected-routes 100\n";
         let err = Config::parse(empty)
             .unwrap()
             .validate_vpp_offload()
@@ -4308,7 +4349,7 @@ module fast-path
         // both members, neither steering.
         let staged = "module fast-path\n  attach eth4 generic\n  attach eth5 generic\n  \
                       forwarding-mode custom-fib\n\n\
-                      module vpp-offload\n  port eth4 cores 1 steer off\n  \
+                      module vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth4 cores 1 steer off\n  \
                       port eth5 cores 1 steer off\n  expected-routes 100\n";
         Config::parse(staged)
             .unwrap()
@@ -4319,7 +4360,7 @@ module fast-path
         // Startup would refuse this; so must a reload.
         let rung_one = "module fast-path\n  attach eth4 generic\n  attach eth5 generic\n  \
                         forwarding-mode custom-fib\n\n\
-                        module vpp-offload\n  port eth5 cores 1 steer on\n  \
+                        module vpp-offload\n  loopback-address 198.51.100.1/32\n  port eth5 cores 1 steer on\n  \
                         expected-routes 100\n";
         let e = Config::parse(rung_one)
             .unwrap()

--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -20,9 +20,14 @@
 //! installed and silently drops. The supervisor orders
 //! `AttachDevices` ahead of `StartResync` for exactly this reason.
 
+use packetframe_common::config::Ipv4Prefix;
+
 use crate::vpp_api::generated::{
-    DevAttach, DevAttachReply, DevCreatePortIf, DevCreatePortIfReply, SwInterfaceDetails,
-    SwInterfaceDump, SwInterfaceSetFlags, SwInterfaceSetFlagsReply,
+    Address, AddressUnion, CreateLoopback, CreateLoopbackReply, DevAttach, DevAttachReply,
+    DevCreatePortIf, DevCreatePortIfReply, Prefix, SwInterfaceAddDelAddress,
+    SwInterfaceAddDelAddressReply, SwInterfaceDetails, SwInterfaceDump, SwInterfaceSetFlags,
+    SwInterfaceSetFlagsReply, SwInterfaceSetMacAddress, SwInterfaceSetMacAddressReply,
+    SwInterfaceSetUnnumbered, SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -66,6 +71,12 @@ pub struct PortAttach {
     pub port_id: u16,
     /// Receive queues, from the operator's `cores` promise.
     pub num_rx_queues: u16,
+    /// The **PF's** MAC, read from `/sys/class/net/<port>/address`.
+    ///
+    /// The VF's own MAC is not usable: MCAM redirects frames addressed
+    /// to the PF, so the interface must answer to that address or punt
+    /// every one of them.
+    pub pf_mac: [u8; 6],
 }
 
 /// A port VPP has accepted, with the index FIB paths must reference.
@@ -106,6 +117,17 @@ pub enum AttachError {
     /// here whether a live FIB still references the old index, and
     /// creating a second interface would leave routes pointing at
     /// something nothing services. A clean restart is the safe answer.
+    /// The MAC we set is not the MAC VPP reports.
+    ///
+    /// Its own variant because the consequence is specific and silent:
+    /// steered frames are addressed to the PF, so an interface holding
+    /// any other MAC punts every one of them at `ethernet-input` while
+    /// the FIB stays perfectly correct and health stays green.
+    MacMismatch {
+        port: String,
+        asked: [u8; 6],
+        got: [u8; 6],
+    },
     StaleIndex {
         port: String,
         sw_if_index: u32,
@@ -126,6 +148,14 @@ pub enum AttachError {
 impl std::fmt::Display for AttachError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::MacMismatch { port, asked, got } => write!(
+                f,
+                "{port}: asked VPP for MAC {} but it reports {}; steered frames are \
+                 addressed to the PF, so this interface would punt every one of them at \
+                 ethernet-input while the FIB and every health check stayed green",
+                hex_mac(asked),
+                hex_mac(got)
+            ),
             AttachError::Transport(e) => write!(f, "{e}"),
             AttachError::Refused {
                 step,
@@ -209,6 +239,7 @@ pub fn attach_ports(
     ports: &[PortAttach],
     known: &[(String, u32)],
     mode: AttachMode,
+    loop_idx: u32,
 ) -> Result<Vec<AttachedPort>, AttachError> {
     // One dump for the whole pass: it both confirms recorded indices
     // still exist and is the only way to see link state.
@@ -242,6 +273,14 @@ pub fn attach_ports(
                 // udapi provisioning can flap interface state under us,
                 // and this is the reconcile point.
                 set_admin_up(t, p, idx)?;
+                // Re-asserted on the reuse path too, for the same
+                // reason admin-up is: a controller deploy or a udapi
+                // provisioning cycle can reset interface state under a
+                // running VPP, and this is the reconcile point. A MAC
+                // that silently reverted would punt every steered frame
+                // while every counter stayed healthy.
+                set_mac(t, p, idx, p.pf_mac)?;
+                set_unnumbered(t, p, idx, loop_idx)?;
                 out.push(AttachedPort {
                     port: p.port.clone(),
                     dev_index: None,
@@ -261,6 +300,13 @@ pub fn attach_ports(
         let dev_index = attach_device(t, p)?;
         let sw_if_index = create_port_if(t, p, dev_index)?;
         set_admin_up(t, p, sw_if_index)?;
+        // Order matters and is not arbitrary: MAC before unnumbered,
+        // both before the port is announced as attached. A port handed
+        // to the sink before it can forward is a port the FIB will
+        // resolve routes onto while every packet dies at
+        // `ip4-not-enabled`.
+        set_mac(t, p, sw_if_index, p.pf_mac)?;
+        set_unnumbered(t, p, sw_if_index, loop_idx)?;
         out.push(AttachedPort {
             port: p.port.clone(),
             dev_index: Some(dev_index),
@@ -290,6 +336,7 @@ pub fn interfaces(t: &mut Transport) -> Result<Vec<Interface>, TransportError> {
             sw_if_index: d.sw_if_index,
             name: d.interface_name,
             flags: d.flags,
+            l2_address: d.l2_address,
         })
         .collect())
 }
@@ -300,6 +347,9 @@ pub struct Interface {
     pub sw_if_index: u32,
     pub name: String,
     pub flags: u32,
+    /// What VPP believes this interface's MAC is. The only way to check
+    /// that `sw_interface_set_mac_address` did anything.
+    pub l2_address: [u8; 6],
 }
 
 impl Interface {
@@ -374,6 +424,182 @@ fn create_port_if(t: &mut Transport, p: &PortAttach, dev_index: u32) -> Result<u
     Ok(reply.sw_if_index)
 }
 
+/// A config prefix as VPP's wire `Prefix`.
+fn prefix_of(p: Ipv4Prefix) -> Prefix {
+    let mut u = [0u8; 16];
+    u[..4].copy_from_slice(&p.addr.octets());
+    Prefix {
+        address: Address {
+            af: ADDRESS_IP4,
+            un: AddressUnion(u),
+        },
+        len: p.prefix_len,
+    }
+}
+
+/// `58:d6:1f:4f:cd:56`, for error messages an operator compares against
+/// `ip link` output.
+fn hex_mac(m: &[u8; 6]) -> String {
+    m.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// Give the interface the PF's MAC, then read the dump back and check.
+///
+/// Steered frames arrive addressed to the **PF**, because that is what
+/// MCAM redirects; the VF carries its own MAC, so without this every one
+/// of them is punted `ethernet-input: l3 mac mismatch`. Traced on
+/// hardware 2026-08-07 — 100 frames in, 100 punted, FIB correct
+/// throughout.
+///
+/// It is also what makes VPP *source* MAC-PF on transmit, which the
+/// design requires: the frame then leaves the same LMAC the kernel uses,
+/// so the upstream switch never sees the address move ports.
+///
+/// The readback is not ceremony. `sw_interface_set_mac_address` can
+/// return 0 and leave the interface unchanged on a driver that does not
+/// implement it, and the failure mode is invisible — every packet
+/// punted, every counter healthy. `sw_interface_dump` reports
+/// `l2_address`, so the check costs one dump we already know how to do.
+fn set_mac(
+    t: &mut Transport,
+    p: &PortAttach,
+    sw_if_index: u32,
+    mac: [u8; 6],
+) -> Result<(), AttachError> {
+    let reply = t.request::<SwInterfaceSetMacAddress, SwInterfaceSetMacAddressReply>(
+        SwInterfaceSetMacAddress {
+            context: 0,
+            sw_if_index,
+            mac_address: mac,
+        },
+    )?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_mac_address",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: format!("mac {}", hex_mac(&mac)),
+        });
+    }
+    let got = interfaces(t)?
+        .into_iter()
+        .find(|i| i.sw_if_index == sw_if_index)
+        .map(|i| i.l2_address)
+        .ok_or_else(|| AttachError::StaleIndex {
+            port: p.port.clone(),
+            sw_if_index,
+        })?;
+    if got != mac {
+        return Err(AttachError::MacMismatch {
+            port: p.port.clone(),
+            asked: mac,
+            got,
+        });
+    }
+    Ok(())
+}
+
+/// Create the loopback that member ports borrow an address from.
+///
+/// One per VPP, holding the router address. Returns its `sw_if_index`
+/// so teardown can delete it and so members can be unnumbered to it.
+pub fn create_loopback(t: &mut Transport, addr: Ipv4Prefix) -> Result<u32, AttachError> {
+    let reply = t.request::<CreateLoopback, CreateLoopbackReply>(CreateLoopback {
+        context: 0,
+        // Zero asks VPP to pick one. A loopback never puts a frame on a
+        // wire, so its address is not load-bearing the way a member
+        // port's is.
+        mac_address: [0; 6],
+    })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "create_loopback",
+            port: "loop0".into(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    let loop_idx = reply.sw_if_index;
+
+    let reply = t.request::<SwInterfaceAddDelAddress, SwInterfaceAddDelAddressReply>(
+        SwInterfaceAddDelAddress {
+            context: 0,
+            sw_if_index: loop_idx,
+            is_add: true,
+            del_all: false,
+            prefix: prefix_of(addr),
+        },
+    )?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_add_del_address",
+            port: "loop0".into(),
+            retval: reply.retval,
+            detail: format!("{}/{}", addr.addr, addr.prefix_len),
+        });
+    }
+
+    let reply =
+        t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
+            context: 0,
+            sw_if_index: loop_idx,
+            flags: IF_STATUS_ADMIN_UP,
+        })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_flags(loop0)",
+            port: "loop0".into(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    Ok(loop_idx)
+}
+
+/// Enable IPv4 on a member by borrowing the loopback's address.
+///
+/// Admin-up is not enough: an interface with no IPv4 drops every packet
+/// at `ip4-not-enabled`, *after* a correct FIB lookup would have
+/// succeeded. Observed on hardware with 1,053,960 routes installed and
+/// verified, forwarding zero.
+///
+/// Unnumbered rather than a per-port address because VPP rejects
+/// overlapping subnets across interfaces, and because one router address
+/// is what should source ICMP — PMTUD's frag-needed has to come from an
+/// address the sender can route back to.
+///
+/// **Not readback-verified**, unlike the MAC: `sw_interface_dump` does
+/// not report IP-enabled state, and no dump in the whitelist does. This
+/// rests on the API's acknowledgement, which is weaker, and the
+/// difference is deliberate rather than overlooked.
+fn set_unnumbered(
+    t: &mut Transport,
+    p: &PortAttach,
+    sw_if_index: u32,
+    loop_idx: u32,
+) -> Result<(), AttachError> {
+    let reply = t.request::<SwInterfaceSetUnnumbered, SwInterfaceSetUnnumberedReply>(
+        SwInterfaceSetUnnumbered {
+            context: 0,
+            sw_if_index: loop_idx,
+            unnumbered_sw_if_index: sw_if_index,
+            is_add: true,
+        },
+    )?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_unnumbered",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    Ok(())
+}
+
 fn set_admin_up(t: &mut Transport, p: &PortAttach, sw_if_index: u32) -> Result<(), AttachError> {
     let reply =
         t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
@@ -405,6 +631,7 @@ mod tests {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         };
         assert_eq!(format!("pci/{}", p.pci_addr), "pci/0002:07:00.1");
     }

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -102,6 +102,33 @@ pub struct Attached {
     pub adopted_process: bool,
 }
 
+/// The PF's MAC, from `/sys/class/net/<iface>/address`.
+///
+/// Read here rather than asked of VPP, because VPP cannot know it: the
+/// interface it owns is the **VF**, which has its own address. MCAM
+/// redirects frames addressed to the PF, so the PF's MAC is what the VPP
+/// interface must answer to — and what it must source on tx, so the
+/// frame leaves the same LMAC and the upstream switch sees no move.
+fn pf_mac(sysfs_net: &Path, iface: &str) -> Result<[u8; 6], String> {
+    let path = sysfs_net.join(iface).join("address");
+    let text =
+        std::fs::read_to_string(&path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    let parts: Vec<&str> = text.trim().split(':').collect();
+    if parts.len() != 6 {
+        return Err(format!(
+            "{} holds {:?}, which is not a MAC address",
+            path.display(),
+            text.trim()
+        ));
+    }
+    let mut out = [0u8; 6];
+    for (slot, byte) in out.iter_mut().zip(&parts) {
+        *slot = u8::from_str_radix(byte, 16)
+            .map_err(|_| format!("{}: {byte:?} is not a hex octet", path.display()))?;
+    }
+    Ok(out)
+}
+
 /// Which completeness handle the runtime should actually gate on.
 ///
 /// A named function rather than an inline `if` because the bug it fixes
@@ -290,6 +317,19 @@ pub fn bring_up(
         .iter()
         .map(|(iface, cores, _)| (iface.clone(), *cores))
         .collect();
+    // Mandatory, and checked in the pure phase so a config that cannot
+    // forward costs no VF and no hugepage reservation.
+    // `Config::validate_vpp_offload` refuses it at load; this is the
+    // guard for callers that reach `bring_up` directly.
+    let Some(loopback) = cfg.loopback_address else {
+        return Err(
+            "no `loopback-address`; member ports are unnumbered to a loopback and forward \
+             nothing without one — while reporting healthy, because the FIB stays correct \
+             and every packet dies at `ip4-not-enabled`"
+                .into(),
+        );
+    };
+
     let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
 
     // From here, every failure releases. `?` would return holding VFs
@@ -306,6 +346,7 @@ pub fn bring_up(
         &vpp_binary,
         steering,
         completeness,
+        loopback,
     ) {
         Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
@@ -375,6 +416,7 @@ fn finish(
     vpp_binary: &Path,
     steering: NtupleSteering,
     completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
+    loopback: packetframe_common::config::Ipv4Prefix,
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
     // rewritten on every attach: it is a pure function of config, and
@@ -406,13 +448,16 @@ fn finish(
     let port_attach: Vec<PortAttach> = state
         .ports
         .iter()
-        .map(|p| PortAttach {
-            port: p.iface.clone(),
-            pci_addr: p.vf_pci.clone(),
-            port_id: 0,
-            num_rx_queues: p.cores,
+        .map(|p| {
+            Ok(PortAttach {
+                port: p.iface.clone(),
+                pci_addr: p.vf_pci.clone(),
+                port_id: 0,
+                num_rx_queues: p.cores,
+                pf_mac: pf_mac(&paths.sys.sysfs_net, &p.iface)?,
+            })
         })
-        .collect();
+        .collect::<Result<Vec<_>, String>>()?;
     // Every member port, whether or not it steers: a steered packet's
     // best path may egress any of them, so the nexthop mapping must
     // resolve all of them (plan v5, membership vs steering).
@@ -523,6 +568,7 @@ fn finish(
             members,
             capacity,
             FamilyPolicy::V4Only,
+            loopback,
         )
         .with_recorded_indices(recorded);
         let owner = SharedOwner::new(ResourceOwner::new(state, sys));
@@ -662,6 +708,10 @@ mod completeness_gate_tests {
             expected_routes: 1_600_000,
             hugepages: None,
             require_table_complete: require,
+            loopback_address: Some(packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            }),
         }
     }
 

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -303,6 +303,12 @@ pub struct ConvergenceEngine {
     transport: Option<Transport>,
 
     ports: Vec<PortAttach>,
+    /// The address the loopback holds; every member is unnumbered to it.
+    loopback: packetframe_common::config::Ipv4Prefix,
+    /// The loopback's index once created. `None` until the first attach
+    /// pass — and reset with the transport, because an index from a VPP
+    /// that has since died names nothing.
+    loop_index: Option<u32>,
     /// `(port, sw_if_index)` recorded from a previous run, for adoption.
     recorded_indices: Vec<(String, u32)>,
     attached: Vec<AttachedPort>,
@@ -351,11 +357,14 @@ impl ConvergenceEngine {
         members: Vec<String>,
         high_water_routes: u64,
         families: FamilyPolicy,
+        loopback: packetframe_common::config::Ipv4Prefix,
     ) -> Self {
         Self {
             api_socket: api_socket.into(),
             transport: None,
             ports,
+            loopback,
+            loop_index: None,
             recorded_indices: Vec::new(),
             attached: Vec::new(),
             port_index: PortIndex::default(),
@@ -598,7 +607,21 @@ impl ConvergenceEngine {
                 return Err(EngineError::NotConnected);
             }
         };
-        let result = attach_ports(t, &ports, &known, mode);
+        // The loopback comes first and exists once per VPP: members are
+        // unnumbered to it, so there is nothing to borrow an address
+        // from until it does. Re-created after a restart because the
+        // index died with the process.
+        let loop_index = match self.loop_index {
+            Some(idx) => Ok(idx),
+            None => crate::attach::create_loopback(t, self.loopback),
+        };
+        let result = match loop_index {
+            Ok(idx) => {
+                self.loop_index = Some(idx);
+                attach_ports(t, &ports, &known, mode, idx)
+            }
+            Err(e) => Err(e),
+        };
         self.ports = ports;
         self.recorded_indices = known;
         let attached = match result {
@@ -1075,6 +1098,11 @@ impl ConvergenceEngine {
         // live FIB still references them — and every recovery after an
         // adopted-process failure was driven straight back into teardown.
         self.recorded_indices.clear();
+        // Same reasoning, one interface further: the loopback belonged
+        // to the dead process. Keeping its index would have the next
+        // attach unnumber every member to an interface that no longer
+        // exists — which VPP would refuse, or worse accept.
+        self.loop_index = None;
         self.pending = PendingMap::new();
         self.ledger = RouteLedger::new(self.ledger_capacity());
         self.phase = None;
@@ -1141,10 +1169,15 @@ mod tests {
                 pci_addr: "0002:07:00.1".into(),
                 port_id: 0,
                 num_rx_queues: 1,
+                pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             }],
             vec!["eth4".into()],
             1_000_000,
             FamilyPolicy::V4Only,
+            packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            },
         )
     }
 
@@ -1260,6 +1293,10 @@ mod tests {
             vec!["eth4".into()],
             2,
             FamilyPolicy::V4Only,
+            packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            },
         );
         e.nexthops.set_device(nh(1), "eth4");
         for i in 0..4u8 {
@@ -1304,6 +1341,10 @@ mod tests {
             vec!["eth4".into()],
             1_000,
             FamilyPolicy::V4Only,
+            packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            },
         );
         e.last_verify = Some(crate::verify::VerifyOutcome {
             sampled: 4,

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -99,6 +99,15 @@ pub struct VppOffloadConfig {
     /// converged against bird. See
     /// [`packetframe_common::fib::TableCompleteness`].
     pub require_table_complete: bool,
+    /// The address VPP's loopback holds; every member port is
+    /// unnumbered to it.
+    ///
+    /// `None` is a config error whenever there are ports, refused at
+    /// load — see [`packetframe_common::config::Config::validate_vpp_offload`].
+    /// Attaching without it produces a VPP that passes every health
+    /// check and forwards nothing, which is the failure this whole
+    /// module is built to make impossible.
+    pub loopback_address: Option<packetframe_common::config::Ipv4Prefix>,
 }
 
 /// Default sizing input when `expected-routes` is absent.
@@ -132,6 +141,7 @@ impl VppOffloadConfig {
                 ModuleDirective::ExpectedRoutes(n) => out.expected_routes = *n,
                 ModuleDirective::VppHugepages(n) => out.hugepages = Some(*n),
                 ModuleDirective::VppRequireTableComplete(v) => out.require_table_complete = *v,
+                ModuleDirective::VppLoopbackAddress(p) => out.loopback_address = Some(*p),
                 _ => {}
             }
         }
@@ -182,6 +192,14 @@ impl VppOffloadConfig {
                 "`hugepages` changed ({:?} → {:?}); the reservation is made at attach and \
                  VPP maps it at start — restart to apply",
                 self.hugepages, new.hugepages
+            ));
+        }
+        if self.loopback_address != new.loopback_address {
+            return Err(format!(
+                "`loopback-address` changed ({:?} → {:?}); the loopback is created and the \
+                 member ports unnumbered to it at attach, and VPP's adjacencies are built \
+                 from it — restart to apply",
+                self.loopback_address, new.loopback_address
             ));
         }
         if self.vpp_binary != new.vpp_binary {
@@ -1297,6 +1315,10 @@ mod tests {
             expected_routes: routes,
             hugepages: None,
             require_table_complete: true,
+            loopback_address: Some(packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            }),
         }
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -869,6 +869,10 @@ mod tests {
             vec!["eth4".into()],
             1_000,
             FamilyPolicy::V4Only,
+            packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            },
         )
     }
 

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -35,6 +35,14 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "ip_neighbor_add_del_reply", crc: "0x1992deab", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_flags", crc: "0xf5aec1b8", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "sw_interface_set_flags_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "sw_interface_set_mac_address", crc: "0xc536e7eb", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "sw_interface_set_mac_address_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "create_loopback", crc: "0x42bb5d22", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "create_loopback_reply", crc: "0x5383d31f", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "sw_interface_add_del_address", crc: "0x5463d73b", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "sw_interface_add_del_address_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "sw_interface_set_unnumbered", crc: "0x154a6439", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "sw_interface_set_unnumbered_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_dump", crc: "0xaa610c27", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "sw_interface_details", crc: "0x6c221fc7", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "dev_attach", crc: "0x44b725fc", context_offset: 6, client_index_prefix: true },
@@ -1072,6 +1080,310 @@ impl Decode for SwInterfaceSetFlagsReply {
 
 impl Message for SwInterfaceSetFlagsReply {
     const NAME: &'static str = "sw_interface_set_flags_reply";
+    const CRC: &'static str = "0xe8d4e804";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_mac_address` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetMacAddress {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub mac_address: [u8; 6],
+}
+
+impl Encode for SwInterfaceSetMacAddress {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.extend_from_slice(&self.mac_address[..]);
+    }
+}
+
+impl Decode for SwInterfaceSetMacAddress {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let mac_address = d.bytes::<6>()?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            mac_address,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetMacAddress {
+    const NAME: &'static str = "sw_interface_set_mac_address";
+    const CRC: &'static str = "0xc536e7eb";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_mac_address_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetMacAddressReply {
+    pub context: u32,
+    pub retval: i32,
+}
+
+impl Encode for SwInterfaceSetMacAddressReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+    }
+}
+
+impl Decode for SwInterfaceSetMacAddressReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        Ok(Self {
+            context,
+            retval,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetMacAddressReply {
+    const NAME: &'static str = "sw_interface_set_mac_address_reply";
+    const CRC: &'static str = "0xe8d4e804";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `create_loopback` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CreateLoopback {
+    pub context: u32,
+    pub mac_address: [u8; 6],
+}
+
+impl Encode for CreateLoopback {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&self.mac_address[..]);
+    }
+}
+
+impl Decode for CreateLoopback {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let mac_address = d.bytes::<6>()?;
+        Ok(Self {
+            context,
+            mac_address,
+        })
+    }
+}
+
+impl Message for CreateLoopback {
+    const NAME: &'static str = "create_loopback";
+    const CRC: &'static str = "0x42bb5d22";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `create_loopback_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CreateLoopbackReply {
+    pub context: u32,
+    pub retval: i32,
+    pub sw_if_index: u32,
+}
+
+impl Encode for CreateLoopbackReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+    }
+}
+
+impl Decode for CreateLoopbackReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        let sw_if_index = d.u32()?;
+        Ok(Self {
+            context,
+            retval,
+            sw_if_index,
+        })
+    }
+}
+
+impl Message for CreateLoopbackReply {
+    const NAME: &'static str = "create_loopback_reply";
+    const CRC: &'static str = "0x5383d31f";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_add_del_address` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceAddDelAddress {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub is_add: bool,
+    pub del_all: bool,
+    pub prefix: Prefix,
+}
+
+impl Encode for SwInterfaceAddDelAddress {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.push(if self.is_add { 1u8 } else { 0u8 });
+        buf.push(if self.del_all { 1u8 } else { 0u8 });
+        self.prefix.encode(buf);
+    }
+}
+
+impl Decode for SwInterfaceAddDelAddress {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let is_add = d.bool()?;
+        let del_all = d.bool()?;
+        let prefix = Prefix::decode(d)?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            is_add,
+            del_all,
+            prefix,
+        })
+    }
+}
+
+impl Message for SwInterfaceAddDelAddress {
+    const NAME: &'static str = "sw_interface_add_del_address";
+    const CRC: &'static str = "0x5463d73b";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_add_del_address_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceAddDelAddressReply {
+    pub context: u32,
+    pub retval: i32,
+}
+
+impl Encode for SwInterfaceAddDelAddressReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+    }
+}
+
+impl Decode for SwInterfaceAddDelAddressReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        Ok(Self {
+            context,
+            retval,
+        })
+    }
+}
+
+impl Message for SwInterfaceAddDelAddressReply {
+    const NAME: &'static str = "sw_interface_add_del_address_reply";
+    const CRC: &'static str = "0xe8d4e804";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_unnumbered` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetUnnumbered {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub unnumbered_sw_if_index: u32,
+    pub is_add: bool,
+}
+
+impl Encode for SwInterfaceSetUnnumbered {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.extend_from_slice(&(self.unnumbered_sw_if_index).to_be_bytes());
+        buf.push(if self.is_add { 1u8 } else { 0u8 });
+    }
+}
+
+impl Decode for SwInterfaceSetUnnumbered {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let unnumbered_sw_if_index = d.u32()?;
+        let is_add = d.bool()?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            unnumbered_sw_if_index,
+            is_add,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetUnnumbered {
+    const NAME: &'static str = "sw_interface_set_unnumbered";
+    const CRC: &'static str = "0x154a6439";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_unnumbered_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetUnnumberedReply {
+    pub context: u32,
+    pub retval: i32,
+}
+
+impl Encode for SwInterfaceSetUnnumberedReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+    }
+}
+
+impl Decode for SwInterfaceSetUnnumberedReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        Ok(Self {
+            context,
+            retval,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetUnnumberedReply {
+    const NAME: &'static str = "sw_interface_set_unnumbered_reply";
     const CRC: &'static str = "0xe8d4e804";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -30,16 +30,21 @@ mod wire;
 use wire::{name_for, read_frame, reply_head, request_context, write_frame};
 
 use packetframe_vpp_offload::vpp_api::generated::{
-    Address, AddressUnion, ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath,
-    FibPathNh, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute, IpRouteAddDel, IpRouteAddDelReply,
-    IpRouteDetails, IpRouteLookupReply, MessageTableEntry, Prefix, SockclntCreateReply,
-    SwInterfaceDetails, SwInterfaceSetFlagsReply, ADDRESS_IP4, FIB_API_PATH_NH_PROTO_IP4,
-    FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
+    Address, AddressUnion, ControlPingReply, CreateLoopbackReply, DevAttachReply,
+    DevCreatePortIfReply, FibPath, FibPathNh, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute,
+    IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails, IpRouteLookupReply, MessageTableEntry,
+    Prefix, SockclntCreateReply, SwInterfaceAddDelAddressReply, SwInterfaceDetails,
+    SwInterfaceSetFlagsReply, SwInterfaceSetMacAddressReply, SwInterfaceSetUnnumberedReply,
+    ADDRESS_IP4, FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
 };
 
 /// The index the fake's `dev_create_port_if` hands out. Routes must
 /// install onto *this*, learned from VPP, never onto a guess.
 pub const ASSIGNED_INDEX: u32 = 3;
+
+/// The index the fake's `create_loopback` hands out. Distinct from
+/// `ASSIGNED_INDEX` so a test crossing the two would show it.
+pub const LOOPBACK_INDEX: u32 = 11;
 
 /// Link-layer address the fake mirror hands out for its one neighbour.
 pub const MAC: [u8; 6] = [0x02, 0x00, 0x00, 0x00, 0x00, 0x01];
@@ -204,6 +209,10 @@ impl Fake {
 }
 
 fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) -> Option<()> {
+    // What `sw_interface_set_mac_address` last set, per interface. The
+    // dump reports it, so `attach::set_mac`'s readback has a real answer
+    // to compare against rather than a constant that always matches.
+    let mut macs: std::collections::HashMap<u32, [u8; 6]> = std::collections::HashMap::new();
     read_frame(sock)?;
     let mut reply = SockclntCreateReply {
         context: 1,
@@ -357,8 +366,60 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
             }
             "sw_interface_dump" => {
                 let mut d = reply_head("sw_interface_details");
-                details(ASSIGNED_INDEX, "octeon0/0", 3, ctx).encode(&mut d);
+                let mut det = details(ASSIGNED_INDEX, "octeon0/0", 3, ctx);
+                if let Some(m) = macs.get(&ASSIGNED_INDEX) {
+                    det.l2_address = *m;
+                }
+                det.encode(&mut d);
                 write_frame(sock, &d);
+                continue;
+            }
+            "sw_interface_set_mac_address" => {
+                // Payload: id(2) client_index(4) context(4) sw_if_index(4)
+                // mac(6). Read by offset because the generated request
+                // types are encode-only.
+                let idx = u32::from_be_bytes([req[10], req[11], req[12], req[13]]);
+                let mut mac = [0u8; 6];
+                mac.copy_from_slice(&req[14..20]);
+                macs.insert(idx, mac);
+                let mut out = reply_head("sw_interface_set_mac_address_reply");
+                SwInterfaceSetMacAddressReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+                write_frame(sock, &out);
+                continue;
+            }
+            "create_loopback" => {
+                let mut out = reply_head("create_loopback_reply");
+                CreateLoopbackReply {
+                    context: ctx,
+                    sw_if_index: LOOPBACK_INDEX,
+                    retval: 0,
+                }
+                .encode(&mut out);
+                write_frame(sock, &out);
+                continue;
+            }
+            "sw_interface_add_del_address" => {
+                let mut out = reply_head("sw_interface_add_del_address_reply");
+                SwInterfaceAddDelAddressReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+                write_frame(sock, &out);
+                continue;
+            }
+            "sw_interface_set_unnumbered" => {
+                let mut out = reply_head("sw_interface_set_unnumbered_reply");
+                SwInterfaceSetUnnumberedReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+                write_frame(sock, &out);
                 continue;
             }
             "control_ping" if behaviour.stall_pings_after == Some(0) => {

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -22,14 +22,22 @@ use packetframe_vpp_offload::fib_sync::{to_prefix, PortIndex};
 use packetframe_vpp_offload::sink::{Capacity, RouteLedger};
 use packetframe_vpp_offload::verify::{verify, Mismatch};
 use packetframe_vpp_offload::vpp_api::codec::{peek_msg_id, Encode, SOCKCLNT_CREATE_MSG_ID};
+/// The loopback index the fake hands out. Attach unnumbers every member
+/// to it; these tests care that the call is made, not what the index is.
+const TEST_LOOP_IDX: u32 = 9;
+
+/// What the fake's `create_loopback` hands back.
+const LOOP_IF_INDEX: u32 = 9;
+
 #[path = "common/wire.rs"]
 mod wire;
 use wire::{name_for, read_frame, reply_head, request_context, write_frame};
 
 use packetframe_vpp_offload::vpp_api::generated::{
-    ControlPingReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute, IpRouteLookupReply,
-    MessageTableEntry, SockclntCreateReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
-    MESSAGE_META,
+    ControlPingReply, CreateLoopbackReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute,
+    IpRouteLookupReply, MessageTableEntry, SockclntCreateReply, SwInterfaceAddDelAddressReply,
+    SwInterfaceDetails, SwInterfaceSetFlagsReply, SwInterfaceSetMacAddressReply,
+    SwInterfaceSetUnnumberedReply, MESSAGE_META,
 };
 use packetframe_vpp_offload::vpp_api::Transport;
 
@@ -106,12 +114,28 @@ impl Fake {
         lookup: LookupBehaviour,
         ifaces: Ifaces,
     ) -> Self {
+        Self::start_full(tag, attach, lookup, ifaces, false)
+    }
+
+    /// `deaf_to_mac` models the failure the readback exists for: a
+    /// driver that answers `sw_interface_set_mac_address` with retval 0
+    /// and leaves the interface unchanged.
+    fn start_full(
+        tag: &str,
+        attach: AttachBehaviour,
+        lookup: LookupBehaviour,
+        ifaces: Ifaces,
+        deaf_to_mac: bool,
+    ) -> Self {
         let dir = tempdir::TempDir::new(tag).unwrap();
         let path = dir.path().join("api.sock");
         let listener = UnixListener::bind(&path).unwrap();
         let (tx, rx): (Sender<String>, Receiver<String>) = channel();
 
         thread::spawn(move || {
+            let mut ifaces = ifaces;
+            let mut macs: std::collections::HashMap<u32, [u8; 6]> =
+                std::collections::HashMap::new();
             let Ok((mut sock, _)) = listener.accept() else {
                 return;
             };
@@ -164,12 +188,72 @@ impl Fake {
                         .encode(&mut out);
                     }
                     "dev_create_port_if" => {
+                        // A created interface shows up in later dumps,
+                        // as it does in VPP. Without this the MAC
+                        // readback cannot find the port it just made,
+                        // and the fake would be failing attach for a
+                        // reason no real VPP has.
+                        if attach.create_retval == 0
+                            && !ifaces.iter().any(|(i, _, _)| *i == attach.sw_if_index)
+                        {
+                            ifaces.push((attach.sw_if_index, "octeon0/0".into(), 3));
+                        }
                         out = reply_head("dev_create_port_if_reply");
                         DevCreatePortIfReply {
                             context: ctx,
                             sw_if_index: attach.sw_if_index,
                             retval: attach.create_retval,
                             error_string: String::new(),
+                        }
+                        .encode(&mut out);
+                    }
+                    // Modelled, not merely acknowledged: the dump below
+                    // reports whatever was set here, so `set_mac`'s
+                    // readback has something real to disagree with. A
+                    // fake that returned 0 and forgot would make the
+                    // readback untestable — and the readback exists
+                    // precisely because a driver can do that.
+                    "sw_interface_set_mac_address" => {
+                        // Read off the wire by offset rather than
+                        // decoded: requests are encode-only in the
+                        // generated types. Payload is
+                        // id(2) client_index(4) context(4) sw_if_index(4)
+                        // mac(6).
+                        let idx = u32::from_be_bytes([req[10], req[11], req[12], req[13]]);
+                        let mut mac = [0u8; 6];
+                        mac.copy_from_slice(&req[14..20]);
+                        if !deaf_to_mac {
+                            macs.insert(idx, mac);
+                        }
+                        out = reply_head("sw_interface_set_mac_address_reply");
+                        SwInterfaceSetMacAddressReply {
+                            context: ctx,
+                            retval: 0,
+                        }
+                        .encode(&mut out);
+                    }
+                    "create_loopback" => {
+                        out = reply_head("create_loopback_reply");
+                        CreateLoopbackReply {
+                            context: ctx,
+                            sw_if_index: LOOP_IF_INDEX,
+                            retval: 0,
+                        }
+                        .encode(&mut out);
+                    }
+                    "sw_interface_add_del_address" => {
+                        out = reply_head("sw_interface_add_del_address_reply");
+                        SwInterfaceAddDelAddressReply {
+                            context: ctx,
+                            retval: 0,
+                        }
+                        .encode(&mut out);
+                    }
+                    "sw_interface_set_unnumbered" => {
+                        out = reply_head("sw_interface_set_unnumbered_reply");
+                        SwInterfaceSetUnnumberedReply {
+                            context: ctx,
+                            retval: 0,
                         }
                         .encode(&mut out);
                     }
@@ -209,7 +293,11 @@ impl Fake {
                     "sw_interface_dump" => {
                         for (idx, name, flags) in &ifaces {
                             let mut d = reply_head("sw_interface_details");
-                            details(*idx, name, *flags, ctx).encode(&mut d);
+                            let mut det = details(*idx, name, *flags, ctx);
+                            if let Some(m) = macs.get(idx) {
+                                det.l2_address = *m;
+                            }
+                            det.encode(&mut d);
                             write_frame(&mut sock, &d);
                         }
                         continue;
@@ -320,11 +408,49 @@ fn ports() -> Vec<PortAttach> {
         pci_addr: "0002:07:00.1".into(),
         port_id: 0,
         num_rx_queues: 1,
+        pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
     }]
 }
 
+/// The MAC readback catches a driver that says yes and does nothing.
+///
+/// This is the whole reason `set_mac` costs an extra dump. A retval of 0
+/// is not evidence: `sw_interface_set_mac_address` can be accepted and
+/// ignored, and the result is invisible everywhere else — the FIB
+/// installs correctly, verification passes, health reports healthy, and
+/// every steered frame is punted at `ethernet-input` because the
+/// interface does not answer to the address MCAM sends traffic to.
+/// Traced on hardware 2026-08-07 before the MAC was set: 100 frames in,
+/// 100 punted, `fib-synced healthy` throughout.
 #[test]
-fn attach_sends_the_three_messages_in_order() {
+fn a_mac_set_that_did_not_take_is_caught_not_trusted() {
+    let fake = Fake::start_full(
+        "deafmac",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![(7, "octeon0/0".into(), 3)],
+        // Acknowledges, changes nothing — the failure mode.
+        true,
+    );
+    let mut t = fake.connect();
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX)
+        .expect_err("a MAC that did not take must not be reported as attached");
+
+    match err {
+        AttachError::MacMismatch { port, asked, got } => {
+            assert_eq!(port, "eth3");
+            assert_ne!(asked, got, "the point is that they differ");
+        }
+        other => panic!("expected MacMismatch, got {other:?}"),
+    }
+}
+
+#[test]
+fn attach_sends_every_message_a_forwarding_port_needs_in_order() {
     let fake = Fake::start(
         "ok",
         AttachBehaviour {
@@ -335,7 +461,8 @@ fn attach_sends_the_three_messages_in_order() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let got = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect("attach");
+    let got =
+        attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX).expect("attach");
 
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].port, "eth3");
@@ -343,9 +470,17 @@ fn attach_sends_the_three_messages_in_order() {
     assert_eq!(got[0].sw_if_index, 7);
 
     // A discovery dump comes first (so an adopted VPP is not
-    // re-attached), then the attach proper. Order within the attach is
-    // not cosmetic: create_port_if consumes dev_attach's index, and
-    // set_flags consumes create_port_if's.
+    // re-attached), then the attach proper. None of this order is
+    // cosmetic: create_port_if consumes dev_attach's index, set_flags
+    // consumes create_port_if's, and the MAC and unnumbered calls must
+    // land before the port is reported attached — a port handed to the
+    // sink before it can forward is one the FIB resolves routes onto
+    // while every packet dies at `ip4-not-enabled`.
+    //
+    // The second dump is the MAC readback. It is in this list on
+    // purpose: `sw_interface_set_mac_address` can return 0 and change
+    // nothing, and the only thing that catches it is asking VPP what
+    // the interface actually holds.
     assert_eq!(
         fake.observed(),
         vec![
@@ -354,6 +489,10 @@ fn attach_sends_the_three_messages_in_order() {
             "dev_attach".to_string(),
             "dev_create_port_if".to_string(),
             "sw_interface_set_flags".to_string(),
+            "sw_interface_set_mac_address".to_string(),
+            "sw_interface_dump".to_string(),
+            "control_ping".to_string(),
+            "sw_interface_set_unnumbered".to_string(),
         ]
     );
 }
@@ -373,8 +512,8 @@ fn an_sw_if_index_of_zero_is_refused_as_local0() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err =
-        attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must refuse index 0");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX)
+        .expect_err("must refuse index 0");
     assert!(matches!(err, AttachError::LocalZero { .. }), "{err:?}");
     let msg = err.to_string();
     assert!(msg.contains("local0"), "{msg}");
@@ -402,7 +541,8 @@ fn a_refused_dev_attach_reports_vpps_own_text() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX)
+        .expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_attach"), "{msg}");
     assert!(msg.contains("eth3"), "names the port: {msg}");
@@ -433,7 +573,8 @@ fn a_refused_create_port_if_names_the_step_that_failed() {
         LookupBehaviour::Missing,
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect_err("must fail");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX)
+        .expect_err("must fail");
     let msg = err.to_string();
     assert!(msg.contains("dev_create_port_if"), "{msg}");
     assert!(msg.contains("-11"), "reports the retval: {msg}");
@@ -464,7 +605,8 @@ fn a_recorded_interface_is_reused_not_re_attached() {
     );
     let mut t = fake.connect();
     let known = vec![("eth3".to_string(), 7u32)];
-    let got = attach_ports(&mut t, &ports(), &known, AttachMode::Adopted).expect("adopt");
+    let got =
+        attach_ports(&mut t, &ports(), &known, AttachMode::Adopted, TEST_LOOP_IDX).expect("adopt");
 
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].sw_if_index, 7);
@@ -501,7 +643,8 @@ fn a_stale_recorded_index_is_refused() {
     );
     let mut t = fake.connect();
     let known = vec![("eth3".to_string(), 7u32)];
-    let err = attach_ports(&mut t, &ports(), &known, AttachMode::Adopted).expect_err("must refuse");
+    let err = attach_ports(&mut t, &ports(), &known, AttachMode::Adopted, TEST_LOOP_IDX)
+        .expect_err("must refuse");
     assert!(matches!(err, AttachError::StaleIndex { .. }), "{err:?}");
     let msg = err.to_string();
     assert!(msg.contains("no longer has it"), "{msg}");
@@ -524,7 +667,8 @@ fn adopting_without_a_recorded_index_refuses_rather_than_duplicating() {
         vec![(7, "octeon0/0".into(), 3)],
     );
     let mut t = fake.connect();
-    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Adopted).expect_err("must refuse");
+    let err = attach_ports(&mut t, &ports(), &[], AttachMode::Adopted, TEST_LOOP_IDX)
+        .expect_err("must refuse");
     assert!(
         matches!(err, AttachError::UnknownIndexOnAdopt { .. }),
         "{err:?}"
@@ -551,7 +695,8 @@ fn a_fresh_process_with_no_recorded_index_attaches_normally() {
         vec![],
     );
     let mut t = fake.connect();
-    let got = attach_ports(&mut t, &ports(), &[], AttachMode::Fresh).expect("attach");
+    let got =
+        attach_ports(&mut t, &ports(), &[], AttachMode::Fresh, TEST_LOOP_IDX).expect("attach");
     assert_eq!(got[0].sw_if_index, 7);
     assert_eq!(got[0].dev_index, Some(1));
 }

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -84,6 +84,16 @@ impl Host {
             let dev = net.join(iface).join("device");
             fs::create_dir_all(&dev).unwrap();
             fs::write(dev.join("sriov_numvfs"), "0").unwrap();
+            // The PF's MAC, which attach gives to the VPP interface so
+            // steered frames — addressed to the PF — are accepted rather
+            // than punted. Distinct per port, so a test that crossed
+            // them would show it.
+            let last = iface.as_bytes()[iface.len() - 1];
+            fs::write(
+                net.join(iface).join("address"),
+                format!("58:d6:1f:4f:cd:{last:02x}\n"),
+            )
+            .unwrap();
             let pci_dev = devices.join(pci);
             fs::create_dir_all(&pci_dev).unwrap();
             std::os::unix::fs::symlink(&pci_dev, dev.join("virtfn0")).unwrap();
@@ -141,6 +151,10 @@ impl Host {
             // against, and none of them steers; the gate is exercised
             // where it lives, in `runtime`.
             require_table_complete: false,
+            loopback_address: Some(packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                prefix_len: 32,
+            }),
         }
     }
 

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -368,11 +368,16 @@ fn measured_convergence_against_a_real_vpp() {
                 pci_addr: pci.clone(),
                 port_id: 0,
                 num_rx_queues: 1,
+                pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
             })
             .collect(),
         ports.clone(),
         HIGH_WATER,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     )
     .with_recorded_indices(recorded);
 

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -58,10 +58,15 @@ fn engine_for(fake: &Fake) -> ConvergenceEngine {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec!["eth4".into()],
         1_000_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     )
 }
 

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -51,10 +51,15 @@ fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec!["eth4".into()],
         1_000_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     );
     let mirror = Mirror {
         routes: (0..n_routes).map(|i| fake_vpp::v4(0, i)).collect(),
@@ -281,10 +286,15 @@ fn a_persist_that_recovers_clears_the_recorded_failure() {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec!["eth4".into()],
         1_000_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     );
     let rt = Runtime::new(
         engine,
@@ -368,6 +378,10 @@ fn a_successful_spawn_persist_clears_an_earlier_store_failure() {
         vec!["eth4".into()],
         1_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     );
     let rt = Runtime::new(
         engine,
@@ -438,10 +452,15 @@ fn a_route_learned_after_convergence_still_reaches_vpp() {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec![dev],
         1_000_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     );
     let rt = Runtime::new(
         engine,
@@ -573,10 +592,15 @@ fn a_nexthop_first_seen_after_convergence_gets_its_adjacency() {
             pci_addr: "0002:07:00.1".into(),
             port_id: 0,
             num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec![dev],
         1_000_000,
         FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
     );
     let rt = Runtime::new(
         engine,

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -52,10 +52,15 @@ fn the_service_converges_publishes_health_and_stops_clean() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -209,6 +214,10 @@ fn an_incompatible_api_fails_attach_with_the_reason() {
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             // Exactly what the attach wiring does: confirm the API
             // answers BEFORE committing to adopt it.
@@ -272,10 +281,15 @@ fn an_unpersisted_identity_degrades_health_and_is_named() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -396,10 +410,15 @@ fn a_failing_verifys_teardown_failures_are_published_and_retained() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -518,6 +537,10 @@ fn the_initial_injections_failures_reach_the_first_snapshot() {
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -590,10 +613,15 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -708,10 +736,15 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -812,10 +845,15 @@ fn an_episode_keeps_its_root_cause_alongside_the_latest_symptom() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -911,10 +949,15 @@ fn a_teardown_that_outlives_the_budget_is_still_observable() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -1037,10 +1080,15 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -1156,10 +1204,15 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -1249,10 +1302,15 @@ fn a_steering_change_before_convergence_is_refused() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -1319,10 +1377,15 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,
@@ -1412,10 +1475,15 @@ fn an_allowlist_change_under_live_steering_is_always_reconciled() {
                     pci_addr: "0002:07:00.1".into(),
                     port_id: 0,
                     num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
                 }],
                 vec!["eth4".into()],
                 1_000_000,
                 FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
             );
             let runtime = Runtime::new(
                 engine,

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -54,6 +54,30 @@ const MESSAGES: &[&str] = &[
     // Interface state.
     "sw_interface_set_flags",
     "sw_interface_set_flags_reply",
+    // Making a member port able to FORWARD, which admin-up does not.
+    //
+    // Both were found by tracing a live VPP on 2026-08-07, in this
+    // order, each hiding behind the previous one:
+    //
+    // - Without the PF's MAC on the interface, every steered frame is
+    //   punted `ethernet-input: l3 mac mismatch`. MCAM redirects frames
+    //   addressed to the PF into the VF, and the VF carries its own MAC,
+    //   so VPP decides they are not for it. Setting it is also what makes
+    //   VPP *source* MAC-PF on tx, which the design requires so the frame
+    //   leaves the same LMAC and the upstream switch sees no MAC move.
+    // - With the MAC right, frames reach IP and die at `ip4-not-enabled`.
+    //   A VPP interface forwards only once IPv4 is enabled on it, and the
+    //   scheme that works here is a loopback holding the router address
+    //   with each member unnumbered to it (no overlapping-subnet
+    //   rejection at /32).
+    "sw_interface_set_mac_address",
+    "sw_interface_set_mac_address_reply",
+    "create_loopback",
+    "create_loopback_reply",
+    "sw_interface_add_del_address",
+    "sw_interface_add_del_address_reply",
+    "sw_interface_set_unnumbered",
+    "sw_interface_set_unnumbered_reply",
     // Interface discovery + link state. `sw_interface_dump` is a DUMP:
     // it streams `sw_interface_details` and is terminated by trailing a
     // `control_ping`. Two jobs neither of which is optional — adoption

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -445,6 +445,33 @@ will fire on every planned restart. Either alert on a sustained
 Unhealthy (30 s or more) or exclude the window explicitly. Measured
 2026-08-06 on the shadow during drill (d).
 
+### A member port needs two things admin-up does not give it
+
+Both were found by tracing a live VPP on 2026-08-07, each hidden behind
+the other, and the module now does both at attach:
+
+1. **The port must carry the PF's MAC.** MCAM redirects frames addressed
+   to the *PF*; the VF has its own address, so without this every steered
+   frame is punted `ethernet-input: l3 mac mismatch`. It is also what
+   makes VPP source MAC-PF on transmit, so the frame leaves the same LMAC
+   and the upstream switch never sees the address move ports. The module
+   sets it and then **reads it back** — `sw_interface_set_mac_address` can
+   return 0 and change nothing, and that failure is invisible in every
+   other surface.
+2. **IPv4 must be enabled on the port.** A member with a correct FIB and
+   no IPv4 drops everything at `ip4-not-enabled`. `loopback-address` in
+   the config is the address VPP's loopback holds; members are unnumbered
+   to it.
+
+**What this looked like before the fix, and why it matters for the
+canary:** with 1,053,960 routes installed and verified on 64 probes,
+`packetframe status` reported `fib-synced healthy` while VPP forwarded
+**zero** packets. Readback verification samples the FIB, and the FIB was
+genuinely right. A verified FIB is not a forwarding dataplane — on a
+steered production port that distinction is the difference between a
+canary that reveals a problem and one that blackholes traffic with every
+gauge green.
+
 ### Verification does not re-run in steady state
 
 `fib-synced` reports the **last completed** readback verify, and the


### PR DESCRIPTION
Everything here came from tracing a live VPP on the shadow today. Two configuration steps `attach` never performed, each hidden behind the other, plus the config that makes the second possible.

## 1. The port must carry the PF's MAC

MCAM redirects frames addressed to the **PF**; the VF has its own address, so VPP decided they weren't for it:

```
error-punt → punt: ethernet-input: l3 mac mismatch      (100 of 100)
```

Setting it is also what makes VPP **source** MAC-PF on transmit — the design requirement so the frame leaves the same LMAC and the upstream switch never sees the address move ports. Confirmed in the rewrite trace: `28704e4769c7 58d61f4fcd56 0800`.

**Set, then read back.** `sw_interface_set_mac_address` can return 0 and change nothing, and that failure is invisible in every other surface: the FIB installs correctly, verification passes, health is green, and every steered frame is punted. `sw_interface_dump` reports `l2_address`, so the check costs one dump we already know how to do.

The fake **models** this rather than acknowledging it — it records what was set and reports it back on the next dump — and a new test drives it deaf (`start_full(..., deaf_to_mac: true)`) to prove the readback is what catches it. A fake that always agreed would make the readback untestable, which is the same shape as the in-memory NIC that round-trips a wrong flow-spec offset perfectly.

## 2. IPv4 must be enabled on the port

With the MAC right, frames reached IP and died:

```
ip4-input → ip4-not-enabled → error-drop → drop (null-node: blackholed)
```

The plan's scheme works as written: one loopback holding the router address, members unnumbered to it, no overlapping-subnet rejection at /32. After both fixes the full path ran — `ip4-lookup → ip4-rewrite → octeon0/0-tx`, TTL 64→63, 100 frames forwarded, zero loss, verified by tcpdump at the far end.

## The config break, and why it's justified

`loopback-address` is **mandatory whenever ports exist**, and restart-only. The address can't be derived — the primary has a different one on each of four member ports and there's one loopback — and it also sources ICMP, so PMTUD's frag-needed is only correct if an operator chose it deliberately.

The reason it's a hard refusal rather than a default: throughout every one of those runs, `packetframe status` reported

```
fib-synced  healthy — 1053960 routes installed, verified on 64 probes
```

while VPP forwarded **zero packets**. Verification samples the FIB, and the FIB was genuinely correct. **A verified FIB is not a forwarding dataplane.** On a steered production port that distinction is the difference between a canary that reveals a problem and one that blackholes traffic with every gauge green — and config-load is the only place that gap closes before traffic moves.

## Also

- Codegen whitelist grows by four messages (`sw_interface_set_mac_address`, `create_loopback`, `sw_interface_add_del_address`, `sw_interface_set_unnumbered`) and `generated.rs` is regenerated.
- `delete_loopback` is **not** included. The loopback dies with the VPP process, so it would be a function with no caller — the exact shape that produced three defects in this module already.
- The order test now asserts the full sequence including the readback dump, and is renamed since it is no longer three messages.

## Verification

`fmt`, `test`, host `clippy`, all four target triples. One caveat worth recording: `an_operator_can_steer_and_unsteer_a_converged_service` failed once during development under heavy parallel load and did not reproduce in 13 subsequent runs (10 isolated, 3 full-workspace). Flagging it rather than assuming it was noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)