### PR TITLE
fix(vpp-offload): the daemon vacates VPP's cores at attach

### DIFF
--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -123,6 +123,7 @@ pub fn acquire(
     ports: &[(String, u16)],
     pages: u32,
     expected_routes: u64,
+    vpp_cores: &[u16],
 ) -> Result<(ResourceState, Acquired), String> {
     // How many leading ports are already recorded. Adoption with a
     // complete record returns early below; a PARTIAL record — a daemon
@@ -224,6 +225,11 @@ pub fn acquire(
         None => {
             let mut state = ResourceState::empty();
             state.expected_routes = expected_routes;
+            // Placement, recorded for the same reason as the sizing:
+            // VPP fixes it at start, so only the file can tell the next
+            // daemon where a surviving VPP's threads actually are. See
+            // `ResourceState::vpp_cores`.
+            state.vpp_cores = vpp_cores.to_vec();
             // Hugepages first. Record the PRIOR count before touching
             // the pool: release restores this value, because zeroing
             // is only correct when the reservation was created from
@@ -833,7 +839,7 @@ mod tests {
             "fresh",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(how, Acquired::Fresh);
         assert_eq!(state.hugepage_pages, 8);
         assert_eq!(state.hugepage_prior_pages, 0);
@@ -856,7 +862,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "0").unwrap(); // no virtfn0
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("eth3"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
 
@@ -894,14 +900,14 @@ mod tests {
             "adopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (first, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (first, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
-        let (second, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (second, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(second, first);
 
         // A config whose port set changed must be refused, not merged.
-        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8, ROUTES).unwrap_err();
+        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("cannot change across an adoption"), "{err}");
     }
 
@@ -915,7 +921,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "3").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(state.hugepage_prior_pages, 3);
 
         release(&f.paths, state).unwrap();
@@ -938,7 +944,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "10").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(state.hugepage_pages, 0, "we own nothing");
 
         release(&f.paths, state).unwrap();
@@ -959,7 +965,7 @@ mod tests {
             "store",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut store = FileStore::new(state, &f.paths.state_dir);
 
         store
@@ -1018,7 +1024,7 @@ mod tests {
         // breaks.
         fs::create_dir_all(f.paths.state_dir.join("vpp-offload.json.tmp")).unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("could not record"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
         // Nothing survives: the hugepage reservation is back to prior.
@@ -1040,7 +1046,7 @@ mod tests {
             "hpadopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (_state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (_state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -1052,7 +1058,7 @@ mod tests {
         // The reset nobody asked for.
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let (_, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(
             fs::read_to_string(f.paths.hugepage_pool.join("nr_hugepages"))
@@ -1072,9 +1078,9 @@ mod tests {
             "cores",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let changed = vec![("eth2".to_string(), 1u16), ("eth3".to_string(), 4u16)];
-        let err = acquire(&f.paths, &changed, 8, ROUTES).unwrap_err();
+        let err = acquire(&f.paths, &changed, 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("core counts"), "{err}");
     }
 
@@ -1090,16 +1096,16 @@ mod tests {
             "sizing",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
         assert_eq!(state.expected_routes, 1_600_000, "sizing was not recorded");
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
 
-        let err = acquire(&f.paths, &two_ports(), 8, 2_000_000).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, 2_000_000, &[]).unwrap_err();
         assert!(err.contains("expected-routes 1600000"), "{err}");
         assert!(err.contains("detach --all"), "{err}");
 
         // The unchanged figure still adopts.
-        let (_, how) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
         assert_eq!(how, Acquired::Adopted);
     }
 
@@ -1119,7 +1125,7 @@ mod tests {
             "sizing-old",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
         state.expected_routes = 0;
         state.save(&f.paths.state_dir).unwrap();
@@ -1128,7 +1134,7 @@ mod tests {
         // sized it — the point is that neither can be *established*, so
         // agreeing by luck must not be the difference.
         for routes in [2_000_000, 1_600_000] {
-            let err = acquire(&f.paths, &two_ports(), 8, routes).unwrap_err();
+            let err = acquire(&f.paths, &two_ports(), 8, routes, &[]).unwrap_err();
             assert!(err.contains("records no `expected-routes`"), "{err}");
             assert!(err.contains("detach --all"), "{err}");
         }
@@ -1147,7 +1153,7 @@ mod tests {
             "wrongpool",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut wrong = f.paths.clone();
         wrong.hugepage_bytes = 2 << 20; // detach pointed at the 2 MiB pool
         let err = release(&wrong, state).unwrap_err();
@@ -1172,7 +1178,7 @@ mod tests {
             "gonevf",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         // eth3's VF disappears out from under the record.
         fs::remove_dir_all(f.paths.pci_devices.join("0002:07:00.1")).unwrap();
 
@@ -1201,7 +1207,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "3").unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("refuses to guess"), "{err}");
         assert_eq!(
             fs::read_to_string(dev.join("sriov_numvfs")).unwrap(),
@@ -1223,7 +1229,7 @@ mod tests {
         // Simulate the interruption: acquire both, then rewrite the
         // state as if the daemon died before eth3's save — eth3's VF
         // exists and is vfio-bound, but the record stops at eth2.
-        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         state.ports.truncate(1);
         state.save(&f.paths.state_dir).unwrap();
         #[cfg(unix)]
@@ -1235,7 +1241,7 @@ mod tests {
             .unwrap();
         }
 
-        let (resumed, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (resumed, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         assert_eq!(how, Acquired::Resumed);
         assert_eq!(resumed.ports.len(), 2);
         assert_eq!(
@@ -1256,7 +1262,7 @@ mod tests {
             "poolchg",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -1273,7 +1279,7 @@ mod tests {
         fs::create_dir_all(&wrong.hugepage_pool).unwrap();
         fs::write(wrong.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let err = acquire(&wrong, &two_ports(), 8, ROUTES).unwrap_err();
+        let err = acquire(&wrong, &two_ports(), 8, ROUTES, &[]).unwrap_err();
         assert!(err.contains("wrong pool"), "{err}");
         assert_eq!(
             fs::read_to_string(wrong.hugepage_pool.join("nr_hugepages"))
@@ -1293,7 +1299,7 @@ mod tests {
             "sweep",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_0"), "").unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_7"), "").unwrap();
 
@@ -1318,7 +1324,7 @@ mod tests {
             "owner",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
 
         // A spawn is recorded the ordinary way, while resources are held.
@@ -1359,7 +1365,7 @@ mod tests {
             "owner-partial",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
 
         // Make eth2's release fail: remove the netdev dir the numvfs
@@ -1404,7 +1410,7 @@ mod tests {
             "owner-steer",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut owner = ResourceOwner::new(state, f.paths.clone());
 
         let rules = vec![
@@ -1436,7 +1442,7 @@ mod tests {
             "owner-unsteer",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
         let mut owner = ResourceOwner::new(state, f.paths.clone());
 
         owner

--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -510,6 +510,9 @@ fn verify_adoptable(
 pub struct FileStore {
     state: ResourceState,
     state_dir: PathBuf,
+    /// See [`FileStore::with_spawn_cores`]. Empty on the adopt path,
+    /// where the recorded placement is already the running VPP's.
+    spawn_cores: Vec<u16>,
 }
 
 impl FileStore {
@@ -520,7 +523,24 @@ impl FileStore {
         Self {
             state,
             state_dir: state_dir.into(),
+            spawn_cores: Vec::new(),
         }
+    }
+
+    /// The CPUs any VPP **this daemon spawns** will run on: the
+    /// placement rendered into startup.conf at attach, which VPP reads
+    /// at start and which does not change while this daemon lives.
+    ///
+    /// Recorded here rather than at the attach-time adopt-or-spawn
+    /// decision because EVERY spawn must update it, not just the first:
+    /// a daemon that adopts an old VPP and later respawns after it dies
+    /// would otherwise keep naming the dead process's cores, and the
+    /// next daemon would vacate a placement nothing runs on (review
+    /// finding). `process_changed` is the one point every spawn passes
+    /// through, so it is the one place this is written.
+    pub fn with_spawn_cores(mut self, cores: Vec<u16>) -> Self {
+        self.spawn_cores = cores;
+        self
     }
 
     pub fn state(&self) -> &ResourceState {
@@ -545,6 +565,18 @@ impl IdentityStore for FileStore {
                 self.state.vpp_pid = Some(id.pid);
                 self.state.vpp_start_ticks = Some(id.start_ticks);
                 self.state.vpp_boot_id = id.boot_id;
+                // A process this daemon started runs on the placement
+                // this daemon rendered — see `with_spawn_cores`. Every
+                // identity reaching here is such a spawn: adoption
+                // records none (the file already holds it), so
+                // `Runtime::spawn` is the only caller with `Some`.
+                //
+                // The emptiness guard is for a store built without a
+                // placement — the unit fixtures — so they cannot blank
+                // a field they know nothing about.
+                if !self.spawn_cores.is_empty() {
+                    self.state.vpp_cores = self.spawn_cores.clone();
+                }
             }
             None => {
                 self.state.vpp_pid = None;
@@ -635,6 +667,13 @@ impl ResourceOwner {
             paths,
             released: false,
         }
+    }
+
+    /// See [`FileStore::with_spawn_cores`] — the placement every VPP
+    /// this daemon spawns will use.
+    pub fn with_spawn_cores(mut self, cores: Vec<u16>) -> Self {
+        self.store = self.store.with_spawn_cores(cores);
+        self
     }
 }
 

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -677,18 +677,24 @@ fn finish(
         // borrow checker just refused.
         let inherited_rule_count: usize =
             state.steer_rules.iter().map(|(_, locs)| locs.len()).sum();
-        // Not adopting means the supervisor will SPAWN, and it will spawn
-        // against the startup.conf just rendered from `core_map` — so
-        // that, not whatever a previous VPP used, is where this process's
-        // threads will be. Recording it here keeps the file describing the
-        // VPP that actually exists; leaving the old value would have the
-        // next daemon vacate a placement nothing runs on, which is the
-        // same silent preemption one generation removed (review finding).
-        let mut state = state;
-        if adopted.is_none() {
-            state.vpp_cores = spawn_cores;
-        }
-        let owner = SharedOwner::new(ResourceOwner::new(state, sys));
+        // The placement any VPP this daemon spawns will run on, handed
+        // to the store rather than written once here: EVERY spawn must
+        // update the record, not just an attach-time decision. A daemon
+        // that adopts an old VPP and later respawns after it dies would
+        // otherwise keep naming the dead process's cores, and the next
+        // daemon would vacate a placement nothing runs on (review
+        // finding). `process_changed` is the single point every spawn
+        // passes through, so the record is written there.
+        //
+        // Unconditional, including on the adopt path: `adopt_process`
+        // records no identity (the file already holds the adopted
+        // one), so the only thing that ever reaches
+        // `process_changed(Some(..))` is a spawn by this daemon — and
+        // an adopted VPP that later dies is replaced by exactly such a
+        // spawn. Gating this on `adopted.is_none()` would leave that
+        // replacement unrecorded, which is the case this finding is
+        // about.
+        let owner = SharedOwner::new(ResourceOwner::new(state, sys).with_spawn_cores(spawn_cores));
         let runtime = Runtime::new(
             engine,
             source,

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -251,29 +251,6 @@ pub fn bring_up(
     let workers = cfg.total_workers();
     let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
     let core_map = cores::derive_from_sysfs(&paths.sysfs_cpu, workers)?;
-    // The daemon vacates VPP's cores BEFORE any VPP exists to protect,
-    // because the harm arrives through the scheduler, not through the
-    // API: a resync's mirror walk landing on the worker's core preempts
-    // the poll loop, the rx ring (1024 descriptors ≈ 2 s at the drill
-    // rate) overflows, and the drops happen at the NIC where no VPP
-    // counter sees them. Measured as a constant ~5.4 s of loss at every
-    // adopted release until this call existed (shadow, 2026-08-08).
-    // Warn-and-continue on partial failure: a cgroup that refuses the
-    // mask degrades protection, and failing the attach over it would
-    // brick deployments that share cores gracefully today.
-    match cores::restrict_daemon_from(&core_map) {
-        Ok(threads) => tracing::info!(
-            threads,
-            vpp_main = core_map.main,
-            vpp_workers = ?core_map.workers,
-            "daemon threads restricted away from VPP's cores"
-        ),
-        Err(e) => tracing::warn!(
-            error = %e,
-            "could not restrict the daemon off VPP's cores; expect loss during \
-             resync bursts if they share a core with a worker"
-        ),
-    }
 
     let hugepage_bytes = paths.sys.hugepage_bytes;
     if hugepage_bytes == 0 {
@@ -353,7 +330,41 @@ pub fn bring_up(
         );
     };
 
-    let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
+    // The daemon vacates VPP's cores here — after the LAST pure check,
+    // so a refused config costs no affinity change, and before anything
+    // whose failure the rollback below undoes. The harm this prevents
+    // arrives through the scheduler, not the API: a resync's mirror
+    // walk landing on the worker's core preempts the poll loop, the
+    // 1024-descriptor rx ring overflows in ~2 s, and the drops happen
+    // at the NIC where no VPP counter sees them — a constant ~5.4 s of
+    // loss at every adopted release until this call existed (shadow,
+    // 2026-08-08). Warn-and-continue on partial failure: a cgroup that
+    // refuses the mask degrades protection, and failing the attach over
+    // it would brick deployments that share cores gracefully today.
+    match cores::restrict_daemon_from(&core_map) {
+        Ok(threads) => tracing::info!(
+            threads,
+            vpp_main = core_map.main,
+            vpp_workers = ?core_map.workers,
+            "daemon threads restricted away from VPP's cores"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "could not restrict the daemon off VPP's cores; expect loss during \
+             resync bursts if they share a core with a worker"
+        ),
+    }
+
+    let (state, acquired) = match acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes) {
+        Ok(v) => v,
+        Err(e) => {
+            // Nothing was acquired and no VPP exists: the affinity
+            // restriction protects nothing, and keeping it would leave
+            // the daemon short two cores over a failed attach.
+            let _ = cores::release_daemon_to(&core_map);
+            return Err(e);
+        }
+    };
 
     // From here, every failure releases. `?` would return holding VFs
     // and a hugepage reservation that only the state file knows about —
@@ -396,12 +407,18 @@ pub fn bring_up(
              for that reason; the state file still records them, so `packetframe detach \
              --all` can release them once VPP is confirmed gone."
         )),
-        Err(e) => Err(match acquire::release(&paths.sys, state) {
-            Ok(()) => format!("{e}; everything acquired was released"),
-            Err(re) => format!(
-                "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
-            ),
-        }),
+        Err(e) => {
+            // No VPP survived this path (the may-hold arm above catches
+            // the one that might), so the cores need no protection and
+            // the daemon gets them back.
+            let _ = cores::release_daemon_to(&core_map);
+            Err(match acquire::release(&paths.sys, state) {
+                Ok(()) => format!("{e}; everything acquired was released"),
+                Err(re) => format!(
+                    "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
+                ),
+            })
+        }
     }
 }
 

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -345,6 +345,19 @@ pub fn bring_up(
     // refuses the mask degrades protection, and failing the attach over
     // it would brick deployments that share cores gracefully today.
     let affinity = match cores::restrict_daemon_from(&core_map) {
+        // `threads == 0` is NOT success: no mask changed, so the daemon
+        // is still free to run on VPP's cores. Logging it at info as a
+        // restriction would be the claim-because-requested shape this
+        // module exists to avoid — say plainly that it did not happen.
+        Ok((0, saved)) => {
+            tracing::warn!(
+                vpp_main = core_map.main,
+                vpp_workers = ?core_map.workers,
+                "no daemon thread accepted an affinity change; the daemon can still be \
+                 scheduled onto VPP's cores and resync bursts may preempt the worker"
+            );
+            saved
+        }
         Ok((threads, saved)) => {
             tracing::info!(
                 threads,

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -100,6 +100,9 @@ pub struct Attached {
     /// dataplane: it may already be forwarding.
     pub acquired: Acquired,
     pub adopted_process: bool,
+    /// Each thread's affinity as captured before the restriction, so
+    /// the release paths restore the operator's policy verbatim.
+    pub affinity: cores::AffinitySnapshot,
 }
 
 /// The PF's MAC, from `/sys/class/net/<iface>/address`.
@@ -341,19 +344,25 @@ pub fn bring_up(
     // 2026-08-08). Warn-and-continue on partial failure: a cgroup that
     // refuses the mask degrades protection, and failing the attach over
     // it would brick deployments that share cores gracefully today.
-    match cores::restrict_daemon_from(&core_map) {
-        Ok(threads) => tracing::info!(
-            threads,
-            vpp_main = core_map.main,
-            vpp_workers = ?core_map.workers,
-            "daemon threads restricted away from VPP's cores"
-        ),
-        Err(e) => tracing::warn!(
-            error = %e,
-            "could not restrict the daemon off VPP's cores; expect loss during \
-             resync bursts if they share a core with a worker"
-        ),
-    }
+    let affinity = match cores::restrict_daemon_from(&core_map) {
+        Ok((threads, saved)) => {
+            tracing::info!(
+                threads,
+                vpp_main = core_map.main,
+                vpp_workers = ?core_map.workers,
+                "daemon threads restricted away from VPP's cores"
+            );
+            saved
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "could not restrict the daemon off VPP's cores; expect loss during \
+                 resync bursts if they share a core with a worker"
+            );
+            cores::AffinitySnapshot::default()
+        }
+    };
 
     let (state, acquired) = match acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes) {
         Ok(v) => v,
@@ -361,7 +370,7 @@ pub fn bring_up(
             // Nothing was acquired and no VPP exists: the affinity
             // restriction protects nothing, and keeping it would leave
             // the daemon short two cores over a failed attach.
-            let _ = cores::release_daemon_to(&core_map);
+            let _ = cores::release_daemon_to(&core_map, &affinity);
             return Err(e);
         }
     };
@@ -382,7 +391,13 @@ pub fn bring_up(
         completeness,
         loopback,
     ) {
-        Ok(attached) => Ok(attached),
+        Ok(mut attached) => {
+            // The snapshot rides with the handle so detach — including a
+            // teardown that settles after detach returns — can restore
+            // the pre-restriction masks exactly.
+            attached.affinity = affinity;
+            Ok(attached)
+        }
         // A supervision panic is the one failure that must NOT roll back.
         //
         // NOT covered by a test, and the reason is structural: the window
@@ -411,7 +426,7 @@ pub fn bring_up(
             // No VPP survived this path (the may-hold arm above catches
             // the one that might), so the cores need no protection and
             // the daemon gets them back.
-            let _ = cores::release_daemon_to(&core_map);
+            let _ = cores::release_daemon_to(&core_map, &affinity);
             Err(match acquire::release(&paths.sys, state) {
                 Ok(()) => format!("{e}; everything acquired was released"),
                 Err(re) => format!(
@@ -761,6 +776,10 @@ fn finish(
         cores: core_map.clone(),
         acquired,
         adopted_process,
+        // Placeholder; `bring_up` overwrites it with the real capture,
+        // which it owns because the restriction happens before `finish`
+        // is called.
+        affinity: cores::AffinitySnapshot::default(),
     })
 }
 

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -100,9 +100,6 @@ pub struct Attached {
     /// dataplane: it may already be forwarding.
     pub acquired: Acquired,
     pub adopted_process: bool,
-    /// Each thread's affinity as captured before the restriction, so
-    /// the release paths restore the operator's policy verbatim.
-    pub affinity: cores::AffinitySnapshot,
 }
 
 /// The PF's MAC, from `/sys/class/net/<iface>/address`.
@@ -344,49 +341,35 @@ pub fn bring_up(
     // 2026-08-08). Warn-and-continue on partial failure: a cgroup that
     // refuses the mask degrades protection, and failing the attach over
     // it would brick deployments that share cores gracefully today.
-    let affinity = match cores::restrict_daemon_from(&core_map) {
-        // `threads == 0` is NOT success: no mask changed, so the daemon
-        // is still free to run on VPP's cores. Logging it at info as a
-        // restriction would be the claim-because-requested shape this
-        // module exists to avoid — say plainly that it did not happen.
-        Ok((0, saved)) => {
-            tracing::warn!(
-                vpp_main = core_map.main,
-                vpp_workers = ?core_map.workers,
-                "no daemon thread accepted an affinity change; the daemon can still be \
-                 scheduled onto VPP's cores and resync bursts may preempt the worker"
-            );
-            saved
-        }
-        Ok((threads, saved)) => {
-            tracing::info!(
-                threads,
-                vpp_main = core_map.main,
-                vpp_workers = ?core_map.workers,
-                "daemon threads restricted away from VPP's cores"
-            );
-            saved
-        }
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                "could not restrict the daemon off VPP's cores; expect loss during \
-                 resync bursts if they share a core with a worker"
-            );
-            cores::AffinitySnapshot::default()
-        }
-    };
+    match cores::restrict_daemon_from(&core_map) {
+        // `0` is NOT success: no mask changed, so the daemon is still
+        // free to run on VPP's cores. Logging it as a restriction would
+        // be the claim-because-requested shape this module exists to
+        // avoid — say plainly that it did not happen.
+        Ok(0) => tracing::warn!(
+            vpp_main = core_map.main,
+            vpp_workers = ?core_map.workers,
+            "no daemon thread accepted an affinity change; the daemon can still be \
+             scheduled onto VPP's cores and resync bursts may preempt the worker"
+        ),
+        Ok(threads) => tracing::info!(
+            threads,
+            vpp_main = core_map.main,
+            vpp_workers = ?core_map.workers,
+            "daemon threads restricted away from VPP's cores"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "could not restrict the daemon off VPP's cores; expect loss during \
+             resync bursts if they share a core with a worker"
+        ),
+    }
 
-    let (state, acquired) = match acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes) {
-        Ok(v) => v,
-        Err(e) => {
-            // Nothing was acquired and no VPP exists: the affinity
-            // restriction protects nothing, and keeping it would leave
-            // the daemon short two cores over a failed attach.
-            let _ = cores::release_daemon_to(&affinity);
-            return Err(e);
-        }
-    };
+    // The affinity restriction is deliberately NOT undone on this or
+    // any other failure path: see `cores::restrict_daemon_from` — a CPU
+    // mask is per-process state and every one of these paths ends the
+    // daemon, so there is nothing to hand it back to.
+    let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
 
     // From here, every failure releases. `?` would return holding VFs
     // and a hugepage reservation that only the state file knows about —
@@ -404,13 +387,7 @@ pub fn bring_up(
         completeness,
         loopback,
     ) {
-        Ok(mut attached) => {
-            // The snapshot rides with the handle so detach — including a
-            // teardown that settles after detach returns — can restore
-            // the pre-restriction masks exactly.
-            attached.affinity = affinity;
-            Ok(attached)
-        }
+        Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
         //
         // NOT covered by a test, and the reason is structural: the window
@@ -430,31 +407,17 @@ pub fn bring_up(
         // through. That is the hazard `Disposition::MustLeak` exists to
         // avoid, arriving by a different route. A leaked VF is a line in
         // `packetframe status`; memory corruption is not.
-        // The affinity snapshot is deliberately dropped here, and that
-        // is not a leak: a CPU mask is per-process state, and an attach
-        // that returns Err ends the daemon — the loader unwinds every
-        // module and `run` exits (RunError::Startup). The `detach --all`
-        // this message recommends is a DIFFERENT process whose mask was
-        // never touched, so there is nothing for it to restore.
-        // Retaining the snapshot for it would be state kept for a
-        // caller that cannot exist.
         Err(e) if crate::service::may_hold_resources(&e) => Err(format!(
             "{e} The acquired VF(s) and hugepage reservation were deliberately NOT released \
              for that reason; the state file still records them, so `packetframe detach \
              --all` can release them once VPP is confirmed gone."
         )),
-        Err(e) => {
-            // No VPP survived this path (the may-hold arm above catches
-            // the one that might), so the cores need no protection and
-            // the daemon gets them back.
-            let _ = cores::release_daemon_to(&affinity);
-            Err(match acquire::release(&paths.sys, state) {
-                Ok(()) => format!("{e}; everything acquired was released"),
-                Err(re) => format!(
-                    "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
-                ),
-            })
-        }
+        Err(e) => Err(match acquire::release(&paths.sys, state) {
+            Ok(()) => format!("{e}; everything acquired was released"),
+            Err(re) => format!(
+                "{e}; AND the rollback did not complete: {re} — run `packetframe detach --all`"
+            ),
+        }),
     }
 }
 
@@ -797,10 +760,6 @@ fn finish(
         cores: core_map.clone(),
         acquired,
         adopted_process,
-        // Placeholder; `bring_up` overwrites it with the real capture,
-        // which it owns because the restriction happens before `finish`
-        // is called.
-        affinity: cores::AffinitySnapshot::default(),
     })
 }
 

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -341,21 +341,48 @@ pub fn bring_up(
     // 2026-08-08). Warn-and-continue on partial failure: a cgroup that
     // refuses the mask degrades protection, and failing the attach over
     // it would brick deployments that share cores gracefully today.
-    match cores::restrict_daemon_from(&core_map) {
+    // The cores to vacate: the map just derived, PLUS any placement a
+    // previous attach recorded.
+    //
+    // The union rather than either alone, because which one is right
+    // depends on something not yet known here — whether `finish` below
+    // will adopt a surviving VPP or spawn a fresh one. VPP fixes thread
+    // placement at start, so an adopted VPP is on the RECORDED cores
+    // while a fresh one will be on the DERIVED cores, and the two differ
+    // exactly when the online CPU set changed in between (a core
+    // offlined for thermal reasons, or administratively). Vacating both
+    // sets is correct under either outcome and costs the daemon nothing
+    // when they agree, which is every ordinary restart (review finding).
+    let derived_cores: Vec<u16> = std::iter::once(core_map.main)
+        .chain(core_map.workers.iter().copied())
+        .collect();
+    let mut vacate = derived_cores.clone();
+    if let Ok(Some(prior)) = ResourceState::load(&paths.sys.state_dir) {
+        for cpu in prior.vpp_cores {
+            if !vacate.contains(&cpu) {
+                tracing::info!(
+                    cpu,
+                    "a previous attach placed a VPP thread here; vacating it too in case \
+                     this attach adopts that VPP rather than spawning a new one"
+                );
+                vacate.push(cpu);
+            }
+        }
+    }
+    vacate.sort_unstable();
+    match cores::restrict_daemon_from(&vacate) {
         // `0` is NOT success: no mask changed, so the daemon is still
         // free to run on VPP's cores. Logging it as a restriction would
         // be the claim-because-requested shape this module exists to
         // avoid — say plainly that it did not happen.
         Ok(0) => tracing::warn!(
-            vpp_main = core_map.main,
-            vpp_workers = ?core_map.workers,
+            vacated = ?vacate,
             "no daemon thread accepted an affinity change; the daemon can still be \
              scheduled onto VPP's cores and resync bursts may preempt the worker"
         ),
         Ok(threads) => tracing::info!(
             threads,
-            vpp_main = core_map.main,
-            vpp_workers = ?core_map.workers,
+            vacated = ?vacate,
             "daemon threads restricted away from VPP's cores"
         ),
         Err(e) => tracing::warn!(
@@ -369,7 +396,13 @@ pub fn bring_up(
     // any other failure path: see `cores::restrict_daemon_from` — a CPU
     // mask is per-process state and every one of these paths ends the
     // daemon, so there is nothing to hand it back to.
-    let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
+    let (state, acquired) = acquire::acquire(
+        &paths.sys,
+        &ports,
+        pages,
+        cfg.expected_routes,
+        &derived_cores,
+    )?;
 
     // From here, every failure releases. `?` would return holding VFs
     // and a hugepage reservation that only the state file knows about —

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -581,6 +581,23 @@ fn finish(
             ));
         }
     };
+    // A recorded process whose PLACEMENT is unknown must not be adopted.
+    //
+    // Same rule as the incomplete identity cookie above, and the same
+    // rule `expected_routes == 0` follows in `acquire`: unknown is not
+    // the same as unconstrained. VPP fixes thread placement at start,
+    // so if the file names a live VPP but not the cores it runs on —
+    // a state written by a binary from before `vpp_cores` existed —
+    // then this daemon cannot know which CPUs to keep off. It would
+    // vacate the freshly derived set, which is only right if the online
+    // CPU set has not changed since, and being wrong reinstates the
+    // preemption silently.
+    if prior.is_some() && state.vpp_cores.is_empty() {
+        return Err(format!(
+            "{}: the state file records a running VPP but not the CPUs it was placed on              (written by a packetframe from before that was recorded). Its worker's core              cannot be known, so this daemon cannot guarantee it stays off it, and a              resync burst sharing that core is exactly the packet loss this avoids. Stop              that VPP and `packetframe detach --all`, then attach again — the new record              will carry the placement.",
+            crate::service::MAY_HOLD_RESOURCES
+        ));
+    }
     let adopted: Option<VppProcess> = match prior {
         // A FAILED adoption is marked, because failing is not the same as
         // finding nothing: `adopt` declines cleanly (`Ok(None)`) when the
@@ -640,6 +657,11 @@ fn finish(
     // (see `service`), which is also why the resource owner is built in
     // here rather than passed in: it shares one record between the
     // identity store and the release seam through an `Rc`.
+    // Owned before the factory closure captures it: the closure outlives
+    // this borrow of `core_map`.
+    let spawn_cores: Vec<u16> = std::iter::once(core_map.main)
+        .chain(core_map.workers.iter().copied())
+        .collect();
     let factory: LoopFactory = Box::new(move || {
         let engine = ConvergenceEngine::new(
             api_socket_path,
@@ -655,6 +677,17 @@ fn finish(
         // borrow checker just refused.
         let inherited_rule_count: usize =
             state.steer_rules.iter().map(|(_, locs)| locs.len()).sum();
+        // Not adopting means the supervisor will SPAWN, and it will spawn
+        // against the startup.conf just rendered from `core_map` — so
+        // that, not whatever a previous VPP used, is where this process's
+        // threads will be. Recording it here keeps the file describing the
+        // VPP that actually exists; leaving the old value would have the
+        // next daemon vacate a placement nothing runs on, which is the
+        // same silent preemption one generation removed (review finding).
+        let mut state = state;
+        if adopted.is_none() {
+            state.vpp_cores = spawn_cores;
+        }
         let owner = SharedOwner::new(ResourceOwner::new(state, sys));
         let runtime = Runtime::new(
             engine,

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -251,6 +251,29 @@ pub fn bring_up(
     let workers = cfg.total_workers();
     let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
     let core_map = cores::derive_from_sysfs(&paths.sysfs_cpu, workers)?;
+    // The daemon vacates VPP's cores BEFORE any VPP exists to protect,
+    // because the harm arrives through the scheduler, not through the
+    // API: a resync's mirror walk landing on the worker's core preempts
+    // the poll loop, the rx ring (1024 descriptors ≈ 2 s at the drill
+    // rate) overflows, and the drops happen at the NIC where no VPP
+    // counter sees them. Measured as a constant ~5.4 s of loss at every
+    // adopted release until this call existed (shadow, 2026-08-08).
+    // Warn-and-continue on partial failure: a cgroup that refuses the
+    // mask degrades protection, and failing the attach over it would
+    // brick deployments that share cores gracefully today.
+    match cores::restrict_daemon_from(&core_map) {
+        Ok(threads) => tracing::info!(
+            threads,
+            vpp_main = core_map.main,
+            vpp_workers = ?core_map.workers,
+            "daemon threads restricted away from VPP's cores"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "could not restrict the daemon off VPP's cores; expect loss during \
+             resync bursts if they share a core with a worker"
+        ),
+    }
 
     let hugepage_bytes = paths.sys.hugepage_bytes;
     if hugepage_bytes == 0 {

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -370,7 +370,7 @@ pub fn bring_up(
             // Nothing was acquired and no VPP exists: the affinity
             // restriction protects nothing, and keeping it would leave
             // the daemon short two cores over a failed attach.
-            let _ = cores::release_daemon_to(&core_map, &affinity);
+            let _ = cores::release_daemon_to(&affinity);
             return Err(e);
         }
     };
@@ -417,6 +417,14 @@ pub fn bring_up(
         // through. That is the hazard `Disposition::MustLeak` exists to
         // avoid, arriving by a different route. A leaked VF is a line in
         // `packetframe status`; memory corruption is not.
+        // The affinity snapshot is deliberately dropped here, and that
+        // is not a leak: a CPU mask is per-process state, and an attach
+        // that returns Err ends the daemon — the loader unwinds every
+        // module and `run` exits (RunError::Startup). The `detach --all`
+        // this message recommends is a DIFFERENT process whose mask was
+        // never touched, so there is nothing for it to restore.
+        // Retaining the snapshot for it would be state kept for a
+        // caller that cannot exist.
         Err(e) if crate::service::may_hold_resources(&e) => Err(format!(
             "{e} The acquired VF(s) and hugepage reservation were deliberately NOT released \
              for that reason; the state file still records them, so `packetframe detach \
@@ -426,7 +434,7 @@ pub fn bring_up(
             // No VPP survived this path (the may-hold arm above catches
             // the one that might), so the cores need no protection and
             // the daemon gets them back.
-            let _ = cores::release_daemon_to(&core_map, &affinity);
+            let _ = cores::release_daemon_to(&affinity);
             Err(match acquire::release(&paths.sys, state) {
                 Ok(()) => format!("{e}; everything acquired was released"),
                 Err(re) => format!(

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -167,6 +167,31 @@ pub fn derive_from_sysfs(sysfs_cpu: &std::path::Path, workers: u32) -> Result<Co
 /// Where the CPU topology lives on a running kernel.
 pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 
+/// A thread's start time, for the identity check in
+/// [`AffinitySnapshot`]. `None` when the thread has already exited or
+/// its stat line cannot be parsed — both of which make it un-restorable
+/// rather than a fault.
+#[cfg(target_os = "linux")]
+fn thread_start_ticks(tid: libc::pid_t) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/self/task/{tid}/stat")).ok()?;
+    crate::process::parse_start_ticks(&stat)
+}
+
+/// Whether a `sched_getaffinity`/`setaffinity` failure means this host
+/// has more CPUs than a fixed `cpu_set_t` can express.
+///
+/// The kernel answers `EINVAL` when the supplied mask is smaller than
+/// its own cpumask. Treating that like a vanished thread — which the
+/// first version did — made every TID "skip", returned `Ok(0)`, and let
+/// attach log that the daemon had been restricted while it remained
+/// free to run on VPP's cores: a claim recorded because the effect was
+/// requested rather than observed. Named and refused instead (review
+/// finding).
+#[cfg(target_os = "linux")]
+fn mask_too_small(e: &std::io::Error) -> bool {
+    e.raw_os_error() == Some(libc::EINVAL)
+}
+
 /// Keep every thread of THIS daemon off VPP's cores — by SUBTRACTING
 /// them from each thread's current mask, never by rebuilding one.
 ///
@@ -220,10 +245,24 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
         };
         if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            if mask_too_small(&err) {
+                return Err(format!(
+                    "this host's CPU mask is wider than a fixed cpu_set_t ({} CPUs) can \
+                     express, so the daemon cannot be kept off VPP's cores from inside the \
+                     process: {err}. Pin it externally instead (systemd `CPUAffinity=`), or \
+                     expect resync bursts to preempt the VPP worker",
+                    libc::CPU_SETSIZE
+                ));
+            }
             // Threads exit between readdir and here; a vanished tid is
             // not a fault.
             continue;
         }
+        // The identity, captured with the mask: see `AffinitySnapshot`.
+        let Some(started) = thread_start_ticks(tid) else {
+            continue; // exited between the two reads
+        };
         let before = mask;
         // Record EVERY thread we observed, with its original mask —
         // before deciding whether to change it. Release keys on this:
@@ -235,7 +274,7 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
         // setaffinity failed, would then be missing from the snapshot
         // and wrongly unioned VPP's cores on release, broadening a
         // policy it never had restricted.
-        saved.masks.push((tid, before));
+        saved.masks.push((tid, started, before));
         // Narrow the intersection with this thread's original policy.
         saved
             .restorable
@@ -298,8 +337,18 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
 /// can reason about.
 #[derive(Default, Clone)]
 pub struct AffinitySnapshot {
+    /// `(tid, start_ticks, original mask)`.
+    ///
+    /// The start time is what makes the tid an IDENTITY rather than a
+    /// number. A thread can exit during a long attachment and Linux can
+    /// reuse its tid; restoring the dead thread's mask onto its
+    /// namesake would hand a live thread a policy that was never its
+    /// own (review finding). This is the same identity-must-be-whole
+    /// rule [`crate::process`] applies to an adopted VPP — pid alone is
+    /// never enough — and it reuses that module's `/proc` stat parser
+    /// rather than growing a second one.
     #[cfg(target_os = "linux")]
-    masks: Vec<(libc::pid_t, libc::cpu_set_t)>,
+    masks: Vec<(libc::pid_t, u64, libc::cpu_set_t)>,
     /// VPP cores present in the original mask of every observed thread.
     /// See the type docs: the only cores a post-attach thread can be
     /// given back without guessing.
@@ -344,13 +393,21 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
         else {
             continue;
         };
-        let mask = match saved.masks.iter().find(|(t, _)| *t == tid) {
+        // The tid must match AND be the same thread: a reused tid names
+        // a stranger, whose mask is none of our business to restore.
+        let started = thread_start_ticks(tid);
+        let mask = match saved
+            .masks
+            .iter()
+            .find(|(t, s, _)| *t == tid && Some(*s) == started)
+        {
             // A surviving thread gets its pre-restriction mask back,
             // verbatim — including any exclusion of VPP's cores the
             // operator had already made.
-            Some((_, m)) => *m,
-            // Born during the restricted epoch: no capture exists, so
-            // only the cores EVERY pre-existing thread held go back —
+            Some((_, _, m)) => *m,
+            // Born during the restricted epoch (or a reused tid, which
+            // is the same thing from here): no capture applies, so only
+            // the cores EVERY pre-existing thread held go back —
             // see `AffinitySnapshot`. Adding all of VPP's cores here
             // would hand a child a core its creator's policy never
             // allowed (review finding).
@@ -360,6 +417,13 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
                     libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut m)
                 };
                 if rc != 0 {
+                    let err = std::io::Error::last_os_error();
+                    if mask_too_small(&err) {
+                        return Err(format!(
+                            "this host's CPU mask is wider than a fixed cpu_set_t can \
+                             express: {err}"
+                        ));
+                    }
                     continue; // vanished between readdir and here
                 }
                 for cpu in &saved.restorable {

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -194,7 +194,16 @@ pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 #[cfg(target_os = "linux")]
 pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
     let mut edited = 0usize;
-    let mut saved = AffinitySnapshot::default();
+    // `restorable` starts as all of VPP's cores and is narrowed by every
+    // thread we observe, ending as the intersection: the cores a thread
+    // born later can be given back without guessing at its creator's
+    // policy.
+    let mut saved = AffinitySnapshot {
+        restorable: std::iter::once(map.main)
+            .chain(map.workers.iter().copied())
+            .collect(),
+        ..Default::default()
+    };
     let mut errors: Vec<String> = Vec::new();
     let tasks =
         std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
@@ -227,6 +236,10 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
         // and wrongly unioned VPP's cores on release, broadening a
         // policy it never had restricted.
         saved.masks.push((tid, before));
+        // Narrow the intersection with this thread's original policy.
+        saved
+            .restorable
+            .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
         for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
             unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
         }
@@ -270,13 +283,33 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
 /// rightly: an operator mask that itself excluded one of VPP's cores
 /// would gain it back on rollback or detach, widening the daemon onto
 /// silicon the operator reserved. Surviving threads restore their
-/// captured mask verbatim; threads born during the restricted epoch
-/// (no capture) fall back to union, which is exact for them — they
-/// inherited a restricted mask whose only edit was ours.
+/// captured mask verbatim.
+///
+/// A thread born DURING the restricted epoch has no capture, and no
+/// exact inverse exists for it — we never saw its creator's original
+/// mask, only the restricted one it inherited. So it gets
+/// [`Self::restorable`] rather than every VPP core: the cores that
+/// EVERY observed thread originally held. Whatever ancestor the new
+/// thread descends from was one of those threads, so each core in that
+/// intersection was demonstrably in its inherited policy and adding it
+/// back cannot broaden anything. Cores held by only some pre-existing
+/// threads stay off — under-restoring a new thread until the daemon's
+/// next start, which is the safe direction and the one the operator
+/// can reason about.
 #[derive(Default, Clone)]
 pub struct AffinitySnapshot {
     #[cfg(target_os = "linux")]
     masks: Vec<(libc::pid_t, libc::cpu_set_t)>,
+    /// VPP cores present in the original mask of every observed thread.
+    /// See the type docs: the only cores a post-attach thread can be
+    /// given back without guessing.
+    ///
+    /// Read only by the Linux `release_daemon_to`; the non-Linux stubs
+    /// never restrict, so nothing there consults it. Gated to match
+    /// `masks` rather than `allow(dead_code)`, so a genuinely unread
+    /// field on Linux would still be caught.
+    #[cfg(target_os = "linux")]
+    restorable: Vec<u16>,
 }
 
 impl std::fmt::Debug for AffinitySnapshot {
@@ -292,8 +325,13 @@ impl std::fmt::Debug for AffinitySnapshot {
 /// is left to protect — a bring-up that rolled back cleanly, and a
 /// detach whose teardown completed (including one that settles late,
 /// after `detach` itself returned).
+///
+/// Takes only the snapshot: it carries both the per-thread originals
+/// and the `restorable` set, so the [`CoreMap`] is not needed here and
+/// is not accepted — a parameter nothing reads is a parameter that can
+/// disagree with the one restriction used.
 #[cfg(target_os = "linux")]
-pub fn release_daemon_to(map: &CoreMap, saved: &AffinitySnapshot) -> Result<usize, String> {
+pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
     let mut edited = 0usize;
     let mut errors: Vec<String> = Vec::new();
     let tasks =
@@ -311,9 +349,11 @@ pub fn release_daemon_to(map: &CoreMap, saved: &AffinitySnapshot) -> Result<usiz
             // verbatim — including any exclusion of VPP's cores the
             // operator had already made.
             Some((_, m)) => *m,
-            // Born during the restricted epoch: its inherited mask is a
-            // restricted one whose only edit was ours, so the union is
-            // exact.
+            // Born during the restricted epoch: no capture exists, so
+            // only the cores EVERY pre-existing thread held go back —
+            // see `AffinitySnapshot`. Adding all of VPP's cores here
+            // would hand a child a core its creator's policy never
+            // allowed (review finding).
             None => {
                 let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
                 let rc = unsafe {
@@ -322,8 +362,8 @@ pub fn release_daemon_to(map: &CoreMap, saved: &AffinitySnapshot) -> Result<usiz
                 if rc != 0 {
                     continue; // vanished between readdir and here
                 }
-                for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
-                    unsafe { libc::CPU_SET(cpu as usize, &mut m) };
+                for cpu in &saved.restorable {
+                    unsafe { libc::CPU_SET(*cpu as usize, &mut m) };
                 }
                 m
             }
@@ -360,7 +400,7 @@ pub fn restrict_daemon_from(_map: &CoreMap) -> Result<(usize, AffinitySnapshot),
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn release_daemon_to(_map: &CoreMap, _saved: &AffinitySnapshot) -> Result<usize, String> {
+pub fn release_daemon_to(_saved: &AffinitySnapshot) -> Result<usize, String> {
     Ok(0)
 }
 
@@ -418,7 +458,7 @@ mod affinity_tests {
         assert!(isset(a), "the rest kept");
         assert!(!isset(c), "subtract, never rebuild");
 
-        release_daemon_to(&map, &snap).expect("release");
+        release_daemon_to(&snap).expect("release");
         assert!(isset(b), "the saved mask gave VPP's core back");
         assert!(!isset(c), "and added nothing the operator excluded");
 
@@ -426,7 +466,7 @@ mod affinity_tests {
         // that ALREADY excluded VPP's core must not gain it back.
         set_mask(&[a]);
         let (_, snap2) = restrict_daemon_from(&map).expect("restrict2");
-        release_daemon_to(&map, &snap2).expect("release2");
+        release_daemon_to(&snap2).expect("release2");
         assert!(
             !isset(b),
             "a mask that never held VPP's core must not acquire it on release"
@@ -441,10 +481,75 @@ mod affinity_tests {
         set_mask(&[b]);
         let (_, snap3) = restrict_daemon_from(&map).expect("skip tolerated");
         assert!(isset(b), "unschedulable is worse than unprotected");
-        release_daemon_to(&map, &snap3).expect("release3");
+        release_daemon_to(&snap3).expect("release3");
         assert!(
             isset(b) && !isset(a) && !isset(c),
             "a skipped thread's original mask is restored verbatim, never unioned"
+        );
+
+        let rc =
+            unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };
+        assert_eq!(rc, 0);
+    }
+
+    /// A thread born during the restricted epoch must never be handed a
+    /// core its creator's policy excluded.
+    ///
+    /// No exact inverse exists for such a thread — we never saw its
+    /// creator's original mask — so release adds only the VPP cores
+    /// EVERY observed thread held. Here the calling thread's policy
+    /// excludes VPP's core, so that intersection is empty and the child
+    /// must come back with nothing added. Unioning all of VPP's cores
+    /// (the previous behaviour) hands it a core the operator never
+    /// allowed; that is what this pins.
+    #[test]
+    fn a_thread_born_after_restriction_gains_only_universally_held_cores() {
+        use std::sync::mpsc::channel;
+
+        let before = current_mask();
+        let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
+            .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })
+            .collect();
+        if allowed.len() < 3 {
+            return;
+        }
+        let (a, b, c) = (allowed[0], allowed[1], allowed[2]);
+
+        // VPP takes b; this thread's policy is {a, c} — b excluded, so
+        // b is NOT universally held.
+        set_mask(&[a, c]);
+        let map = CoreMap {
+            main: b as u16,
+            workers: vec![],
+        };
+        let (_, snap) = restrict_daemon_from(&map).expect("restrict");
+
+        let (born_tx, born_rx) = channel();
+        let (go_tx, go_rx) = channel();
+        let (got_tx, got_rx) = channel();
+        let child = std::thread::spawn(move || {
+            born_tx.send(()).expect("announce");
+            go_rx.recv().expect("wait for release");
+            let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+            let rc = unsafe {
+                libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut m)
+            };
+            assert_eq!(rc, 0);
+            got_tx
+                .send(unsafe { libc::CPU_ISSET(b, &m) })
+                .expect("report");
+        });
+        born_rx.recv().expect("child exists before release");
+
+        release_daemon_to(&snap).expect("release");
+        go_tx.send(()).expect("let the child read its mask");
+        let child_has_vpp_core = got_rx.recv().expect("child reported");
+        child.join().expect("child joined");
+
+        assert!(
+            !child_has_vpp_core,
+            "a thread born after restriction must not gain a core its creator's \
+             policy excluded"
         );
 
         let rc =

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -167,6 +167,132 @@ pub fn derive_from_sysfs(sysfs_cpu: &std::path::Path, workers: u32) -> Result<Co
 /// Where the CPU topology lives on a running kernel.
 pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 
+/// Keep every thread of THIS daemon off VPP's cores.
+///
+/// The missing half of the plan's "cpuset + SCHED_FIFO" promise, found
+/// by a week of drills (shadow, 2026-08-08). VPP's worker polls its rx
+/// ring from a dedicated core, but `isolcpus` on this fleet belongs to
+/// unifi-core and nothing constrained the daemon: at every adopted
+/// resync's release, `begin_resync` walks a 1.3M-entry mirror and the
+/// first drain batches encode thousands of routes — seconds of
+/// memory-heavy burst that the scheduler was free to place on the
+/// worker's core. A preempted poll loop overflows a 1024-descriptor rx
+/// ring in ~2 s at the drill rate, and the drops happen at the NIC,
+/// invisible to every VPP error counter — which is how three correct
+/// fixes to the FIB-side work at the release instant each left the
+/// measured ~5.4 s gap unmoved.
+///
+/// Applied to every task in `/proc/self/task` at attach; threads
+/// spawned afterwards inherit their creator's mask. Errors are
+/// collected, not fatal: a cgroup cpuset that refuses us is a reason to
+/// warn, and refusing to attach over it would fail deployments that
+/// merely share cores gracefully today.
+#[cfg(target_os = "linux")]
+pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
+    let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+    let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+    if online <= 0 {
+        return Err("cannot determine online CPU count".into());
+    }
+    let mut kept = 0usize;
+    for cpu in 0..online as u16 {
+        if cpu == map.main || map.workers.contains(&cpu) {
+            continue;
+        }
+        unsafe { libc::CPU_SET(cpu as usize, &mut mask) };
+        kept += 1;
+    }
+    if kept == 0 {
+        return Err("the core map claims every online CPU; refusing an empty mask".into());
+    }
+    let mut set = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let tasks =
+        std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
+    for entry in tasks.flatten() {
+        let Some(tid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+        let rc =
+            unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
+        if rc == 0 {
+            set += 1;
+        } else {
+            errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
+        }
+    }
+    if set == 0 {
+        return Err(format!(
+            "no thread accepted the affinity mask: {}",
+            errors.join("; ")
+        ));
+    }
+    if !errors.is_empty() {
+        tracing::warn!(
+            set,
+            failed = errors.len(),
+            "some threads kept their old affinity: {}",
+            errors.join("; ")
+        );
+    }
+    Ok(set)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn restrict_daemon_from(_map: &CoreMap) -> Result<usize, String> {
+    // Non-Linux never attaches a VPP; there is nothing to protect.
+    Ok(0)
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod affinity_tests {
+    use super::*;
+
+    /// The mask really lands on the calling process: after restriction,
+    /// the current thread's affinity excludes VPP's cores and includes
+    /// at least one other. Read back via sched_getaffinity — asserting
+    /// the syscall's effect, not our intent to make it.
+    #[test]
+    fn restriction_excludes_vpp_cores_and_keeps_the_rest() {
+        let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+        if online < 2 {
+            // A single-CPU runner cannot express "everything but".
+            return;
+        }
+        let map = CoreMap {
+            main: (online - 1) as u16,
+            workers: vec![],
+        };
+        let set = restrict_daemon_from(&map).expect("restriction");
+        assert!(set >= 1, "at least this thread's mask was set");
+
+        let mut got: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        let rc =
+            unsafe { libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut got) };
+        assert_eq!(rc, 0);
+        assert!(
+            !unsafe { libc::CPU_ISSET((online - 1) as usize, &got) },
+            "VPP's core must be excluded"
+        );
+        assert!(
+            unsafe { libc::CPU_ISSET(0, &got) },
+            "the remaining cores must stay usable"
+        );
+
+        // Restore a full mask so later tests in this process are not
+        // constrained by this one.
+        let mut all: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        for cpu in 0..online as usize {
+            unsafe { libc::CPU_SET(cpu, &mut all) };
+        }
+        unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &all) };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -217,7 +217,7 @@ fn mask_too_small(e: &std::io::Error) -> bool {
 /// Applied to every task in `/proc/self/task`; threads spawned later
 /// inherit their creator's mask.
 #[cfg(target_os = "linux")]
-pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
+pub fn restrict_daemon_from(vpp_cores: &[u16]) -> Result<usize, String> {
     let mut edited = 0usize;
     let mut errors: Vec<String> = Vec::new();
     // Rescan until a whole pass finds nothing new.
@@ -286,14 +286,8 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
                 // not a fault.
                 continue;
             }
-            // Exactly the VPP cores this thread actually held — the set
-            // release will put back, and nothing more.
-            let mut removed: Vec<u16> = Vec::new();
-            for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
-                if unsafe { libc::CPU_ISSET(cpu as usize, &mask) } {
-                    unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
-                    removed.push(cpu);
-                }
+            for cpu in vpp_cores {
+                unsafe { libc::CPU_CLR(*cpu as usize, &mut mask) };
             }
             if unsafe { libc::CPU_COUNT(&mask) } == 0 {
                 tracing::warn!(
@@ -359,7 +353,7 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
 // design, not by omission.
 
 #[cfg(not(target_os = "linux"))]
-pub fn restrict_daemon_from(_map: &CoreMap) -> Result<usize, String> {
+pub fn restrict_daemon_from(_vpp_cores: &[u16]) -> Result<usize, String> {
     // Non-Linux never attaches a VPP; there is nothing to protect.
     Ok(0)
 }
@@ -424,15 +418,12 @@ mod affinity_tests {
             return; // cannot express "narrower than allowed" here
         }
         let (a, b, c) = (allowed[0], allowed[1], allowed[2]);
-        let map = CoreMap {
-            main: b as u16,
-            workers: vec![],
-        };
+        let vpp = [b as u16];
 
         // Operator narrowed the daemon to {a, b}; VPP takes b. Their
         // exclusion of c must survive: subtract, never rebuild.
         set_mask(&[a, b]);
-        let edited = restrict_daemon_from(&map).expect("restrict");
+        let edited = restrict_daemon_from(&vpp).expect("restrict");
         assert!(edited >= 1, "at least this thread was edited");
         assert!(!isset(b), "VPP's core is excluded");
         assert!(isset(a), "the rest of the policy is kept");
@@ -441,7 +432,7 @@ mod affinity_tests {
         // A mask that IS VPP's cores is skipped, not emptied: an
         // unschedulable thread is worse than an unprotected worker.
         set_mask(&[b]);
-        restrict_daemon_from(&map).expect("skip tolerated");
+        restrict_daemon_from(&vpp).expect("skip tolerated");
         assert!(isset(b), "the only usable core is left in place");
 
         let rc =
@@ -472,10 +463,7 @@ mod affinity_tests {
         }
         let (a, b) = (allowed[0], allowed[1]);
         set_mask(&[a, b]);
-        let map = CoreMap {
-            main: b as u16,
-            workers: vec![],
-        };
+        let vpp = [b as u16];
 
         let (born_tx, born_rx) = channel();
         let (go_tx, go_rx) = channel();
@@ -494,7 +482,7 @@ mod affinity_tests {
         });
         born_rx.recv().expect("child exists before the scan");
 
-        restrict_daemon_from(&map).expect("restrict");
+        restrict_daemon_from(&vpp).expect("restrict");
         go_tx.send(()).expect("let the child read its mask");
         let child_on_vpp_core = got_rx.recv().expect("child reported");
         child.join().expect("child joined");

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -230,84 +230,128 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
         ..Default::default()
     };
     let mut errors: Vec<String> = Vec::new();
-    let tasks =
-        std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
-    for entry in tasks.flatten() {
-        let Some(tid) = entry
-            .file_name()
-            .to_str()
-            .and_then(|s| s.parse::<libc::pid_t>().ok())
-        else {
-            continue;
-        };
-        let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-        let rc = unsafe {
-            libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
-        };
-        if rc != 0 {
-            let err = std::io::Error::last_os_error();
-            if mask_too_small(&err) {
-                return Err(format!(
-                    "this host's CPU mask is wider than a fixed cpu_set_t ({} CPUs) can \
+    // Rescan until a whole pass finds nothing new.
+    //
+    // One pass is not enough, and the gap is reachable rather than
+    // theoretical: the fast-path runtime is already live before VPP
+    // attaches, and its integrity checker uses `spawn_blocking`
+    // (`fast-path/src/fib/integrity.rs`). A thread created DURING the
+    // walk, by a creator we have not visited yet, inherits an
+    // unrestricted mask and may never appear in the directory batch we
+    // already read — leaving it free to run on VPP's cores forever,
+    // which is precisely the interference this function exists to stop
+    // (review finding).
+    //
+    // Once a pass adds nothing, every thread alive is restricted, so
+    // anything created after can only inherit a restricted mask. The
+    // cap bounds a daemon that spawns continuously; hitting it means
+    // protection is partial and says so, rather than looping.
+    const MAX_PASSES: u32 = 8;
+    let mut passes = 0u32;
+    loop {
+        passes += 1;
+        let mut found_new = 0usize;
+        let tasks =
+            std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
+        for entry in tasks.flatten() {
+            let Some(tid) = entry
+                .file_name()
+                .to_str()
+                .and_then(|s| s.parse::<libc::pid_t>().ok())
+            else {
+                continue;
+            };
+            // Identity first, so an already-processed thread costs one
+            // stat and nothing else — and so a tid reused mid-loop is
+            // treated as the new thread it is.
+            let Some(started) = thread_start_ticks(tid) else {
+                continue; // exited between readdir and here
+            };
+            if saved
+                .masks
+                .iter()
+                .any(|(t, st, _)| *t == tid && *st == started)
+            {
+                continue;
+            }
+            found_new += 1;
+            let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+            let rc = unsafe {
+                libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
+            };
+            if rc != 0 {
+                let err = std::io::Error::last_os_error();
+                if mask_too_small(&err) {
+                    return Err(format!(
+                        "this host's CPU mask is wider than a fixed cpu_set_t ({} CPUs) can \
                      express, so the daemon cannot be kept off VPP's cores from inside the \
                      process: {err}. Pin it externally instead (systemd `CPUAffinity=`), or \
                      expect resync bursts to preempt the VPP worker",
-                    libc::CPU_SETSIZE
-                ));
+                        libc::CPU_SETSIZE
+                    ));
+                }
+                // Threads exit between readdir and here; a vanished tid is
+                // not a fault.
+                continue;
             }
-            // Threads exit between readdir and here; a vanished tid is
-            // not a fault.
-            continue;
-        }
-        // The identity, captured with the mask: see `AffinitySnapshot`.
-        let Some(started) = thread_start_ticks(tid) else {
-            continue; // exited between the two reads
-        };
-        let before = mask;
-        // Record EVERY thread we observed, with its original mask —
-        // before deciding whether to change it. Release keys on this:
-        // a tid present here restores its original verbatim (a no-op for
-        // the ones we leave untouched below), and only a tid ABSENT is
-        // treated as born-after-restriction and unioned. Recording just
-        // the successfully-restricted threads was the bug (review
-        // finding): a thread skipped for an empty mask, or one whose
-        // setaffinity failed, would then be missing from the snapshot
-        // and wrongly unioned VPP's cores on release, broadening a
-        // policy it never had restricted.
-        // Narrow the intersection with this thread's original policy.
-        saved
-            .restorable
-            .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
-        // Exactly the VPP cores this thread actually held — the set
-        // release will put back, and nothing more.
-        let mut removed: Vec<u16> = Vec::new();
-        for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
-            if unsafe { libc::CPU_ISSET(cpu as usize, &mask) } {
-                unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
-                removed.push(cpu);
+            let before = mask;
+            // Record EVERY thread we observed, with its original mask —
+            // before deciding whether to change it. Release keys on this:
+            // a tid present here restores its original verbatim (a no-op for
+            // the ones we leave untouched below), and only a tid ABSENT is
+            // treated as born-after-restriction and unioned. Recording just
+            // the successfully-restricted threads was the bug (review
+            // finding): a thread skipped for an empty mask, or one whose
+            // setaffinity failed, would then be missing from the snapshot
+            // and wrongly unioned VPP's cores on release, broadening a
+            // policy it never had restricted.
+            // Narrow the intersection with this thread's original policy.
+            saved
+                .restorable
+                .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
+            // Exactly the VPP cores this thread actually held — the set
+            // release will put back, and nothing more.
+            let mut removed: Vec<u16> = Vec::new();
+            for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
+                if unsafe { libc::CPU_ISSET(cpu as usize, &mask) } {
+                    unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
+                    removed.push(cpu);
+                }
             }
-        }
-        if unsafe { libc::CPU_COUNT(&mask) } == 0 {
-            tracing::warn!(
-                tid,
-                "this thread's whole mask IS VPP's cores; leaving it untouched — an \
+            if unsafe { libc::CPU_COUNT(&mask) } == 0 {
+                tracing::warn!(
+                    tid,
+                    "this thread's whole mask IS VPP's cores; leaving it untouched — an \
                  unschedulable thread is worse than an unprotected worker"
-            );
-            // Observed, but nothing removed: recorded so release knows
-            // it is not a post-attach stranger, and leaves it alone.
-            saved.masks.push((tid, started, Vec::new()));
-            continue;
+                );
+                // Observed, but nothing removed: recorded so release knows
+                // it is not a post-attach stranger, and leaves it alone.
+                saved.masks.push((tid, started, Vec::new()));
+                continue;
+            }
+            let rc = unsafe {
+                libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask)
+            };
+            if rc == 0 {
+                edited += 1;
+                saved.masks.push((tid, started, removed));
+            } else {
+                // The change did not land, so nothing was removed from this
+                // thread — but it was observed, and release must know that.
+                saved.masks.push((tid, started, Vec::new()));
+                errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
+            }
         }
-        let rc =
-            unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
-        if rc == 0 {
-            edited += 1;
-            saved.masks.push((tid, started, removed));
-        } else {
-            // The change did not land, so nothing was removed from this
-            // thread — but it was observed, and release must know that.
-            saved.masks.push((tid, started, Vec::new()));
-            errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
+        if found_new == 0 {
+            break;
+        }
+        if passes >= MAX_PASSES {
+            tracing::warn!(
+                passes,
+                "threads are still appearing after {passes} affinity passes; some may remain \
+                 eligible for VPP's cores"
+            );
+            break;
         }
     }
     // Not an error even when nothing was restricted: the snapshot still
@@ -395,6 +439,14 @@ impl std::fmt::Debug for AffinitySnapshot {
 /// is left to protect — a bring-up that rolled back cleanly, and a
 /// detach whose teardown completed (including one that settles late,
 /// after `detach` itself returned).
+///
+/// Single-pass, deliberately, where restriction rescans to a fixpoint.
+/// The asymmetry follows the consequence: a thread missed by
+/// RESTRICTION can run on VPP's cores and preempt the poll loop, which
+/// is the fault this whole mechanism exists to prevent; a thread missed
+/// by RELEASE merely keeps a narrower mask than it might, costing
+/// scheduling breadth on a daemon that no longer has a VPP to protect,
+/// and correcting itself at the next daemon start.
 ///
 /// Takes only the snapshot: it carries both the per-thread originals
 /// and the `restorable` set, so the [`CoreMap`] is not needed here and

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -408,6 +408,31 @@ pub fn release_daemon_to(_saved: &AffinitySnapshot) -> Result<usize, String> {
 mod affinity_tests {
     use super::*;
 
+    /// Serialises the tests in this module, because what they exercise
+    /// is **process-wide**: `restrict_daemon_from` walks
+    /// `/proc/self/task` and edits every TID — including the harness
+    /// thread running the *other* test. Under the default parallel
+    /// harness each test therefore rewrites the other's mask mid-
+    /// assertion, which passes alone and with `--test-threads=1` and
+    /// fails when both run together (review finding; CI had been
+    /// getting away with it on timing).
+    ///
+    /// Held for the whole snapshot-to-restoration interval, not just
+    /// the syscall: the window that must be exclusive is "my mask is
+    /// modified", which spans every assertion between them.
+    ///
+    /// Poisoning is absorbed deliberately. A panicking test leaves the
+    /// masks it was mid-way through restoring, and the next test's
+    /// first act is to capture and later restore them itself — so the
+    /// lock's job is mutual exclusion, not integrity, and refusing to
+    /// run after an unrelated failure would just hide the second
+    /// result behind the first.
+    static AFFINITY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn lock_affinity() -> std::sync::MutexGuard<'static, ()> {
+        AFFINITY_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     fn current_mask() -> libc::cpu_set_t {
         let mut got: libc::cpu_set_t = unsafe { std::mem::zeroed() };
         let rc =
@@ -436,6 +461,7 @@ mod affinity_tests {
     /// (review finding).
     #[test]
     fn restriction_subtracts_and_release_restores_the_saved_masks() {
+        let _serialised = lock_affinity();
         let before = current_mask();
         let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
             .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })
@@ -506,6 +532,7 @@ mod affinity_tests {
     fn a_thread_born_after_restriction_gains_only_universally_held_cores() {
         use std::sync::mpsc::channel;
 
+        let _serialised = lock_affinity();
         let before = current_mask();
         let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
             .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -168,9 +168,9 @@ pub fn derive_from_sysfs(sysfs_cpu: &std::path::Path, workers: u32) -> Result<Co
 pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 
 /// A thread's start time, for the identity check in
-/// [`AffinitySnapshot`]. `None` when the thread has already exited or
-/// its stat line cannot be parsed — both of which make it un-restorable
-/// rather than a fault.
+/// the rescan loop's `seen` set. `None` when the thread has already
+/// exited or its stat line cannot be parsed — both of which make it
+/// unprocessable rather than a fault.
 #[cfg(target_os = "linux")]
 fn thread_start_ticks(tid: libc::pid_t) -> Option<u64> {
     let stat = std::fs::read_to_string(format!("/proc/self/task/{tid}/stat")).ok()?;
@@ -217,9 +217,8 @@ fn mask_too_small(e: &std::io::Error) -> bool {
 /// Applied to every task in `/proc/self/task`; threads spawned later
 /// inherit their creator's mask.
 #[cfg(target_os = "linux")]
-pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
+pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
     let mut edited = 0usize;
-    let mut saved = AffinitySnapshot::default();
     let mut errors: Vec<String> = Vec::new();
     // Rescan until a whole pass finds nothing new.
     //
@@ -239,23 +238,13 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
     // protection is partial and says so, rather than looping.
     const MAX_PASSES: u32 = 8;
     let mut passes = 0u32;
-    // Loop bookkeeping, deliberately SEPARATE from `saved.masks`.
-    //
-    // Only the first pass sees threads in their pre-restriction state,
-    // so only the first pass may contribute to the restoration record.
-    // A thread discovered later was created by an already-restricted
-    // parent, so the mask it carries is one WE caused — treating it as
-    // that thread's original policy would intersect `restorable` down
-    // to nothing (poisoning restoration for every post-attach thread)
-    // and record it as having nothing to give back, leaving it narrowed
-    // until the daemon restarts (review finding, caused by the rescan
-    // added one commit earlier). Later passes therefore restrict but do
-    // not record, which puts those threads on release's descendant path
-    // where `restorable` is the right answer for them.
+    // Identities already processed, so the loop terminates and a thread
+    // is not restricted twice. Keyed on `(tid, start_ticks)` rather
+    // than the tid alone: Linux reuses tids, and a reused one names a
+    // different thread that has not been visited.
     let mut seen: Vec<(libc::pid_t, u64)> = Vec::new();
     loop {
         passes += 1;
-        let first_pass = passes == 1;
         let mut found_new = 0usize;
         let tasks =
             std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
@@ -312,14 +301,6 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
                     "this thread's whole mask IS VPP's cores; leaving it untouched — an \
                  unschedulable thread is worse than an unprotected worker"
                 );
-                // Observed with nothing removed. Recorded ONLY on the
-                // first pass, where it proves the thread is not a
-                // post-attach stranger and release must leave it alone;
-                // a later-pass thread belongs on the descendant path
-                // instead.
-                if first_pass {
-                    saved.masks.push((tid, started, Vec::new()));
-                }
                 continue;
             }
             let rc = unsafe {
@@ -327,16 +308,7 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             };
             if rc == 0 {
                 edited += 1;
-                if first_pass {
-                    saved.masks.push((tid, started, removed));
-                }
             } else {
-                // The change did not land, so nothing was removed from
-                // this thread — but it was observed, and (on the first
-                // pass) release must know that.
-                if first_pass {
-                    saved.masks.push((tid, started, Vec::new()));
-                }
                 errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
             }
         }
@@ -352,172 +324,9 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             break;
         }
     }
-    // Not an error even when nothing was restricted: the snapshot still
-    // names every pre-existing thread, which is what keeps a later
-    // release from unioning cores onto a thread that was never touched.
-    // Degraded protection is a warning; discarding the snapshot via `Err`
-    // (the caller falls back to an empty one) is what actually caused the
-    // broadening.
-    if !errors.is_empty() {
-        tracing::warn!(
-            edited,
-            failed = errors.len(),
-            "some threads kept their old affinity: {}",
-            errors.join("; ")
-        );
-    }
-    Ok((edited, saved))
-}
-
-/// What this attachment removed from each thread, so release is the
-/// exact inverse of the restriction and nothing else.
-///
-/// Storing the whole pre-attach mask was the previous design and review
-/// rejected it rightly: restoring it verbatim discards any change the
-/// operator made WHILE VPP was attached (a `taskset` mid-attachment),
-/// re-enabling CPUs they had since excluded. Restriction only ever
-/// clears VPP-core bits, so its inverse is to set exactly those bits
-/// back on whatever the thread's mask is at release time — every other
-/// bit, however it got that way, is left alone.
-///
-/// Recording the removed set per thread also subsumes two earlier
-/// findings for free: a thread whose policy already excluded a VPP core
-/// has that core in nobody's removed set, so it can never gain it; and
-/// a thread we observed but skipped (its mask would have emptied) or
-/// failed to set has an EMPTY removed set, so release leaves it exactly
-/// as found while still proving it is not a post-attach stranger.
-///
-/// Only threads seen on the FIRST scan pass appear here, and only they
-/// are ever edited by release. Later passes exist to catch threads
-/// spawned mid-scan; those carry a mask this function already narrowed,
-/// so there is no original policy to record for them — and release
-/// leaves them alone rather than guessing. They keep a mask missing
-/// VPP's cores until the daemon restarts, which is under-restoration:
-/// the direction this whole mechanism prefers, and the only one that
-/// cannot override an operator who retuned that thread by hand while
-/// VPP was attached (review finding).
-///
-/// A thread born DURING the restricted epoch has no capture, and no
-/// exact inverse exists for it — we never saw its creator's original
-/// mask, only the restricted one it inherited. So it gets
-/// [`Self::restorable`] rather than every VPP core: the cores that
-/// EVERY observed thread originally held. Whatever ancestor the new
-/// thread descends from was one of those threads, so each core in that
-/// intersection was demonstrably in its inherited policy and adding it
-/// back cannot broaden anything. Cores held by only some pre-existing
-/// threads stay off — under-restoring a new thread until the daemon's
-/// next start, which is the safe direction and the one the operator
-/// can reason about.
-#[derive(Default, Clone)]
-pub struct AffinitySnapshot {
-    /// `(tid, start_ticks, the VPP cores THIS attachment removed)`.
-    ///
-    /// The start time is what makes the tid an IDENTITY rather than a
-    /// number. A thread can exit during a long attachment and Linux can
-    /// reuse its tid; restoring the dead thread's mask onto its
-    /// namesake would hand a live thread a policy that was never its
-    /// own (review finding). This is the same identity-must-be-whole
-    /// rule [`crate::process`] applies to an adopted VPP — pid alone is
-    /// never enough — and it reuses that module's `/proc` stat parser
-    /// rather than growing a second one.
-    #[cfg(target_os = "linux")]
-    masks: Vec<(libc::pid_t, u64, Vec<u16>)>,
-}
-
-impl std::fmt::Debug for AffinitySnapshot {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        #[cfg(target_os = "linux")]
-        return write!(f, "AffinitySnapshot({} threads)", self.masks.len());
-        #[cfg(not(target_os = "linux"))]
-        write!(f, "AffinitySnapshot")
-    }
-}
-
-/// The inverse of [`restrict_daemon_from`], for the paths where no VPP
-/// is left to protect — a bring-up that rolled back cleanly, and a
-/// detach whose teardown completed (including one that settles late,
-/// after `detach` itself returned).
-///
-/// Single-pass, deliberately, where restriction rescans to a fixpoint.
-/// The asymmetry follows the consequence: a thread missed by
-/// RESTRICTION can run on VPP's cores and preempt the poll loop, which
-/// is the fault this whole mechanism exists to prevent; a thread missed
-/// by RELEASE merely keeps a narrower mask than it might, costing
-/// scheduling breadth on a daemon that no longer has a VPP to protect,
-/// and correcting itself at the next daemon start.
-///
-/// Takes only the snapshot: it carries both the per-thread originals
-/// and the `restorable` set, so the [`CoreMap`] is not needed here and
-/// is not accepted — a parameter nothing reads is a parameter that can
-/// disagree with the one restriction used.
-#[cfg(target_os = "linux")]
-pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
-    let mut edited = 0usize;
-    let mut errors: Vec<String> = Vec::new();
-    let tasks =
-        std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
-    for entry in tasks.flatten() {
-        let Some(tid) = entry
-            .file_name()
-            .to_str()
-            .and_then(|s| s.parse::<libc::pid_t>().ok())
-        else {
-            continue;
-        };
-        // The tid must match AND be the same thread: a reused tid names
-        // a stranger, whose mask is none of our business to restore.
-        let started = thread_start_ticks(tid);
-        // Only a thread THIS attachment restricted is edited. A thread
-        // born during the epoch — or a reused tid, which is the same
-        // thing from here — is left exactly as it is: we never took a
-        // core from it, we do not know what its creator's policy was,
-        // and an operator may have retuned it by hand since. Adding
-        // anything there would override a live policy on a guess, and
-        // the guess has now been wrong in three distinct ways (review
-        // findings). Under-restoring until the daemon's next start is
-        // the direction this mechanism prefers.
-        let Some((_, _, removed)) = saved
-            .masks
-            .iter()
-            .find(|(t, s, _)| *t == tid && Some(*s) == started)
-        else {
-            continue;
-        };
-        if removed.is_empty() {
-            continue; // nothing was taken; nothing to give back
-        }
-        // The CURRENT mask, so an operator's mid-attachment `taskset`
-        // survives — release adds bits, it never replaces a policy.
-        let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-        let rc = unsafe {
-            libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
-        };
-        if rc != 0 {
-            let err = std::io::Error::last_os_error();
-            if mask_too_small(&err) {
-                return Err(format!(
-                    "this host's CPU mask is wider than a fixed cpu_set_t can express: {err}"
-                ));
-            }
-            continue; // vanished between readdir and here
-        }
-        for cpu in removed {
-            unsafe { libc::CPU_SET(*cpu as usize, &mut mask) };
-        }
-        let rc =
-            unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
-        if rc == 0 {
-            edited += 1;
-        } else {
-            errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
-        }
-    }
-    if edited == 0 && !errors.is_empty() {
-        return Err(format!(
-            "no thread accepted its affinity change: {}",
-            errors.join("; ")
-        ));
-    }
+    // Not an error even when nothing was restricted: degraded
+    // protection is a warning, and the caller reports it — see
+    // `bring_up`, where zero edits is explicitly not logged as success.
     if !errors.is_empty() {
         tracing::warn!(
             edited,
@@ -529,17 +338,31 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
     Ok(edited)
 }
 
-#[cfg(not(target_os = "linux"))]
-pub fn restrict_daemon_from(_map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
-    // Non-Linux never attaches a VPP; there is nothing to protect.
-    Ok((0, AffinitySnapshot::default()))
-}
+// There is deliberately **no** inverse of `restrict_daemon_from`.
+//
+// A CPU affinity mask is per-process state, and every path that stops
+// this daemon protecting a VPP also ends the process: `Module::detach`
+// has exactly two callers in the loader — the startup-unwind macro,
+// which returns `Err` and exits, and the breaker-trip arm, which runs
+// after the loop has already ended — and `packetframe detach --all` is
+// a different process that never touches live modules. So the
+// restriction dies with the daemon that made it, and there is nothing
+// for a restore to restore.
+//
+// Worth stating because the restore path existed for several revisions
+// and produced a review finding on every one of them: how to undo an
+// edit for a thread born mid-epoch, for a reused tid, for a thread an
+// operator retuned meanwhile, for one discovered on a later scan pass.
+// Each answer was a guess about state we never observed — and the whole
+// question was moot, because the process holding the state is on its
+// way out in every case that would ask it. Restriction is one-way by
+// design, not by omission.
 
 #[cfg(not(target_os = "linux"))]
-pub fn release_daemon_to(_saved: &AffinitySnapshot) -> Result<usize, String> {
+pub fn restrict_daemon_from(_map: &CoreMap) -> Result<usize, String> {
+    // Non-Linux never attaches a VPP; there is nothing to protect.
     Ok(0)
 }
-
 #[cfg(all(test, target_os = "linux"))]
 mod affinity_tests {
     use super::*;
@@ -550,19 +373,12 @@ mod affinity_tests {
     /// thread running the *other* test. Under the default parallel
     /// harness each test therefore rewrites the other's mask mid-
     /// assertion, which passes alone and with `--test-threads=1` and
-    /// fails when both run together (review finding; CI had been
-    /// getting away with it on timing).
+    /// fails when both run together (review finding).
     ///
-    /// Held for the whole snapshot-to-restoration interval, not just
-    /// the syscall: the window that must be exclusive is "my mask is
-    /// modified", which spans every assertion between them.
-    ///
-    /// Poisoning is absorbed deliberately. A panicking test leaves the
-    /// masks it was mid-way through restoring, and the next test's
-    /// first act is to capture and later restore them itself — so the
-    /// lock's job is mutual exclusion, not integrity, and refusing to
-    /// run after an unrelated failure would just hide the second
-    /// result behind the first.
+    /// Poisoning is absorbed deliberately: a panicking test leaves the
+    /// mask it was mid-way through changing, the next test restores the
+    /// mask itself, and refusing to run after an unrelated failure
+    /// would just hide the second result behind the first.
     static AFFINITY_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     fn lock_affinity() -> std::sync::MutexGuard<'static, ()> {
@@ -590,13 +406,15 @@ mod affinity_tests {
         unsafe { libc::CPU_ISSET(cpu, &current_mask()) }
     }
 
-    /// Asserting the SYSCALL's effect via readback, not the intent.
-    /// CPU ids come from THIS process's allowed mask, not from ids
-    /// synthesized off a count — a container whose cpuset excludes low
-    /// ids would otherwise fail the harness before the implementation
+    /// Restriction SUBTRACTS VPP's cores and touches nothing else.
+    ///
+    /// Asserting the syscall's effect via readback, not the intent. CPU
+    /// ids come from this process's own allowed mask rather than being
+    /// synthesised from a count, so a container whose cpuset excludes
+    /// low ids does not fail the harness before the implementation
     /// (review finding).
     #[test]
-    fn restriction_subtracts_and_release_restores_the_saved_masks() {
+    fn restriction_subtracts_vpps_cores_and_preserves_the_rest() {
         let _serialised = lock_affinity();
         let before = current_mask();
         let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
@@ -611,68 +429,37 @@ mod affinity_tests {
             workers: vec![],
         };
 
-        // Operator narrowed the daemon to {a, b}; VPP takes b; the
-        // operator's exclusion of c must survive every step.
+        // Operator narrowed the daemon to {a, b}; VPP takes b. Their
+        // exclusion of c must survive: subtract, never rebuild.
         set_mask(&[a, b]);
-        let (n, snap) = restrict_daemon_from(&map).expect("restrict");
-        assert!(n >= 1);
-        assert!(!isset(b), "VPP's core excluded");
-        assert!(isset(a), "the rest kept");
-        assert!(!isset(c), "subtract, never rebuild");
+        let edited = restrict_daemon_from(&map).expect("restrict");
+        assert!(edited >= 1, "at least this thread was edited");
+        assert!(!isset(b), "VPP's core is excluded");
+        assert!(isset(a), "the rest of the policy is kept");
+        assert!(!isset(c), "a core the operator excluded is not added");
 
-        // An operator retunes the daemon WHILE VPP is attached: c is
-        // added, and that change must survive release. Restoring a
-        // whole pre-attach mask would silently discard it (review
-        // finding); adding back only what was removed cannot.
-        set_mask(&[a, c]);
-        release_daemon_to(&snap).expect("release");
-        assert!(isset(b), "the core this attachment removed came back");
-        assert!(
-            isset(c),
-            "an affinity change made during the attachment must survive release"
-        );
-
-        // The finding that killed union-on-release: an operator mask
-        // that ALREADY excluded VPP's core must not gain it back.
-        set_mask(&[a]);
-        let (_, snap2) = restrict_daemon_from(&map).expect("restrict2");
-        release_daemon_to(&snap2).expect("release2");
-        assert!(
-            !isset(b),
-            "a mask that never held VPP's core must not acquire it on release"
-        );
-
-        // A mask that IS VPP's cores is skipped, not emptied — AND the
-        // skipped thread must still be recorded, so release restores its
-        // original verbatim rather than unioning (which here would be a
-        // no-op, but the recording is what makes a DIFFERENT skipped
-        // thread safe). Narrow to {a, b}, exclude c, so a broadening
-        // union would be visible as c appearing.
+        // A mask that IS VPP's cores is skipped, not emptied: an
+        // unschedulable thread is worse than an unprotected worker.
         set_mask(&[b]);
-        let (_, snap3) = restrict_daemon_from(&map).expect("skip tolerated");
-        assert!(isset(b), "unschedulable is worse than unprotected");
-        release_daemon_to(&snap3).expect("release3");
-        assert!(
-            isset(b) && !isset(a) && !isset(c),
-            "a skipped thread's original mask is restored verbatim, never unioned"
-        );
+        restrict_daemon_from(&map).expect("skip tolerated");
+        assert!(isset(b), "the only usable core is left in place");
 
         let rc =
             unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };
         assert_eq!(rc, 0);
     }
 
-    /// A thread born during the restricted epoch is left alone by
-    /// release — never handed a core on a guess.
+    /// A thread created while the scan is running is still restricted.
     ///
-    /// We took nothing from it, we never saw its creator's policy, and
-    /// an operator may have retuned it by hand since. Three successive
-    /// review findings showed every flavour of guess here to be wrong
-    /// in some reachable case, so release now edits only the threads it
-    /// actually restricted. This pins the consequence: the child does
-    /// not acquire VPP's core.
+    /// One pass is not enough and the gap is reachable: the fast-path
+    /// runtime is live before VPP attaches and spawns blocking threads,
+    /// so a thread born mid-scan from an unvisited parent would inherit
+    /// an unrestricted mask and never be seen — free to preempt VPP's
+    /// worker forever, which is the whole fault this prevents. The scan
+    /// rescans until a pass finds nothing new; this asserts the
+    /// consequence for a thread that exists by the final pass.
     #[test]
-    fn a_thread_born_after_restriction_is_left_alone_by_release() {
+    fn a_thread_alive_during_the_scan_ends_up_restricted() {
         use std::sync::mpsc::channel;
 
         let _serialised = lock_affinity();
@@ -680,26 +467,22 @@ mod affinity_tests {
         let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
             .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })
             .collect();
-        if allowed.len() < 3 {
+        if allowed.len() < 2 {
             return;
         }
-        let (a, b, c) = (allowed[0], allowed[1], allowed[2]);
-
-        // VPP takes b; this thread's policy is {a, c} — b excluded, so
-        // b is NOT universally held.
-        set_mask(&[a, c]);
+        let (a, b) = (allowed[0], allowed[1]);
+        set_mask(&[a, b]);
         let map = CoreMap {
             main: b as u16,
             workers: vec![],
         };
-        let (_, snap) = restrict_daemon_from(&map).expect("restrict");
 
         let (born_tx, born_rx) = channel();
         let (go_tx, go_rx) = channel();
         let (got_tx, got_rx) = channel();
         let child = std::thread::spawn(move || {
             born_tx.send(()).expect("announce");
-            go_rx.recv().expect("wait for release");
+            go_rx.recv().expect("wait for the scan");
             let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
             let rc = unsafe {
                 libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut m)
@@ -709,17 +492,16 @@ mod affinity_tests {
                 .send(unsafe { libc::CPU_ISSET(b, &m) })
                 .expect("report");
         });
-        born_rx.recv().expect("child exists before release");
+        born_rx.recv().expect("child exists before the scan");
 
-        release_daemon_to(&snap).expect("release");
+        restrict_daemon_from(&map).expect("restrict");
         go_tx.send(()).expect("let the child read its mask");
-        let child_has_vpp_core = got_rx.recv().expect("child reported");
+        let child_on_vpp_core = got_rx.recv().expect("child reported");
         child.join().expect("child joined");
 
         assert!(
-            !child_has_vpp_core,
-            "a thread born after restriction must not gain a core its creator's \
-             policy excluded"
+            !child_on_vpp_core,
+            "a thread alive during the scan must not stay eligible for VPP's core"
         );
 
         let rc =

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -167,45 +167,52 @@ pub fn derive_from_sysfs(sysfs_cpu: &std::path::Path, workers: u32) -> Result<Co
 /// Where the CPU topology lives on a running kernel.
 pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 
-/// Keep every thread of THIS daemon off VPP's cores.
+/// Keep every thread of THIS daemon off VPP's cores — by SUBTRACTING
+/// them from each thread's current mask, never by rebuilding one.
 ///
 /// The missing half of the plan's "cpuset + SCHED_FIFO" promise, found
-/// by a week of drills (shadow, 2026-08-08). VPP's worker polls its rx
-/// ring from a dedicated core, but `isolcpus` on this fleet belongs to
-/// unifi-core and nothing constrained the daemon: at every adopted
-/// resync's release, `begin_resync` walks a 1.3M-entry mirror and the
-/// first drain batches encode thousands of routes — seconds of
-/// memory-heavy burst that the scheduler was free to place on the
-/// worker's core. A preempted poll loop overflows a 1024-descriptor rx
-/// ring in ~2 s at the drill rate, and the drops happen at the NIC,
-/// invisible to every VPP error counter — which is how three correct
-/// fixes to the FIB-side work at the release instant each left the
-/// measured ~5.4 s gap unmoved.
+/// by a week of drills (shadow, 2026-08-08): a resync burst scheduled
+/// onto the worker's core preempts the poll loop, the 1024-descriptor
+/// rx ring overflows in ~2 s, and the drops happen at the NIC where no
+/// VPP counter sees them — a constant ~5.4 s of loss at every adopted
+/// release, invariant under three correct FIB-side fixes.
 ///
-/// Applied to every task in `/proc/self/task` at attach; threads
-/// spawned afterwards inherit their creator's mask. Errors are
-/// collected, not fatal: a cgroup cpuset that refuses us is a reason to
-/// warn, and refusing to attach over it would fail deployments that
-/// merely share cores gracefully today.
+/// Subtract-only is load-bearing three ways (all review findings on
+/// the first version, which built a host-wide mask from a CPU COUNT):
+/// an operator's narrower `CPUAffinity=`/taskset policy survives,
+/// because bits they cleared stay cleared; non-contiguous online CPU
+/// IDs need no enumeration at all, because the kernel's own answer per
+/// thread is the starting point; and the worst possible outcome of
+/// running with no VPP is the loss of exactly VPP's cores, not
+/// collapse onto CPU 0. A thread whose mask would become EMPTY — the
+/// operator pinned the daemon precisely onto VPP's cores — is left
+/// untouched and warned about, because an unprotected worker degrades
+/// while an unschedulable daemon thread stops.
+///
+/// Applied to every task in `/proc/self/task`; threads spawned later
+/// inherit their creator's mask.
 #[cfg(target_os = "linux")]
 pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
-    let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-    let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-    if online <= 0 {
-        return Err("cannot determine online CPU count".into());
-    }
-    let mut kept = 0usize;
-    for cpu in 0..online as u16 {
-        if cpu == map.main || map.workers.contains(&cpu) {
-            continue;
-        }
-        unsafe { libc::CPU_SET(cpu as usize, &mut mask) };
-        kept += 1;
-    }
-    if kept == 0 {
-        return Err("the core map claims every online CPU; refusing an empty mask".into());
-    }
-    let mut set = 0usize;
+    edit_all_thread_masks(map, false)
+}
+
+/// The inverse: give VPP's cores back to every daemon thread, for the
+/// paths where no VPP is left to protect — a bring-up that rolled back
+/// cleanly, and a detach whose teardown completed. Union rather than a
+/// saved-mask restore: threads born during the restricted epoch have no
+/// prior mask to restore, and a union is correct for every thread that
+/// was restricted here. The one distortion — an operator mask that
+/// itself excluded VPP's cores gains them back — corrects itself at the
+/// daemon's next start, and is the price of not persisting per-thread
+/// state across an epoch in which threads are born and die.
+#[cfg(target_os = "linux")]
+pub fn release_daemon_to(map: &CoreMap) -> Result<usize, String> {
+    edit_all_thread_masks(map, true)
+}
+
+#[cfg(target_os = "linux")]
+fn edit_all_thread_masks(map: &CoreMap, add: bool) -> Result<usize, String> {
+    let mut edited = 0usize;
     let mut errors: Vec<String> = Vec::new();
     let tasks =
         std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
@@ -217,29 +224,53 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
         else {
             continue;
         };
+        let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
+        };
+        if rc != 0 {
+            // Threads exit between readdir and here; a vanished tid is
+            // not a fault.
+            continue;
+        }
+        for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
+            if add {
+                unsafe { libc::CPU_SET(cpu as usize, &mut mask) };
+            } else {
+                unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
+            }
+        }
+        if !add && unsafe { libc::CPU_COUNT(&mask) } == 0 {
+            tracing::warn!(
+                tid,
+                "this thread's whole mask IS VPP's cores; leaving it untouched — an \
+                 unschedulable thread is worse than an unprotected worker"
+            );
+            continue;
+        }
         let rc =
             unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
         if rc == 0 {
-            set += 1;
+            edited += 1;
         } else {
             errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
         }
     }
-    if set == 0 {
+    if edited == 0 && !errors.is_empty() {
         return Err(format!(
-            "no thread accepted the affinity mask: {}",
+            "no thread accepted its affinity change: {}",
             errors.join("; ")
         ));
     }
     if !errors.is_empty() {
         tracing::warn!(
-            set,
+            edited,
             failed = errors.len(),
             "some threads kept their old affinity: {}",
             errors.join("; ")
         );
     }
-    Ok(set)
+    Ok(edited)
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -248,48 +279,82 @@ pub fn restrict_daemon_from(_map: &CoreMap) -> Result<usize, String> {
     Ok(0)
 }
 
+#[cfg(not(target_os = "linux"))]
+pub fn release_daemon_to(_map: &CoreMap) -> Result<usize, String> {
+    Ok(0)
+}
+
 #[cfg(all(test, target_os = "linux"))]
 mod affinity_tests {
     use super::*;
 
-    /// The mask really lands on the calling process: after restriction,
-    /// the current thread's affinity excludes VPP's cores and includes
-    /// at least one other. Read back via sched_getaffinity — asserting
-    /// the syscall's effect, not our intent to make it.
-    #[test]
-    fn restriction_excludes_vpp_cores_and_keeps_the_rest() {
-        let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-        if online < 2 {
-            // A single-CPU runner cannot express "everything but".
-            return;
-        }
-        let map = CoreMap {
-            main: (online - 1) as u16,
-            workers: vec![],
-        };
-        let set = restrict_daemon_from(&map).expect("restriction");
-        assert!(set >= 1, "at least this thread's mask was set");
-
+    fn current_mask() -> libc::cpu_set_t {
         let mut got: libc::cpu_set_t = unsafe { std::mem::zeroed() };
         let rc =
             unsafe { libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut got) };
         assert_eq!(rc, 0);
+        got
+    }
+
+    fn set_mask(cpus: &[usize]) {
+        let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        for &c in cpus {
+            unsafe { libc::CPU_SET(c, &mut m) };
+        }
+        let rc = unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &m) };
+        assert_eq!(rc, 0);
+    }
+
+    /// Asserting the SYSCALL's effect via readback, not the intent:
+    /// subtraction preserves an operator's narrower policy (bits they
+    /// cleared stay cleared), release unions VPP's cores back, and a
+    /// mask that would become empty is left untouched.
+    #[test]
+    fn subtraction_preserves_narrow_masks_and_release_returns_the_cores() {
+        let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
+        if online < 3 {
+            return; // cannot express "narrower than the host" on <3 CPUs
+        }
+        let before = current_mask();
+
+        // Operator narrowed the daemon to {0, 1}; VPP takes core 1.
+        set_mask(&[0, 1]);
+        let map = CoreMap {
+            main: 1,
+            workers: vec![],
+        };
+        restrict_daemon_from(&map).expect("restrict");
+        let got = current_mask();
+        assert!(!unsafe { libc::CPU_ISSET(1, &got) }, "VPP's core excluded");
+        assert!(unsafe { libc::CPU_ISSET(0, &got) }, "the rest kept");
         assert!(
-            !unsafe { libc::CPU_ISSET((online - 1) as usize, &got) },
-            "VPP's core must be excluded"
-        );
-        assert!(
-            unsafe { libc::CPU_ISSET(0, &got) },
-            "the remaining cores must stay usable"
+            !unsafe { libc::CPU_ISSET(2, &got) },
+            "the operator's exclusion of CPU 2 must survive — subtract, never rebuild"
         );
 
-        // Restore a full mask so later tests in this process are not
-        // constrained by this one.
-        let mut all: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-        for cpu in 0..online as usize {
-            unsafe { libc::CPU_SET(cpu, &mut all) };
-        }
-        unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &all) };
+        release_daemon_to(&map).expect("release");
+        let got = current_mask();
+        assert!(
+            unsafe { libc::CPU_ISSET(1, &got) },
+            "release gives VPP's core back"
+        );
+        assert!(
+            !unsafe { libc::CPU_ISSET(2, &got) },
+            "and adds nothing else"
+        );
+
+        // A mask that IS VPP's cores must be skipped, not emptied.
+        set_mask(&[1]);
+        restrict_daemon_from(&map).expect("restrict tolerates the skip");
+        let got = current_mask();
+        assert!(
+            unsafe { libc::CPU_ISSET(1, &got) },
+            "an unschedulable thread is worse than an unprotected worker"
+        );
+
+        let rc =
+            unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };
+        assert_eq!(rc, 0);
     }
 }
 

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -248,8 +248,23 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
     // protection is partial and says so, rather than looping.
     const MAX_PASSES: u32 = 8;
     let mut passes = 0u32;
+    // Loop bookkeeping, deliberately SEPARATE from `saved.masks`.
+    //
+    // Only the first pass sees threads in their pre-restriction state,
+    // so only the first pass may contribute to the restoration record.
+    // A thread discovered later was created by an already-restricted
+    // parent, so the mask it carries is one WE caused — treating it as
+    // that thread's original policy would intersect `restorable` down
+    // to nothing (poisoning restoration for every post-attach thread)
+    // and record it as having nothing to give back, leaving it narrowed
+    // until the daemon restarts (review finding, caused by the rescan
+    // added one commit earlier). Later passes therefore restrict but do
+    // not record, which puts those threads on release's descendant path
+    // where `restorable` is the right answer for them.
+    let mut seen: Vec<(libc::pid_t, u64)> = Vec::new();
     loop {
         passes += 1;
+        let first_pass = passes == 1;
         let mut found_new = 0usize;
         let tasks =
             std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
@@ -267,13 +282,10 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             let Some(started) = thread_start_ticks(tid) else {
                 continue; // exited between readdir and here
             };
-            if saved
-                .masks
-                .iter()
-                .any(|(t, st, _)| *t == tid && *st == started)
-            {
+            if seen.iter().any(|(t, st)| *t == tid && *st == started) {
                 continue;
             }
+            seen.push((tid, started));
             found_new += 1;
             let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
             let rc = unsafe {
@@ -295,20 +307,14 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
                 continue;
             }
             let before = mask;
-            // Record EVERY thread we observed, with its original mask —
-            // before deciding whether to change it. Release keys on this:
-            // a tid present here restores its original verbatim (a no-op for
-            // the ones we leave untouched below), and only a tid ABSENT is
-            // treated as born-after-restriction and unioned. Recording just
-            // the successfully-restricted threads was the bug (review
-            // finding): a thread skipped for an empty mask, or one whose
-            // setaffinity failed, would then be missing from the snapshot
-            // and wrongly unioned VPP's cores on release, broadening a
-            // policy it never had restricted.
-            // Narrow the intersection with this thread's original policy.
-            saved
-                .restorable
-                .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
+            // Narrow the intersection with this thread's ORIGINAL
+            // policy — first pass only, since that is the only pass
+            // whose masks predate our own edits.
+            if first_pass {
+                saved
+                    .restorable
+                    .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
+            }
             // Exactly the VPP cores this thread actually held — the set
             // release will put back, and nothing more.
             let mut removed: Vec<u16> = Vec::new();
@@ -324,9 +330,14 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
                     "this thread's whole mask IS VPP's cores; leaving it untouched — an \
                  unschedulable thread is worse than an unprotected worker"
                 );
-                // Observed, but nothing removed: recorded so release knows
-                // it is not a post-attach stranger, and leaves it alone.
-                saved.masks.push((tid, started, Vec::new()));
+                // Observed with nothing removed. Recorded ONLY on the
+                // first pass, where it proves the thread is not a
+                // post-attach stranger and release must leave it alone;
+                // a later-pass thread belongs on the descendant path
+                // instead.
+                if first_pass {
+                    saved.masks.push((tid, started, Vec::new()));
+                }
                 continue;
             }
             let rc = unsafe {
@@ -334,11 +345,16 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             };
             if rc == 0 {
                 edited += 1;
-                saved.masks.push((tid, started, removed));
+                if first_pass {
+                    saved.masks.push((tid, started, removed));
+                }
             } else {
-                // The change did not land, so nothing was removed from this
-                // thread — but it was observed, and release must know that.
-                saved.masks.push((tid, started, Vec::new()));
+                // The change did not land, so nothing was removed from
+                // this thread — but it was observed, and (on the first
+                // pass) release must know that.
+                if first_pass {
+                    saved.masks.push((tid, started, Vec::new()));
+                }
                 errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
             }
         }
@@ -388,6 +404,12 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
 /// a thread we observed but skipped (its mask would have emptied) or
 /// failed to set has an EMPTY removed set, so release leaves it exactly
 /// as found while still proving it is not a post-attach stranger.
+///
+/// Only threads seen on the FIRST scan pass appear here. Later passes
+/// exist to catch threads spawned mid-scan, and those carry a mask this
+/// function already narrowed — recording that as their "original" would
+/// both empty `restorable` and promise them nothing back. They belong
+/// on the descendant path, which `restorable` answers correctly.
 ///
 /// A thread born DURING the restricted epoch has no capture, and no
 /// exact inverse exists for it — we never saw its creator's original

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -216,6 +216,17 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             continue;
         }
         let before = mask;
+        // Record EVERY thread we observed, with its original mask —
+        // before deciding whether to change it. Release keys on this:
+        // a tid present here restores its original verbatim (a no-op for
+        // the ones we leave untouched below), and only a tid ABSENT is
+        // treated as born-after-restriction and unioned. Recording just
+        // the successfully-restricted threads was the bug (review
+        // finding): a thread skipped for an empty mask, or one whose
+        // setaffinity failed, would then be missing from the snapshot
+        // and wrongly unioned VPP's cores on release, broadening a
+        // policy it never had restricted.
+        saved.masks.push((tid, before));
         for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
             unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
         }
@@ -231,17 +242,16 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
             unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
         if rc == 0 {
             edited += 1;
-            saved.masks.push((tid, before));
         } else {
             errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
         }
     }
-    if edited == 0 && !errors.is_empty() {
-        return Err(format!(
-            "no thread accepted its affinity change: {}",
-            errors.join("; ")
-        ));
-    }
+    // Not an error even when nothing was restricted: the snapshot still
+    // names every pre-existing thread, which is what keeps a later
+    // release from unioning cores onto a thread that was never touched.
+    // Degraded protection is a warning; discarding the snapshot via `Err`
+    // (the caller falls back to an empty one) is what actually caused the
+    // broadening.
     if !errors.is_empty() {
         tracing::warn!(
             edited,
@@ -422,11 +432,20 @@ mod affinity_tests {
             "a mask that never held VPP's core must not acquire it on release"
         );
 
-        // A mask that IS VPP's cores is skipped, not emptied.
+        // A mask that IS VPP's cores is skipped, not emptied — AND the
+        // skipped thread must still be recorded, so release restores its
+        // original verbatim rather than unioning (which here would be a
+        // no-op, but the recording is what makes a DIFFERENT skipped
+        // thread safe). Narrow to {a, b}, exclude c, so a broadening
+        // union would be visible as c appearing.
         set_mask(&[b]);
         let (_, snap3) = restrict_daemon_from(&map).expect("skip tolerated");
         assert!(isset(b), "unschedulable is worse than unprotected");
         release_daemon_to(&map, &snap3).expect("release3");
+        assert!(
+            isset(b) && !isset(a) && !isset(c),
+            "a skipped thread's original mask is restored verbatim, never unioned"
+        );
 
         let rc =
             unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -192,27 +192,9 @@ pub const SYSFS_CPU: &str = "/sys/devices/system/cpu";
 /// Applied to every task in `/proc/self/task`; threads spawned later
 /// inherit their creator's mask.
 #[cfg(target_os = "linux")]
-pub fn restrict_daemon_from(map: &CoreMap) -> Result<usize, String> {
-    edit_all_thread_masks(map, false)
-}
-
-/// The inverse: give VPP's cores back to every daemon thread, for the
-/// paths where no VPP is left to protect — a bring-up that rolled back
-/// cleanly, and a detach whose teardown completed. Union rather than a
-/// saved-mask restore: threads born during the restricted epoch have no
-/// prior mask to restore, and a union is correct for every thread that
-/// was restricted here. The one distortion — an operator mask that
-/// itself excluded VPP's cores gains them back — corrects itself at the
-/// daemon's next start, and is the price of not persisting per-thread
-/// state across an epoch in which threads are born and die.
-#[cfg(target_os = "linux")]
-pub fn release_daemon_to(map: &CoreMap) -> Result<usize, String> {
-    edit_all_thread_masks(map, true)
-}
-
-#[cfg(target_os = "linux")]
-fn edit_all_thread_masks(map: &CoreMap, add: bool) -> Result<usize, String> {
+pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
     let mut edited = 0usize;
+    let mut saved = AffinitySnapshot::default();
     let mut errors: Vec<String> = Vec::new();
     let tasks =
         std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
@@ -233,14 +215,11 @@ fn edit_all_thread_masks(map: &CoreMap, add: bool) -> Result<usize, String> {
             // not a fault.
             continue;
         }
+        let before = mask;
         for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
-            if add {
-                unsafe { libc::CPU_SET(cpu as usize, &mut mask) };
-            } else {
-                unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
-            }
+            unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
         }
-        if !add && unsafe { libc::CPU_COUNT(&mask) } == 0 {
+        if unsafe { libc::CPU_COUNT(&mask) } == 0 {
             tracing::warn!(
                 tid,
                 "this thread's whole mask IS VPP's cores; leaving it untouched — an \
@@ -248,6 +227,97 @@ fn edit_all_thread_masks(map: &CoreMap, add: bool) -> Result<usize, String> {
             );
             continue;
         }
+        let rc =
+            unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
+        if rc == 0 {
+            edited += 1;
+            saved.masks.push((tid, before));
+        } else {
+            errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
+        }
+    }
+    if edited == 0 && !errors.is_empty() {
+        return Err(format!(
+            "no thread accepted its affinity change: {}",
+            errors.join("; ")
+        ));
+    }
+    if !errors.is_empty() {
+        tracing::warn!(
+            edited,
+            failed = errors.len(),
+            "some threads kept their old affinity: {}",
+            errors.join("; ")
+        );
+    }
+    Ok((edited, saved))
+}
+
+/// The masks each thread held BEFORE restriction, so release restores
+/// the operator's policy exactly rather than approximating it.
+///
+/// Union-on-release was the first design and review rejected it
+/// rightly: an operator mask that itself excluded one of VPP's cores
+/// would gain it back on rollback or detach, widening the daemon onto
+/// silicon the operator reserved. Surviving threads restore their
+/// captured mask verbatim; threads born during the restricted epoch
+/// (no capture) fall back to union, which is exact for them — they
+/// inherited a restricted mask whose only edit was ours.
+#[derive(Default, Clone)]
+pub struct AffinitySnapshot {
+    #[cfg(target_os = "linux")]
+    masks: Vec<(libc::pid_t, libc::cpu_set_t)>,
+}
+
+impl std::fmt::Debug for AffinitySnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[cfg(target_os = "linux")]
+        return write!(f, "AffinitySnapshot({} threads)", self.masks.len());
+        #[cfg(not(target_os = "linux"))]
+        write!(f, "AffinitySnapshot")
+    }
+}
+
+/// The inverse of [`restrict_daemon_from`], for the paths where no VPP
+/// is left to protect — a bring-up that rolled back cleanly, and a
+/// detach whose teardown completed (including one that settles late,
+/// after `detach` itself returned).
+#[cfg(target_os = "linux")]
+pub fn release_daemon_to(map: &CoreMap, saved: &AffinitySnapshot) -> Result<usize, String> {
+    let mut edited = 0usize;
+    let mut errors: Vec<String> = Vec::new();
+    let tasks =
+        std::fs::read_dir("/proc/self/task").map_err(|e| format!("/proc/self/task: {e}"))?;
+    for entry in tasks.flatten() {
+        let Some(tid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+        let mask = match saved.masks.iter().find(|(t, _)| *t == tid) {
+            // A surviving thread gets its pre-restriction mask back,
+            // verbatim — including any exclusion of VPP's cores the
+            // operator had already made.
+            Some((_, m)) => *m,
+            // Born during the restricted epoch: its inherited mask is a
+            // restricted one whose only edit was ours, so the union is
+            // exact.
+            None => {
+                let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let rc = unsafe {
+                    libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut m)
+                };
+                if rc != 0 {
+                    continue; // vanished between readdir and here
+                }
+                for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
+                    unsafe { libc::CPU_SET(cpu as usize, &mut m) };
+                }
+                m
+            }
+        };
         let rc =
             unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
         if rc == 0 {
@@ -274,13 +344,13 @@ fn edit_all_thread_masks(map: &CoreMap, add: bool) -> Result<usize, String> {
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn restrict_daemon_from(_map: &CoreMap) -> Result<usize, String> {
+pub fn restrict_daemon_from(_map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
     // Non-Linux never attaches a VPP; there is nothing to protect.
-    Ok(0)
+    Ok((0, AffinitySnapshot::default()))
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn release_daemon_to(_map: &CoreMap) -> Result<usize, String> {
+pub fn release_daemon_to(_map: &CoreMap, _saved: &AffinitySnapshot) -> Result<usize, String> {
     Ok(0)
 }
 
@@ -305,52 +375,58 @@ mod affinity_tests {
         assert_eq!(rc, 0);
     }
 
-    /// Asserting the SYSCALL's effect via readback, not the intent:
-    /// subtraction preserves an operator's narrower policy (bits they
-    /// cleared stay cleared), release unions VPP's cores back, and a
-    /// mask that would become empty is left untouched.
-    #[test]
-    fn subtraction_preserves_narrow_masks_and_release_returns_the_cores() {
-        let online = unsafe { libc::sysconf(libc::_SC_NPROCESSORS_ONLN) };
-        if online < 3 {
-            return; // cannot express "narrower than the host" on <3 CPUs
-        }
-        let before = current_mask();
+    fn isset(cpu: usize) -> bool {
+        unsafe { libc::CPU_ISSET(cpu, &current_mask()) }
+    }
 
-        // Operator narrowed the daemon to {0, 1}; VPP takes core 1.
-        set_mask(&[0, 1]);
+    /// Asserting the SYSCALL's effect via readback, not the intent.
+    /// CPU ids come from THIS process's allowed mask, not from ids
+    /// synthesized off a count — a container whose cpuset excludes low
+    /// ids would otherwise fail the harness before the implementation
+    /// (review finding).
+    #[test]
+    fn restriction_subtracts_and_release_restores_the_saved_masks() {
+        let before = current_mask();
+        let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
+            .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })
+            .collect();
+        if allowed.len() < 3 {
+            return; // cannot express "narrower than allowed" here
+        }
+        let (a, b, c) = (allowed[0], allowed[1], allowed[2]);
         let map = CoreMap {
-            main: 1,
+            main: b as u16,
             workers: vec![],
         };
-        restrict_daemon_from(&map).expect("restrict");
-        let got = current_mask();
-        assert!(!unsafe { libc::CPU_ISSET(1, &got) }, "VPP's core excluded");
-        assert!(unsafe { libc::CPU_ISSET(0, &got) }, "the rest kept");
+
+        // Operator narrowed the daemon to {a, b}; VPP takes b; the
+        // operator's exclusion of c must survive every step.
+        set_mask(&[a, b]);
+        let (n, snap) = restrict_daemon_from(&map).expect("restrict");
+        assert!(n >= 1);
+        assert!(!isset(b), "VPP's core excluded");
+        assert!(isset(a), "the rest kept");
+        assert!(!isset(c), "subtract, never rebuild");
+
+        release_daemon_to(&map, &snap).expect("release");
+        assert!(isset(b), "the saved mask gave VPP's core back");
+        assert!(!isset(c), "and added nothing the operator excluded");
+
+        // The finding that killed union-on-release: an operator mask
+        // that ALREADY excluded VPP's core must not gain it back.
+        set_mask(&[a]);
+        let (_, snap2) = restrict_daemon_from(&map).expect("restrict2");
+        release_daemon_to(&map, &snap2).expect("release2");
         assert!(
-            !unsafe { libc::CPU_ISSET(2, &got) },
-            "the operator's exclusion of CPU 2 must survive — subtract, never rebuild"
+            !isset(b),
+            "a mask that never held VPP's core must not acquire it on release"
         );
 
-        release_daemon_to(&map).expect("release");
-        let got = current_mask();
-        assert!(
-            unsafe { libc::CPU_ISSET(1, &got) },
-            "release gives VPP's core back"
-        );
-        assert!(
-            !unsafe { libc::CPU_ISSET(2, &got) },
-            "and adds nothing else"
-        );
-
-        // A mask that IS VPP's cores must be skipped, not emptied.
-        set_mask(&[1]);
-        restrict_daemon_from(&map).expect("restrict tolerates the skip");
-        let got = current_mask();
-        assert!(
-            unsafe { libc::CPU_ISSET(1, &got) },
-            "an unschedulable thread is worse than an unprotected worker"
-        );
+        // A mask that IS VPP's cores is skipped, not emptied.
+        set_mask(&[b]);
+        let (_, snap3) = restrict_daemon_from(&map).expect("skip tolerated");
+        assert!(isset(b), "unschedulable is worse than unprotected");
+        release_daemon_to(&map, &snap3).expect("release3");
 
         let rc =
             unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -274,13 +274,18 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
         // setaffinity failed, would then be missing from the snapshot
         // and wrongly unioned VPP's cores on release, broadening a
         // policy it never had restricted.
-        saved.masks.push((tid, started, before));
         // Narrow the intersection with this thread's original policy.
         saved
             .restorable
             .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
+        // Exactly the VPP cores this thread actually held — the set
+        // release will put back, and nothing more.
+        let mut removed: Vec<u16> = Vec::new();
         for cpu in std::iter::once(map.main).chain(map.workers.iter().copied()) {
-            unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
+            if unsafe { libc::CPU_ISSET(cpu as usize, &mask) } {
+                unsafe { libc::CPU_CLR(cpu as usize, &mut mask) };
+                removed.push(cpu);
+            }
         }
         if unsafe { libc::CPU_COUNT(&mask) } == 0 {
             tracing::warn!(
@@ -288,13 +293,20 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
                 "this thread's whole mask IS VPP's cores; leaving it untouched — an \
                  unschedulable thread is worse than an unprotected worker"
             );
+            // Observed, but nothing removed: recorded so release knows
+            // it is not a post-attach stranger, and leaves it alone.
+            saved.masks.push((tid, started, Vec::new()));
             continue;
         }
         let rc =
             unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
         if rc == 0 {
             edited += 1;
+            saved.masks.push((tid, started, removed));
         } else {
+            // The change did not land, so nothing was removed from this
+            // thread — but it was observed, and release must know that.
+            saved.masks.push((tid, started, Vec::new()));
             errors.push(format!("tid {tid}: {}", std::io::Error::last_os_error()));
         }
     }
@@ -315,14 +327,23 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
     Ok((edited, saved))
 }
 
-/// The masks each thread held BEFORE restriction, so release restores
-/// the operator's policy exactly rather than approximating it.
+/// What this attachment removed from each thread, so release is the
+/// exact inverse of the restriction and nothing else.
 ///
-/// Union-on-release was the first design and review rejected it
-/// rightly: an operator mask that itself excluded one of VPP's cores
-/// would gain it back on rollback or detach, widening the daemon onto
-/// silicon the operator reserved. Surviving threads restore their
-/// captured mask verbatim.
+/// Storing the whole pre-attach mask was the previous design and review
+/// rejected it rightly: restoring it verbatim discards any change the
+/// operator made WHILE VPP was attached (a `taskset` mid-attachment),
+/// re-enabling CPUs they had since excluded. Restriction only ever
+/// clears VPP-core bits, so its inverse is to set exactly those bits
+/// back on whatever the thread's mask is at release time — every other
+/// bit, however it got that way, is left alone.
+///
+/// Recording the removed set per thread also subsumes two earlier
+/// findings for free: a thread whose policy already excluded a VPP core
+/// has that core in nobody's removed set, so it can never gain it; and
+/// a thread we observed but skipped (its mask would have emptied) or
+/// failed to set has an EMPTY removed set, so release leaves it exactly
+/// as found while still proving it is not a post-attach stranger.
 ///
 /// A thread born DURING the restricted epoch has no capture, and no
 /// exact inverse exists for it — we never saw its creator's original
@@ -337,7 +358,7 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
 /// can reason about.
 #[derive(Default, Clone)]
 pub struct AffinitySnapshot {
-    /// `(tid, start_ticks, original mask)`.
+    /// `(tid, start_ticks, the VPP cores THIS attachment removed)`.
     ///
     /// The start time is what makes the tid an IDENTITY rather than a
     /// number. A thread can exit during a long attachment and Linux can
@@ -348,7 +369,7 @@ pub struct AffinitySnapshot {
     /// never enough — and it reuses that module's `/proc` stat parser
     /// rather than growing a second one.
     #[cfg(target_os = "linux")]
-    masks: Vec<(libc::pid_t, u64, libc::cpu_set_t)>,
+    masks: Vec<(libc::pid_t, u64, Vec<u16>)>,
     /// VPP cores present in the original mask of every observed thread.
     /// See the type docs: the only cores a post-attach thread can be
     /// given back without guessing.
@@ -396,42 +417,39 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
         // The tid must match AND be the same thread: a reused tid names
         // a stranger, whose mask is none of our business to restore.
         let started = thread_start_ticks(tid);
-        let mask = match saved
+        // Read the CURRENT mask either way: release edits what the
+        // thread has now, so an operator's mid-attachment `taskset`
+        // survives (review finding).
+        let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
+        };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            if mask_too_small(&err) {
+                return Err(format!(
+                    "this host's CPU mask is wider than a fixed cpu_set_t can express: {err}"
+                ));
+            }
+            continue; // vanished between readdir and here
+        }
+        let give_back: &[u16] = match saved
             .masks
             .iter()
             .find(|(t, s, _)| *t == tid && Some(*s) == started)
         {
-            // A surviving thread gets its pre-restriction mask back,
-            // verbatim — including any exclusion of VPP's cores the
-            // operator had already made.
-            Some((_, _, m)) => *m,
+            // A surviving thread gets back exactly the cores THIS
+            // attachment took from it — never a whole stale mask.
+            Some((_, _, removed)) => removed,
             // Born during the restricted epoch (or a reused tid, which
-            // is the same thing from here): no capture applies, so only
-            // the cores EVERY pre-existing thread held go back —
-            // see `AffinitySnapshot`. Adding all of VPP's cores here
-            // would hand a child a core its creator's policy never
-            // allowed (review finding).
-            None => {
-                let mut m: libc::cpu_set_t = unsafe { std::mem::zeroed() };
-                let rc = unsafe {
-                    libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut m)
-                };
-                if rc != 0 {
-                    let err = std::io::Error::last_os_error();
-                    if mask_too_small(&err) {
-                        return Err(format!(
-                            "this host's CPU mask is wider than a fixed cpu_set_t can \
-                             express: {err}"
-                        ));
-                    }
-                    continue; // vanished between readdir and here
-                }
-                for cpu in &saved.restorable {
-                    unsafe { libc::CPU_SET(*cpu as usize, &mut m) };
-                }
-                m
-            }
+            // is the same thing from here): no per-thread record
+            // applies, so only the cores EVERY pre-existing thread held
+            // go back — see `AffinitySnapshot`.
+            None => &saved.restorable,
         };
+        for cpu in give_back {
+            unsafe { libc::CPU_SET(*cpu as usize, &mut mask) };
+        }
         let rc =
             unsafe { libc::sched_setaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mask) };
         if rc == 0 {
@@ -548,9 +566,17 @@ mod affinity_tests {
         assert!(isset(a), "the rest kept");
         assert!(!isset(c), "subtract, never rebuild");
 
+        // An operator retunes the daemon WHILE VPP is attached: c is
+        // added, and that change must survive release. Restoring a
+        // whole pre-attach mask would silently discard it (review
+        // finding); adding back only what was removed cannot.
+        set_mask(&[a, c]);
         release_daemon_to(&snap).expect("release");
-        assert!(isset(b), "the saved mask gave VPP's core back");
-        assert!(!isset(c), "and added nothing the operator excluded");
+        assert!(isset(b), "the core this attachment removed came back");
+        assert!(
+            isset(c),
+            "an affinity change made during the attachment must survive release"
+        );
 
         // The finding that killed union-on-release: an operator mask
         // that ALREADY excluded VPP's core must not gain it back.

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -219,16 +219,7 @@ fn mask_too_small(e: &std::io::Error) -> bool {
 #[cfg(target_os = "linux")]
 pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), String> {
     let mut edited = 0usize;
-    // `restorable` starts as all of VPP's cores and is narrowed by every
-    // thread we observe, ending as the intersection: the cores a thread
-    // born later can be given back without guessing at its creator's
-    // policy.
-    let mut saved = AffinitySnapshot {
-        restorable: std::iter::once(map.main)
-            .chain(map.workers.iter().copied())
-            .collect(),
-        ..Default::default()
-    };
+    let mut saved = AffinitySnapshot::default();
     let mut errors: Vec<String> = Vec::new();
     // Rescan until a whole pass finds nothing new.
     //
@@ -305,15 +296,6 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
                 // Threads exit between readdir and here; a vanished tid is
                 // not a fault.
                 continue;
-            }
-            let before = mask;
-            // Narrow the intersection with this thread's ORIGINAL
-            // policy — first pass only, since that is the only pass
-            // whose masks predate our own edits.
-            if first_pass {
-                saved
-                    .restorable
-                    .retain(|cpu| unsafe { libc::CPU_ISSET(*cpu as usize, &before) });
             }
             // Exactly the VPP cores this thread actually held — the set
             // release will put back, and nothing more.
@@ -405,11 +387,15 @@ pub fn restrict_daemon_from(map: &CoreMap) -> Result<(usize, AffinitySnapshot), 
 /// failed to set has an EMPTY removed set, so release leaves it exactly
 /// as found while still proving it is not a post-attach stranger.
 ///
-/// Only threads seen on the FIRST scan pass appear here. Later passes
-/// exist to catch threads spawned mid-scan, and those carry a mask this
-/// function already narrowed — recording that as their "original" would
-/// both empty `restorable` and promise them nothing back. They belong
-/// on the descendant path, which `restorable` answers correctly.
+/// Only threads seen on the FIRST scan pass appear here, and only they
+/// are ever edited by release. Later passes exist to catch threads
+/// spawned mid-scan; those carry a mask this function already narrowed,
+/// so there is no original policy to record for them — and release
+/// leaves them alone rather than guessing. They keep a mask missing
+/// VPP's cores until the daemon restarts, which is under-restoration:
+/// the direction this whole mechanism prefers, and the only one that
+/// cannot override an operator who retuned that thread by hand while
+/// VPP was attached (review finding).
 ///
 /// A thread born DURING the restricted epoch has no capture, and no
 /// exact inverse exists for it — we never saw its creator's original
@@ -436,16 +422,6 @@ pub struct AffinitySnapshot {
     /// rather than growing a second one.
     #[cfg(target_os = "linux")]
     masks: Vec<(libc::pid_t, u64, Vec<u16>)>,
-    /// VPP cores present in the original mask of every observed thread.
-    /// See the type docs: the only cores a post-attach thread can be
-    /// given back without guessing.
-    ///
-    /// Read only by the Linux `release_daemon_to`; the non-Linux stubs
-    /// never restrict, so nothing there consults it. Gated to match
-    /// `masks` rather than `allow(dead_code)`, so a genuinely unread
-    /// field on Linux would still be caught.
-    #[cfg(target_os = "linux")]
-    restorable: Vec<u16>,
 }
 
 impl std::fmt::Debug for AffinitySnapshot {
@@ -491,9 +467,27 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
         // The tid must match AND be the same thread: a reused tid names
         // a stranger, whose mask is none of our business to restore.
         let started = thread_start_ticks(tid);
-        // Read the CURRENT mask either way: release edits what the
-        // thread has now, so an operator's mid-attachment `taskset`
-        // survives (review finding).
+        // Only a thread THIS attachment restricted is edited. A thread
+        // born during the epoch — or a reused tid, which is the same
+        // thing from here — is left exactly as it is: we never took a
+        // core from it, we do not know what its creator's policy was,
+        // and an operator may have retuned it by hand since. Adding
+        // anything there would override a live policy on a guess, and
+        // the guess has now been wrong in three distinct ways (review
+        // findings). Under-restoring until the daemon's next start is
+        // the direction this mechanism prefers.
+        let Some((_, _, removed)) = saved
+            .masks
+            .iter()
+            .find(|(t, s, _)| *t == tid && Some(*s) == started)
+        else {
+            continue;
+        };
+        if removed.is_empty() {
+            continue; // nothing was taken; nothing to give back
+        }
+        // The CURRENT mask, so an operator's mid-attachment `taskset`
+        // survives — release adds bits, it never replaces a policy.
         let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
         let rc = unsafe {
             libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
@@ -507,21 +501,7 @@ pub fn release_daemon_to(saved: &AffinitySnapshot) -> Result<usize, String> {
             }
             continue; // vanished between readdir and here
         }
-        let give_back: &[u16] = match saved
-            .masks
-            .iter()
-            .find(|(t, s, _)| *t == tid && Some(*s) == started)
-        {
-            // A surviving thread gets back exactly the cores THIS
-            // attachment took from it — never a whole stale mask.
-            Some((_, _, removed)) => removed,
-            // Born during the restricted epoch (or a reused tid, which
-            // is the same thing from here): no per-thread record
-            // applies, so only the cores EVERY pre-existing thread held
-            // go back — see `AffinitySnapshot`.
-            None => &saved.restorable,
-        };
-        for cpu in give_back {
+        for cpu in removed {
             unsafe { libc::CPU_SET(*cpu as usize, &mut mask) };
         }
         let rc =
@@ -682,18 +662,17 @@ mod affinity_tests {
         assert_eq!(rc, 0);
     }
 
-    /// A thread born during the restricted epoch must never be handed a
-    /// core its creator's policy excluded.
+    /// A thread born during the restricted epoch is left alone by
+    /// release — never handed a core on a guess.
     ///
-    /// No exact inverse exists for such a thread — we never saw its
-    /// creator's original mask — so release adds only the VPP cores
-    /// EVERY observed thread held. Here the calling thread's policy
-    /// excludes VPP's core, so that intersection is empty and the child
-    /// must come back with nothing added. Unioning all of VPP's cores
-    /// (the previous behaviour) hands it a core the operator never
-    /// allowed; that is what this pins.
+    /// We took nothing from it, we never saw its creator's policy, and
+    /// an operator may have retuned it by hand since. Three successive
+    /// review findings showed every flavour of guess here to be wrong
+    /// in some reachable case, so release now edits only the threads it
+    /// actually restricted. This pins the consequence: the child does
+    /// not acquire VPP's core.
     #[test]
-    fn a_thread_born_after_restriction_gains_only_universally_held_cores() {
+    fn a_thread_born_after_restriction_is_left_alone_by_release() {
         use std::sync::mpsc::channel;
 
         let _serialised = lock_affinity();

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -387,7 +387,7 @@ pub struct VppOffloadModule {
     /// teardown that finished successfully afterwards left the daemon
     /// confined to a subset of its cores until restart, even though VPP
     /// was gone (review finding).
-    deferred_core_release: Option<(cores::CoreMap, cores::AffinitySnapshot)>,
+    deferred_core_release: Option<cores::AffinitySnapshot>,
     /// Set when a `detach` could not confirm the teardown.
     ///
     /// Outlives the attachment on purpose. `detach` takes `attached` before
@@ -495,15 +495,15 @@ impl VppOffloadModule {
         // so the cores held across the budget overrun go back now, with
         // the operator's saved masks. A late teardown that settled dirty
         // keeps them: resources may still be held on those cores.
-        if let Some((cm, snap)) = self.deferred_core_release.take() {
+        if let Some(snap) = self.deferred_core_release.take() {
             if self.teardown_failure.is_none() {
-                if let Err(e) = cores::release_daemon_to(&cm, &snap) {
+                if let Err(e) = cores::release_daemon_to(&snap) {
                     tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
                 }
             } else {
-                // Dirty settle: hold the cores AND keep the pair, so a
-                // later reconcile that flips to clean can still restore.
-                self.deferred_core_release = Some((cm, snap));
+                // Dirty settle: hold the cores AND keep the snapshot, so
+                // a later reconcile that flips to clean can still restore.
+                self.deferred_core_release = Some(snap);
             }
         }
     }
@@ -860,7 +860,7 @@ impl Module for VppOffloadModule {
         // affinity restore needs them on every exit — including the one
         // where `stop()` overruns and `attached` is gone by the time the
         // teardown settles.
-        let core_release = (attached.cores.clone(), attached.affinity.clone());
+        let core_release = attached.affinity.clone();
         // `stop` drives the supervisor's full teardown ordering —
         // unsteer if steered, abort convergence, kill, release — and
         // waits out its bounded patience. The final snapshot is the only
@@ -909,8 +909,7 @@ impl Module for VppOffloadModule {
         // with the operator's pre-restriction masks. This path did not
         // stash into `deferred_core_release` (pending was None), so there
         // is nothing there to double-release.
-        let (cm, snap) = &core_release;
-        if let Err(e) = cores::release_daemon_to(cm, snap) {
+        if let Err(e) = cores::release_daemon_to(&core_release) {
             tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
         }
         Ok(())

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -867,6 +867,13 @@ impl Module for VppOffloadModule {
                 }
             )));
         }
+        // The teardown completed and released everything: no VPP is
+        // left to protect, so the daemon gets its cores back. Failure
+        // paths above deliberately do NOT — resources still held means
+        // a VPP may still be running on those cores.
+        if let Err(e) = cores::release_daemon_to(&attached.cores) {
+            tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
+        }
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -378,6 +378,16 @@ pub struct VppOffloadModule {
     /// and why — instead of the message pointing at a status nobody can
     /// reach.
     teardown_pending: Option<service::PendingTeardown>,
+    /// VPP's cores and the pre-restriction masks, held across a pending
+    /// teardown so `reconcile_pending_teardown` can restore the daemon's
+    /// affinity once a late teardown settles clean.
+    ///
+    /// Without this, a `stop()` that overran the detach budget dropped
+    /// `attached` — and with it the `CoreMap`/`AffinitySnapshot` — so a
+    /// teardown that finished successfully afterwards left the daemon
+    /// confined to a subset of its cores until restart, even though VPP
+    /// was gone (review finding).
+    deferred_core_release: Option<(cores::CoreMap, cores::AffinitySnapshot)>,
     /// Set when a `detach` could not confirm the teardown.
     ///
     /// Outlives the attachment on purpose. `detach` takes `attached` before
@@ -400,6 +410,7 @@ impl VppOffloadModule {
             source: None,
             attached: None,
             teardown_pending: None,
+            deferred_core_release: None,
             teardown_failure: None,
         }
     }
@@ -480,6 +491,21 @@ impl VppOffloadModule {
         // `None` clears the provisional failure: it finished cleanly after
         // all, and the failure was about the budget rather than the outcome.
         self.teardown_failure = settled_verdict(&final_status);
+        // A late teardown that settled clean means VPP is finally gone —
+        // so the cores held across the budget overrun go back now, with
+        // the operator's saved masks. A late teardown that settled dirty
+        // keeps them: resources may still be held on those cores.
+        if let Some((cm, snap)) = self.deferred_core_release.take() {
+            if self.teardown_failure.is_none() {
+                if let Err(e) = cores::release_daemon_to(&cm, &snap) {
+                    tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
+                }
+            } else {
+                // Dirty settle: hold the cores AND keep the pair, so a
+                // later reconcile that flips to clean can still restore.
+                self.deferred_core_release = Some((cm, snap));
+            }
+        }
     }
 
     /// Record a teardown that could not be confirmed, and build the error
@@ -830,6 +856,11 @@ impl Module for VppOffloadModule {
         let Some(attached) = self.attached.take() else {
             return Ok(());
         };
+        // Captured before `stop()` consumes the service, because the
+        // affinity restore needs them on every exit — including the one
+        // where `stop()` overruns and `attached` is gone by the time the
+        // teardown settles.
+        let core_release = (attached.cores.clone(), attached.affinity.clone());
         // `stop` drives the supervisor's full teardown ordering —
         // unsteer if steered, abort convergence, kill, release — and
         // waits out its bounded patience. The final snapshot is the only
@@ -839,6 +870,12 @@ impl Module for VppOffloadModule {
         // dropped: `stop()`'s message sends the operator to `packetframe
         // status`, and this is what makes that reachable — `health_check`
         // below reports through it until the loop settles.
+        if report.pending.is_some() {
+            // Hand the cores to reconciliation, which runs when the loop
+            // finally settles: releasing now would return them while VPP
+            // may still be alive on them.
+            self.deferred_core_release = Some(core_release.clone());
+        }
         self.teardown_pending = report.pending;
         let Some(p) = report.published else {
             return Err(self.remember_teardown_failure(
@@ -867,11 +904,13 @@ impl Module for VppOffloadModule {
                 }
             )));
         }
-        // The teardown completed and released everything: no VPP is
-        // left to protect, so the daemon gets its cores back. Failure
-        // paths above deliberately do NOT — resources still held means
-        // a VPP may still be running on those cores.
-        if let Err(e) = cores::release_daemon_to(&attached.cores) {
+        // The teardown completed synchronously and released everything:
+        // no VPP is left to protect, so the daemon gets its cores back
+        // with the operator's pre-restriction masks. This path did not
+        // stash into `deferred_core_release` (pending was None), so there
+        // is nothing there to double-release.
+        let (cm, snap) = &core_release;
+        if let Err(e) = cores::release_daemon_to(cm, snap) {
             tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
         }
         Ok(())

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -378,16 +378,6 @@ pub struct VppOffloadModule {
     /// and why — instead of the message pointing at a status nobody can
     /// reach.
     teardown_pending: Option<service::PendingTeardown>,
-    /// VPP's cores and the pre-restriction masks, held across a pending
-    /// teardown so `reconcile_pending_teardown` can restore the daemon's
-    /// affinity once a late teardown settles clean.
-    ///
-    /// Without this, a `stop()` that overran the detach budget dropped
-    /// `attached` — and with it the `CoreMap`/`AffinitySnapshot` — so a
-    /// teardown that finished successfully afterwards left the daemon
-    /// confined to a subset of its cores until restart, even though VPP
-    /// was gone (review finding).
-    deferred_core_release: Option<cores::AffinitySnapshot>,
     /// Set when a `detach` could not confirm the teardown.
     ///
     /// Outlives the attachment on purpose. `detach` takes `attached` before
@@ -410,7 +400,6 @@ impl VppOffloadModule {
             source: None,
             attached: None,
             teardown_pending: None,
-            deferred_core_release: None,
             teardown_failure: None,
         }
     }
@@ -491,21 +480,6 @@ impl VppOffloadModule {
         // `None` clears the provisional failure: it finished cleanly after
         // all, and the failure was about the budget rather than the outcome.
         self.teardown_failure = settled_verdict(&final_status);
-        // A late teardown that settled clean means VPP is finally gone —
-        // so the cores held across the budget overrun go back now, with
-        // the operator's saved masks. A late teardown that settled dirty
-        // keeps them: resources may still be held on those cores.
-        if let Some(snap) = self.deferred_core_release.take() {
-            if self.teardown_failure.is_none() {
-                if let Err(e) = cores::release_daemon_to(&snap) {
-                    tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
-                }
-            } else {
-                // Dirty settle: hold the cores AND keep the snapshot, so
-                // a later reconcile that flips to clean can still restore.
-                self.deferred_core_release = Some(snap);
-            }
-        }
     }
 
     /// Record a teardown that could not be confirmed, and build the error
@@ -856,11 +830,6 @@ impl Module for VppOffloadModule {
         let Some(attached) = self.attached.take() else {
             return Ok(());
         };
-        // Captured before `stop()` consumes the service, because the
-        // affinity restore needs them on every exit — including the one
-        // where `stop()` overruns and `attached` is gone by the time the
-        // teardown settles.
-        let core_release = attached.affinity.clone();
         // `stop` drives the supervisor's full teardown ordering —
         // unsteer if steered, abort convergence, kill, release — and
         // waits out its bounded patience. The final snapshot is the only
@@ -870,12 +839,6 @@ impl Module for VppOffloadModule {
         // dropped: `stop()`'s message sends the operator to `packetframe
         // status`, and this is what makes that reachable — `health_check`
         // below reports through it until the loop settles.
-        if report.pending.is_some() {
-            // Hand the cores to reconciliation, which runs when the loop
-            // finally settles: releasing now would return them while VPP
-            // may still be alive on them.
-            self.deferred_core_release = Some(core_release.clone());
-        }
         self.teardown_pending = report.pending;
         let Some(p) = report.published else {
             return Err(self.remember_teardown_failure(
@@ -904,14 +867,9 @@ impl Module for VppOffloadModule {
                 }
             )));
         }
-        // The teardown completed synchronously and released everything:
-        // no VPP is left to protect, so the daemon gets its cores back
-        // with the operator's pre-restriction masks. This path did not
-        // stash into `deferred_core_release` (pending was None), so there
-        // is nothing there to double-release.
-        if let Err(e) = cores::release_daemon_to(&core_release) {
-            tracing::warn!(error = %e, "could not return VPP's cores to the daemon");
-        }
+        // The daemon's affinity restriction is deliberately not undone:
+        // a CPU mask is per-process state and every caller of this
+        // method exits the process (see `cores::restrict_daemon_from`).
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -121,6 +121,26 @@ pub struct ResourceState {
     /// newer than this field.)
     #[serde(default)]
     pub expected_routes: u64,
+    /// The CPUs VPP's threads were placed on — main plus every worker,
+    /// as one flat set.
+    ///
+    /// Recorded for the same reason as `expected_routes`, and it is the
+    /// same failure one variable over: VPP fixes thread placement **at
+    /// start**, so a daemon restart that re-derives the map from a
+    /// CHANGED online CPU set (a core offlined for thermal reasons, or
+    /// administratively) computes cores the surviving VPP is not on.
+    /// The daemon would then vacate the wrong CPUs and leave the real
+    /// worker sharing one with a resync burst — silently restoring the
+    /// preemption this whole mechanism exists to remove, and doing it
+    /// only on an adoption, which is where it is hardest to notice.
+    ///
+    /// `serde(default)` for the reason the field above carries it: a
+    /// file written before this existed must still parse, since
+    /// `detach --all` reads the same struct and a parse error would
+    /// wedge the release door. An empty set simply means "nothing
+    /// recorded", and the derived map stands alone.
+    #[serde(default)]
+    pub vpp_cores: Vec<u16>,
     /// Hugepages reserved at attach: (pool bytes, page count).
     /// `(0, 0)` = attach found a sufficient pre-existing reservation
     /// and owns nothing (release then leaves reservations alone).
@@ -188,6 +208,7 @@ impl ResourceState {
         Self {
             version: STATE_VERSION,
             expected_routes: 0,
+            vpp_cores: Vec::new(),
             hugepage_pool_bytes: 0,
             hugepage_pages: 0,
             hugepage_prior_pages: 0,


### PR DESCRIPTION
## Why three correct fixes never moved the number

Runs 3–6 measured 5.51 s, 5.46 s, 5.46 s, 5.38 s — invariant while we closed three real FIB-side doors (both neighbour senders, then the adj-fib withdrawal; run 6 finally showed the neighbour age monotonic through a full adoption). The counters had been pointing away from the FIB the whole time: `null-node` grew ~500 across two runs against ~3,600 lost frames. **The loss never enters VPP's graph.**

The remaining actor is the scheduler:

```
pid 659758's current affinity list: 0-17     ← the daemon, allowed on every core
RX queue 0: Size is 1024 ... Polling thread is 1   ← the worker, polling core 17
```

`isolcpus` on this fleet belongs to unifi-core; nothing protects VPP's cores from the daemon. At every adopted release, `begin_resync` walks a 1.3M-entry mirror and the first drain batches encode thousands of routes — several seconds of memory-heavy burst that can land on core 17 and preempt the poll loop. The 1024-descriptor rx ring absorbs ~2 s at the drill rate; the arithmetic closes exactly: ~5.4 s stall − ~2 s ring ≈ 1,700 frames ≈ the 1,770–1,905 measured per run, dropped at the NIC where no VPP error counter can see them. It also explains why drill (a) and the 5-hour soak never showed it: no steered traffic during a daemon burst.

## The fix

The cpuset half of the plan's core-map promise ("cpuset + SCHED_FIFO"), automated: at attach — before any VPP exists to protect — every thread in `/proc/self/task` is restricted to online-cores-minus-VPP's (main + workers); threads spawned later inherit. Warn-and-continue on partial refusal (a constraining cgroup degrades protection; failing the attach would brick boxes that currently share cores gracefully); an empty mask is refused outright.

## Verification

- Linux-gated test asserts the **syscall's effect** (sched_getaffinity readback: VPP's core excluded, the rest kept), not the intent — runs in the qemu matrix.
- Full workspace suites, fmt, clippy host + all four targets green.
- The measured verdict belongs to the seventh drill run; every code-side mechanism is now closed, so a residual gap would be new information rather than a missed door.

🤖 Generated with [Claude Code](https://claude.com/claude-code)