### PR TITLE
fix(vpp-offload): one acknowledged-neighbour ledger for both send paths

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -352,6 +352,24 @@ pub struct ConvergenceEngine {
     pending: PendingMap,
     ledger: RouteLedger,
     nexthops: NexthopMap,
+    /// Static neighbours VPP has ACKNOWLEDGED holding, keyed by
+    /// `(sw_if_index, nexthop)` with the MAC as the value.
+    ///
+    /// The single ledger both neighbour-programming paths consult
+    /// before sending, because a re-add of an identical static
+    /// neighbour is not a no-op: VPP replaces the entry and walks every
+    /// dependent FIB entry — ~1M routes hang off ONE adjacency on this
+    /// topology — null-noding traffic through it for the duration.
+    /// #146 taught `program_neighbours` to skip via a dump and the
+    /// 5.5 s blackhole did not move, because `apply_changes` is a
+    /// second path to the same message: the deltas accumulated during
+    /// the resync deferral re-added the very neighbour the resync walk
+    /// had just left untouched. Two paths, one ledger, one skip.
+    ///
+    /// Written only on VPP's acknowledgement (in `send_neighbour`) or
+    /// from VPP's own dump (in `program_neighbours`); cleared with the
+    /// process, because it describes a table that died with it.
+    neighbours_installed: std::collections::HashMap<(u32, IpAddr), [u8; 6]>,
     drainer: Drainer,
 
     /// Whether MCAM rules are diverting traffic right now.
@@ -406,6 +424,7 @@ impl ConvergenceEngine {
             pending: PendingMap::new(),
             ledger: RouteLedger::new(Capacity::new(high_water_routes)),
             nexthops: NexthopMap::new(members),
+            neighbours_installed: std::collections::HashMap::new(),
             drainer: Drainer::new(DEFAULT_WINDOW).with_families(families),
             steered: false,
             last_api_error: None,
@@ -785,6 +804,12 @@ impl ConvergenceEngine {
                 }
             }
         }
+        // Seed the acknowledged ledger from VPP's own answer, so the
+        // DELTA path's skip covers adopted entries too — not only ones
+        // this process sent.
+        for &(idx, ip, mac) in &existing {
+            self.neighbours_installed.insert((idx, ip), mac);
+        }
 
         // Collect first: the visitor borrows `src` while the sends need
         // `&mut self`.
@@ -859,12 +884,22 @@ impl ConvergenceEngine {
             // because every route through that nexthop would install
             // cleanly and then blackhole.
             if !is_add {
+                self.neighbours_installed.remove(&(sw_if_index, ip));
                 return Ok(());
             }
             return Err(EngineError::NeighbourRefused {
                 nexthop: ip,
                 retval: reply.retval,
             });
+        }
+        // Recorded on the acknowledgement, in the one function both
+        // callers share — the ledger the skip consults must have a
+        // single writer, or the two paths drift apart again.
+        if is_add {
+            self.neighbours_installed
+                .insert((sw_if_index, ip), mac_address);
+        } else {
+            self.neighbours_installed.remove(&(sw_if_index, ip));
         }
         Ok(())
     }
@@ -1013,7 +1048,16 @@ impl ConvergenceEngine {
                         .resolve(&nh)
                         .and_then(|t| self.port_index.get(&t))
                     {
-                        self.send_neighbour(nh, idx, mac, true)?;
+                        // Identical to what VPP acknowledged: nothing to
+                        // send. The delta path re-learning a neighbour at
+                        // daemon start is routine — the resolver re-reads
+                        // the kernel table — and re-adding it walks every
+                        // dependent route (the second door of the 5.5 s
+                        // adoption blackhole; the first was
+                        // `program_neighbours`).
+                        if self.neighbours_installed.get(&(idx, nh)) != Some(&mac) {
+                            self.send_neighbour(nh, idx, mac, true)?;
+                        }
                     }
                 }
                 // Forgotten rather than left at its last known device —
@@ -1219,6 +1263,8 @@ impl ConvergenceEngine {
         // attach unnumber every member to an interface that no longer
         // exists — which VPP would refuse, or worse accept.
         self.loop_index = None;
+        // The neighbour ledger describes the dead instance's table.
+        self.neighbours_installed.clear();
         self.pending = PendingMap::new();
         self.ledger = RouteLedger::new(self.ledger_capacity());
         self.phase = None;

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -725,3 +725,104 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
         "the stale, missing, and extra-flag neighbours must all be programmed: {sent_macs:?}"
     );
 }
+
+/// The delta path consults the same acknowledged-neighbour ledger as
+/// the resync path — pinned against the second door of the 5.5 s
+/// adoption blackhole (shadow, 2026-08-08).
+///
+/// #146 taught `program_neighbours` to skip neighbours VPP already
+/// holds, and the measured gap did not move: the deltas accumulated
+/// during the resync deferral re-added the very neighbour the resync
+/// walk had just left untouched, through `apply_changes` — a second
+/// path to the same message. Both paths now consult one ledger,
+/// written only on VPP's acknowledgement or from VPP's own dump.
+#[test]
+fn the_delta_path_does_not_re_add_an_acknowledged_neighbour() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+    use std::sync::Mutex;
+
+    const STATIC: u8 = 1;
+    const MAC_NEW: [u8; 6] = [0x02, 0, 0, 0, 0, 0xee];
+
+    /// A source whose deltas the test scripts per drain.
+    struct ScriptedSource {
+        changes: Mutex<Vec<SourceChanges>>,
+    }
+    impl RouteSource for ScriptedSource {
+        fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(nh(), "eth4", MAC);
+        }
+        fn drain_changes(&self, _max: usize) -> SourceChanges {
+            self.changes.lock().unwrap().pop().unwrap_or_default()
+        }
+        fn route_count(&self) -> u64 {
+            0
+        }
+        fn change_seq(&self) -> u64 {
+            0
+        }
+    }
+
+    // VPP already holds the neighbour, correct and static.
+    const EXISTING_NEIGHBOURS: &[([u8; 4], u32, [u8; 6], u8)] =
+        &[([192, 0, 2, 1], ASSIGNED_INDEX, MAC, STATIC)];
+    let fake = Fake::start_behaving(
+        "delta-neigh",
+        Behaviour {
+            existing_neighbours: EXISTING_NEIGHBOURS,
+            ..Default::default()
+        },
+    );
+    let src = ScriptedSource {
+        // Popped in reverse: first drain re-announces the identical
+        // neighbour (the daemon-start re-learn), second changes its MAC.
+        changes: Mutex::new(vec![
+            SourceChanges {
+                routes: Vec::new(),
+                neighbours: vec![(nh(), Some(("eth4".into(), MAC_NEW)))],
+            },
+            SourceChanges {
+                routes: Vec::new(),
+                neighbours: vec![(nh(), Some(("eth4".into(), MAC)))],
+            },
+        ]),
+    };
+    let mut engine = engine_for(&fake);
+    assert!(engine.api_ready(), "handshake");
+    engine.attach_devices(AttachMode::Fresh).expect("attach");
+    engine.begin_resync(&src);
+    // Seeds the ledger from VPP's dump; sends nothing (kept=1).
+    assert_eq!(engine.program_neighbours(&src).expect("programming"), 0);
+    let _ = fake.drain_events();
+
+    // Delta 1: identical re-announcement — the ledger must absorb it.
+    engine.apply_changes(&src, 64).expect("identical delta");
+    let sent: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter(|e| matches!(e, Event::Neighbour { .. }))
+        .collect();
+    assert!(
+        sent.is_empty(),
+        "an identical re-announcement must not reach VPP — re-adding walks \
+         every dependent route: {sent:?}"
+    );
+
+    // Delta 2: the MAC genuinely changed — that walk is the price of
+    // correctness, and the send must happen.
+    engine.apply_changes(&src, 64).expect("changed delta");
+    let sent: Vec<[u8; 6]> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Neighbour { mac, .. } => Some(mac),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        sent,
+        vec![MAC_NEW],
+        "a genuine MAC change must be programmed"
+    );
+}


### PR DESCRIPTION
## The fourth drill-(d) rerun: #146 worked, and the gap did not move

```
INFO neighbours VPP already holds correct were left untouched; kept=1 programmed=0   ← #146 firing
worst service gap: 5.46s                                                             ← unchanged
```

The mechanism (neighbour re-add → dependent walk over ~1M routes → null-node) was right; #146 closed **one of two doors**. `apply_changes` — the steady-state delta path — also sends `ip_neighbor_add_del`, unconditionally. The resolver re-reads the kernel neighbour table at daemon start; those deltas accumulate while the resync deferral holds (deliberately — deltas are not applied during the wait); and the instant the gate releases, the accumulated delta re-adds the very neighbour `program_neighbours` had just left untouched, three log lines earlier. The gap sits exactly there in both instrumented runs.

This is the repo's recorded second-path defect class verbatim, so the fix is the recorded antidote: make the asymmetry inexpressible.

## The fix

One acknowledged-neighbour ledger in the engine, `(sw_if_index, nexthop) → MAC`:

- **written in exactly two places** — VPP's ack inside `send_neighbour` (the function both paths already share) and VPP's own dump in `program_neighbours`
- **consulted by both send paths** — an identical entry is never re-sent; a changed MAC always is (that walk is the price of correctness)
- **cleared with the process** it describes (`on_process_gone`)

## Verification

- New test at the delta door: adoption dump seeds the ledger; an identical re-announcement drains without reaching VPP; a changed MAC still sends. **Revert-tested**: removing the ledger consult fails it on the must-not-reach-VPP assertion.
- #146's resync-door test still passes; full workspace suites, fmt, clippy host + all four targets green.

## Hardware follow-up

Fifth drill-(d) rerun. Every mechanism found across five runs is now closed: loopback recreation, mid-load diff, cadence-dependent release, resync-door neighbour re-add, delta-door neighbour re-add. Expected: flat capture at the ~0.1 s noise floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)