### PR TITLE
fix(vpp-offload): defer the adopted resync while the route source loads

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -64,6 +64,29 @@ use crate::supervisor::{Event, State, Supervisor};
 
 /// What the world reports. Every one of these is an observation; none
 /// of them requests a state change.
+/// What one `drain_batch` pass accomplished.
+///
+/// A bool almost sufficed, and the third case is why it could not: an
+/// adopted resync whose route source is still loading is neither "done"
+/// (that would send the supervisor to verify against a diff that never
+/// ran) nor "more to drain" (that asks for an immediate re-tick and
+/// spins a core polling a count that changes at feed speed, not tick
+/// speed). It is its own thing — deliberate waiting — and the driver
+/// treats it as such: no `SyncComplete`, no re-tick, and the phase
+/// deadline is re-armed so `CONVERGENCE_BUDGET` times the convergence
+/// rather than bird's reload.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Drain {
+    /// Nothing left pending.
+    Idle,
+    /// A batch went out; more remains.
+    More,
+    /// The adopted resync is deliberately deferred: the route source
+    /// holds `have` routes against a floor of `want`. See
+    /// [`crate::runtime::ADOPTED_SOURCE_FLOOR_DIVISOR`].
+    AwaitingSource { have: u64, want: u64 },
+}
+
 pub trait Observe {
     /// Non-blocking. `Some(status)` = the process has exited.
     ///
@@ -82,14 +105,13 @@ pub trait Observe {
     fn ping(&mut self) -> Result<(), String>;
 
     /// Drain **one bounded batch** of pending routes.
-    /// `Ok(true)` = nothing left pending.
     ///
     /// Bounded is the contract, not an implementation detail. A blocking
     /// full-table drain would hold the loop for the whole convergence
     /// budget, during which no ping is sent and no exit is noticed — so
     /// the wedge detector would either be useless or fire on a VPP that
     /// was working fine.
-    fn drain_batch(&mut self) -> Result<bool, String>;
+    fn drain_batch(&mut self) -> Result<Drain, String>;
 }
 
 /// One tick's result.
@@ -266,9 +288,20 @@ impl Driver {
                     // Empty means the resync is done — and only the
                     // drain can say so, which is why this is observed
                     // rather than assumed after issuing StartResync.
-                    Ok(true) if resyncing => events.push(Event::SyncComplete),
-                    Ok(true) => {}
-                    Ok(false) => more_to_drain = true,
+                    Ok(Drain::Idle) if resyncing => events.push(Event::SyncComplete),
+                    Ok(Drain::Idle) => {}
+                    Ok(Drain::More) => more_to_drain = true,
+                    // Deliberate waiting, not progress and not
+                    // completion. The phase deadline is pushed forward
+                    // on every deferred tick so `CONVERGENCE_BUDGET`
+                    // starts when the diff actually runs — otherwise a
+                    // slow feed reload spends the budget and
+                    // `PhaseTimedOut` tears down a healthy adopted VPP,
+                    // which is the same defect the deferral exists to
+                    // prevent, arriving through the clock.
+                    Ok(Drain::AwaitingSource { .. }) => {
+                        self.sched.extend_phase(now, self.sup.phase());
+                    }
                     // Failing mid-resync is a convergence failure: the
                     // table is known-incomplete and nothing is forwarding
                     // through it yet.
@@ -476,6 +509,9 @@ mod tests {
         api: bool,
         /// Batches remaining before the drain reports empty.
         batches: usize,
+        /// Drain calls that report `AwaitingSource` before any batch
+        /// moves — the deferred adopted resync.
+        deferred_ticks: usize,
         drain_fails: bool,
         ping_fails: bool,
         pings: usize,
@@ -499,13 +535,21 @@ mod tests {
                 Ok(())
             }
         }
-        fn drain_batch(&mut self) -> Result<bool, String> {
+        fn drain_batch(&mut self) -> Result<Drain, String> {
             self.drains += 1;
             if self.drain_fails {
                 return Err("socket closed".into());
             }
+            if let Some(n) = self.deferred_ticks.checked_sub(1) {
+                self.deferred_ticks = n;
+                return Ok(Drain::AwaitingSource { have: 0, want: 1 });
+            }
             self.batches = self.batches.saturating_sub(1);
-            Ok(self.batches == 0)
+            Ok(if self.batches == 0 {
+                Drain::Idle
+            } else {
+                Drain::More
+            })
         }
     }
 

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -164,6 +164,27 @@ pub trait RouteSource {
     fn backlog(&self) -> u64 {
         0
     }
+
+    /// How many routes the source currently holds.
+    ///
+    /// Exists for one consumer: the adopted-resync deferral. A resync is
+    /// a diff whose withdrawals are "everything the ledger holds that the
+    /// source does not" — which is only meaningful when the source is
+    /// COMPLETE. A daemon restart is precisely when it is not: the BGP
+    /// feed reconnects at startup and takes tens of seconds to reload,
+    /// and an adopted ledger diffed against that window queues mass
+    /// withdrawals against a live, possibly steered VPP. Observed on the
+    /// shadow (drill (d), 2026-08-07): ~1M withdrawals began draining a
+    /// verified forwarding table, convergence failed, and the teardown
+    /// killed the adopted VPP that preserve-on-restart exists to keep.
+    ///
+    /// The default walks the table, which is fine for fixtures; the live
+    /// feed overrides it with its mirror's O(1) length.
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
 }
 
 /// One route change: the prefix, and its new nexthop set — or `None`

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -251,6 +251,12 @@ impl RouteSource for RouteFeed {
         (g.pending.len() + g.neigh_pending.len()) as u64
     }
 
+    fn route_count(&self) -> u64 {
+        // The mirror's own length — O(1), safe to poll every tick while
+        // an adopted resync waits for the feed to finish loading.
+        self.lock().routes.len() as u64
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         // Chunked so the writer never waits for more than `WALK_CHUNK`
         // copies. `after` is the resume cursor; a prefix inserted below it

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -299,7 +299,32 @@ struct Core {
     /// operator would see a stalled `pending_ops` with nothing saying
     /// why.
     last_drain_error: Option<String>,
+    /// `Some(floor)` while an adopted resync is deferred: the diff will
+    /// not run until the route source holds at least `floor` routes.
+    ///
+    /// Set by `start_resync` when it adopts a populated FIB and finds
+    /// the source still loading; cleared by `drain_batch` when the
+    /// source crosses the floor and the diff actually begins. While
+    /// set, the adopted VPP is left exactly as found — steered, routes
+    /// intact — because a diff against a loading source is ~all
+    /// withdrawals, and draining those into a live dataplane is the
+    /// drill-(d) blackhole (2026-08-07).
+    deferred_resync_floor: Option<u64>,
 }
+
+/// An adopted resync is deferred while the route source holds fewer
+/// routes than `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
+///
+/// Half, not "equal": the source and the adopted FIB legitimately
+/// differ by whatever churned while packetframe was down, and demanding
+/// near-parity would deadlock against a genuinely shrunken table (an
+/// upstream loss can remove a real fraction). Half is far above any
+/// plausible legitimate shrink and far below any partially-loaded feed
+/// — the two distributions this constant separates. If the source
+/// never crosses the floor (feed down), the deferral holds forever and
+/// health stays degraded: stale-but-verified forwarding plus an alarm
+/// beats withdrawing a live table.
+pub const ADOPTED_SOURCE_FLOOR_DIVISOR: u64 = 2;
 
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
 pub struct Runtime {
@@ -341,6 +366,7 @@ impl Runtime {
                 pending: Vec::new(),
                 last_store_error: None,
                 last_drain_error: None,
+                deferred_resync_floor: None,
             })),
         }
     }
@@ -443,6 +469,9 @@ impl Runtime {
             drain_error: c.last_drain_error.clone(),
             source_backlog: c.source.backlog(),
             steer_configured_ports: c.steering.configured_ports(),
+            resync_deferred: c
+                .deferred_resync_floor
+                .map(|want| (c.source.route_count(), want)),
         }
     }
 }
@@ -470,6 +499,9 @@ pub struct RuntimeStatus {
     /// differently: a backlog here means the engine is not draining, a
     /// backlog there means VPP is not accepting.
     pub source_backlog: u64,
+    /// `Some((have, want))` while an adopted resync is deferred for a
+    /// still-loading route source. See `Core::deferred_resync_floor`.
+    pub resync_deferred: Option<(u64, u64)>,
 }
 
 impl Core {
@@ -612,8 +644,35 @@ impl Observe for ObserveView {
             .map_err(|e| e.to_string())
     }
 
-    fn drain_batch(&mut self) -> Result<bool, String> {
+    fn drain_batch(&mut self) -> Result<crate::driver::Drain, String> {
         let mut c = self.core.borrow_mut();
+        // A deferred adopted resync is re-checked here, on the driver's
+        // paced cadence, because this is the only Observe call that runs
+        // every tick of a resync state. While the source is below the
+        // floor NOTHING touches the engine — no deltas either, since the
+        // coming diff reads the full mirror and covers them, and
+        // applying a partial feed's withdrawals early is the exact
+        // hazard being deferred.
+        if let Some(floor) = c.deferred_resync_floor {
+            let have = c.source.route_count();
+            if have < floor {
+                return Ok(crate::driver::Drain::AwaitingSource { have, want: floor });
+            }
+            tracing::info!(
+                have,
+                floor,
+                "route source crossed the deferral floor; running the adopted resync diff"
+            );
+            {
+                let Core { engine, source, .. } = &mut *c;
+                let _plan = engine.begin_resync(source.as_ref());
+                engine
+                    .program_neighbours(source.as_ref())
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())?;
+            }
+            c.deferred_resync_floor = None;
+        }
         // Live changes are pulled in FIRST, so a route learned while VPP
         // was already converged goes out in this same batch rather than
         // waiting for a resync that may never come. The engine's pending
@@ -632,7 +691,13 @@ impl Observe for ObserveView {
             Err(e) => Err(e.to_string()),
             Ok(_) => engine
                 .drain_batch()
-                .map(|(done, _stats)| done)
+                .map(|(done, _stats)| {
+                    if done {
+                        crate::driver::Drain::Idle
+                    } else {
+                        crate::driver::Drain::More
+                    }
+                })
                 .map_err(|e| e.to_string()),
         };
         // Set on failure and cleared on success, in one place, for the
@@ -779,28 +844,58 @@ impl Effects for EffectsView {
         let mut c = self.core.borrow_mut();
         // Split borrow: the engine walks the source while both live in
         // the same core.
-        let Core { engine, source, .. } = &mut *c;
-        // BEFORE the diff, because the diff is what consumes it: the
-        // ledger's contents are where withdrawals come from, and on an
-        // adoption it is empty while the surviving VPP's FIB is not.
-        // A no-op unless the ledger is empty, so a fresh spawn pays one
-        // round trip and adopts nothing.
-        let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
-        if adopted > 0 {
-            tracing::info!(
-                routes = adopted,
-                "adopted VPP's existing FIB; the resync diff can now withdraw what the \
-                 route source no longer advertises"
-            );
-        }
-        let _plan = engine.begin_resync(source.as_ref());
-        // Neighbours between attach and the first drain, and fatal on
-        // refusal: a route through an unprogrammed adjacency installs
-        // cleanly, verifies cleanly, and drops every packet.
-        engine
-            .program_neighbours(source.as_ref())
-            .map(|_| ())
-            .map_err(|e| e.to_string())
+        let deferral = {
+            let Core { engine, source, .. } = &mut *c;
+            // BEFORE the diff, because the diff is what consumes it: the
+            // ledger's contents are where withdrawals come from, and on an
+            // adoption it is empty while the surviving VPP's FIB is not.
+            // A no-op unless the ledger is empty, so a fresh spawn pays one
+            // round trip and adopts nothing.
+            let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
+            if adopted > 0 {
+                tracing::info!(
+                    routes = adopted,
+                    "adopted VPP's existing FIB; the resync diff can now withdraw what the \
+                     route source no longer advertises"
+                );
+            }
+            // The diff is only meaningful against a source that has
+            // finished loading, and a daemon restart is exactly when it
+            // has not: the feed reconnects at startup and takes tens of
+            // seconds to reload. Diffing an adopted ledger against that
+            // window queues ~everything as a withdrawal — against a
+            // live, possibly steered VPP. Drill (d) on the shadow
+            // (2026-08-07): the drain began emptying a verified
+            // forwarding table, convergence failed, and the teardown
+            // killed the adopted VPP. So the diff waits below the floor;
+            // `drain_batch` runs it once the source crosses.
+            let floor = adopted / ADOPTED_SOURCE_FLOOR_DIVISOR;
+            let have = source.route_count();
+            if have < floor {
+                tracing::warn!(
+                    have,
+                    adopted,
+                    floor,
+                    "adopted resync deferred: the route source is still loading, and a diff \
+                     now would withdraw most of a table VPP is forwarding with; keeping the \
+                     adopted FIB untouched until the source catches up"
+                );
+                Some(floor)
+            } else {
+                let _plan = engine.begin_resync(source.as_ref());
+                // Neighbours between attach and the first drain, and
+                // fatal on refusal: a route through an unprogrammed
+                // adjacency installs cleanly, verifies cleanly, and
+                // drops every packet.
+                engine
+                    .program_neighbours(source.as_ref())
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())?;
+                None
+            }
+        };
+        c.deferred_resync_floor = deferral;
+        Ok(())
     }
 
     fn start_verify(&mut self) -> Result<(), String> {

--- a/crates/modules/vpp-offload/src/schedule.rs
+++ b/crates/modules/vpp-offload/src/schedule.rs
@@ -82,6 +82,26 @@ impl Schedule {
         }
     }
 
+    /// Push the phase deadline forward: the current phase is
+    /// deliberately waiting, not working.
+    ///
+    /// Distinct from [`Self::arm_phase`], whose same-kind arm is a no-op
+    /// by design — transitions within a phase must share one budget. A
+    /// deferred adopted resync is the case that needs the opposite: it
+    /// is *inside* the Convergence phase but has chosen not to start the
+    /// diff until the route source finishes loading, and letting the
+    /// budget run during that wait re-creates the very teardown the
+    /// deferral prevents, arriving through the clock instead of the
+    /// drain. Restarting the budget from `now` on each deferred tick
+    /// means it begins counting when the work does.
+    pub fn extend_phase(&mut self, now: Instant, phase: Option<(PhaseKind, Duration)>) {
+        if let Some((kind, budget)) = phase {
+            if self.phase_kind == Some(kind) {
+                self.phase_deadline = Some(now + budget);
+            }
+        }
+    }
+
     /// Arm the restart backoff, from `Action::ArmBackoff`.
     ///
     /// Also disarms the phase deadline: the backoff states have no phase

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1001,6 +1001,7 @@ fn run_loop(
             rs.parked_ops,
             driver.api_health(now),
             fib,
+            rs.resync_deferred,
             rs.port_links,
             rs.store_error.clone(),
             rs.drain_error.clone(),

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -268,6 +268,11 @@ pub struct StatusSnapshot {
     pub parked_ops: u64,
     pub api: ApiHealth,
     pub fib: FibSync,
+    /// `Some((have, want))` while an adopted resync waits for the route
+    /// source to finish loading. See `Runtime`'s deferral: the adopted
+    /// FIB is deliberately left forwarding, so this reads as Degraded
+    /// with the reason, never as steered-but-broken.
+    pub resync_deferred: Option<(u64, u64)>,
     pub ports: Vec<PortLink>,
     /// The runtime could not persist something it observed.
     ///
@@ -318,6 +323,7 @@ impl StatusSnapshot {
             pending.withheld_len() as u64,
             api,
             fib,
+            None,
             ports,
             None,
             None,
@@ -339,6 +345,7 @@ impl StatusSnapshot {
         parked_ops: u64,
         api: ApiHealth,
         fib: FibSync,
+        resync_deferred: Option<(u64, u64)>,
         ports: Vec<PortLink>,
         store_error: Option<String>,
         drain_error: Option<String>,
@@ -357,6 +364,7 @@ impl StatusSnapshot {
             parked_ops,
             api,
             fib,
+            resync_deferred,
             ports,
             store_error,
             drain_error,
@@ -377,10 +385,17 @@ impl StatusSnapshot {
     /// a wedged one, a FIB never verified or known wrong, or a port
     /// whose link is down under paths that resolve through it.
     fn steered_but_broken(&self) -> bool {
+        // A deferred adopted resync is steered with `fib` unverified BY
+        // THIS DAEMON — deliberately: the table it forwards with was
+        // verified by the previous daemon, and preserving it untouched is
+        // the protection. Counting that as "steered but broken" would
+        // report the safeguard as the module's worst fault for as long
+        // as bird takes to reload.
+        let fib_unverified = !self.fib.verified() && self.resync_deferred.is_none();
         self.steered
             && (!self.state.has_process()
                 || matches!(self.api, ApiHealth::Silent { .. })
-                || !self.fib.verified()
+                || fib_unverified
                 || !self.dead_ports().is_empty())
     }
 
@@ -563,6 +578,26 @@ impl StatusSnapshot {
 
     fn fib_health(&self) -> SubsystemHealth {
         let (state, message) = match &self.fib {
+            // Checked before the steered arm below, deliberately: a
+            // deferred adopted resync IS steered — the whole point of the
+            // deferral is leaving a forwarding VPP alone — and the
+            // steered arm's "traffic steered into an unverified FIB"
+            // would report the designed protection as the worst fault
+            // the module has. The FIB in question was verified by the
+            // previous daemon and is being deliberately preserved; what
+            // the operator needs is the reason convergence has not
+            // started, not an alarm that invites them to restart it.
+            FibSync::NeverVerified if self.resync_deferred.is_some() => {
+                let (have, want) = self.resync_deferred.expect("checked above");
+                (
+                    HealthState::Degraded,
+                    Some(format!(
+                        "resync deferred: the route source is still loading ({have} of the \
+                         {want} required); the adopted FIB keeps forwarding untouched until \
+                         it catches up"
+                    )),
+                )
+            }
             FibSync::NeverVerified if self.steered => (
                 HealthState::Unhealthy,
                 Some("traffic steered into an unverified FIB".into()),

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -678,6 +678,7 @@ impl Encode for ControlPingReply {
     fn encode(&self, buf: &mut Vec<u8>) {
         buf.extend_from_slice(&(self.context).to_be_bytes());
         buf.extend_from_slice(&(self.retval).to_be_bytes());
+        buf.extend_from_slice(&0u32.to_be_bytes()); // client_index
         buf.extend_from_slice(&(self.vpe_pid).to_be_bytes());
     }
 }

--- a/crates/modules/vpp-offload/src/vpp_api/transport.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/transport.rs
@@ -409,6 +409,7 @@ impl Transport {
             }
         })?;
         let len = parse_frame_header(&hdr);
+
         if len > MAX_PAYLOAD {
             return Err(TransportError::PayloadTooLarge(len));
         }

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -568,3 +568,44 @@ fn adoption_withdraws_stale_routes_without_touching_vpps_own() {
         "the stale route is withdrawn and nothing else is: {deleted:?}"
     );
 }
+
+/// The generated `Encode` and `Decode` must agree on a reply's
+/// geometry, proven by round-tripping a ping through the fake.
+///
+/// `control_ping_reply` carries `client_index` mid-body (after retval —
+/// schema fact, not header convention). The decoder consumed it
+/// positionally; the encoder skipped it as "transport-owned", so every
+/// fake-built ping reply was 4 bytes short of what the client demands.
+/// Nothing in production encodes a reply — only the fakes do — which is
+/// how EVERY fake-backed test ran its liveness path on a silently
+/// failing ping (error, disconnect, reconnect next tick) without one
+/// test noticing: they all converge inside the wedge budget. Found the
+/// first time a test deliberately sat in a live state for minutes (the
+/// adopted-resync deferral), which the wedge detector then "caught".
+///
+/// The codegen now emits a placeholder for mid-body transport-owned
+/// fields, and this pins the symmetry where it was missing.
+#[test]
+fn a_fakes_ping_reply_is_decodable_not_just_writable() {
+    const SIX: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "ping-geometry",
+        Behaviour {
+            existing_routes: SIX,
+            ..Default::default()
+        },
+    );
+    let mut engine = engine_for(&fake);
+    assert!(engine.api_ready(), "handshake");
+    engine.ping().expect("a bare ping must decode");
+    engine.attach_devices(AttachMode::Fresh).expect("attach");
+    let adopted = engine.adopt_vpp_fib().expect("dump");
+    assert_eq!(adopted, 3);
+    engine
+        .ping()
+        .expect("the stream must still be clean after a populated dump");
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -43,7 +43,7 @@ impl RouteSource for Mirror {
     }
 }
 
-fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
+fn runtime_with_source(fake: &Fake, source: Box<dyn RouteSource>) -> Runtime {
     let engine = ConvergenceEngine::new(
         &fake.path,
         vec![PortAttach {
@@ -61,18 +61,22 @@ fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
             prefix_len: 32,
         },
     );
-    let mirror = Mirror {
-        routes: (0..n_routes).map(|i| fake_vpp::v4(0, i)).collect(),
-    };
     Runtime::new(
         engine,
-        Box::new(mirror),
+        source,
         Box::new(SteeringUnavailable),
         Box::new(NullStore),
         Box::new(NoResources),
         "/usr/bin/vpp",
         "/tmp/startup.conf",
     )
+}
+
+fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
+    let mirror = Mirror {
+        routes: (0..n_routes).map(|i| fake_vpp::v4(0, i)).collect(),
+    };
+    runtime_with_source(fake, Box::new(mirror))
 }
 
 /// The production loop shape: tick, inject completed work, honour the
@@ -662,5 +666,179 @@ fn a_nexthop_first_seen_after_convergence_gets_its_adjacency() {
         saw_neigh,
         "the new nexthop's static neighbour was never programmed — its routes \
          would install, verify clean, and blackhole"
+    );
+}
+
+/// Drill (d) on the shadow (2026-08-07), pinned end to end.
+///
+/// A daemon restart adopted a steered VPP forwarding a verified table,
+/// and the adopted resync ran ~6 s later — against a route source whose
+/// BGP feed had just reconnected and held almost nothing. The diff read
+/// "the source is authoritative" literally and queued ~1M withdrawals
+/// against the live dataplane; the drain began emptying the forwarding
+/// table (5.43 s of measured loss), convergence failed, and the teardown
+/// killed the very VPP preserve-on-restart exists to keep.
+///
+/// The fix under test: the adopted diff is DEFERRED while the source
+/// holds less than the floor (`adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`).
+/// While deferred, nothing touches VPP — no withdrawals, no upserts, no
+/// phase timeout however long bird takes — and the deferral is visible
+/// on the status surface. When the source crosses the floor, the diff
+/// runs and withdraws exactly what is genuinely gone.
+#[test]
+fn an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table() {
+    use std::sync::{Arc, Mutex};
+
+    /// A mirror the test can fill while the runtime holds it — the
+    /// route feed mid-reload, as a fixture.
+    struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
+    impl RouteSource for SharedMirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in self.0.lock().unwrap().iter() {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+
+    // The surviving VPP forwards six routes that look self-installed.
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 3, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "loop-defer",
+        fake_vpp::Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    // The feed has delivered one route of an eventual five: well below
+    // the floor of 6/2 = 3.
+    let shared = Arc::new(Mutex::new(vec![fake_vpp::v4(0, 0)]));
+    let rt = runtime_with_source(&fake, Box::new(SharedMirror(shared.clone())));
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        // Steered — the case whose blackhole this exists to prevent.
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    assert_eq!(d.state(), State::AdoptedResyncing);
+    rt.set_steered(true);
+
+    // Hold below the floor for far longer than CONVERGENCE_BUDGET,
+    // pacing the clock by each tick's own permitted sleep — jumping it
+    // in big steps would outrun the ping cadence and fabricate a wedge
+    // the way no wall clock ever does. Nothing may time out and nothing
+    // may reach VPP's FIB.
+    let mut now = t0;
+    let mut held = Vec::new();
+    let past_budget = t0 + Duration::from_secs(150);
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..2_000 {
+            if now >= past_budget {
+                break;
+            }
+            let t = d.tick(now, &mut obs, &mut fx);
+            held.extend(t.events.clone());
+            assert!(
+                !t.events.contains(&Event::PhaseTimedOut),
+                "the convergence budget must time the diff, not bird's reload: {:?}",
+                t.events
+            );
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "a deferred resync must not report complete: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                held.extend(d.inject(now, e, &mut fx).events);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert!(
+        now >= past_budget,
+        "the loop must actually outlast CONVERGENCE_BUDGET for this to prove anything"
+    );
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "still converging, still steered, still untouched; saw {held:?}"
+    );
+    let touched: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        touched.is_empty(),
+        "no route op may reach a live table while the source loads: {touched:?}"
+    );
+    assert_eq!(
+        rt.status().resync_deferred,
+        Some((1, 3)),
+        "the deferral must be visible, not silent"
+    );
+
+    // The feed finishes: five routes survive, 10.0.5.0/24 was withdrawn
+    // while packetframe was down.
+    *shared.lock().unwrap() = (0..5).map(|i| fake_vpp::v4(0, i)).collect();
+
+    let mut seen: Vec<Event> = Vec::new();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..64 {
+            now += Duration::from_millis(100);
+            let t = d.tick(now, &mut obs, &mut fx);
+            seen.extend(t.events.clone());
+            if seen.contains(&Event::SyncComplete) {
+                break;
+            }
+        }
+    }
+    assert!(
+        seen.contains(&Event::SyncComplete),
+        "once the source crosses the floor the resync must actually run: {seen:?}"
+    );
+    assert!(
+        rt.status().resync_deferred.is_none(),
+        "the deferral must clear when the diff runs"
+    );
+
+    // And the diff withdrew exactly the route that is genuinely gone —
+    // not the table.
+    let deletes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        deletes,
+        vec![([10, 0, 5, 0], 24)],
+        "one withdrawal for the one prefix the source really dropped"
     );
 }

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -456,13 +456,35 @@ fn emit_encode(out: &mut String, api: &Api, name: &str, fields: &[Field], is_msg
                 .map(|c| (c.clone(), field_ident(&f.name)))
         })
         .collect();
+    // Whether this message's client_index sits at the prefix position
+    // (before context). Only there is it the transport's to write —
+    // `send` and the fakes' `reply_head` stamp id + prefix client_index
+    // and nothing else. A MID-BODY client_index (control_ping_reply
+    // puts it after retval) is written by nobody on that path, and the
+    // decoder consumes it positionally, so an encoder that skips it
+    // produces a frame 4 bytes short of what its own decoder demands.
+    // Nothing in production ever encodes a reply, which is exactly why
+    // this asymmetry survived: the only encoders of replies are the
+    // test fakes, and a fake whose ping replies cannot be decoded made
+    // every fake-backed liveness test run on a silently failing ping.
+    let ci_prefix = is_msg && header_geometry(fields).1;
     writeln!(out, "impl Encode for {rname} {{").unwrap();
     writeln!(out, "    fn encode(&self, buf: &mut Vec<u8>) {{").unwrap();
     if fields.is_empty() {
         writeln!(out, "        let _ = buf;").unwrap();
     }
     for f in fields {
-        if is_msg && (f.name == "_vl_msg_id" || f.name == "client_index") {
+        if is_msg && (f.name == "_vl_msg_id" || (f.name == "client_index" && ci_prefix)) {
+            continue;
+        }
+        if is_msg && f.name == "client_index" {
+            // Transport-owned but mid-body: emit the placeholder so
+            // encode and decode agree on the frame's length.
+            writeln!(
+                out,
+                "        buf.extend_from_slice(&0u32.to_be_bytes()); // client_index"
+            )
+            .unwrap();
             continue;
         }
         // A count field is DERIVED, never taken from the struct. VPP


### PR DESCRIPTION
## The defect, from drill (d) on the shadow (2026-08-07)

A daemon restart adopted a **steered** VPP forwarding a verified 1.05M-route table. The adopted resync ran ~6 s after start — against a route source whose BGP feed had just reconnected and held almost nothing. The diff queued ~1M withdrawals against the live dataplane, the drain began emptying the forwarding table (**5.43 s of measured loss** on the drill flow, 1,831 frames), convergence failed, and the teardown unsteered and **killed the adopted VPP** — drill (d) inverted into drill (a). Log signature: `steering DOWN` at +6 s, fresh spawn, `steering UP` at +48 s, VPP pid changed.

The plan had the insight and the code lost it: *"the first convergence may cover a fraction… safe only because a first attach never steers."* Adoption-while-steered voids the "safe only because" clause, and nothing re-derived it. The completeness gate can't help on the shadow (it compares against the local bird's 19 routes).

## The fix

The adopted diff **defers** while the source holds fewer routes than half the adopted ledger (`ADOPTED_SOURCE_FLOOR_DIVISOR`, with the half-not-parity reasoning in its doc). While deferred:

- nothing touches VPP — no withdrawals, no deltas; the adopted FIB keeps forwarding untouched
- no phase timeout however long bird takes: `Schedule::extend_phase` restarts `CONVERGENCE_BUDGET` on deferred ticks, so the budget times the diff, not the reload
- the deferral is loud, not silent: `fib-synced DEGRADED — resync deferred: the route source is still loading (N of M)`, and `steered_but_broken` exempts it (the preserved table was verified by the previous daemon; reporting the safeguard as the module's worst fault invites the operator to restart it)

`drain_batch` grows a third outcome (`Drain::AwaitingSource`) because a bool couldn't say "deliberately waiting" — `true` would send the supervisor to verify a diff that never ran, `false` would spin a core.

## The second bug the test flushed out

The generated `Encode` skipped `client_index` everywhere; `control_ping_reply` carries it **mid-body**, where `Decode` consumes it positionally. Every fake-built ping reply was 4 bytes short. Production never encodes a reply — only the fakes do — so **every fake-backed test has been running its liveness path on a silently failing ping** (error → disconnect → reconnect next tick), unnoticed because every test converges inside the wedge budget. The new deferral test was the first to sit in a live state for minutes of virtual time, and the wedge detector "caught" it.

The codegen now emits a placeholder for mid-body transport-owned fields (one generated line changed); `a_fakes_ping_reply_is_decodable_not_just_writable` pins the symmetry, before and after a populated dump.

## Verification

- `an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table`: end-to-end over the fake — steered adoption, source below floor across >120 s virtual time: no route op reaches VPP, no timeout, deferral visible on status; source crosses the floor: resync runs and withdraws exactly the one genuinely-gone prefix. **Revert-tested**: disabling the deferral fails it on the no-withdrawals invariant.
- Ping regression test fails against the pre-fix generated code.
- fmt, clippy (host + all four targets), full workspace suite green.

## Hardware follow-up

Rerun drill (d)'s restart half on the shadow: expect `resync deferred` in the log, zero `steering DOWN`, zero loss on the drill flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)