### PR TITLE
feat(vpp-offload): log when traffic moves between forwarding tiers

### DIFF
--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -571,6 +571,11 @@ fn finish(
             loopback,
         )
         .with_recorded_indices(recorded);
+        // Counted before the record moves into the owner: the log line
+        // below needs it, and reaching for it afterwards is what the
+        // borrow checker just refused.
+        let inherited_rule_count: usize =
+            state.steer_rules.iter().map(|(_, locs)| locs.len()).sum();
         let owner = SharedOwner::new(ResourceOwner::new(state, sys));
         let runtime = Runtime::new(
             engine,
@@ -651,7 +656,22 @@ fn finish(
             // true and the VF stays withheld. Doing the removal here
             // instead would be a second, unsupervised path to the same
             // effect, whose failures nothing would ever retry.
-            None if steered => vec![Event::InheritedSteering, Event::StartRequested],
+            None if steered => {
+                // Visible, because everything that follows from it is
+                // consequential and none of it is obvious: this process
+                // will unsteer rules it did not install, spawn a new
+                // VPP, and — once the resync verifies — steer again,
+                // restoring a state the operator set on a previous run.
+                // Observed on the shadow 2026-08-07 happening in
+                // complete silence.
+                tracing::warn!(
+                    rules = inherited_rule_count,
+                    "MCAM rules from a previous run are still installed and the process that \
+                     owned them is gone; they will be removed now and re-applied only after \
+                     this VPP's table verifies"
+                );
+                vec![Event::InheritedSteering, Event::StartRequested]
+            }
             None => vec![Event::StartRequested],
         };
         Ok((Driver::new(), runtime, initial))

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -128,11 +128,19 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                 // is down. Reporting this rather than letting `fail()`
                 // assume it is what stops a later teardown from
                 // releasing a VF that MCAM is still pointing at.
-                Ok(()) => Event::Unsteered,
+                Ok(()) => {
+                    tracing::info!("steering DOWN: traffic returned to the eBPF fast-path tier");
+                    Event::Unsteered
+                }
                 Err(e) => {
                     // Traffic is still being diverted to a dataplane we
                     // are about to stop supervising. Loud, and it
                     // forfeits the right to release the VF.
+                    tracing::error!(
+                        error = %e,
+                        "steering could NOT be removed; traffic is still diverted into a VPP \
+                         that is being stopped, and the VF will be withheld"
+                    );
                     out.failures.push((*action, e));
                     teardown_clean = false;
                     Event::UnsteerFailed
@@ -179,8 +187,25 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                 }
             }
             Action::Steer => out.events.push(match fx.steer() {
-                Ok(()) => Event::Steered,
+                Ok(()) => {
+                    // The one action that moves customer traffic between
+                    // forwarding tiers. It had no log line at all until
+                    // a shadow run came up steered with nothing in the
+                    // log to say when, or by which path — the state
+                    // field was the only record, and an incident
+                    // reconstruction needs a timestamp.
+                    tracing::info!(
+                        "steering UP: allowlisted traffic is now diverted to VPP (the eBPF \
+                         tier remains the failover)"
+                    );
+                    Event::Steered
+                }
                 Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        rules_remain = fx.steering_in_place(),
+                        "steer failed; traffic stays on the eBPF tier"
+                    );
                     out.failures.push((*action, e));
                     // Verified but not steered as asked: reported, not
                     // papered over, and NOT a process restart — the


### PR DESCRIPTION
Found by running #139 on the shadow: it came up **steered**, correctly, with **nothing in the log** to say when or by which path.

## What was missing

`executor.rs` had no logging at all. `Action::Steer` and `Action::Unsteer` succeeded silently; only failures surfaced, and only through health. So the single action that moves customer traffic between forwarding tiers existed in the record as a status field somebody had to go and read.

That is the wrong thing to leave quiet. The canary ladder's whole premise is an operator pacing traffic movement by hand, and "when did traffic actually move" is the first question of any incident reconstruction.

## Also logged: inherited rules

The shadow's run did something quite involved and said none of it: the state file recorded rules from a previous run, so bring-up unsteered rules it had not installed, spawned a fresh VPP, converged, verified, and steered again — restoring a state set by a process that no longer exists. Correct behaviour (it is the documented recovery path: re-steer only after a verified resync), but invisible.

It now warns, with the rule count, before any of that happens.

## Severities

Failures already reached health; they now reach the log at the level each earns:

- **`warn`** — a steer that did not take. Traffic stays on the eBPF tier, which is the safe side.
- **`error`** — an unsteer that did not. Traffic is still diverted into a VPP being stopped, and the VF is withheld as a result.

## Verification

`fmt`, `test`, host `clippy`, all four triples. No behaviour change — every event, transition and failure path is exactly as before; this only makes them observable.

Context: #139 is confirmed working on hardware. The module now performs the MAC set (with readback), loopback creation and unnumbering itself — verified on the shadow with a fresh VPP, `octeon0/0` carrying the PF's MAC, `loop0` at `169.254.254.3/32`, 1,054,104 routes converged and verified, and 4 MCAM rules installed. The mandatory-config refusal also fired correctly at `feasibility` and at `run`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)