### PR TITLE
fix(vpp-offload): adoption must not probe the loopback address

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -552,59 +552,35 @@ pub fn find_loopback(t: &mut Transport) -> Result<Option<u32>, TransportError> {
     Ok(found.first().copied())
 }
 
-/// `VNET_API_ERROR_DUPLICATE_IF_ADDRESS` from vnet/error.h (stable/2506).
+/// Reconcile an adopted loopback: re-assert admin-up, and admin-up
+/// ONLY.
 ///
-/// VPP's error string says "already present on another interface" and the
-/// string is wrong: `ip4_add_del_interface_address_internal` returns this
-/// for an exact-prefix re-add on the **same** interface. The
-/// cross-interface conflict is `-105 ADDRESS_IN_USE` — which is what the
-/// shadow produced when a second loopback was given the first one's
-/// address, and that observation is what disambiguates the two. Checked
-/// against the source rather than recalled, because "re-adding an address
-/// is idempotent" was the recalled version and it is false.
-pub const VNET_API_ERROR_DUPLICATE_IF_ADDRESS: i32 = -127;
-
-/// Reconcile an adopted loopback: re-assert its address and admin-up.
+/// The address is deliberately **not** re-asserted, and the history is
+/// the argument. The first version trusted the name alone; the second
+/// re-asserted the address, accepting `-127 DUPLICATE_IF_ADDRESS` as
+/// "already exactly where we want it" (correct per stable/2506 source
+/// for a plain same-interface re-add). Hardware then refuted the model
+/// (shadow, 2026-08-08): with member ports **unnumbered to the
+/// loopback**, VPP's cross-interface conflict scan sees the borrowed
+/// address as held by another interface and answers `-105
+/// ADDRESS_IN_USE` — on every healthy adoption of this design's own
+/// steady state. `-105` is also the genuine-conflict signal, so on this
+/// topology the re-assert carries zero distinguishing information, and
+/// whitelisting it would bless real conflicts. The failure it caused
+/// was not hypothetical: the refusal drove teardown, killed the adopted
+/// VPP, and the fresh respawn re-steered into a 6-second-old partial
+/// table for 27 s of measured blackhole.
 ///
-/// Discovery alone is not adoption. [`find_loopback`] matches by name,
-/// and a name proves nothing about the two properties `create_loopback`
-/// establishes after creating: the address members borrow, and admin-up.
-/// A daemon crash between `create_loopback`'s create and its address-add
-/// leaves exactly that — a named, addressless loopback — and adopting it
-/// blind puts every member behind `ip4-not-enabled` with the FIB verified
-/// green. The member reuse path re-asserts admin-up, MAC and unnumbered
-/// for the same reason; this is the loopback's version of that reconcile
-/// point.
-///
-/// The address re-assert cannot be a plain "must return 0": VPP answers
-/// an exact re-add on the same interface with
-/// [`VNET_API_ERROR_DUPLICATE_IF_ADDRESS`], which here means *the address
-/// is already exactly where we want it* — the common case on every
-/// healthy adoption. Anything else, including `-105 ADDRESS_IN_USE`
-/// (something *else* holds the address), stays fatal.
-pub fn adopt_loopback(
-    t: &mut Transport,
-    loop_idx: u32,
-    addr: Ipv4Prefix,
-) -> Result<(), AttachError> {
-    let reply = t.request::<SwInterfaceAddDelAddress, SwInterfaceAddDelAddressReply>(
-        SwInterfaceAddDelAddress {
-            context: 0,
-            sw_if_index: loop_idx,
-            is_add: true,
-            del_all: false,
-            prefix: prefix_of(addr),
-        },
-    )?;
-    if reply.retval != 0 && reply.retval != VNET_API_ERROR_DUPLICATE_IF_ADDRESS {
-        return Err(AttachError::Refused {
-            step: "sw_interface_add_del_address (adopt)",
-            port: "loop0".into(),
-            retval: reply.retval,
-            detail: format!("{}/{}", addr.addr, addr.prefix_len),
-        });
-    }
-
+/// What this deliberately leaves open: a daemon crash between
+/// `create_loopback`'s create and its address-add leaves a named,
+/// addressless loopback that adoption will trust. That window is two
+/// adjacent API round trips on a unix socket, no whitelisted message
+/// can dump addresses to check (`sw_interface_dump` reports MACs, not
+/// prefixes), and the cure measured worse than the disease. Closing it
+/// properly means adding `ip_address_dump` to the API whitelist and
+/// doing a true readback — tracked as future hardening, not faked with
+/// a probe whose answer cannot be interpreted.
+pub fn adopt_loopback(t: &mut Transport, loop_idx: u32) -> Result<(), AttachError> {
     let reply =
         t.request::<SwInterfaceSetFlags, SwInterfaceSetFlagsReply>(SwInterfaceSetFlags {
             context: 0,

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -639,18 +639,19 @@ impl ConvergenceEngine {
             // assigning the same address fails ADDRESS_IN_USE, and the
             // attach step never completes.
             //
-            // Adoption then reconciles rather than trusting the name:
-            // the address and admin-up are re-asserted, because a crash
-            // between create and address-add leaves a named loopback
-            // with neither, and no whitelisted message can dump
-            // addresses to check.
+            // Adoption re-asserts admin-up and trusts the address. The
+            // address CANNOT be probed: re-adding it answers -105
+            // through the members' unnumbered borrow on every healthy
+            // adoption (hardware, 2026-08-08), and no whitelisted
+            // message dumps addresses. See `adopt_loopback` for the
+            // full argument and the accepted crash window.
             None => match crate::attach::find_loopback(t) {
                 Ok(Some(idx)) => {
                     tracing::info!(
                         sw_if_index = idx,
                         "reusing the loopback this VPP already has rather than creating another"
                     );
-                    crate::attach::adopt_loopback(t, idx, self.loopback).map(|()| idx)
+                    crate::attach::adopt_loopback(t, idx).map(|()| idx)
                 }
                 Ok(None) => crate::attach::create_loopback(t, self.loopback),
                 Err(e) => Err(e.into()),

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -526,19 +526,23 @@ fn addr_key(p: packetframe_common::config::Ipv4Prefix) -> Vec<u8> {
     k
 }
 
-/// The common case of every healthy adoption: the loopback already holds
-/// the address, and VPP answers the re-assert with -127
-/// DUPLICATE_IF_ADDRESS — its spelling of "already exactly where you
-/// want it". Adoption must read that as success.
+/// Adoption re-asserts admin-up and sends NO address message — pinned
+/// against the exact hardware scenario that killed the re-assert
+/// design (shadow, 2026-08-08).
 ///
-/// Remove the -127 acceptance from `adopt_loopback` and this fails,
-/// which is the point: the fake now refuses duplicates the way VPP does,
-/// so an address-shaped adoption bug fails on host CI instead of on the
-/// shadow.
+/// The member port is unnumbered to the loopback, so the router
+/// address is visible on it; VPP's conflict scan therefore answers a
+/// loopback address re-add with `-105 ADDRESS_IN_USE` on every healthy
+/// adoption, indistinguishable from a genuine conflict. The seeded
+/// address on the MEMBER below is that borrow, as close as this fake
+/// can express it (it does not model unnumbered — which is exactly how
+/// the re-assert design passed CI and failed on hardware). If adoption
+/// ever asks the address question again, this fake refuses it the way
+/// the real NIC did, and this test fails the way the shadow did.
 #[test]
-fn an_adopted_loopback_holding_its_address_reconciles_clean() {
+fn adoption_reasserts_admin_up_and_never_touches_the_address() {
     let fake = Fake::start_seeded(
-        "loopdup",
+        "loopadoptup",
         AttachBehaviour {
             dev_index: 3,
             sw_if_index: 7,
@@ -550,84 +554,27 @@ fn an_adopted_loopback_holding_its_address_reconciles_clean() {
             (LOOP_IF_INDEX, "loop0".into(), 3),
         ],
         false,
-        vec![(LOOP_IF_INDEX, addr_key(loop_addr()))],
+        // The unnumbered borrow: the member "holds" the router address.
+        vec![(7, addr_key(loop_addr()))],
     );
     let mut t = fake.connect();
 
     let found = packetframe_vpp_offload::attach::find_loopback(&mut t)
         .expect("dump")
         .expect("loop0 seeded");
-    packetframe_vpp_offload::attach::adopt_loopback(&mut t, found, loop_addr())
-        .expect("a duplicate address on the adopted loopback is the healthy case");
+    packetframe_vpp_offload::attach::adopt_loopback(&mut t, found)
+        .expect("a healthy adoption must not be refused over the borrowed address");
 
     let seen = fake.observed();
     assert!(
-        seen.contains(&"sw_interface_add_del_address".to_string()),
-        "the address must be re-asserted, not assumed: {seen:?}"
+        !seen.contains(&"sw_interface_add_del_address".to_string()),
+        "the address must not be probed on adoption — the answer is -105 through the \
+         unnumbered borrow and carries no signal: {seen:?}"
     );
     assert!(
         seen.contains(&"sw_interface_set_flags".to_string()),
-        "admin-up must be re-asserted, as the member reuse path does: {seen:?}"
+        "admin-up is still re-asserted, as the member reuse path does: {seen:?}"
     );
-}
-
-/// A crash between `create_loopback`'s create and its address-add leaves
-/// a named, addressless loopback. Blind adoption then puts every member
-/// behind `ip4-not-enabled` with the FIB verified green. Reconcile adds
-/// the missing address — proven by the second adopt answering
-/// "duplicate", which it can only do if the first one's add took.
-#[test]
-fn an_adopted_loopback_that_lost_its_address_gets_it_back() {
-    let fake = Fake::start_seeded(
-        "loopbare",
-        AttachBehaviour {
-            dev_index: 3,
-            sw_if_index: 7,
-            ..Default::default()
-        },
-        LookupBehaviour::Missing,
-        vec![(LOOP_IF_INDEX, "loop0".into(), 3)],
-        false,
-        Vec::new(), // the crash window: loop0 exists, no address
-    );
-    let mut t = fake.connect();
-
-    packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
-        .expect("an addressless adopted loopback must be repaired, not trusted");
-    packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
-        .expect("the repair must have taken: the second pass sees the duplicate");
-}
-
-/// -105 stays fatal. The duplicate acceptance is for the address being
-/// exactly where we want it; an address held by a *different* interface
-/// is a conflict, and whitelisting broadly would adopt an addressless
-/// loopback while something else answers for the router address.
-#[test]
-fn a_cross_interface_address_conflict_still_refuses() {
-    let fake = Fake::start_seeded(
-        "loopconflict",
-        AttachBehaviour {
-            dev_index: 3,
-            sw_if_index: 7,
-            ..Default::default()
-        },
-        LookupBehaviour::Missing,
-        vec![
-            (7, "octeon0/0".into(), 3),
-            (LOOP_IF_INDEX, "loop0".into(), 3),
-        ],
-        false,
-        // The router address lives on the member port, not the loopback.
-        vec![(7, addr_key(loop_addr()))],
-    );
-    let mut t = fake.connect();
-
-    let err = packetframe_vpp_offload::attach::adopt_loopback(&mut t, LOOP_IF_INDEX, loop_addr())
-        .expect_err("an address held elsewhere is a conflict, not a reconcile");
-    match err {
-        AttachError::Refused { retval, .. } => assert_eq!(retval, -105),
-        other => panic!("expected Refused with ADDRESS_IN_USE, got {other:?}"),
-    }
 }
 
 /// The MAC readback catches a driver that says yes and does nothing.


### PR DESCRIPTION
## What the drill (d) rerun found (shadow, 2026-08-08)

The loopback address re-assert added alongside #142 fails on real topology: with member ports **unnumbered to the loopback**, VPP's cross-interface conflict scan sees the borrowed address as held by another interface and answers `-105 ADDRESS_IN_USE` on **every healthy adoption**:

```
last-tick DEGRADED — AttachDevices: sw_interface_add_del_address (adopt) for loop0 failed (retval -105): 169.254.254.3/32
```

`-105` is also the genuine-conflict signal, so on this topology the probe carries zero distinguishing information — whitelisting it would bless real conflicts. The consequence chain on the drill: refusal → teardown → **adopted VPP killed** → fresh respawn re-steered into a 6-second-old partial table (`require-table-complete off` is structurally mandatory on the shadow) → **27.28 s measured blackhole**.

The fake validated the broken design because it modelled my reading of the address semantics and does not model unnumbered — the exact "a fake with the wrong geometry validates a client with the same wrong geometry" trap `tests/common/wire.rs` warns about.

## The fix

`adopt_loopback` re-asserts **admin-up only** and trusts the discovered address. The reopened crash window (daemon dies between `create_loopback`'s create and address-add → named, addressless loopback adopted blind) is two adjacent API round trips wide, cannot be checked with any whitelisted message, and its cure measured worse than the disease — documented in the doc comment, with `ip_address_dump` readback named as the future hardening.

The replacement test seeds the borrowed address on the member port and asserts adoption sends **no** `sw_interface_add_del_address` at all (the fake's refusal semantics make any reintroduced probe fail the way the shadow did) while still re-asserting admin-up.

## Also recorded, not coded

The 27.28 s partial-table steer is the plan's documented first-steer gap getting its first measured number. It is reachable only where the completeness gate is off (the shadow — its local bird holds 19 routes); production runs the gate and refuses the steer until the table is complete.

## Hardware follow-up

Rerun drill (d)'s restart half: expect `reusing the loopback` → *(no address message)* → `adopted resync deferred` → `crossed the deferral floor` → convergence, zero `steering DOWN`, same VPP pid throughout, zero loss.

🤖 Generated with [Claude Code](https://claude.com/claude-code)