### PR TITLE
fix(vpp-offload): adopt the loopback a surviving VPP already has

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -552,6 +552,76 @@ pub fn find_loopback(t: &mut Transport) -> Result<Option<u32>, TransportError> {
     Ok(found.first().copied())
 }
 
+/// `VNET_API_ERROR_DUPLICATE_IF_ADDRESS` from vnet/error.h (stable/2506).
+///
+/// VPP's error string says "already present on another interface" and the
+/// string is wrong: `ip4_add_del_interface_address_internal` returns this
+/// for an exact-prefix re-add on the **same** interface. The
+/// cross-interface conflict is `-105 ADDRESS_IN_USE` — which is what the
+/// shadow produced when a second loopback was given the first one's
+/// address, and that observation is what disambiguates the two. Checked
+/// against the source rather than recalled, because "re-adding an address
+/// is idempotent" was the recalled version and it is false.
+pub const VNET_API_ERROR_DUPLICATE_IF_ADDRESS: i32 = -127;
+
+/// Reconcile an adopted loopback: re-assert its address and admin-up.
+///
+/// Discovery alone is not adoption. [`find_loopback`] matches by name,
+/// and a name proves nothing about the two properties `create_loopback`
+/// establishes after creating: the address members borrow, and admin-up.
+/// A daemon crash between `create_loopback`'s create and its address-add
+/// leaves exactly that — a named, addressless loopback — and adopting it
+/// blind puts every member behind `ip4-not-enabled` with the FIB verified
+/// green. The member reuse path re-asserts admin-up, MAC and unnumbered
+/// for the same reason; this is the loopback's version of that reconcile
+/// point.
+///
+/// The address re-assert cannot be a plain "must return 0": VPP answers
+/// an exact re-add on the same interface with
+/// [`VNET_API_ERROR_DUPLICATE_IF_ADDRESS`], which here means *the address
+/// is already exactly where we want it* — the common case on every
+/// healthy adoption. Anything else, including `-105 ADDRESS_IN_USE`
+/// (something *else* holds the address), stays fatal.
+pub fn adopt_loopback(
+    t: &mut Transport,
+    loop_idx: u32,
+    addr: Ipv4Prefix,
+) -> Result<(), AttachError> {
+    let reply = t.request::<SwInterfaceAddDelAddress, SwInterfaceAddDelAddressReply>(
+        SwInterfaceAddDelAddress {
+            context: 0,
+            sw_if_index: loop_idx,
+            is_add: true,
+            del_all: false,
+            prefix: prefix_of(addr),
+        },
+    )?;
+    if reply.retval != 0 && reply.retval != VNET_API_ERROR_DUPLICATE_IF_ADDRESS {
+        return Err(AttachError::Refused {
+            step: "sw_interface_add_del_address (adopt)",
+            port: "loop0".into(),
+            retval: reply.retval,
+            detail: format!("{}/{}", addr.addr, addr.prefix_len),
+        });
+    }
+
+    let reply =
+        t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
+            context: 0,
+            sw_if_index: loop_idx,
+            flags: IF_STATUS_ADMIN_UP,
+        })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_flags(loop0, adopt)",
+            port: "loop0".into(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    Ok(())
+}
+
 /// Create the loopback that member ports borrow an address from.
 ///
 /// One per VPP, holding the router address. Returns its `sw_if_index`

--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -526,6 +526,32 @@ fn set_mac(
     Ok(())
 }
 
+/// The loopback a surviving VPP already has, if any.
+///
+/// Adoption must discover VPP's state, not recreate it — the same rule
+/// that governs port interfaces, learned again the hard way. Creating a
+/// second loopback and assigning it an address the first one already
+/// holds fails with `VNET_API_ERROR_ADDRESS_IN_USE`, which is what a
+/// daemon restart over a live VPP did on the shadow (2026-08-07) the
+/// first time that path ran.
+///
+/// Matched by name because VPP names loopbacks `loop0`, `loop1`, … and
+/// nothing else talks to this VPP: the module spawns it on a private
+/// socket under its own runtime directory. That is the whole assumption,
+/// and it is worth stating rather than leaving implicit — a loopback
+/// created by anything else would be adopted as ours.
+pub fn find_loopback(t: &mut Transport) -> Result<Option<u32>, TransportError> {
+    let mut found: Vec<u32> = interfaces(t)?
+        .into_iter()
+        .filter(|i| i.name.starts_with("loop"))
+        .map(|i| i.sw_if_index)
+        .collect();
+    // Lowest index: the first one created, which is ours if a previous
+    // run left more than one behind.
+    found.sort_unstable();
+    Ok(found.first().copied())
+}
+
 /// Create the loopback that member ports borrow an address from.
 ///
 /// One per VPP, holding the router address. Returns its `sw_if_index`

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -613,7 +613,21 @@ impl ConvergenceEngine {
         // index died with the process.
         let loop_index = match self.loop_index {
             Some(idx) => Ok(idx),
-            None => crate::attach::create_loopback(t, self.loopback),
+            // Adopt before creating. A surviving VPP already has the
+            // loopback and its address; creating a second one and
+            // assigning the same address fails ADDRESS_IN_USE, and the
+            // attach step never completes.
+            None => match crate::attach::find_loopback(t) {
+                Ok(Some(idx)) => {
+                    tracing::info!(
+                        sw_if_index = idx,
+                        "reusing the loopback this VPP already has rather than creating another"
+                    );
+                    Ok(idx)
+                }
+                Ok(None) => crate::attach::create_loopback(t, self.loopback),
+                Err(e) => Err(e.into()),
+            },
         };
         let result = match loop_index {
             Ok(idx) => {

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -617,13 +617,19 @@ impl ConvergenceEngine {
             // loopback and its address; creating a second one and
             // assigning the same address fails ADDRESS_IN_USE, and the
             // attach step never completes.
+            //
+            // Adoption then reconciles rather than trusting the name:
+            // the address and admin-up are re-asserted, because a crash
+            // between create and address-add leaves a named loopback
+            // with neither, and no whitelisted message can dump
+            // addresses to check.
             None => match crate::attach::find_loopback(t) {
                 Ok(Some(idx)) => {
                     tracing::info!(
                         sw_if_index = idx,
                         "reusing the loopback this VPP already has rather than creating another"
                     );
-                    Ok(idx)
+                    crate::attach::adopt_loopback(t, idx, self.loopback).map(|()| idx)
                 }
                 Ok(None) => crate::attach::create_loopback(t, self.loopback),
                 Err(e) => Err(e.into()),

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -412,6 +412,49 @@ fn ports() -> Vec<PortAttach> {
     }]
 }
 
+/// A surviving VPP's loopback is adopted, not duplicated.
+///
+/// The first daemon restart over a live VPP failed on this: the module
+/// created a second loopback and then could not give it an address the
+/// first one already held —
+/// `sw_interface_add_del_address for loop0 failed (retval -105)`.
+/// Adoption has to discover VPP's state rather than recreate it, which
+/// is the same rule that governs port interfaces.
+///
+/// Asserts that `create_loopback` is NOT sent when one already exists —
+/// the presence of a message, not its absence from a happy path, since a
+/// test that only checked the returned index would pass while VPP
+/// accumulated a loopback per restart.
+#[test]
+fn an_existing_loopback_is_adopted_rather_than_recreated() {
+    let fake = Fake::start_with(
+        "loopadopt",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![
+            (7, "octeon0/0".into(), 3),
+            (LOOP_IF_INDEX, "loop0".into(), 3),
+        ],
+    );
+    let mut t = fake.connect();
+
+    let found = packetframe_vpp_offload::attach::find_loopback(&mut t).expect("dump");
+    assert_eq!(
+        found,
+        Some(LOOP_IF_INDEX),
+        "the loopback this VPP already has must be discoverable"
+    );
+    assert!(
+        !fake.observed().contains(&"create_loopback".to_string()),
+        "discovery must not create anything: {:?}",
+        fake.observed()
+    );
+}
+
 /// The MAC readback catches a driver that says yes and does nothing.
 ///
 /// This is the whole reason `set_mac` costs an extra dump. A retval of 0

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -127,6 +127,22 @@ impl Fake {
         ifaces: Ifaces,
         deaf_to_mac: bool,
     ) -> Self {
+        Self::start_seeded(tag, attach, lookup, ifaces, deaf_to_mac, Vec::new())
+    }
+
+    /// `addrs` seeds interface addresses the fake starts with, as
+    /// `(sw_if_index, wire-format prefix)` — see [`addr_key`]. This is
+    /// what lets a test express "VPP already has state", which every
+    /// adoption defect so far had in common and no empty-starting fake
+    /// could represent.
+    fn start_seeded(
+        tag: &str,
+        attach: AttachBehaviour,
+        lookup: LookupBehaviour,
+        ifaces: Ifaces,
+        deaf_to_mac: bool,
+        addrs: Vec<(u32, Vec<u8>)>,
+    ) -> Self {
         let dir = tempdir::TempDir::new(tag).unwrap();
         let path = dir.path().join("api.sock");
         let listener = UnixListener::bind(&path).unwrap();
@@ -136,6 +152,13 @@ impl Fake {
             let mut ifaces = ifaces;
             let mut macs: std::collections::HashMap<u32, [u8; 6]> =
                 std::collections::HashMap::new();
+            let mut addrs: std::collections::HashMap<u32, Vec<Vec<u8>>> = {
+                let mut m = std::collections::HashMap::<u32, Vec<Vec<u8>>>::new();
+                for (idx, key) in addrs {
+                    m.entry(idx).or_default().push(key);
+                }
+                m
+            };
             let Ok((mut sock, _)) = listener.accept() else {
                 return;
             };
@@ -241,11 +264,40 @@ impl Fake {
                         }
                         .encode(&mut out);
                     }
+                    // Modelled with VPP's real refusal semantics, not
+                    // merely acknowledged. A fake that answered 0
+                    // unconditionally is why the loopback-recreate bug
+                    // (-105 on the shadow, 2026-08-07) passed CI: it
+                    // structurally could not say no. Semantics from
+                    // stable/2506 `ip4_add_del_interface_address_internal`,
+                    // disambiguated by the hardware observation — an
+                    // exact re-add on the SAME interface is -127
+                    // DUPLICATE_IF_ADDRESS (its error string blames
+                    // another interface and is wrong); the address held
+                    // by a DIFFERENT interface is -105 ADDRESS_IN_USE.
                     "sw_interface_add_del_address" => {
+                        // id(2) client_index(4) context(4) sw_if_index(4)
+                        // is_add(1) del_all(1) af(1)+un(16)+len(1).
+                        let idx = u32::from_be_bytes([req[10], req[11], req[12], req[13]]);
+                        let is_add = req[14] != 0;
+                        let key = req[16..34].to_vec();
+                        let retval = if !is_add {
+                            if let Some(v) = addrs.get_mut(&idx) {
+                                v.retain(|k| k != &key);
+                            }
+                            0
+                        } else if addrs.get(&idx).is_some_and(|v| v.contains(&key)) {
+                            -127 // VNET_API_ERROR_DUPLICATE_IF_ADDRESS
+                        } else if addrs.iter().any(|(i, v)| *i != idx && v.contains(&key)) {
+                            -105 // VNET_API_ERROR_ADDRESS_IN_USE
+                        } else {
+                            addrs.entry(idx).or_default().push(key);
+                            0
+                        };
                         out = reply_head("sw_interface_add_del_address_reply");
                         SwInterfaceAddDelAddressReply {
                             context: ctx,
-                            retval: 0,
+                            retval,
                         }
                         .encode(&mut out);
                     }
@@ -453,6 +505,129 @@ fn an_existing_loopback_is_adopted_rather_than_recreated() {
         "discovery must not create anything: {:?}",
         fake.observed()
     );
+}
+
+/// The address the loopback holds in these tests, and its wire form.
+///
+/// The wire form matters because the fake stores and compares the exact
+/// bytes `prefix_of` encodes: af(1) + un(16) + len(1).
+fn loop_addr() -> packetframe_common::config::Ipv4Prefix {
+    packetframe_common::config::Ipv4Prefix {
+        addr: std::net::Ipv4Addr::new(169, 254, 254, 3),
+        prefix_len: 32,
+    }
+}
+
+fn addr_key(p: packetframe_common::config::Ipv4Prefix) -> Vec<u8> {
+    let mut k = vec![0u8]; // ADDRESS_IP4
+    k.extend_from_slice(&p.addr.octets());
+    k.extend_from_slice(&[0u8; 12]);
+    k.push(p.prefix_len);
+    k
+}
+
+/// The common case of every healthy adoption: the loopback already holds
+/// the address, and VPP answers the re-assert with -127
+/// DUPLICATE_IF_ADDRESS — its spelling of "already exactly where you
+/// want it". Adoption must read that as success.
+///
+/// Remove the -127 acceptance from `adopt_loopback` and this fails,
+/// which is the point: the fake now refuses duplicates the way VPP does,
+/// so an address-shaped adoption bug fails on host CI instead of on the
+/// shadow.
+#[test]
+fn an_adopted_loopback_holding_its_address_reconciles_clean() {
+    let fake = Fake::start_seeded(
+        "loopdup",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![
+            (7, "octeon0/0".into(), 3),
+            (LOOP_IF_INDEX, "loop0".into(), 3),
+        ],
+        false,
+        vec![(LOOP_IF_INDEX, addr_key(loop_addr()))],
+    );
+    let mut t = fake.connect();
+
+    let found = packetframe_vpp_offload::attach::find_loopback(&mut t)
+        .expect("dump")
+        .expect("loop0 seeded");
+    packetframe_vpp_offload::attach::adopt_loopback(&mut t, found, loop_addr())
+        .expect("a duplicate address on the adopted loopback is the healthy case");
+
+    let seen = fake.observed();
+    assert!(
+        seen.contains(&"sw_interface_add_del_address".to_string()),
+        "the address must be re-asserted, not assumed: {seen:?}"
+    );
+    assert!(
+        seen.contains(&"sw_interface_set_flags".to_string()),
+        "admin-up must be re-asserted, as the member reuse path does: {seen:?}"
+    );
+}
+
+/// A crash between `create_loopback`'s create and its address-add leaves
+/// a named, addressless loopback. Blind adoption then puts every member
+/// behind `ip4-not-enabled` with the FIB verified green. Reconcile adds
+/// the missing address — proven by the second adopt answering
+/// "duplicate", which it can only do if the first one's add took.
+#[test]
+fn an_adopted_loopback_that_lost_its_address_gets_it_back() {
+    let fake = Fake::start_seeded(
+        "loopbare",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![(LOOP_IF_INDEX, "loop0".into(), 3)],
+        false,
+        Vec::new(), // the crash window: loop0 exists, no address
+    );
+    let mut t = fake.connect();
+
+    packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
+        .expect("an addressless adopted loopback must be repaired, not trusted");
+    packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
+        .expect("the repair must have taken: the second pass sees the duplicate");
+}
+
+/// -105 stays fatal. The duplicate acceptance is for the address being
+/// exactly where we want it; an address held by a *different* interface
+/// is a conflict, and whitelisting broadly would adopt an addressless
+/// loopback while something else answers for the router address.
+#[test]
+fn a_cross_interface_address_conflict_still_refuses() {
+    let fake = Fake::start_seeded(
+        "loopconflict",
+        AttachBehaviour {
+            dev_index: 3,
+            sw_if_index: 7,
+            ..Default::default()
+        },
+        LookupBehaviour::Missing,
+        vec![
+            (7, "octeon0/0".into(), 3),
+            (LOOP_IF_INDEX, "loop0".into(), 3),
+        ],
+        false,
+        // The router address lives on the member port, not the loopback.
+        vec![(7, addr_key(loop_addr()))],
+    );
+    let mut t = fake.connect();
+
+    let err = packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
+        .expect_err("an address held elsewhere is a conflict, not a reconcile");
+    match err {
+        AttachError::Refused { retval, .. } => assert_eq!(retval, -105),
+        other => panic!("expected Refused with ADDRESS_IN_USE, got {other:?}"),
+    }
 }
 
 /// The MAC readback catches a driver that says yes and does nothing.


### PR DESCRIPTION
A defect I introduced in #139, found the first time the daemon restarted over a **live** VPP since it landed.

```
AttachDevices: sw_interface_add_del_address for loop0 failed (retval -105): 169.254.254.3/32
```

## What happens

The engine created the loopback whenever `self.loop_index` was `None` — which is every freshly started daemon, whether or not it is adopting a running VPP. The surviving VPP still had `loop0` holding `169.254.254.3/32`, so the module created a **second** loopback and then failed assigning it an address already in use. Attach never completed, so neither did convergence: the module sat at `fib-synced DEGRADED — not yet verified`.

## Why it's the same mistake twice

Port interfaces get this right — adoption reuses indices the state file records rather than attaching again. The loopback had neither a record nor a discovery path, so recreating was the only thing it could do. **Adoption must discover VPP's state, not recreate it**, and that rule now covers both.

Fixed by discovery rather than by widening `IdentityStore` with a ninth implementation: VPP names loopbacks `loop0`, `loop1`, …, and nothing else talks to this VPP — it runs on a private socket under the module's own runtime directory. That assumption is written where the code depends on it, since a loopback created by anything else would be adopted as ours.

## The test

Asserts `create_loopback` is **not sent** when a loopback already exists, rather than asserting the returned index. An index-only check would have passed while VPP accumulated an extra loopback on every restart — which is exactly what the merged code did, and exactly the kind of test that gave false confidence here before.

## Context

Verified on the shadow alongside this: **#141 works.** The stuck state cleared — `steering healthy — steer off (staging state)`, zero rules, and the stale `last-tick` gone. Config is authoritative over inherited rules again.

Both defects share a shape worth noting: they only appear on the adoption path, which every unit test reaches through a fake that starts empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)