### PR TITLE
fix(vpp-offload): two recovery-path defects a restart on hardware found

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -288,13 +288,37 @@ pub fn attach_ports(
                 });
                 continue;
             }
-            // Recorded but gone: the state file outlived the interface.
-            // Refuse rather than attach a second one, because we cannot
-            // tell whether the live FIB still references the old index.
-            return Err(AttachError::StaleIndex {
-                port: p.port.clone(),
-                sw_if_index: idx,
-            });
+            // Recorded but gone. What that means depends entirely on
+            // which VPP we are talking to.
+            //
+            // Adopted: refuse. A running VPP's FIB may still reference
+            // the old index, and attaching a second interface would
+            // leave two, with routes pointing at the one we are not
+            // managing.
+            //
+            // Fresh: the index is stale by construction. We spawned this
+            // process; it has no FIB and no interfaces, so nothing can
+            // reference the recorded index and re-attaching is the only
+            // correct move. Refusing here stranded the module on the
+            // shadow (2026-08-07) after VPP was killed while packetframe
+            // was not running — nothing had observed the exit, so
+            // `on_process_gone` never cleared the record, and every
+            // restart spawned a VPP it then refused to attach to. It
+            // could not self-heal; only killing VPP again *with the
+            // daemon watching* recovered it.
+            if mode == AttachMode::Adopted {
+                return Err(AttachError::StaleIndex {
+                    port: p.port.clone(),
+                    sw_if_index: idx,
+                });
+            }
+            tracing::warn!(
+                port = %p.port,
+                stale_sw_if_index = idx,
+                "state file records an interface this freshly spawned VPP does not have; \
+                 discarding the record and attaching — a new process has no FIB that could \
+                 reference it"
+            );
         }
 
         let dev_index = attach_device(t, p)?;

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -532,6 +532,13 @@ fn finish(
     // the relaxed 10 s socket budget while packets are on VPP, defeating
     // the published ≤2 s wedge bound.
     let steered = !state.steer_rules.is_empty();
+    // The CONFIG's answer, captured before `steering` moves into the
+    // runtime. Inherited rules say what the NIC holds; only this says
+    // what the operator asked for.
+    let config_wants_steer = {
+        use crate::runtime::Steering as _;
+        steering.configured_ports() > 0
+    };
     let adopted_process = adopted.is_some();
 
     // Take ownership of the rules the record names, so `unsteer` can
@@ -660,17 +667,26 @@ fn finish(
                 // Visible, because everything that follows from it is
                 // consequential and none of it is obvious: this process
                 // will unsteer rules it did not install, spawn a new
-                // VPP, and — once the resync verifies — steer again,
-                // restoring a state the operator set on a previous run.
-                // Observed on the shadow 2026-08-07 happening in
-                // complete silence.
+                // VPP, and — if the config still asks for steering —
+                // steer again once the resync verifies. Observed on the
+                // shadow 2026-08-07 happening in complete silence.
                 tracing::warn!(
                     rules = inherited_rule_count,
+                    still_configured = config_wants_steer,
                     "MCAM rules from a previous run are still installed and the process that \
-                     owned them is gone; they will be removed now and re-applied only after \
-                     this VPP's table verifies"
+                     owned them is gone; removing them now, and restoring steering after this \
+                     VPP's table verifies ONLY if the config still asks for it"
                 );
-                vec![Event::InheritedSteering, Event::StartRequested]
+                vec![
+                    Event::InheritedSteering {
+                        // The config's answer, not the NIC's. A
+                        // deployment sitting at `steer off` must come
+                        // back at `steer off`, however its last run
+                        // ended.
+                        still_configured: config_wants_steer,
+                    },
+                    Event::StartRequested,
+                ]
             }
             None => vec![Event::StartRequested],
         };

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -258,7 +258,18 @@ pub enum Event {
     /// *want* is recorded too — steering was established and never
     /// deliberately stopped — so the replacement re-steers once it
     /// verifies, which is what closes the blackhole.
-    InheritedSteering,
+    InheritedSteering {
+        /// Does the CONFIG still ask this deployment to steer?
+        ///
+        /// Carried rather than assumed. Inheriting rules means the NIC
+        /// holds them; it does not mean the operator still wants them.
+        /// With `steer off` in the file, forcing the want on left the
+        /// module permanently `steering intended but not in place` —
+        /// the unsteer cleared `steered`, the target had no ports, and
+        /// every retry failed with "nothing to steer" (shadow,
+        /// 2026-08-07).
+        still_configured: bool,
+    },
     /// The operator turned the canary lever ON: a `steer on` appeared,
     /// or the allowlist changed under a port that is already steering.
     ///
@@ -555,9 +566,22 @@ impl Supervisor {
             // Only from `Stopped`: this is an attach-time fact, injected
             // before the first `StartRequested`. Anywhere else it would
             // be describing a process that exists.
-            (Stopped, InheritedSteering) => {
+            (Stopped, InheritedSteering { still_configured }) => {
                 self.steered = true;
-                self.steer_wanted = true;
+                // The *want* survives a crash — a restart nobody watched
+                // should not silently leave the offload off and make an
+                // operator re-walk the canary ladder — but only while
+                // the config still asks for it.
+                //
+                // Setting it unconditionally left the module unable to
+                // reach a healthy state: with `steer off` in the file
+                // the unsteer cleared `steered`, the target had no ports
+                // because the config says off, and every retry failed
+                // "nothing to steer". Permanently Degraded, which also
+                // held the failure episode open so `last-tick` showed
+                // stale text beside a freshly verified FIB. Observed on
+                // the shadow 2026-08-07.
+                self.steer_wanted = still_configured;
                 vec![Action::Unsteer]
             }
 
@@ -1452,7 +1476,12 @@ mod tests {
     #[test]
     fn inherited_steering_is_taken_down_before_anything_else() {
         let mut s = Supervisor::new();
-        assert_eq!(s.on(Event::InheritedSteering), vec![Action::Unsteer]);
+        assert_eq!(
+            s.on(Event::InheritedSteering {
+                still_configured: true,
+            }),
+            vec![Action::Unsteer]
+        );
         assert!(
             s.is_steered(),
             "the record is the only evidence there is, and believing it is what makes \
@@ -1476,7 +1505,9 @@ mod tests {
     #[test]
     fn a_replacement_re_steers_what_the_dead_vpp_was_steering() {
         let mut s = Supervisor::new();
-        s.on(Event::InheritedSteering);
+        s.on(Event::InheritedSteering {
+            still_configured: true,
+        });
         s.on(Event::Unsteered);
         assert!(!s.is_steered(), "the stale rules are gone");
         assert!(s.steer_intended(), "but the want survives them");
@@ -1488,6 +1519,48 @@ mod tests {
         assert!(
             s.on(Event::VerifyPassed).contains(&Action::Steer),
             "a verified replacement must restore the offload without being asked"
+        );
+    }
+
+    /// Inherited rules do NOT resurrect steering the config turned off.
+    ///
+    /// The mirror of the test above, and the one that was missing. A
+    /// deployment sitting at `steer off` must come back at `steer off`
+    /// however its last run ended — otherwise the rules on the NIC, not
+    /// the operator, decide where traffic goes.
+    ///
+    /// Getting this wrong was not a subtle degradation: with the want
+    /// forced on and no ports configured to steer, the module reported
+    /// `steering intended but not in place` forever and every retry
+    /// failed "nothing to steer". Health never returned to Healthy, so
+    /// the failure episode never closed either, and `last-tick` showed
+    /// stale attach errors beside a freshly verified FIB. Observed on
+    /// the shadow, 2026-08-07.
+    #[test]
+    fn inherited_rules_do_not_override_a_config_that_says_steer_off() {
+        let mut s = Supervisor::new();
+        assert_eq!(
+            s.on(Event::InheritedSteering {
+                still_configured: false,
+            }),
+            vec![Action::Unsteer],
+            "the stale rules still come down — they point at a dead VF"
+        );
+        s.on(Event::Unsteered);
+
+        assert!(!s.is_steered());
+        assert!(
+            !s.steer_intended(),
+            "and nothing is left wanting: the config said off"
+        );
+
+        s.on(Event::StartRequested);
+        s.on(Event::Spawned);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert!(
+            !s.on(Event::VerifyPassed).contains(&Action::Steer),
+            "a verified replacement must NOT steer a deployment the operator turned off"
         );
     }
 


### PR DESCRIPTION
Both surface only when VPP dies while packetframe is **not running**. No test covered that, because every test that kills VPP has a supervisor watching — and the supervisor's `on_process_gone` is exactly what papers over the first defect.

## 1. A freshly spawned VPP was refused for a stale index

```
AttachDevices: state file records sw_if_index 2 for eth1 but VPP no longer has it;
refusing to attach a duplicate while a live FIB may still reference the old index
```

The justification is sound when **adopting** a running VPP: its FIB may still reference the old index, and a second interface would leave routes pointing at the one we aren't managing. It is vacuous for a VPP this process just spawned — no FIB, no interfaces, nothing that could reference anything.

`attach_ports` applied it regardless of `AttachMode`. On the shadow the module spawned a VPP and refused to attach to it on every restart, and **could not self-heal**: nothing had observed the original exit, so `on_process_gone` never cleared the record. Only killing VPP again *with the daemon watching* recovered it.

Now: refuse under `Adopted`, discard and re-attach under `Fresh`, with a `warn` saying what was discarded.

## 2. Inherited rules overrode a config saying `steer off`

`InheritedSteering` set `steer_wanted` unconditionally — rules found on the NIC decided intent instead of the operator. With `steer off` in the file the sequence was: inherit → unsteer (clears `steered`) → retry steer → fail `nothing to steer`, because the target has no ports *precisely because* the config says off. Permanently `steering intended but not in place`.

**My first attempt at this fix was wrong.** I removed `steer_wanted` outright and a test caught it: `a_replacement_re_steers_what_the_dead_vpp_was_steering`. The want *should* survive a crash — a restart nobody watched must not silently leave the offload off and force an operator back down the canary ladder. It must not survive the operator changing their mind.

So the event carries the config's answer, sourced from `Steering::configured_ports` (added in #135). The mirror-image test that was missing — inherited rules against `steer off` — now exists.

## 3. `last-tick` staleness: no separate fix needed

`remember_failures` accumulates deliberately and clears "when health returns to `Healthy`". The rule is right; health simply never returned, because of defect 2. Fixing that closes the episode. Worth knowing the coupling exists: **any long-lived Degraded keeps stale failure text on screen indefinitely.**

## How these were found

A restart sequence on the shadow, not review. Evidence that defect 3 was reporting rather than reality: `last-tick` was character-identical across 20 seconds while `fib-synced` advanced 87s → 107s and the route count drifted with BGP churn.

## Verification

`fmt`, `test`, host `clippy`, all four triples. Two new tests: the `steer off` mirror case, and the existing recovery test updated to carry the config's answer explicitly rather than by omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)