### PR TITLE
fix(vpp-offload): the deferral releases on quiescence, not on a count

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -111,7 +111,12 @@ pub trait Observe {
     /// budget, during which no ping is sent and no exit is noticed — so
     /// the wedge detector would either be useless or fire on a VPP that
     /// was working fine.
-    fn drain_batch(&mut self) -> Result<Drain, String>;
+    /// `now` is the loop's clock, for the adopted-resync release gate:
+    /// quiescence is a RATE over elapsed time, never a count of calls —
+    /// the production loop caps sleeps at 50 ms for stop-responsiveness,
+    /// so per-call growth shrinks with cadence and a per-call threshold
+    /// would call a full-speed reload "quiet" (review finding).
+    fn drain_batch(&mut self, now: Instant) -> Result<Drain, String>;
 }
 
 /// One tick's result.
@@ -284,7 +289,7 @@ impl Driver {
             // the settled tick's sleep to run the resync phase deadline
             // out and fail a convergence that was fine.
             if (resyncing || api_up_at_entry) && before != State::Verifying {
-                match obs.drain_batch() {
+                match obs.drain_batch(now) {
                     // Empty means the resync is done — and only the
                     // drain can say so, which is why this is observed
                     // rather than assumed after issuing StartResync.
@@ -535,7 +540,7 @@ mod tests {
                 Ok(())
             }
         }
-        fn drain_batch(&mut self) -> Result<Drain, String> {
+        fn drain_batch(&mut self, _now: Instant) -> Result<Drain, String> {
             self.drains += 1;
             if self.drain_fails {
                 return Err("socket closed".into());

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -188,6 +188,17 @@ pub trait RouteSource {
     /// The compiler now makes every implementor answer; a fixture's
     /// answer is one line.
     fn route_count(&self) -> u64;
+
+    /// Mutations ever applied to this source — a monotonic activity
+    /// counter, NOT the table size. The adopted-resync gate's
+    /// quiescence signal: net size hides balanced churn and reads a
+    /// shrinking source as quiet, and both of those mid-reload would
+    /// release a diff against an incomplete mirror (review finding). A
+    /// static fixture may return any constant (including its length);
+    /// what matters is that it changes exactly when the source does.
+    /// No default body, same reason as `route_count`: a defaulted
+    /// method lets a delegating wrapper silently not-delegate.
+    fn change_seq(&self) -> u64;
 }
 
 /// One route change: the prefix, and its new nexthop set — or `None`
@@ -1198,6 +1209,9 @@ mod tests {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
             n
+        }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
         }
 
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -178,13 +178,16 @@ pub trait RouteSource {
     /// verified forwarding table, convergence failed, and the teardown
     /// killed the adopted VPP that preserve-on-restart exists to keep.
     ///
-    /// The default walks the table, which is fine for fixtures; the live
-    /// feed overrides it with its mirror's O(1) length.
-    fn route_count(&self) -> u64 {
-        let mut n = 0u64;
-        self.for_each_route(&mut |_, _| n += 1);
-        n
-    }
+    /// Deliberately **no default body**, and it used to have one (a
+    /// full-table walk "fine for fixtures"): a defaulted method lets a
+    /// delegating wrapper silently not-delegate, and that is not a
+    /// hypothetical — the production loader's `Arc<RouteFeed>` wrapper
+    /// forwarded every explicit method and inherited the default for
+    /// this one, so the gate that polls it every ~50 ms was walking a
+    /// 1.05M-entry mirror instead of reading a length (review finding).
+    /// The compiler now makes every implementor answer; a fixture's
+    /// answer is one line.
+    fn route_count(&self) -> u64;
 }
 
 /// One route change: the prefix, and its new nexthop set — or `None`
@@ -1191,6 +1194,12 @@ mod tests {
     }
 
     impl RouteSource for Mirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for (p, nhs) in &self.routes {
                 visit(*p, nhs);

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -98,6 +98,12 @@ pub struct FeedStats {
 
 #[derive(Default)]
 struct Inner {
+    /// Mutations ever applied, monotonic. The adopted-resync gate's
+    /// quiescence signal: net table size hides churn (adds balanced by
+    /// withdrawals read as zero growth) and reads a shrinking source as
+    /// quiet, and both of those mid-reload would release a diff against
+    /// an incomplete mirror (review finding). Every mutator bumps this.
+    seq: u64,
     /// The authoritative mirror: every prefix the other tier resolved.
     routes: BTreeMap<PrefixKey, SetId>,
     /// Interned nexthop sets, indexed by [`SetId`]. Append-only.
@@ -176,6 +182,7 @@ impl RouteFeed {
 impl ResolvedRouteSink for RouteFeed {
     fn route_resolved(&self, prefix: IpPrefix, nexthops: &[IpAddr]) {
         let mut g = self.lock();
+        g.seq += 1;
         let id = g.intern(nexthops);
         let key = PrefixKey::from(prefix);
         g.routes.insert(key, id);
@@ -184,6 +191,7 @@ impl ResolvedRouteSink for RouteFeed {
 
     fn route_withdrawn(&self, prefix: IpPrefix) {
         let mut g = self.lock();
+        g.seq += 1;
         let key = PrefixKey::from(prefix);
         g.routes.remove(&key);
         // Queued even when the mirror held nothing. A withdrawal for a
@@ -197,12 +205,14 @@ impl ResolvedRouteSink for RouteFeed {
 
     fn neighbour_resolved(&self, nh: IpAddr, mac: [u8; 6], ifindex: u32) {
         let mut g = self.lock();
+        g.seq += 1;
         g.neighbours.insert(nh, (mac, ifindex));
         g.neigh_pending.insert(nh, Some((mac, ifindex)));
     }
 
     fn neighbour_lost(&self, nh: IpAddr) {
         let mut g = self.lock();
+        g.seq += 1;
         g.neighbours.remove(&nh);
         // Queued even if the map held nothing, for the same reason a
         // withdrawal is: the engine's nexthop map is filled by resync too,
@@ -255,6 +265,10 @@ impl RouteSource for RouteFeed {
         // The mirror's own length — O(1), safe to poll every tick while
         // an adopted resync waits for the feed to finish loading.
         self.lock().routes.len() as u64
+    }
+
+    fn change_seq(&self) -> u64 {
+        self.lock().seq
     }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
@@ -337,6 +351,9 @@ impl RouteSource for std::sync::Arc<RouteFeed> {
     // O(1) length one deref away (review finding).
     fn route_count(&self) -> u64 {
         (**self).route_count()
+    }
+    fn change_seq(&self) -> u64 {
+        (**self).change_seq()
     }
 }
 

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -329,6 +329,15 @@ impl RouteSource for std::sync::Arc<RouteFeed> {
     fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
         (**self).for_each_neighbour(visit)
     }
+    // EVERY method with a default body must be forwarded here by hand,
+    // because a default hides its own omission: this delegation compiled
+    // cleanly while routing `route_count` — polled every ~50 ms by the
+    // adopted-resync gate, and this Arc is exactly what the production
+    // loader boxes — to the default full-mirror walk instead of the
+    // O(1) length one deref away (review finding).
+    fn route_count(&self) -> u64 {
+        (**self).route_count()
+    }
 }
 
 /// Kernel interface name for `ifindex`, or `None` if the link is gone.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -989,6 +989,9 @@ mod tests {
         fn route_count(&self) -> u64 {
             0
         }
+        fn change_seq(&self) -> u64 {
+            0
+        }
     }
 
     /// A published snapshot the loop would produce in the designed

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -986,6 +986,9 @@ mod tests {
         ) {
         }
         fn for_each_neighbour(&self, _: &mut dyn FnMut(std::net::IpAddr, &str, [u8; 6])) {}
+        fn route_count(&self) -> u64 {
+            0
+        }
     }
 
     /// A published snapshot the loop would produce in the designed

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -318,10 +318,15 @@ struct DeferredResync {
     adopted: u64,
     /// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
     floor: u64,
-    /// The source's count at the previous check, for the growth test.
+    /// The source's count at the previous check, for the growth rate.
     last_have: u64,
-    /// Consecutive checks with sub-threshold growth.
-    quiet_ticks: u32,
+    /// When `last_have` was observed. `None` until the first check —
+    /// a rate needs two observations.
+    last_check: Option<std::time::Instant>,
+    /// Since when the source has stayed below the quiet rate, or `None`
+    /// while it is loading. Release requires this to have lasted
+    /// [`SOURCE_QUIET_FOR`].
+    quiet_since: Option<std::time::Instant>,
 }
 
 /// The adopted diff runs only when the source holds at least
@@ -346,23 +351,26 @@ struct DeferredResync {
 ///   the growth rate can.
 pub const ADOPTED_SOURCE_FLOOR_DIVISOR: u64 = 2;
 
-/// Consecutive sub-threshold-growth checks before the source counts as
-/// loaded. Checks happen on the driver's tick cadence (sub-second), so
-/// this costs an adoption ~1.5–3 s — paid even when the source was
-/// already complete, deliberately, so there is exactly one path to the
-/// diff. The residual risk is a feed that stalls mid-load for the whole
-/// window; on this fleet the feed is one hop away (bird reloads at
-/// ~18k routes/s observed), making a multi-second silent stall the rare
-/// case, and its cost is bounded by the same deltas that finish the
-/// load.
-pub const SOURCE_QUIET_TICKS: u32 = 3;
+/// How long the source must stay below the quiet RATE before it counts
+/// as loaded. A duration, never a number of checks: the production loop
+/// caps its sleeps at 50 ms for stop-responsiveness, so check cadence is
+/// an implementation detail that varies by two orders of magnitude
+/// between the service loop and the tests — a per-check threshold
+/// shrinks per-call growth with cadence until a full-speed reload
+/// classifies as quiet (review finding; at 50 ms checks an 18k routes/s
+/// reload adds ~900 per check). This costs every populated adoption
+/// ~2 s of deliberate patience. The residual risk is a feed that stalls
+/// mid-load for the whole window; the feed is one hop away on this
+/// fleet, making a 2 s silent stall the rare case, and its cost is
+/// bounded by the same deltas that finish the load.
+pub const SOURCE_QUIET_FOR: Duration = Duration::from_secs(2);
 
-/// Growth per check below which the source is "quiet": 1/1024th of the
-/// adopted table, floored at 64 so tiny fixtures release promptly.
-/// Steady-state BGP churn on the reference fleet is tens of routes per
-/// second; a reload is tens of thousands — three orders of magnitude
-/// apart, so the exact divisor is not delicate.
-fn source_quiet_threshold(adopted: u64) -> u64 {
+/// Growth rate (routes per second) below which the source is "quiet":
+/// 1/1024th of the adopted table per second, floored at 64/s so tiny
+/// fixtures release promptly. Steady-state BGP churn on the reference
+/// fleet is tens of routes per second; a reload is ~18k/s — orders of
+/// magnitude on either side, so the exact divisor is not delicate.
+fn source_quiet_rate_per_sec(adopted: u64) -> u64 {
     (adopted / 1024).max(64)
 }
 
@@ -682,7 +690,7 @@ impl Observe for ObserveView {
             .map_err(|e| e.to_string())
     }
 
-    fn drain_batch(&mut self) -> Result<crate::driver::Drain, String> {
+    fn drain_batch(&mut self, now: std::time::Instant) -> Result<crate::driver::Drain, String> {
         let mut c = self.core.borrow_mut();
         // A deferred adopted resync is re-checked here, on the driver's
         // paced cadence, because this is the only Observe call that runs
@@ -694,20 +702,35 @@ impl Observe for ObserveView {
         if let Some(mut d) = c.deferred_resync {
             let have = c.source.route_count();
             // Both gates, in order: below the floor nothing else
-            // matters, and above it only sustained quiet counts — a
-            // loading feed passes through the floor by construction,
-            // which is how the floor-only version withdrew half a live
-            // table (2026-08-08).
-            let still_loading = have < d.floor
-                || have.saturating_sub(d.last_have) > source_quiet_threshold(d.adopted);
-            let released = if still_loading {
-                d.quiet_ticks = 0;
-                false
-            } else {
-                d.quiet_ticks += 1;
-                d.quiet_ticks >= SOURCE_QUIET_TICKS
+            // matters, and above it only quiet SUSTAINED FOR A DURATION
+            // counts — a loading feed passes through the floor by
+            // construction (the floor-only version withdrew half a live
+            // table, 2026-08-08), and "quiet" is a rate over elapsed
+            // time, never a per-call delta: the production loop caps
+            // its sleeps at 50 ms, so a per-call threshold shrinks with
+            // cadence until a full-speed reload classifies as quiet.
+            let growth_per_sec = match d.last_check {
+                // A rate needs two observations; the first check only
+                // baselines, and reports as loading — which a source
+                // this young almost certainly is.
+                None => u64::MAX,
+                Some(prev) => {
+                    let ms = now.duration_since(prev).as_millis().max(1) as u64;
+                    have.saturating_sub(d.last_have).saturating_mul(1_000) / ms
+                }
             };
+            let still_loading =
+                have < d.floor || growth_per_sec > source_quiet_rate_per_sec(d.adopted);
+            if still_loading {
+                d.quiet_since = None;
+            } else if d.quiet_since.is_none() {
+                d.quiet_since = Some(now);
+            }
+            let released = d
+                .quiet_since
+                .is_some_and(|since| now.duration_since(since) >= SOURCE_QUIET_FOR);
             d.last_have = have;
+            d.last_check = Some(now);
             if !released {
                 c.deferred_resync = Some(d);
                 return Ok(crate::driver::Drain::AwaitingSource {
@@ -962,7 +985,8 @@ impl Effects for EffectsView {
                     adopted,
                     floor: adopted / ADOPTED_SOURCE_FLOOR_DIVISOR,
                     last_have: have,
-                    quiet_ticks: 0,
+                    last_check: None,
+                    quiet_since: None,
                 })
             }
         };
@@ -1293,7 +1317,7 @@ mod tests {
         assert_eq!(obs.poll_exit(), None);
         assert!(!obs.api_ready(), "nothing is listening");
         assert!(obs.ping().is_err());
-        assert!(obs.drain_batch().is_err());
+        assert!(obs.drain_batch(std::time::Instant::now()).is_err());
     }
 
     /// A store that fails at spawn time must kill the child. A VPP

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -318,9 +318,11 @@ struct DeferredResync {
     adopted: u64,
     /// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
     floor: u64,
-    /// The source's count at the previous check, for the growth rate.
-    last_have: u64,
-    /// When `last_have` was observed. `None` until the first check —
+    /// The source's change counter at the previous check, for the
+    /// activity rate. The COUNTER, not the table size: net size hides
+    /// balanced churn and reads a shrinking source as quiet.
+    last_seq: u64,
+    /// When `last_seq` was observed. `None` until the first check —
     /// a rate needs two observations.
     last_check: Option<std::time::Instant>,
     /// Since when the source has stayed below the quiet rate, or `None`
@@ -365,11 +367,14 @@ pub const ADOPTED_SOURCE_FLOOR_DIVISOR: u64 = 2;
 /// bounded by the same deltas that finish the load.
 pub const SOURCE_QUIET_FOR: Duration = Duration::from_secs(2);
 
-/// Growth rate (routes per second) below which the source is "quiet":
-/// 1/1024th of the adopted table per second, floored at 64/s so tiny
-/// fixtures release promptly. Steady-state BGP churn on the reference
-/// fleet is tens of routes per second; a reload is ~18k/s — orders of
-/// magnitude on either side, so the exact divisor is not delicate.
+/// Activity rate (mutations per second) below which the source is
+/// "quiet": 1/1024th of the adopted table per second, floored at 64/s
+/// so tiny fixtures release promptly. Measured on the CHANGE COUNTER,
+/// not on table growth — balanced churn and active shrink are zero
+/// growth and are anything but quiet (review finding). Steady-state
+/// BGP churn on the reference fleet is tens of mutations per second; a
+/// reload is ~18k/s — orders of magnitude on either side, so the exact
+/// divisor is not delicate.
 fn source_quiet_rate_per_sec(adopted: u64) -> u64 {
     (adopted / 1024).max(64)
 }
@@ -709,18 +714,19 @@ impl Observe for ObserveView {
             // time, never a per-call delta: the production loop caps
             // its sleeps at 50 ms, so a per-call threshold shrinks with
             // cadence until a full-speed reload classifies as quiet.
-            let growth_per_sec = match d.last_check {
+            let seq = c.source.change_seq();
+            let activity_per_sec = match d.last_check {
                 // A rate needs two observations; the first check only
                 // baselines, and reports as loading — which a source
                 // this young almost certainly is.
                 None => u64::MAX,
                 Some(prev) => {
                     let ms = now.duration_since(prev).as_millis().max(1) as u64;
-                    have.saturating_sub(d.last_have).saturating_mul(1_000) / ms
+                    seq.saturating_sub(d.last_seq).saturating_mul(1_000) / ms
                 }
             };
             let still_loading =
-                have < d.floor || growth_per_sec > source_quiet_rate_per_sec(d.adopted);
+                have < d.floor || activity_per_sec > source_quiet_rate_per_sec(d.adopted);
             if still_loading {
                 d.quiet_since = None;
             } else if d.quiet_since.is_none() {
@@ -729,7 +735,7 @@ impl Observe for ObserveView {
             let released = d
                 .quiet_since
                 .is_some_and(|since| now.duration_since(since) >= SOURCE_QUIET_FOR);
-            d.last_have = have;
+            d.last_seq = seq;
             d.last_check = Some(now);
             if !released {
                 c.deferred_resync = Some(d);
@@ -975,6 +981,7 @@ impl Effects for EffectsView {
                 None
             } else {
                 let have = source.route_count();
+                let seq = source.change_seq();
                 tracing::info!(
                     have,
                     adopted,
@@ -990,7 +997,7 @@ impl Effects for EffectsView {
                     // exists for (review finding). A populated
                     // adoption's floor is never satisfied by nothing.
                     floor: (adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1),
-                    last_have: have,
+                    last_seq: seq,
                     last_check: None,
                     quiet_since: None,
                 })
@@ -1058,6 +1065,9 @@ mod tests {
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
         fn for_each_neighbour(&self, _: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
         fn route_count(&self) -> u64 {
+            0
+        }
+        fn change_seq(&self) -> u64 {
             0
         }
     }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -983,7 +983,13 @@ impl Effects for EffectsView {
                 );
                 Some(DeferredResync {
                     adopted,
-                    floor: adopted / ADOPTED_SOURCE_FLOOR_DIVISOR,
+                    // Clamped to 1: integer division floors adopted=1
+                    // to zero, and a floor of zero lets a DEAD source
+                    // (have=0) pass the gate, go quiet, and withdraw
+                    // the sole live route — the exact case the floor
+                    // exists for (review finding). A populated
+                    // adoption's floor is never satisfied by nothing.
+                    floor: (adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1),
                     last_have: have,
                     last_check: None,
                     quiet_since: None,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -922,26 +922,49 @@ impl Effects for EffectsView {
             // seconds to reload. Diffing an adopted ledger against that
             // window queues ~everything as a withdrawal — against a
             // live, possibly steered VPP (drill (d), 2026-08-07). EVERY
-            // adoption defers, even one whose source already looks
-            // complete — a count cannot say "complete", only the
-            // floor-plus-quiescence gate in `drain_batch` can, and an
-            // above-floor count at this instant is exactly what a
+            // adoption of a POPULATED FIB defers, even one whose source
+            // already looks complete — a count cannot say "complete",
+            // only the floor-plus-quiescence gate in `drain_batch` can,
+            // and an above-floor count at this instant is exactly what a
             // half-finished reload looks like (2026-08-08). One path to
             // the diff, ~1.5–3 s of deliberate patience on the path
             // that used to skip it.
-            let have = source.route_count();
-            tracing::info!(
-                have,
-                adopted,
-                "adopted resync deferred until the route source is loaded and quiet; \
-                 the adopted FIB keeps forwarding untouched meanwhile"
-            );
-            Some(DeferredResync {
-                adopted,
-                floor: adopted / ADOPTED_SOURCE_FLOOR_DIVISOR,
-                last_have: have,
-                quiet_ticks: 0,
-            })
+            //
+            // `adopted == 0` — a fresh spawn, or a survivor with an
+            // empty FIB — starts immediately instead: there is no
+            // withdrawal universe to protect, the resync is pure
+            // installs that safely trickle in as the feed loads, and a
+            // floor of zero would otherwise turn the gate into a bare
+            // quiescence wait — deferring an EMPTY dataplane behind a
+            // loading feed, the one situation where converging as fast
+            // as routes arrive is strictly better (review finding on
+            // this PR).
+            if adopted == 0 {
+                let _plan = engine.begin_resync(source.as_ref());
+                // Neighbours between attach and the first drain, and
+                // fatal on refusal: a route through an unprogrammed
+                // adjacency installs cleanly, verifies cleanly, and
+                // drops every packet.
+                engine
+                    .program_neighbours(source.as_ref())
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())?;
+                None
+            } else {
+                let have = source.route_count();
+                tracing::info!(
+                    have,
+                    adopted,
+                    "adopted resync deferred until the route source is loaded and quiet; \
+                     the adopted FIB keeps forwarding untouched meanwhile"
+                );
+                Some(DeferredResync {
+                    adopted,
+                    floor: adopted / ADOPTED_SOURCE_FLOOR_DIVISOR,
+                    last_have: have,
+                    quiet_ticks: 0,
+                })
+            }
         };
         c.deferred_resync = deferral;
         Ok(())

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -299,32 +299,72 @@ struct Core {
     /// operator would see a stalled `pending_ops` with nothing saying
     /// why.
     last_drain_error: Option<String>,
-    /// `Some(floor)` while an adopted resync is deferred: the diff will
-    /// not run until the route source holds at least `floor` routes.
-    ///
-    /// Set by `start_resync` when it adopts a populated FIB and finds
-    /// the source still loading; cleared by `drain_batch` when the
-    /// source crosses the floor and the diff actually begins. While
-    /// set, the adopted VPP is left exactly as found — steered, routes
-    /// intact — because a diff against a loading source is ~all
-    /// withdrawals, and draining those into a live dataplane is the
-    /// drill-(d) blackhole (2026-08-07).
-    deferred_resync_floor: Option<u64>,
+    /// `Some` while an adopted resync is deferred, holding the release
+    /// gate's state. Set by `start_resync` on EVERY adoption of a
+    /// populated FIB; cleared by `drain_batch` when the gate opens and
+    /// the diff actually begins. While set, the adopted VPP is left
+    /// exactly as found — steered, routes intact — because a diff
+    /// against a loading source is ~all withdrawals, and draining those
+    /// into a live dataplane is the drill-(d) blackhole (2026-08-07).
+    deferred_resync: Option<DeferredResync>,
 }
 
-/// An adopted resync is deferred while the route source holds fewer
-/// routes than `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
+/// Release-gate state for a deferred adopted resync. See
+/// [`ADOPTED_SOURCE_FLOOR_DIVISOR`] and [`SOURCE_QUIET_TICKS`] for the
+/// two conditions, and why both are load-bearing.
+#[derive(Debug, Clone, Copy)]
+struct DeferredResync {
+    /// Routes adopted from VPP's FIB — the diff's withdrawal universe.
+    adopted: u64,
+    /// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
+    floor: u64,
+    /// The source's count at the previous check, for the growth test.
+    last_have: u64,
+    /// Consecutive checks with sub-threshold growth.
+    quiet_ticks: u32,
+}
+
+/// The adopted diff runs only when the source holds at least
+/// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR` routes **and** has been
+/// quiet for [`SOURCE_QUIET_TICKS`] checks. Both conditions, because
+/// each covers the other's blind spot:
 ///
-/// Half, not "equal": the source and the adopted FIB legitimately
-/// differ by whatever churned while packetframe was down, and demanding
-/// near-parity would deadlock against a genuinely shrunken table (an
-/// upstream loss can remove a real fraction). Half is far above any
-/// plausible legitimate shrink and far below any partially-loaded feed
-/// — the two distributions this constant separates. If the source
-/// never crosses the floor (feed down), the deferral holds forever and
-/// health stays degraded: stale-but-verified forwarding plus an alarm
-/// beats withdrawing a live table.
+/// - **Quiescence alone** releases against a DEAD feed — a source that
+///   never loaded anything is perfectly quiet, and the diff would
+///   withdraw the entire adopted table, which is the original disaster.
+///   The floor holds that case deferred forever, health degraded:
+///   stale-but-verified forwarding plus an alarm beats withdrawing a
+///   live table.
+/// - **The floor alone** releases MID-LOAD, because a loading feed
+///   passes through every fraction on its way to full — by
+///   construction, not by bad luck. The first version used only the
+///   floor and hardware billed it precisely (shadow, 2026-08-08): the
+///   diff ran at have=527,557 of an eventual 1.05M, withdrew the
+///   not-yet-reloaded half from the live steered VPP, and the drill
+///   flow measured 12.75 s of blackhole. A count threshold cannot
+///   distinguish "loading, at 60%" from "loaded, shrunk to 60%"; only
+///   the growth rate can.
 pub const ADOPTED_SOURCE_FLOOR_DIVISOR: u64 = 2;
+
+/// Consecutive sub-threshold-growth checks before the source counts as
+/// loaded. Checks happen on the driver's tick cadence (sub-second), so
+/// this costs an adoption ~1.5–3 s — paid even when the source was
+/// already complete, deliberately, so there is exactly one path to the
+/// diff. The residual risk is a feed that stalls mid-load for the whole
+/// window; on this fleet the feed is one hop away (bird reloads at
+/// ~18k routes/s observed), making a multi-second silent stall the rare
+/// case, and its cost is bounded by the same deltas that finish the
+/// load.
+pub const SOURCE_QUIET_TICKS: u32 = 3;
+
+/// Growth per check below which the source is "quiet": 1/1024th of the
+/// adopted table, floored at 64 so tiny fixtures release promptly.
+/// Steady-state BGP churn on the reference fleet is tens of routes per
+/// second; a reload is tens of thousands — three orders of magnitude
+/// apart, so the exact divisor is not delicate.
+fn source_quiet_threshold(adopted: u64) -> u64 {
+    (adopted / 1024).max(64)
+}
 
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
 pub struct Runtime {
@@ -366,7 +406,7 @@ impl Runtime {
                 pending: Vec::new(),
                 last_store_error: None,
                 last_drain_error: None,
-                deferred_resync_floor: None,
+                deferred_resync: None,
             })),
         }
     }
@@ -469,9 +509,7 @@ impl Runtime {
             drain_error: c.last_drain_error.clone(),
             source_backlog: c.source.backlog(),
             steer_configured_ports: c.steering.configured_ports(),
-            resync_deferred: c
-                .deferred_resync_floor
-                .map(|want| (c.source.route_count(), want)),
+            resync_deferred: c.deferred_resync.map(|d| (c.source.route_count(), d.floor)),
         }
     }
 }
@@ -500,7 +538,7 @@ pub struct RuntimeStatus {
     /// backlog there means VPP is not accepting.
     pub source_backlog: u64,
     /// `Some((have, want))` while an adopted resync is deferred for a
-    /// still-loading route source. See `Core::deferred_resync_floor`.
+    /// still-loading route source. See `Core::deferred_resync`.
     pub resync_deferred: Option<(u64, u64)>,
 }
 
@@ -653,15 +691,34 @@ impl Observe for ObserveView {
         // coming diff reads the full mirror and covers them, and
         // applying a partial feed's withdrawals early is the exact
         // hazard being deferred.
-        if let Some(floor) = c.deferred_resync_floor {
+        if let Some(mut d) = c.deferred_resync {
             let have = c.source.route_count();
-            if have < floor {
-                return Ok(crate::driver::Drain::AwaitingSource { have, want: floor });
+            // Both gates, in order: below the floor nothing else
+            // matters, and above it only sustained quiet counts — a
+            // loading feed passes through the floor by construction,
+            // which is how the floor-only version withdrew half a live
+            // table (2026-08-08).
+            let still_loading = have < d.floor
+                || have.saturating_sub(d.last_have) > source_quiet_threshold(d.adopted);
+            let released = if still_loading {
+                d.quiet_ticks = 0;
+                false
+            } else {
+                d.quiet_ticks += 1;
+                d.quiet_ticks >= SOURCE_QUIET_TICKS
+            };
+            d.last_have = have;
+            if !released {
+                c.deferred_resync = Some(d);
+                return Ok(crate::driver::Drain::AwaitingSource {
+                    have,
+                    want: d.floor,
+                });
             }
             tracing::info!(
                 have,
-                floor,
-                "route source crossed the deferral floor; running the adopted resync diff"
+                adopted = d.adopted,
+                "route source loaded and quiet; running the adopted resync diff"
             );
             {
                 let Core { engine, source, .. } = &mut *c;
@@ -671,7 +728,7 @@ impl Observe for ObserveView {
                     .map(|_| ())
                     .map_err(|e| e.to_string())?;
             }
-            c.deferred_resync_floor = None;
+            c.deferred_resync = None;
         }
         // Live changes are pulled in FIRST, so a route learned while VPP
         // was already converged goes out in this same batch rather than
@@ -864,37 +921,29 @@ impl Effects for EffectsView {
             // has not: the feed reconnects at startup and takes tens of
             // seconds to reload. Diffing an adopted ledger against that
             // window queues ~everything as a withdrawal — against a
-            // live, possibly steered VPP. Drill (d) on the shadow
-            // (2026-08-07): the drain began emptying a verified
-            // forwarding table, convergence failed, and the teardown
-            // killed the adopted VPP. So the diff waits below the floor;
-            // `drain_batch` runs it once the source crosses.
-            let floor = adopted / ADOPTED_SOURCE_FLOOR_DIVISOR;
+            // live, possibly steered VPP (drill (d), 2026-08-07). EVERY
+            // adoption defers, even one whose source already looks
+            // complete — a count cannot say "complete", only the
+            // floor-plus-quiescence gate in `drain_batch` can, and an
+            // above-floor count at this instant is exactly what a
+            // half-finished reload looks like (2026-08-08). One path to
+            // the diff, ~1.5–3 s of deliberate patience on the path
+            // that used to skip it.
             let have = source.route_count();
-            if have < floor {
-                tracing::warn!(
-                    have,
-                    adopted,
-                    floor,
-                    "adopted resync deferred: the route source is still loading, and a diff \
-                     now would withdraw most of a table VPP is forwarding with; keeping the \
-                     adopted FIB untouched until the source catches up"
-                );
-                Some(floor)
-            } else {
-                let _plan = engine.begin_resync(source.as_ref());
-                // Neighbours between attach and the first drain, and
-                // fatal on refusal: a route through an unprogrammed
-                // adjacency installs cleanly, verifies cleanly, and
-                // drops every packet.
-                engine
-                    .program_neighbours(source.as_ref())
-                    .map(|_| ())
-                    .map_err(|e| e.to_string())?;
-                None
-            }
+            tracing::info!(
+                have,
+                adopted,
+                "adopted resync deferred until the route source is loaded and quiet; \
+                 the adopted FIB keeps forwarding untouched meanwhile"
+            );
+            Some(DeferredResync {
+                adopted,
+                floor: adopted / ADOPTED_SOURCE_FLOOR_DIVISOR,
+                last_have: have,
+                quiet_ticks: 0,
+            })
         };
-        c.deferred_resync_floor = deferral;
+        c.deferred_resync = deferral;
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1051,6 +1051,9 @@ mod tests {
     impl RouteSource for EmptySource {
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
         fn for_each_neighbour(&self, _: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
+        fn route_count(&self) -> u64 {
+            0
+        }
     }
 
     fn engine() -> ConvergenceEngine {

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -589,14 +589,25 @@ impl StatusSnapshot {
             // started, not an alarm that invites them to restart it.
             FibSync::NeverVerified if self.resync_deferred.is_some() => {
                 let (have, want) = self.resync_deferred.expect("checked above");
-                (
-                    HealthState::Degraded,
-                    Some(format!(
+                // Two phases, two messages: below the floor the source
+                // is plainly still loading; at or above it the gate is
+                // waiting for the growth to stop, because a loading
+                // feed passes through every count on its way to full
+                // and only quiescence says "done".
+                let msg = if have < want {
+                    format!(
                         "resync deferred: the route source is still loading ({have} of the \
                          {want} required); the adopted FIB keeps forwarding untouched until \
                          it catches up"
-                    )),
-                )
+                    )
+                } else {
+                    format!(
+                        "resync deferred: the route source holds {have} routes and is still \
+                         growing; the diff runs once the feed goes quiet, and the adopted \
+                         FIB keeps forwarding untouched until then"
+                    )
+                };
+                (HealthState::Degraded, Some(msg))
             }
             FibSync::NeverVerified if self.steered => (
                 HealthState::Unhealthy,

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -50,6 +50,12 @@ const ALLOW: [IpPrefix; 1] = [IpPrefix::V4 {
 /// route source; convergence itself is `vpp_service.rs`'s job.
 struct Mirror;
 impl RouteSource for Mirror {
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         visit(fake_vpp::v4(0, 0), &[fake_vpp::nh()]);
     }

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -55,6 +55,9 @@ impl RouteSource for Mirror {
         self.for_each_route(&mut |_, _| n += 1);
         n
     }
+    fn change_seq(&self) -> u64 {
+        self.route_count()
+    }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         visit(fake_vpp::v4(0, 0), &[fake_vpp::nh()]);

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -106,6 +106,9 @@ impl RouteSource for FileSource {
     fn route_count(&self) -> u64 {
         self.routes.len() as u64
     }
+    fn change_seq(&self) -> u64 {
+        self.routes.len() as u64
+    }
 }
 
 fn parse_prefix(s: &str) -> Option<IpPrefix> {

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -103,6 +103,9 @@ impl RouteSource for FileSource {
             visit(*ip, dev, *mac);
         }
     }
+    fn route_count(&self) -> u64 {
+        self.routes.len() as u64
+    }
 }
 
 fn parse_prefix(s: &str) -> Option<IpPrefix> {

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -39,6 +39,9 @@ impl RouteSource for Mirror {
         self.for_each_route(&mut |_, _| n += 1);
         n
     }
+    fn change_seq(&self) -> u64 {
+        self.route_count()
+    }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
@@ -269,6 +272,9 @@ impl RouteSource for OrphanedMirror {
         self.for_each_route(&mut |_, _| n += 1);
         n
     }
+    fn change_seq(&self) -> u64 {
+        self.route_count()
+    }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
@@ -461,6 +467,9 @@ fn neighbours_on_foreign_devices_are_skipped() {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
             n
+        }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
         }
 
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -34,6 +34,12 @@ struct Mirror {
 }
 
 impl RouteSource for Mirror {
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
             visit(*p, &[nh()]);
@@ -258,6 +264,12 @@ struct OrphanedMirror {
 }
 
 impl RouteSource for OrphanedMirror {
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
             visit(*p, &[nh()]);
@@ -445,6 +457,12 @@ fn static_neighbours_are_programmed_before_the_routes_that_need_them() {
 fn neighbours_on_foreign_devices_are_skipped() {
     struct MixedMirror;
     impl RouteSource for MixedMirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             visit(v4(0, 0), &[nh()]);
         }

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -38,6 +38,9 @@ impl RouteSource for Mirror {
         self.for_each_route(&mut |_, _| n += 1);
         n
     }
+    fn change_seq(&self) -> u64 {
+        self.route_count()
+    }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
@@ -713,6 +716,9 @@ fn an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table() {
             self.for_each_route(&mut |_, _| n += 1);
             n
         }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
+        }
 
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in self.0.lock().unwrap().iter() {
@@ -883,6 +889,9 @@ fn a_source_still_growing_past_the_floor_keeps_deferring() {
             self.for_each_route(&mut |_, _| n += 1);
             n
         }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
+        }
 
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in self.0.lock().unwrap().iter() {
@@ -1044,6 +1053,9 @@ fn quiescence_is_a_rate_not_a_per_check_delta() {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
             n
+        }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
         }
 
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
@@ -1233,4 +1245,134 @@ fn a_dead_source_never_releases_a_populated_adoption() {
             .all(|e| !matches!(e, fake_vpp::Event::Route(_))),
         "the sole live route must not be withdrawn"
     );
+}
+
+/// Quiescence is measured on the change counter, not on net table size.
+///
+/// A source churning in place — every add balanced by a withdrawal —
+/// has zero net growth and is anything but quiet; releasing the diff
+/// into that turbulence withdraws whatever the churn has not yet
+/// restored (review finding). This holds a source whose SIZE never
+/// moves while its change counter runs hot, far past the quiet window,
+/// and insists the diff stays shut; when the churn stops, it releases.
+#[test]
+fn balanced_churn_is_not_quiescence() {
+    use std::sync::{Arc, Mutex};
+
+    /// Fixed-size route set with an explicit activity counter.
+    struct ChurningMirror {
+        routes: Vec<IpPrefix>,
+        seq: Arc<Mutex<u64>>,
+    }
+    impl RouteSource for ChurningMirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in &self.routes {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+        fn route_count(&self) -> u64 {
+            self.routes.len() as u64
+        }
+        fn change_seq(&self) -> u64 {
+            *self.seq.lock().unwrap()
+        }
+    }
+
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 3, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "loop-churn",
+        fake_vpp::Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    let seq = Arc::new(Mutex::new(0u64));
+    // Above the floor from the first check: five of the six adopted
+    // prefixes. Only the churn keeps the gate shut.
+    let rt = runtime_with_source(
+        &fake,
+        Box::new(ChurningMirror {
+            routes: (0..5).map(|i| fake_vpp::v4(0, i)).collect(),
+            seq: seq.clone(),
+        }),
+    );
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // 100 mutations per 100 ms check = 1000/s, fifteen times the quiet
+    // threshold — with the table size frozen throughout.
+    let mut now = t0;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..60 {
+            *seq.lock().unwrap() += 100;
+            now += Duration::from_millis(100);
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "balanced churn has zero net growth and must still read as \
+                 loading: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+        }
+    }
+    assert_eq!(d.state(), State::AdoptedResyncing);
+    assert!(
+        fake.drain_events()
+            .into_iter()
+            .all(|e| !matches!(e, fake_vpp::Event::Route(_))),
+        "no route op may reach the live table during churn"
+    );
+
+    // The churn stops; the gate releases and the diff withdraws exactly
+    // the one genuinely-gone prefix.
+    let mut seen: Vec<Event> = Vec::new();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..128 {
+            now += Duration::from_millis(100);
+            let t = d.tick(now, &mut obs, &mut fx);
+            seen.extend(t.events.clone());
+            if seen.contains(&Event::SyncComplete) {
+                break;
+            }
+        }
+    }
+    assert!(
+        seen.contains(&Event::SyncComplete),
+        "a genuinely quiet source must release the diff: {seen:?}"
+    );
+    let deletes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(deletes, vec![([10, 0, 5, 0], 24)]);
 }

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -135,6 +135,15 @@ fn the_full_loop_converges_an_adopted_vpp_to_ready() {
         d.inject(t0, Event::Adopted { steered: false }, &mut fx);
     }
     assert_eq!(d.state(), State::Syncing);
+    // An adoption that found an EMPTY FIB has no withdrawal universe to
+    // protect, so the source-quiescence gate must not engage — a floor
+    // of zero would reduce it to a bare wait that defers an empty
+    // dataplane behind a loading feed (review finding on the
+    // quiescence PR).
+    assert!(
+        rt.status().resync_deferred.is_none(),
+        "adopting nothing must start the resync immediately"
+    );
 
     let (_, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
 

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1168,3 +1168,69 @@ fn quiescence_is_a_rate_not_a_per_check_delta() {
         "one withdrawal for the one prefix the source really dropped"
     );
 }
+
+/// A dead source never releases a populated adoption — at any scale.
+///
+/// `adopted = 1` floors to zero under integer division, and a floor of
+/// zero is satisfied by an EMPTY source: dead feed, perfectly quiet,
+/// gate opens, diff withdraws the one route the VPP is forwarding with
+/// (review finding). The floor is clamped to 1 for any populated
+/// adoption; this holds a one-route survivor against an empty source
+/// far past the quiet window and insists nothing moves.
+#[test]
+fn a_dead_source_never_releases_a_populated_adoption() {
+    const ONE: &[([u8; 4], u8, u32, bool)] = &[([10, 0, 0, 0], 24, ASSIGNED_INDEX, true)];
+    let fake = Fake::start_behaving(
+        "loop-dead-feed",
+        fake_vpp::Behaviour {
+            existing_routes: ONE,
+            ..Default::default()
+        },
+    );
+    // The feed never delivers anything: the daemon restarted and its
+    // route source is dead.
+    let rt = runtime_with_source(&fake, Box::new(Mirror { routes: Vec::new() }));
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // Far past SOURCE_QUIET_FOR: a dead feed is perfectly quiet, so
+    // only the floor stands between it and the diff.
+    let mut now = t0;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..200 {
+            now += Duration::from_millis(100);
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "a dead source must never satisfy the gate: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+        }
+    }
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "still holding, still steered"
+    );
+    assert!(
+        fake.drain_events()
+            .into_iter()
+            .all(|e| !matches!(e, fake_vpp::Event::Route(_))),
+        "the sole live route must not be withdrawn"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1004,3 +1004,143 @@ fn a_source_still_growing_past_the_floor_keeps_deferring() {
         "one withdrawal for the one prefix the source really dropped"
     );
 }
+
+/// Quiescence is a rate over elapsed time, never a per-check delta —
+/// pinned at production's check cadence.
+///
+/// The service loop caps its sleeps at 50 ms for stop-responsiveness,
+/// so `drain_batch` can be checked twenty times a second. At that
+/// cadence an 18k routes/s reload adds only ~900 per check — under any
+/// plausible per-check threshold — so a per-check gate calls a
+/// full-speed reload "quiet" and releases the diff ~150 ms into it
+/// (review finding on this PR). This drives the gate at exactly that
+/// cadence with per-check growth small and the RATE unmistakably a
+/// reload, and insists the diff stays shut.
+#[test]
+fn quiescence_is_a_rate_not_a_per_check_delta() {
+    use std::sync::{Arc, Mutex};
+
+    struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
+    impl RouteSource for SharedMirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in self.0.lock().unwrap().iter() {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+    fn stranger(i: usize) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [10, 8, (i / 250) as u8, (i % 250) as u8],
+            prefix_len: 32,
+        }
+    }
+
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 3, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "loop-cadence",
+        fake_vpp::Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    let shared = Arc::new(Mutex::new(vec![fake_vpp::v4(0, 0)]));
+    let rt = runtime_with_source(&fake, Box::new(SharedMirror(shared.clone())));
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // 30 routes per 50 ms check: tiny per check, 600/s as a rate —
+    // ten times the quiet threshold. The clock advances by the 50 ms
+    // production cap regardless of the tick's requested sleep, which
+    // is exactly what the service loop does.
+    let mut now = t0;
+    let mut n = 0usize;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..80 {
+            {
+                let mut g = shared.lock().unwrap();
+                for i in n..n + 30 {
+                    g.push(stranger(i));
+                }
+            }
+            n += 30;
+            now += Duration::from_millis(50);
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "a reload checked often enough to look small per-check must still \
+                 read as loading: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+        }
+    }
+    assert_eq!(d.state(), State::AdoptedResyncing);
+    assert!(
+        fake.drain_events()
+            .into_iter()
+            .all(|e| !matches!(e, fake_vpp::Event::Route(_))),
+        "no route op may reach the live table during the reload"
+    );
+
+    // The reload ends; the source completes and goes quiet. Release
+    // needs SOURCE_QUIET_FOR of sustained quiet, then the diff runs.
+    {
+        let mut g = shared.lock().unwrap();
+        for i in 0..5u8 {
+            g.push(fake_vpp::v4(0, i));
+        }
+    }
+    let mut seen: Vec<Event> = Vec::new();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..128 {
+            now += Duration::from_millis(50);
+            let t = d.tick(now, &mut obs, &mut fx);
+            seen.extend(t.events.clone());
+            if seen.contains(&Event::SyncComplete) {
+                break;
+            }
+        }
+    }
+    assert!(
+        seen.contains(&Event::SyncComplete),
+        "a quiet, loaded source must release the diff: {seen:?}"
+    );
+    let deletes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        deletes,
+        vec![([10, 0, 5, 0], 24)],
+        "one withdrawal for the one prefix the source really dropped"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -33,6 +33,12 @@ struct Mirror {
 }
 
 impl RouteSource for Mirror {
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.routes {
             visit(*p, &[fake_vpp::nh()]);
@@ -702,6 +708,12 @@ fn an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table() {
     /// route feed mid-reload, as a fixture.
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in self.0.lock().unwrap().iter() {
                 visit(*p, &[fake_vpp::nh()]);
@@ -866,6 +878,12 @@ fn a_source_still_growing_past_the_floor_keeps_deferring() {
 
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in self.0.lock().unwrap().iter() {
                 visit(*p, &[fake_vpp::nh()]);
@@ -1022,6 +1040,12 @@ fn quiescence_is_a_rate_not_a_per_check_delta() {
 
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in self.0.lock().unwrap().iter() {
                 visit(*p, &[fake_vpp::nh()]);

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -842,3 +842,156 @@ fn an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table() {
         "one withdrawal for the one prefix the source really dropped"
     );
 }
+
+/// The floor is not the release condition — quiescence is. Pinned
+/// against the second drill-(d) failure (shadow, 2026-08-08): the
+/// floor-only gate released the diff at have=527,557 of an eventual
+/// 1.05M, withdrew the not-yet-reloaded half from the live steered
+/// VPP, and the drill flow measured 12.75 s of blackhole. A loading
+/// feed passes through every count on its way to full, so a source
+/// that keeps growing must keep deferring — however far past the
+/// floor it is.
+#[test]
+fn a_source_still_growing_past_the_floor_keeps_deferring() {
+    use std::sync::{Arc, Mutex};
+
+    struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
+    impl RouteSource for SharedMirror {
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in self.0.lock().unwrap().iter() {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+
+    /// A stranger prefix per index, disjoint from the adopted set.
+    fn stranger(i: usize) -> IpPrefix {
+        IpPrefix::V4 {
+            addr: [10, 9, (i / 250) as u8, (i % 250) as u8],
+            prefix_len: 32,
+        }
+    }
+
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 3, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "loop-grow",
+        fake_vpp::Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    let shared = Arc::new(Mutex::new(vec![fake_vpp::v4(0, 0)]));
+    let rt = runtime_with_source(&fake, Box::new(SharedMirror(shared.clone())));
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // The feed loads in big strides: every tick adds 200 routes — far
+    // past the floor of 3 within two ticks, and far above the quiet
+    // threshold every single tick. The mid-load reality, as a fixture.
+    let mut now = t0;
+    let mut n_strangers = 0usize;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..12 {
+            {
+                let mut g = shared.lock().unwrap();
+                for i in n_strangers..n_strangers + 200 {
+                    g.push(stranger(i));
+                }
+            }
+            n_strangers += 200;
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "a growing source must keep the diff deferred, however far past the \
+                 floor: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert_eq!(d.state(), State::AdoptedResyncing);
+    let touched: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        touched.is_empty(),
+        "no route op may reach the live table while the feed grows: {touched:?}"
+    );
+
+    // The reload finishes: the last stride lands the surviving five of
+    // the six adopted prefixes, then the feed goes quiet.
+    {
+        let mut g = shared.lock().unwrap();
+        for i in 0..5u8 {
+            g.push(fake_vpp::v4(0, i));
+        }
+    }
+    let mut seen: Vec<Event> = Vec::new();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..128 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            seen.extend(t.events.clone());
+            if seen.contains(&Event::SyncComplete) {
+                break;
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert!(
+        seen.contains(&Event::SyncComplete),
+        "a quiet, loaded source must release the diff: {seen:?}"
+    );
+
+    // And the withdrawal set is exactly the one genuinely-gone prefix,
+    // not the half of the table that happened to load late.
+    let deletes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        deletes,
+        vec![([10, 0, 5, 0], 24)],
+        "one withdrawal for the one prefix the source really dropped"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -32,6 +32,9 @@ impl RouteSource for Mirror {
         self.for_each_route(&mut |_, _| n += 1);
         n
     }
+    fn change_seq(&self) -> u64 {
+        self.route_count()
+    }
 
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.0 {

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -27,6 +27,12 @@ use packetframe_vpp_offload::supervisor::{Event, State};
 
 struct Mirror(Vec<IpPrefix>);
 impl RouteSource for Mirror {
+    fn route_count(&self) -> u64 {
+        let mut n = 0u64;
+        self.for_each_route(&mut |_, _| n += 1);
+        n
+    }
+
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for p in &self.0 {
             visit(*p, &[fake_vpp::nh()]);


### PR DESCRIPTION
## What the second drill-(d) rerun showed (shadow, 2026-08-08)

The good news first — everything landed in the last two PRs worked on hardware, visibly:

```
INFO reusing the loopback this VPP already has rather than creating another
WARN adopted resync deferred: ... have=225014 adopted=1054570 floor=527285
fib-synced DEGRADED — resync deferred: the route source is still loading (317197 of the 527285 required)
INFO route source crossed the deferral floor; running the adopted resync diff have=527557
```

No address probe, no `steering DOWN`, same VPP pid end to end. And that third line is the bug: **the floor released the diff when bird was half done reloading** (have=527,557 of an eventual 1.05M). The diff withdrew the not-yet-reloaded half from the live steered VPP and re-added it as the feed caught up — **12.75 s of measured blackhole** on the drill flow. A loading feed passes through every fraction on its way to full, by construction; a count threshold cannot distinguish "loading, at 60%" from "loaded, shrunk to 60%". Only the growth rate can.

## The fix

Release requires **floor AND quiescence**: at least half the adopted table present, and growth below `adopted/1024` per check (floored at 64) for **3 consecutive checks**. Each condition covers the other's blind spot:

- quiescence alone releases against a **dead feed** — perfectly quiet, the diff would withdraw everything (the original drill-(d) disaster)
- the floor alone releases **mid-load** — measured tonight at 12.75 s

The distributions are three orders of magnitude apart on this fleet (steady-state churn: tens of routes/s; reload: ~18k/s observed tonight), so neither constant is delicate.

`start_resync` also loses its diff-immediately arm: **every** adoption of a populated FIB goes through the gate, because an above-floor count at attach time is exactly what a half-finished fast reload looks like — the old arm was a second path to the same destination. An already-complete source pays ~1.5–3 s of deliberate patience.

The status surface distinguishes the phases: below the floor "still loading (N of M required)", above it "holds N routes and is still growing; the diff runs once the feed goes quiet".

## Verification

- New end-to-end test: a source growing in 200-route strides far past the floor keeps the diff deferred with zero route ops reaching the fake VPP; when growth stops, the diff runs and withdraws exactly the one genuinely-gone prefix. **Revert-tested**: a floor-only gate fails it on the keeps-deferring assertion — the same failure hardware showed.
- Existing deferral, adoption, and full workspace suites green ×3 consecutive runs; fmt + clippy on host and all four targets.
- One unrelated flake observed once under full-suite parallelism (`a_reconfigure_that_did_not_move_the_lever_does_not_steer`, empty-FIB adoption — the deferral never engages there); passes standalone and in three consecutive full runs.

## Hardware follow-up

Third drill-(d) rerun: expect `deferred until the route source is loaded and quiet`, the still-growing status message while bird reloads, `loaded and quiet; running the adopted resync diff` only after the feed settles, zero `steering DOWN`, same pid, and this time a flat capture at the noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)