### PR TITLE
fix(vpp-offload): adoption programs only the neighbours VPP is missing

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -772,7 +772,12 @@ impl ConvergenceEngine {
                 }
             };
             for d in details {
-                if d.neighbor.flags & IP_NEIGHBOR_STATIC == 0 {
+                // EXACT flags, not a bit test: `send_neighbour` programs
+                // precisely IP_NEIGHBOR_STATIC, so an entry carrying any
+                // extra flag (STATIC|NO_FIB_ENTRY, say) is not the entry
+                // we would create, and skipping it would silently
+                // preserve the difference forever (review finding).
+                if d.neighbor.flags != IP_NEIGHBOR_STATIC {
                     continue;
                 }
                 if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -47,8 +47,8 @@ use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
 use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
 use crate::vpp_api::generated::{
-    IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute, IpRouteDetails, IpRouteDump,
-    IpTable, FIB_API_PATH_TYPE_NORMAL,
+    IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails, IpNeighborDump,
+    IpRoute, IpRouteDetails, IpRouteDump, IpTable, ADDRESS_IP4, FIB_API_PATH_TYPE_NORMAL,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -739,6 +739,48 @@ impl ConvergenceEngine {
             return Err(EngineError::NotConnected);
         }
 
+        // What VPP already holds — so nothing it has is re-added.
+        //
+        // Re-adding an existing static neighbour is NOT a no-op: VPP
+        // replaces the entry (the dump's own `age` field resets), and
+        // the replacement walks every dependent FIB entry. On this
+        // topology ~1M routes resolve through ONE adjacency, and while
+        // that walk runs, traffic through it goes to null-node.
+        // Measured on the shadow (2026-08-08): a 5.51 s blackhole at
+        // the moment of an otherwise perfect adoption, 21,055
+        // `null-node blackholed` across the three drill-(d) runs that
+        // re-added blind. Discover, don't recreate — the same rule as
+        // ports and the loopback, one object further down.
+        //
+        // Skipped only on an EXACT match (interface, MAC, and the
+        // static flag): an entry with a stale MAC must be replaced —
+        // that walk is the price of correctness — and a dynamic entry
+        // must be replaced with a static one, because VPP can never
+        // refresh it here (MCAM cannot steer ARP).
+        let mut existing: HashSet<(u32, IpAddr, [u8; 6])> = HashSet::new();
+        {
+            let t = self.transport.as_mut().expect("checked just above");
+            let details: Vec<IpNeighborDetails> = match t.dump(IpNeighborDump {
+                context: 0,
+                sw_if_index: u32::MAX,
+                af: ADDRESS_IP4,
+            }) {
+                Ok(d) => d,
+                Err(e) => {
+                    self.disconnect();
+                    return Err(EngineError::Transport(e));
+                }
+            };
+            for d in details {
+                if d.neighbor.flags & IP_NEIGHBOR_STATIC == 0 {
+                    continue;
+                }
+                if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {
+                    existing.insert((d.neighbor.sw_if_index, ip, d.neighbor.mac_address));
+                }
+            }
+        }
+
         // Collect first: the visitor borrows `src` while the sends need
         // `&mut self`.
         let mut wanted: Vec<(IpAddr, u32, [u8; 6])> = Vec::new();
@@ -755,9 +797,22 @@ impl ConvergenceEngine {
         }
 
         let mut programmed = 0u64;
+        let mut kept = 0u64;
         for (ip, sw_if_index, mac_address) in wanted {
+            if existing.contains(&(sw_if_index, ip, mac_address)) {
+                kept += 1;
+                continue;
+            }
             self.send_neighbour(ip, sw_if_index, mac_address, true)?;
             programmed += 1;
+        }
+        if kept > 0 {
+            tracing::info!(
+                kept,
+                programmed,
+                "neighbours VPP already holds correct were left untouched; re-adding one \
+                 walks every dependent route"
+            );
         }
         Ok(programmed)
     }

--- a/crates/modules/vpp-offload/src/fib_sync.rs
+++ b/crates/modules/vpp-offload/src/fib_sync.rs
@@ -123,6 +123,21 @@ pub fn to_address(ip: IpAddr) -> Address {
     }
 }
 
+/// The inverse of [`to_address`], for reading VPP's neighbour table
+/// back. `None` for an address family the wire can carry but this
+/// module does not speak.
+pub fn from_address(a: &Address) -> Option<IpAddr> {
+    match a.af {
+        ADDRESS_IP4 => {
+            let mut o = [0u8; 4];
+            o.copy_from_slice(&a.un.0[..4]);
+            Some(IpAddr::V4(o.into()))
+        }
+        ADDRESS_IP6 => Some(IpAddr::V6(a.un.0.into())),
+        _ => None,
+    }
+}
+
 /// A delete for `prefix`. VPP matches deletes on the prefix alone, so
 /// no paths are needed — and sending them would only invite a mismatch
 /// against whatever was actually installed.

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -33,6 +33,8 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "ip_route_details", crc: "0xbda8f315", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "ip_neighbor_add_del", crc: "0x0607c257", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "ip_neighbor_add_del_reply", crc: "0x1992deab", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "ip_neighbor_dump", crc: "0xd817a484", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "ip_neighbor_details", crc: "0xe29d79f0", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_flags", crc: "0xf5aec1b8", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "sw_interface_set_flags_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_mac_address", crc: "0xc536e7eb", context_offset: 6, client_index_prefix: true },
@@ -1009,6 +1011,83 @@ impl Decode for IpNeighborAddDelReply {
 impl Message for IpNeighborAddDelReply {
     const NAME: &'static str = "ip_neighbor_add_del_reply";
     const CRC: &'static str = "0x1992deab";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `ip_neighbor_dump` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IpNeighborDump {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub af: u8,
+}
+
+impl Encode for IpNeighborDump {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.extend_from_slice(&(self.af as u8).to_be_bytes());
+    }
+}
+
+impl Decode for IpNeighborDump {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let af = d.u8()?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            af,
+        })
+    }
+}
+
+impl Message for IpNeighborDump {
+    const NAME: &'static str = "ip_neighbor_dump";
+    const CRC: &'static str = "0xd817a484";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `ip_neighbor_details` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct IpNeighborDetails {
+    pub context: u32,
+    pub age: f64,
+    pub neighbor: IpNeighbor,
+}
+
+impl Encode for IpNeighborDetails {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.age).to_be_bytes());
+        self.neighbor.encode(buf);
+    }
+}
+
+impl Decode for IpNeighborDetails {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let age = d.f64()?;
+        let neighbor = IpNeighbor::decode(d)?;
+        Ok(Self {
+            context,
+            age,
+            neighbor,
+        })
+    }
+}
+
+impl Message for IpNeighborDetails {
+    const NAME: &'static str = "ip_neighbor_details";
+    const CRC: &'static str = "0xe29d79f0";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;
     fn set_context(&mut self, context: u32) { self.context = context; }

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -31,11 +31,12 @@ use wire::{name_for, read_frame, reply_head, request_context, write_frame};
 
 use packetframe_vpp_offload::vpp_api::generated::{
     Address, AddressUnion, ControlPingReply, CreateLoopbackReply, DevAttachReply,
-    DevCreatePortIfReply, FibPath, FibPathNh, IpNeighborAddDel, IpNeighborAddDelReply, IpRoute,
-    IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails, IpRouteLookupReply, MessageTableEntry,
-    Prefix, SockclntCreateReply, SwInterfaceAddDelAddressReply, SwInterfaceDetails,
-    SwInterfaceSetFlagsReply, SwInterfaceSetMacAddressReply, SwInterfaceSetUnnumberedReply,
-    ADDRESS_IP4, FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
+    DevCreatePortIfReply, FibPath, FibPathNh, IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply,
+    IpNeighborDetails, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails,
+    IpRouteLookupReply, MessageTableEntry, Prefix, SockclntCreateReply,
+    SwInterfaceAddDelAddressReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
+    SwInterfaceSetMacAddressReply, SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
+    FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
 };
 
 /// The index the fake's `dev_create_port_if` hands out. Routes must
@@ -140,6 +141,11 @@ pub struct Behaviour {
     /// `VerifyFailed` teardown from a test, because the verdict arrives
     /// as an INJECTED event rather than from an ordinary tick.
     pub verify_mismatch: bool,
+    /// Static neighbours this VPP already holds when the client
+    /// connects, as `(v4 octets, sw_if_index, mac, flags)`. Adoption
+    /// must leave an identical one untouched: re-adding walks every
+    /// dependent route (5.51 s of null-node on the shadow, 2026-08-08).
+    pub existing_neighbours: &'static [([u8; 4], u32, [u8; 6], u8)],
     /// Prefixes this VPP already holds when the client connects, as
     /// `(addr, len, sw_if_index, nexthop_is_set)`.
     ///
@@ -311,6 +317,31 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                     stats_index: 0,
                 }
                 .encode(&mut out);
+            }
+            // A DUMP, streamed like the others: details frames, no
+            // terminator, ended by the trailing control_ping's reply.
+            "ip_neighbor_dump" => {
+                for &(ip, sw_if_index, mac, flags) in behaviour.existing_neighbours {
+                    let mut d = reply_head("ip_neighbor_details");
+                    let mut un = [0u8; 16];
+                    un[..4].copy_from_slice(&ip);
+                    IpNeighborDetails {
+                        context: ctx,
+                        age: 1.0,
+                        neighbor: IpNeighbor {
+                            sw_if_index,
+                            flags,
+                            mac_address: mac,
+                            ip_address: Address {
+                                af: ADDRESS_IP4,
+                                un: AddressUnion(un),
+                            },
+                        },
+                    }
+                    .encode(&mut d);
+                    write_frame(sock, &d);
+                }
+                continue;
             }
             "ip_neighbor_add_del" => {
                 let mut d = Decoder::new(&req);

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -657,6 +657,8 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
     const MAC_C: [u8; 6] = [0x02, 0, 0, 0, 0, 0xcc];
     const STATIC: u8 = 1;
 
+    const MAC_D: [u8; 6] = [0x02, 0, 0, 0, 0, 0xdd];
+
     struct ThreeNeighbours;
     impl RouteSource for ThreeNeighbours {
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
@@ -664,6 +666,7 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
             visit(nh(), "eth4", MAC); // identical in VPP: keep
             visit(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 11)), "eth4", MAC_B); // stale MAC: replace
             visit(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 12)), "eth4", MAC_C); // missing: add
+            visit(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 13)), "eth4", MAC_D); // extra flags: replace
         }
         fn route_count(&self) -> u64 {
             0
@@ -678,6 +681,9 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
     const EXISTING_NEIGHBOURS: &[([u8; 4], u32, [u8; 6], u8)] = &[
         ([192, 0, 2, 1], ASSIGNED_INDEX, MAC, STATIC),
         ([192, 0, 2, 11], ASSIGNED_INDEX, MAC_B_OLD, STATIC),
+        // Right MAC, extra flag: not the entry we would create, so it
+        // must be re-programmed to exactly STATIC, not preserved.
+        ([192, 0, 2, 13], ASSIGNED_INDEX, MAC_D, STATIC | 4),
     ];
     let fake = Fake::start_behaving(
         "adopt-neigh",
@@ -697,8 +703,8 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
         .program_neighbours(&ThreeNeighbours)
         .expect("programming");
     assert_eq!(
-        programmed, 2,
-        "exactly the stale one and the missing one; the identical one is kept"
+        programmed, 3,
+        "the stale-MAC, missing, and extra-flag neighbours; only the exact match is kept"
     );
 
     let sent_macs: Vec<[u8; 6]> = fake
@@ -715,7 +721,7 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
          re-adding walks every dependent route: {sent_macs:?}"
     );
     assert!(
-        sent_macs.contains(&MAC_B) && sent_macs.contains(&MAC_C),
-        "the stale and missing neighbours must both be programmed: {sent_macs:?}"
+        sent_macs.contains(&MAC_B) && sent_macs.contains(&MAC_C) && sent_macs.contains(&MAC_D),
+        "the stale, missing, and extra-flag neighbours must all be programmed: {sent_macs:?}"
     );
 }

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -636,3 +636,86 @@ fn a_fakes_ping_reply_is_decodable_not_just_writable() {
         .ping()
         .expect("the stream must still be clean after a populated dump");
 }
+
+/// Adoption programs only the neighbours VPP is missing or holds wrong.
+///
+/// Re-adding an existing static neighbour is not a no-op: VPP replaces
+/// the entry and walks every dependent FIB entry — ~1M routes hang off
+/// ONE adjacency on this topology — and traffic through it goes to
+/// null-node for the duration. Measured on the shadow (2026-08-08):
+/// 5.51 s of blackhole at the moment of an otherwise perfect adoption,
+/// 21,055 blackholed packets across the three drill-(d) runs that
+/// re-added it blind.
+///
+/// Three neighbours, three verdicts: an identical one is left
+/// untouched; one whose MAC changed is re-programmed (that walk is the
+/// price of correctness); one VPP lacks is programmed.
+#[test]
+fn adoption_programs_only_missing_or_stale_neighbours() {
+    const MAC_B: [u8; 6] = [0x02, 0, 0, 0, 0, 0xbb];
+    const MAC_B_OLD: [u8; 6] = [0x02, 0, 0, 0, 0, 0xb0];
+    const MAC_C: [u8; 6] = [0x02, 0, 0, 0, 0, 0xcc];
+    const STATIC: u8 = 1;
+
+    struct ThreeNeighbours;
+    impl RouteSource for ThreeNeighbours {
+        fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(nh(), "eth4", MAC); // identical in VPP: keep
+            visit(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 11)), "eth4", MAC_B); // stale MAC: replace
+            visit(IpAddr::V4(Ipv4Addr::new(192, 0, 2, 12)), "eth4", MAC_C); // missing: add
+        }
+        fn route_count(&self) -> u64 {
+            0
+        }
+        fn change_seq(&self) -> u64 {
+            0
+        }
+    }
+
+    // nh() is 192.0.2.1 (see fake_vpp); VPP already holds it correct,
+    // and holds .11 with a MAC the resolver has since replaced.
+    const EXISTING_NEIGHBOURS: &[([u8; 4], u32, [u8; 6], u8)] = &[
+        ([192, 0, 2, 1], ASSIGNED_INDEX, MAC, STATIC),
+        ([192, 0, 2, 11], ASSIGNED_INDEX, MAC_B_OLD, STATIC),
+    ];
+    let fake = Fake::start_behaving(
+        "adopt-neigh",
+        Behaviour {
+            existing_neighbours: EXISTING_NEIGHBOURS,
+            ..Default::default()
+        },
+    );
+    let mut engine = engine_for(&fake);
+    assert!(engine.api_ready(), "handshake");
+    engine.attach_devices(AttachMode::Fresh).expect("attach");
+    // The nexthop->device map is refreshed by the resync walk;
+    // program_neighbours resolves against it.
+    engine.begin_resync(&ThreeNeighbours);
+
+    let programmed = engine
+        .program_neighbours(&ThreeNeighbours)
+        .expect("programming");
+    assert_eq!(
+        programmed, 2,
+        "exactly the stale one and the missing one; the identical one is kept"
+    );
+
+    let sent_macs: Vec<[u8; 6]> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Neighbour { mac, .. } => Some(mac),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !sent_macs.contains(&MAC),
+        "the neighbour VPP already holds correct must not be re-added — \
+         re-adding walks every dependent route: {sent_macs:?}"
+    );
+    assert!(
+        sent_macs.contains(&MAC_B) && sent_macs.contains(&MAC_C),
+        "the stale and missing neighbours must both be programmed: {sent_macs:?}"
+    );
+}

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -51,6 +51,17 @@ const MESSAGES: &[&str] = &[
     "ip_route_details",
     "ip_neighbor_add_del",
     "ip_neighbor_add_del_reply",
+    // Reading VPP's neighbour table back, so adoption programs only the
+    // neighbours VPP is MISSING. Re-adding an existing static neighbour
+    // is not a no-op: VPP replaces the entry (the dump's own `age`
+    // resets), and the replacement walks every dependent FIB entry —
+    // ~1M routes hang off ONE adjacency on this topology — during which
+    // traffic through it goes to null-node. Measured on the shadow
+    // (2026-08-08): a 5.51 s blackhole at the moment of an otherwise
+    // perfect adoption, and 21,055 blackholed packets across the three
+    // drill-(d) runs that re-added it blind.
+    "ip_neighbor_dump",
+    "ip_neighbor_details",
     // Interface state.
     "sw_interface_set_flags",
     "sw_interface_set_flags_reply",


### PR DESCRIPTION
## The last gap in drill (d) (shadow, 2026-08-08)

The third rerun proved the whole adoption chain — no recreation, deferral through bird's reload, release on loaded-and-quiet, zero `steering DOWN`, same VPP pid across two daemon replacements — and still lost 1,854 frames in a **5.51 s gap at the exact moment the gate released**.

VPP itself named the mechanism:

```
21055  null-node  blackholed packets      ← the ONLY nonzero error counter; absorbs all three runs' losses
169.254.254.2  S  28:70:4e:47:69:c7  octeon0/0   Age 971.8  ← created at the gap
```

`program_neighbours` re-added the static neighbour blind. **Re-adding an existing static neighbour is not a no-op**: VPP replaces the entry (the age reset is the proof) and walks every dependent FIB entry — and on this topology ~1M routes resolve through that one adjacency, null-noding traffic for the duration. Every convergence paid this; only a steered adoption made it visible.

## The fix

`ip_neighbor_dump`/`ip_neighbor_details` join the API whitelist (the #125 recipe), and `program_neighbours` dumps first, skipping neighbours whose **interface, MAC, and static flag** all match. Deliberately narrow: a stale MAC is still replaced (that walk is the price of correctness), and a dynamic entry is still replaced with a static one (VPP can never refresh it — MCAM cannot steer ARP).

Discover, don't recreate — now enforced for ports, the loopback, the FIB, and neighbours. That's every object adoption touches.

## Verification

- Fake VPP grows a seedable neighbour table + dump support; the test presents identical, stale-MAC, and missing neighbours and asserts exactly the last two are programmed. **Revert-tested**: disabling the skip fails it on both assertions.
- Full workspace suites, fmt, clippy host + all four targets green.

## Hardware follow-up

Fourth drill-(d) rerun: expect `neighbours VPP already holds correct were left untouched` in the log, and — with every known mechanism now closed — a capture flat at the ~0.1 s noise floor. That would close drill (d).

🤖 Generated with [Claude Code](https://claude.com/claude-code)