### PR TITLE
fix(vpp-offload): never adopt the neighbour's adj-fib

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -979,11 +979,28 @@ impl ConvergenceEngine {
     /// Whether a route read back from VPP is one this module installed.
     /// See [`Self::adopt_vpp_fib`] for why the answer must be
     /// conservative.
+    ///
+    /// The adj-fib exclusion is the hard-won clause. VPP auto-creates a
+    /// host route for every neighbour — `169.254.254.2/32` via the
+    /// member port here — and it wears our exact signature: NORMAL
+    /// path, owned interface, non-zero nexthop. Adopting it hands it to
+    /// the diff, the route source never advertises it, and every
+    /// adoption withdrew the neighbour's own host route: cover churn on
+    /// the adjacency every route in the table resolves through, a
+    /// dependent walk over ~1M entries, and a constant ~5.5 s blackhole
+    /// that survived BOTH neighbour-send fixes because nothing here
+    /// sent a neighbour message at all — the withdrawal recreated the
+    /// entry from the route side (neighbour age reset at the release
+    /// instant with both senders provably silent, shadow 2026-08-08).
+    /// The tell is exact: a host route whose prefix IS its own nexthop,
+    /// which this module never installs — our prefixes are the DFZ and
+    /// our nexthops are the interconnect.
     fn looks_self_installed(&self, route: &IpRoute) -> bool {
         route.paths.iter().any(|p| {
             p.r#type == FIB_API_PATH_TYPE_NORMAL
                 && self.port_index.owns(p.sw_if_index)
                 && p.nh.address.0.iter().any(|b| *b != 0)
+                && !is_neighbour_adj_fib(route, &p.nh.address.0)
         })
     }
 
@@ -1280,6 +1297,20 @@ impl ConvergenceEngine {
 
 /// splitmix64. Deterministic successor so verify samples differ per pass
 /// while staying replayable from the recorded seed.
+/// The adj-fib signature: a HOST route whose prefix is its own nexthop.
+///
+/// `nh` is the path's 16-byte wire address (v4 in the first four bytes,
+/// zero-padded — the same layout `Prefix.address.un` uses), so equality
+/// over the whole union plus the host length is the exact test. See
+/// [`ConvergenceEngine::looks_self_installed`] for why this exists.
+fn is_neighbour_adj_fib(route: &IpRoute, nh: &[u8; 16]) -> bool {
+    let host = match route.prefix.address.af {
+        crate::vpp_api::generated::ADDRESS_IP4 => route.prefix.len == 32,
+        _ => route.prefix.len == 128,
+    };
+    host && route.prefix.address.un.0 == *nh
+}
+
 fn next_seed(prev: u64) -> u64 {
     let mut z = prev.wrapping_add(0x9E37_79B9_7F4A_7C15);
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -826,3 +826,69 @@ fn the_delta_path_does_not_re_add_an_acknowledged_neighbour() {
         "a genuine MAC change must be programmed"
     );
 }
+
+/// The neighbour's adj-fib is never adopted — so never withdrawn.
+///
+/// VPP auto-creates a host route for each neighbour (192.0.2.1/32 via
+/// the member port here), and it wears the self-installed signature
+/// exactly: NORMAL path, owned interface, non-zero nexthop. Adopting it
+/// handed it to the diff, the source never advertises it, and every
+/// adoption withdrew the neighbour's own host route — cover churn on
+/// the one adjacency the whole table resolves through, a ~1M-entry
+/// dependent walk, and a constant ~5.5 s blackhole that survived both
+/// neighbour-send fixes because no neighbour message was involved at
+/// all (shadow, 2026-08-08). The tell is exact: a host route whose
+/// prefix IS its own nexthop, which this module never installs.
+#[test]
+fn the_neighbours_adj_fib_is_never_adopted_or_withdrawn() {
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        // A route we really installed, still advertised.
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        // The neighbour's adj-fib: host route, prefix == its own nexthop.
+        ([192, 0, 2, 1], 32, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "adopt-adjfib",
+        Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    let mut engine = engine_for(&fake);
+    assert!(engine.api_ready(), "handshake");
+    engine.attach_devices(AttachMode::Fresh).expect("attach");
+
+    let mirror = Mirror {
+        routes: vec![v4(0, 1)],
+    };
+    let adopted = engine.adopt_vpp_fib().expect("readback");
+    assert_eq!(
+        adopted, 1,
+        "the real route is adopted; the neighbour's adj-fib is VPP's, not ours"
+    );
+
+    let plan = engine.begin_resync(&mirror);
+    assert_eq!(
+        plan.withdrawals, 0,
+        "nothing to withdraw — and above all not the host route covering the \
+         adjacency every route in the table resolves through: {plan:?}"
+    );
+
+    while !engine.drain_batch().expect("drain").0 {}
+    let deletes: Vec<[u8; 4]> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            Event::Route(WireRoute {
+                is_add: false,
+                addr,
+                ..
+            }) => Some(addr),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        deletes.is_empty(),
+        "no withdrawal may reach VPP, least of all the adj-fib: {deletes:?}"
+    );
+}


### PR DESCRIPTION
## The third door (shadow, 2026-08-08)

Run 5 eliminated both neighbour senders — `kept=1 programmed=0`, delta ledger silent — and the 5.46 s gap did not move. The neighbour's age **still reset at the release instant**, so something recreated it without any `ip_neighbor_add_del` from us. `show ip fib 169.254.254.2/32` names it:

```
169.254.254.2/32 ... entry-flags:attached, src-flags:added,contributing,active
  path: attached-nexthop: 169.254.254.2 octeon0/0
 forwarding: UNRESOLVED        ← the scar
```

VPP auto-creates this **adj-fib** host route for every neighbour, and it wears `looks_self_installed`'s signature perfectly: NORMAL path, owned interface, non-zero nexthop. Adoption claimed it → the source never advertises it → **every adoption diff withdrew the neighbour's own host route** → cover churn on the one adjacency the entire table resolves through → ~1M-entry dependent walk → the constant ~5.5 s. The two neighbour-send fixes (#146, #147) were correct and necessary — they closed real doors to the same walk — but this door is on the route side, which is why the number never moved.

Corroborating detail: `null-node` grew only 528 across runs 4–5 against ~3,600 lost frames — most of the loss is rx-side while the walk holds the dataplane, not FIB-miss drops.

## The fix

One exact clause in `looks_self_installed`: refuse a **host route whose prefix is its own nexthop**. This module never installs that shape — our prefixes are the DFZ, our nexthops are the interconnect — so the exclusion costs nothing and cannot misfire on a route we own.

## Verification

- New test seeds a real route plus the adj-fib into the fake's FIB: adoption takes exactly one, `begin_resync` computes zero withdrawals, no delete reaches the wire. **Revert-tested**: disabling the exclusion fails on the adopted count.
- Full workspace suites, fmt, clippy host + all four targets green.

## Hardware follow-up

Sixth drill-(d) rerun, now with all three doors closed — two neighbour senders and the route-side withdrawal. Also worth capturing `show interface` rx counters before/after to confirm the rx-side loss theory dies with the walk. Expected: flat at the noise floor. Note: the shadow's live VPP carries the UNRESOLVED adj-fib scar from earlier runs; if the flow misbehaves before the drill starts, restart VPP fresh first — the scar predates this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)