### PR TITLE
fix(vpp-offload): observe an adopted VPP's placement instead of recording it

### DIFF
--- a/crates/modules/vpp-offload/src/acquire.rs
+++ b/crates/modules/vpp-offload/src/acquire.rs
@@ -123,7 +123,6 @@ pub fn acquire(
     ports: &[(String, u16)],
     pages: u32,
     expected_routes: u64,
-    vpp_cores: &[u16],
 ) -> Result<(ResourceState, Acquired), String> {
     // How many leading ports are already recorded. Adoption with a
     // complete record returns early below; a PARTIAL record — a daemon
@@ -225,11 +224,6 @@ pub fn acquire(
         None => {
             let mut state = ResourceState::empty();
             state.expected_routes = expected_routes;
-            // Placement, recorded for the same reason as the sizing:
-            // VPP fixes it at start, so only the file can tell the next
-            // daemon where a surviving VPP's threads actually are. See
-            // `ResourceState::vpp_cores`.
-            state.vpp_cores = vpp_cores.to_vec();
             // Hugepages first. Record the PRIOR count before touching
             // the pool: release restores this value, because zeroing
             // is only correct when the reservation was created from
@@ -510,9 +504,6 @@ fn verify_adoptable(
 pub struct FileStore {
     state: ResourceState,
     state_dir: PathBuf,
-    /// See [`FileStore::with_spawn_cores`]. Empty on the adopt path,
-    /// where the recorded placement is already the running VPP's.
-    spawn_cores: Vec<u16>,
 }
 
 impl FileStore {
@@ -523,24 +514,7 @@ impl FileStore {
         Self {
             state,
             state_dir: state_dir.into(),
-            spawn_cores: Vec::new(),
         }
-    }
-
-    /// The CPUs any VPP **this daemon spawns** will run on: the
-    /// placement rendered into startup.conf at attach, which VPP reads
-    /// at start and which does not change while this daemon lives.
-    ///
-    /// Recorded here rather than at the attach-time adopt-or-spawn
-    /// decision because EVERY spawn must update it, not just the first:
-    /// a daemon that adopts an old VPP and later respawns after it dies
-    /// would otherwise keep naming the dead process's cores, and the
-    /// next daemon would vacate a placement nothing runs on (review
-    /// finding). `process_changed` is the one point every spawn passes
-    /// through, so it is the one place this is written.
-    pub fn with_spawn_cores(mut self, cores: Vec<u16>) -> Self {
-        self.spawn_cores = cores;
-        self
     }
 
     pub fn state(&self) -> &ResourceState {
@@ -565,18 +539,6 @@ impl IdentityStore for FileStore {
                 self.state.vpp_pid = Some(id.pid);
                 self.state.vpp_start_ticks = Some(id.start_ticks);
                 self.state.vpp_boot_id = id.boot_id;
-                // A process this daemon started runs on the placement
-                // this daemon rendered — see `with_spawn_cores`. Every
-                // identity reaching here is such a spawn: adoption
-                // records none (the file already holds it), so
-                // `Runtime::spawn` is the only caller with `Some`.
-                //
-                // The emptiness guard is for a store built without a
-                // placement — the unit fixtures — so they cannot blank
-                // a field they know nothing about.
-                if !self.spawn_cores.is_empty() {
-                    self.state.vpp_cores = self.spawn_cores.clone();
-                }
             }
             None => {
                 self.state.vpp_pid = None;
@@ -667,13 +629,6 @@ impl ResourceOwner {
             paths,
             released: false,
         }
-    }
-
-    /// See [`FileStore::with_spawn_cores`] — the placement every VPP
-    /// this daemon spawns will use.
-    pub fn with_spawn_cores(mut self, cores: Vec<u16>) -> Self {
-        self.store = self.store.with_spawn_cores(cores);
-        self
     }
 }
 
@@ -878,7 +833,7 @@ mod tests {
             "fresh",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Fresh);
         assert_eq!(state.hugepage_pages, 8);
         assert_eq!(state.hugepage_prior_pages, 0);
@@ -901,7 +856,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "0").unwrap(); // no virtfn0
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("eth3"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
 
@@ -939,14 +894,14 @@ mod tests {
             "adopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (first, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (first, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
-        let (second, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (second, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(second, first);
 
         // A config whose port set changed must be refused, not merged.
-        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&f.paths, &[("eth2".into(), 1)], 8, ROUTES).unwrap_err();
         assert!(err.contains("cannot change across an adoption"), "{err}");
     }
 
@@ -960,7 +915,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "3").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(state.hugepage_prior_pages, 3);
 
         release(&f.paths, state).unwrap();
@@ -983,7 +938,7 @@ mod tests {
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "10").unwrap();
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(state.hugepage_pages, 0, "we own nothing");
 
         release(&f.paths, state).unwrap();
@@ -1004,7 +959,7 @@ mod tests {
             "store",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut store = FileStore::new(state, &f.paths.state_dir);
 
         store
@@ -1063,7 +1018,7 @@ mod tests {
         // breaks.
         fs::create_dir_all(f.paths.state_dir.join("vpp-offload.json.tmp")).unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("could not record"), "{err}");
         assert!(err.contains("rolled back"), "{err}");
         // Nothing survives: the hugepage reservation is back to prior.
@@ -1085,7 +1040,7 @@ mod tests {
             "hpadopt",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (_state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (_state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -1097,7 +1052,7 @@ mod tests {
         // The reset nobody asked for.
         fs::write(f.paths.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let (_, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Adopted);
         assert_eq!(
             fs::read_to_string(f.paths.hugepage_pool.join("nr_hugepages"))
@@ -1117,9 +1072,9 @@ mod tests {
             "cores",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let changed = vec![("eth2".to_string(), 1u16), ("eth3".to_string(), 4u16)];
-        let err = acquire(&f.paths, &changed, 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&f.paths, &changed, 8, ROUTES).unwrap_err();
         assert!(err.contains("core counts"), "{err}");
     }
 
@@ -1135,16 +1090,16 @@ mod tests {
             "sizing",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
         assert_eq!(state.expected_routes, 1_600_000, "sizing was not recorded");
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
 
-        let err = acquire(&f.paths, &two_ports(), 8, 2_000_000, &[]).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, 2_000_000).unwrap_err();
         assert!(err.contains("expected-routes 1600000"), "{err}");
         assert!(err.contains("detach --all"), "{err}");
 
         // The unchanged figure still adopts.
-        let (_, how) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
+        let (_, how) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
         assert_eq!(how, Acquired::Adopted);
     }
 
@@ -1164,7 +1119,7 @@ mod tests {
             "sizing-old",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000, &[]).unwrap();
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, 1_600_000).unwrap();
         plant_vfio_links(&f, &["0002:07:00.0", "0002:07:00.1"]);
         state.expected_routes = 0;
         state.save(&f.paths.state_dir).unwrap();
@@ -1173,7 +1128,7 @@ mod tests {
         // sized it — the point is that neither can be *established*, so
         // agreeing by luck must not be the difference.
         for routes in [2_000_000, 1_600_000] {
-            let err = acquire(&f.paths, &two_ports(), 8, routes, &[]).unwrap_err();
+            let err = acquire(&f.paths, &two_ports(), 8, routes).unwrap_err();
             assert!(err.contains("records no `expected-routes`"), "{err}");
             assert!(err.contains("detach --all"), "{err}");
         }
@@ -1192,7 +1147,7 @@ mod tests {
             "wrongpool",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut wrong = f.paths.clone();
         wrong.hugepage_bytes = 2 << 20; // detach pointed at the 2 MiB pool
         let err = release(&wrong, state).unwrap_err();
@@ -1217,7 +1172,7 @@ mod tests {
             "gonevf",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         // eth3's VF disappears out from under the record.
         fs::remove_dir_all(f.paths.pci_devices.join("0002:07:00.1")).unwrap();
 
@@ -1246,7 +1201,7 @@ mod tests {
         fs::create_dir_all(&dev).unwrap();
         fs::write(dev.join("sriov_numvfs"), "3").unwrap();
 
-        let err = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("refuses to guess"), "{err}");
         assert_eq!(
             fs::read_to_string(dev.join("sriov_numvfs")).unwrap(),
@@ -1268,7 +1223,7 @@ mod tests {
         // Simulate the interruption: acquire both, then rewrite the
         // state as if the daemon died before eth3's save — eth3's VF
         // exists and is vfio-bound, but the record stops at eth2.
-        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (mut state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         state.ports.truncate(1);
         state.save(&f.paths.state_dir).unwrap();
         #[cfg(unix)]
@@ -1280,7 +1235,7 @@ mod tests {
             .unwrap();
         }
 
-        let (resumed, how) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (resumed, how) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         assert_eq!(how, Acquired::Resumed);
         assert_eq!(resumed.ports.len(), 2);
         assert_eq!(
@@ -1301,7 +1256,7 @@ mod tests {
             "poolchg",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let _ = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         #[cfg(unix)]
         for pci in ["0002:07:00.0", "0002:07:00.1"] {
             std::os::unix::fs::symlink(
@@ -1318,7 +1273,7 @@ mod tests {
         fs::create_dir_all(&wrong.hugepage_pool).unwrap();
         fs::write(wrong.hugepage_pool.join("nr_hugepages"), "0").unwrap();
 
-        let err = acquire(&wrong, &two_ports(), 8, ROUTES, &[]).unwrap_err();
+        let err = acquire(&wrong, &two_ports(), 8, ROUTES).unwrap_err();
         assert!(err.contains("wrong pool"), "{err}");
         assert_eq!(
             fs::read_to_string(wrong.hugepage_pool.join("nr_hugepages"))
@@ -1338,7 +1293,7 @@ mod tests {
             "sweep",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_0"), "").unwrap();
         fs::write(f.paths.hugetlbfs.join("rtemap_7"), "").unwrap();
 
@@ -1363,7 +1318,7 @@ mod tests {
             "owner",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
 
         // A spawn is recorded the ordinary way, while resources are held.
@@ -1404,7 +1359,7 @@ mod tests {
             "owner-partial",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut owner = SharedOwner::new(ResourceOwner::new(state, f.paths.clone()));
 
         // Make eth2's release fail: remove the netdev dir the numvfs
@@ -1449,7 +1404,7 @@ mod tests {
             "owner-steer",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut owner = ResourceOwner::new(state, f.paths.clone());
 
         let rules = vec![
@@ -1481,7 +1436,7 @@ mod tests {
             "owner-unsteer",
             &[("eth2", "0002:07:00.0"), ("eth3", "0002:07:00.1")],
         );
-        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES, &[]).unwrap();
+        let (state, _) = acquire(&f.paths, &two_ports(), 8, ROUTES).unwrap();
         let mut owner = ResourceOwner::new(state, f.paths.clone());
 
         owner

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -330,79 +330,7 @@ pub fn bring_up(
         );
     };
 
-    // The daemon vacates VPP's cores here — after the LAST pure check,
-    // so a refused config costs no affinity change, and before anything
-    // whose failure the rollback below undoes. The harm this prevents
-    // arrives through the scheduler, not the API: a resync's mirror
-    // walk landing on the worker's core preempts the poll loop, the
-    // 1024-descriptor rx ring overflows in ~2 s, and the drops happen
-    // at the NIC where no VPP counter sees them — a constant ~5.4 s of
-    // loss at every adopted release until this call existed (shadow,
-    // 2026-08-08). Warn-and-continue on partial failure: a cgroup that
-    // refuses the mask degrades protection, and failing the attach over
-    // it would brick deployments that share cores gracefully today.
-    // The cores to vacate: the map just derived, PLUS any placement a
-    // previous attach recorded.
-    //
-    // The union rather than either alone, because which one is right
-    // depends on something not yet known here — whether `finish` below
-    // will adopt a surviving VPP or spawn a fresh one. VPP fixes thread
-    // placement at start, so an adopted VPP is on the RECORDED cores
-    // while a fresh one will be on the DERIVED cores, and the two differ
-    // exactly when the online CPU set changed in between (a core
-    // offlined for thermal reasons, or administratively). Vacating both
-    // sets is correct under either outcome and costs the daemon nothing
-    // when they agree, which is every ordinary restart (review finding).
-    let derived_cores: Vec<u16> = std::iter::once(core_map.main)
-        .chain(core_map.workers.iter().copied())
-        .collect();
-    let mut vacate = derived_cores.clone();
-    if let Ok(Some(prior)) = ResourceState::load(&paths.sys.state_dir) {
-        for cpu in prior.vpp_cores {
-            if !vacate.contains(&cpu) {
-                tracing::info!(
-                    cpu,
-                    "a previous attach placed a VPP thread here; vacating it too in case \
-                     this attach adopts that VPP rather than spawning a new one"
-                );
-                vacate.push(cpu);
-            }
-        }
-    }
-    vacate.sort_unstable();
-    match cores::restrict_daemon_from(&vacate) {
-        // `0` is NOT success: no mask changed, so the daemon is still
-        // free to run on VPP's cores. Logging it as a restriction would
-        // be the claim-because-requested shape this module exists to
-        // avoid — say plainly that it did not happen.
-        Ok(0) => tracing::warn!(
-            vacated = ?vacate,
-            "no daemon thread accepted an affinity change; the daemon can still be \
-             scheduled onto VPP's cores and resync bursts may preempt the worker"
-        ),
-        Ok(threads) => tracing::info!(
-            threads,
-            vacated = ?vacate,
-            "daemon threads restricted away from VPP's cores"
-        ),
-        Err(e) => tracing::warn!(
-            error = %e,
-            "could not restrict the daemon off VPP's cores; expect loss during \
-             resync bursts if they share a core with a worker"
-        ),
-    }
-
-    // The affinity restriction is deliberately NOT undone on this or
-    // any other failure path: see `cores::restrict_daemon_from` — a CPU
-    // mask is per-process state and every one of these paths ends the
-    // daemon, so there is nothing to hand it back to.
-    let (state, acquired) = acquire::acquire(
-        &paths.sys,
-        &ports,
-        pages,
-        cfg.expected_routes,
-        &derived_cores,
-    )?;
+    let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
 
     // From here, every failure releases. `?` would return holding VFs
     // and a hugepage reservation that only the state file knows about —
@@ -598,31 +526,82 @@ fn finish(
         })?,
         None => None,
     };
-    // A LIVE adopted process whose placement is unknown must not be kept.
+    // The daemon vacates VPP's cores here — after adoption has settled
+    // WHOSE cores they are, and before the loop that will do the
+    // bursting starts. The harm arrives through the scheduler, not the
+    // API: a resync's mirror walk landing on the worker's core
+    // preempts the poll loop, the 1024-descriptor rx ring overflows in
+    // ~2 s, and the drops happen at the NIC where no VPP counter sees
+    // them — a constant ~5.4 s of loss at every adopted release until
+    // this existed (shadow, 2026-08-08).
     //
-    // Checked here rather than on the record alone, because the record
-    // naming a pid does not mean that pid is running: `adopt` answers
-    // `Ok(None)` for one that is gone, and a dead VPP constrains
-    // nothing — this daemon will spawn a fresh one and record where it
-    // put it. Refusing on the record was the first version and it
-    // refused every upgrade whose recorded VPP had already exited,
-    // which is most of them (observed on the shadow, 2026-08-08).
+    // The set starts from the derived map, which is where any VPP this
+    // daemon spawns — at attach or as a later supervised respawn —
+    // will be placed. For an ADOPTED process it adds the cores the
+    // process's pinned threads are OBSERVED on, read live from
+    // /proc/<pid>/task (`cores::observed_placement`). Observed rather
+    // than recorded, deliberately: the state-file placement this
+    // replaces went stale along every lifecycle review examined, and
+    // its upgrade guard refused the attach outright — leaving the box
+    // an unsupervised VPP as its only forwarding tier, strictly worse
+    // than the preemption it guarded against (shadow, 2026-08-08).
     //
-    // For a process that IS running the refusal stands, and for the
-    // same reason the incomplete identity cookie is refused above:
-    // unknown is not unconstrained. VPP fixes placement at start, so a
-    // record without it cannot say which cores to keep off, and being
-    // wrong reinstates the preemption silently.
-    if adopted.is_some() && state.vpp_cores.is_empty() {
-        return Err(format!(
-            "{}: the state file records a running VPP but not the CPUs it was placed on \
-             (written by a packetframe from before that was recorded). Its worker's core \
-             cannot be known, so this daemon cannot guarantee it stays off it, and a \
-             resync burst sharing that core is exactly the packet loss this avoids. Stop \
-             that VPP and `packetframe detach --all`, then attach again — the new record \
-             will carry the placement.",
-            crate::service::MAY_HOLD_RESOURCES
-        ));
+    // Every partial failure warns and continues: degraded protection
+    // beats a refused attach for exactly the reason above. And the
+    // restriction is one-way — see `cores::restrict_daemon_from` for
+    // why no path can ever want it undone.
+    let mut vacate: Vec<u16> = std::iter::once(core_map.main)
+        .chain(core_map.workers.iter().copied())
+        .collect();
+    if let Some(vpp) = &adopted {
+        match cores::observed_placement(vpp.pid()) {
+            Ok(observed) if observed.is_empty() => tracing::warn!(
+                pid = vpp.pid(),
+                "the adopted VPP has no pinned threads to observe; vacating the derived \
+                 map only — if its real placement differs, resync bursts may preempt its \
+                 worker"
+            ),
+            Ok(observed) => {
+                for cpu in observed {
+                    if !vacate.contains(&cpu) {
+                        tracing::info!(
+                            cpu,
+                            "the adopted VPP has a thread pinned here, outside the derived \
+                             map; vacating this core too"
+                        );
+                        vacate.push(cpu);
+                    }
+                }
+            }
+            Err(e) => tracing::warn!(
+                pid = vpp.pid(),
+                error = %e,
+                "could not observe the adopted VPP's placement; vacating the derived map \
+                 only — if its real placement differs, resync bursts may preempt its worker"
+            ),
+        }
+    }
+    vacate.sort_unstable();
+    match cores::restrict_daemon_from(&vacate) {
+        // `0` is NOT success: no mask changed, so the daemon is still
+        // free to run on VPP's cores. Logging it as a restriction would
+        // be the claim-because-requested shape this module exists to
+        // avoid — say plainly that it did not happen.
+        Ok(0) => tracing::warn!(
+            vacated = ?vacate,
+            "no daemon thread accepted an affinity change; the daemon can still be \
+             scheduled onto VPP's cores and resync bursts may preempt the worker"
+        ),
+        Ok(threads) => tracing::info!(
+            threads,
+            vacated = ?vacate,
+            "daemon threads restricted away from VPP's cores"
+        ),
+        Err(e) => tracing::warn!(
+            error = %e,
+            "could not restrict the daemon off VPP's cores; expect loss during \
+             resync bursts if they share a core with a worker"
+        ),
     }
     // Whether that VPP is diverting traffic right now. From the recorded
     // steering rules, because that is the only durable evidence — and
@@ -666,11 +645,6 @@ fn finish(
     // (see `service`), which is also why the resource owner is built in
     // here rather than passed in: it shares one record between the
     // identity store and the release seam through an `Rc`.
-    // Owned before the factory closure captures it: the closure outlives
-    // this borrow of `core_map`.
-    let spawn_cores: Vec<u16> = std::iter::once(core_map.main)
-        .chain(core_map.workers.iter().copied())
-        .collect();
     let factory: LoopFactory = Box::new(move || {
         let engine = ConvergenceEngine::new(
             api_socket_path,
@@ -686,24 +660,7 @@ fn finish(
         // borrow checker just refused.
         let inherited_rule_count: usize =
             state.steer_rules.iter().map(|(_, locs)| locs.len()).sum();
-        // The placement any VPP this daemon spawns will run on, handed
-        // to the store rather than written once here: EVERY spawn must
-        // update the record, not just an attach-time decision. A daemon
-        // that adopts an old VPP and later respawns after it dies would
-        // otherwise keep naming the dead process's cores, and the next
-        // daemon would vacate a placement nothing runs on (review
-        // finding). `process_changed` is the single point every spawn
-        // passes through, so the record is written there.
-        //
-        // Unconditional, including on the adopt path: `adopt_process`
-        // records no identity (the file already holds the adopted
-        // one), so the only thing that ever reaches
-        // `process_changed(Some(..))` is a spawn by this daemon — and
-        // an adopted VPP that later dies is replaced by exactly such a
-        // spawn. Gating this on `adopted.is_none()` would leave that
-        // replacement unrecorded, which is the case this finding is
-        // about.
-        let owner = SharedOwner::new(ResourceOwner::new(state, sys).with_spawn_cores(spawn_cores));
+        let owner = SharedOwner::new(ResourceOwner::new(state, sys));
         let runtime = Runtime::new(
             engine,
             source,

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -554,7 +554,7 @@ fn finish(
         .chain(core_map.workers.iter().copied())
         .collect();
     if let Some(vpp) = &adopted {
-        match cores::observed_placement(vpp.pid()) {
+        match cores::observed_placement(vpp.pid(), vpp.start_ticks()) {
             Ok(observed) if observed.is_empty() => tracing::warn!(
                 pid = vpp.pid(),
                 "the adopted VPP has no pinned threads to observe; vacating the derived \

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -581,23 +581,6 @@ fn finish(
             ));
         }
     };
-    // A recorded process whose PLACEMENT is unknown must not be adopted.
-    //
-    // Same rule as the incomplete identity cookie above, and the same
-    // rule `expected_routes == 0` follows in `acquire`: unknown is not
-    // the same as unconstrained. VPP fixes thread placement at start,
-    // so if the file names a live VPP but not the cores it runs on —
-    // a state written by a binary from before `vpp_cores` existed —
-    // then this daemon cannot know which CPUs to keep off. It would
-    // vacate the freshly derived set, which is only right if the online
-    // CPU set has not changed since, and being wrong reinstates the
-    // preemption silently.
-    if prior.is_some() && state.vpp_cores.is_empty() {
-        return Err(format!(
-            "{}: the state file records a running VPP but not the CPUs it was placed on              (written by a packetframe from before that was recorded). Its worker's core              cannot be known, so this daemon cannot guarantee it stays off it, and a              resync burst sharing that core is exactly the packet loss this avoids. Stop              that VPP and `packetframe detach --all`, then attach again — the new record              will carry the placement.",
-            crate::service::MAY_HOLD_RESOURCES
-        ));
-    }
     let adopted: Option<VppProcess> = match prior {
         // A FAILED adoption is marked, because failing is not the same as
         // finding nothing: `adopt` declines cleanly (`Ok(None)`) when the
@@ -615,6 +598,32 @@ fn finish(
         })?,
         None => None,
     };
+    // A LIVE adopted process whose placement is unknown must not be kept.
+    //
+    // Checked here rather than on the record alone, because the record
+    // naming a pid does not mean that pid is running: `adopt` answers
+    // `Ok(None)` for one that is gone, and a dead VPP constrains
+    // nothing — this daemon will spawn a fresh one and record where it
+    // put it. Refusing on the record was the first version and it
+    // refused every upgrade whose recorded VPP had already exited,
+    // which is most of them (observed on the shadow, 2026-08-08).
+    //
+    // For a process that IS running the refusal stands, and for the
+    // same reason the incomplete identity cookie is refused above:
+    // unknown is not unconstrained. VPP fixes placement at start, so a
+    // record without it cannot say which cores to keep off, and being
+    // wrong reinstates the preemption silently.
+    if adopted.is_some() && state.vpp_cores.is_empty() {
+        return Err(format!(
+            "{}: the state file records a running VPP but not the CPUs it was placed on \
+             (written by a packetframe from before that was recorded). Its worker's core \
+             cannot be known, so this daemon cannot guarantee it stays off it, and a \
+             resync burst sharing that core is exactly the packet loss this avoids. Stop \
+             that VPP and `packetframe detach --all`, then attach again — the new record \
+             will carry the placement.",
+            crate::service::MAY_HOLD_RESOURCES
+        ));
+    }
     // Whether that VPP is diverting traffic right now. From the recorded
     // steering rules, because that is the only durable evidence — and
     // getting it wrong in the `false` direction would run the resync on

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -394,6 +394,24 @@ pub fn observed_placement(pid: i32) -> Result<Vec<u16>, String> {
         if unsafe { libc::CPU_COUNT(&mask) } > PINNED_WIDTH_MAX {
             continue;
         }
+        // The tid must still be VPP's AFTER the read, not just at
+        // readdir: `sched_getaffinity` addresses tids globally, so a
+        // VPP thread that exited in between can have its tid recycled
+        // by an unrelated process, whose narrow mask would then be
+        // subtracted from every daemon thread as if it were placement —
+        // and the restriction is one-way, so wrongly for good. A task
+        // directory lists only its own thread group's tids, so this
+        // existence check fails for a tid that migrated to a foreign
+        // process, while a reuse WITHIN VPP names a VPP thread anyway.
+        // Same identity discipline as `restrict_daemon_from`'s
+        // `(tid, start_ticks)` set, shaped for a foreign process
+        // (review finding).
+        if !std::path::Path::new(&task_dir)
+            .join(tid.to_string())
+            .exists()
+        {
+            continue;
+        }
         for cpu in 0..libc::CPU_SETSIZE as usize {
             if unsafe { libc::CPU_ISSET(cpu, &mask) } && !cores.contains(&(cpu as u16)) {
                 cores.push(cpu as u16);

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -360,11 +360,23 @@ const PINNED_WIDTH_MAX: i32 = 2;
 /// any tid's mask (the getter carries no privilege gate, and this
 /// daemon is root regardless). An empty answer means no thread is
 /// pinned narrowly enough to be placement; an `Err` means the process
-/// could not be inspected at all. The caller must treat both as
-/// "observe failed, fall back to the derived map with a warning" —
-/// never as "pinned nowhere, nothing to vacate".
+/// could not be inspected at all — or turned out mid-scan not to be
+/// the process asked about. The caller must treat both as "observe
+/// failed, fall back to the derived map with a warning" — never as
+/// "pinned nowhere, nothing to vacate".
+///
+/// `start_ticks` is the identity the pid must still carry, and it is
+/// re-verified AFTER the walk, which covers the walk: if the process
+/// at `pid` still has the adopted start time when the scan is done,
+/// then it had it throughout — a pid does not return to a process
+/// that lost it. Without this, a VPP that exits after adoption and
+/// has its LEADER pid recycled rebinds the whole `/proc/<pid>/task`
+/// path to the replacement process, and the per-tid membership check
+/// below then vouches for every one of the stranger's threads
+/// (review finding — the same identity rule as adoption itself,
+/// `(pid, start_ticks)`, applied to the read side).
 #[cfg(target_os = "linux")]
-pub fn observed_placement(pid: i32) -> Result<Vec<u16>, String> {
+pub fn observed_placement(pid: i32, start_ticks: u64) -> Result<Vec<u16>, String> {
     let task_dir = format!("/proc/{pid}/task");
     let tasks = std::fs::read_dir(&task_dir).map_err(|e| format!("{task_dir}: {e}"))?;
     let mut cores: Vec<u16> = Vec::new();
@@ -418,12 +430,20 @@ pub fn observed_placement(pid: i32) -> Result<Vec<u16>, String> {
             }
         }
     }
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))
+        .map_err(|e| format!("pid {pid} vanished during the placement scan: {e}"))?;
+    if crate::process::parse_start_ticks(&stat) != Some(start_ticks) {
+        return Err(format!(
+            "the process now at pid {pid} is not the adopted VPP (start-time cookie \
+             changed during the scan), so the masks just read belong to a stranger"
+        ));
+    }
     cores.sort_unstable();
     Ok(cores)
 }
 
 #[cfg(not(target_os = "linux"))]
-pub fn observed_placement(_pid: i32) -> Result<Vec<u16>, String> {
+pub fn observed_placement(_pid: i32, _start_ticks: u64) -> Result<Vec<u16>, String> {
     // Non-Linux never has a VPP to observe.
     Err("thread affinity is not readable on this platform".into())
 }
@@ -564,7 +584,12 @@ mod affinity_tests {
         });
         pinned_rx.recv().expect("child pinned before observing");
 
-        let observed = observed_placement(std::process::id() as i32).expect("observe self");
+        let own_pid = std::process::id() as i32;
+        let own_ticks = crate::process::parse_start_ticks(
+            &std::fs::read_to_string(format!("/proc/{own_pid}/stat")).expect("own stat"),
+        )
+        .expect("own start ticks");
+        let observed = observed_placement(own_pid, own_ticks).expect("observe self");
         done_tx.send(()).expect("release the child");
         child.join().expect("child joined");
 
@@ -575,6 +600,13 @@ mod affinity_tests {
         assert!(
             !observed.contains(&(b as u16)),
             "a CPU held only by wide-mask threads is not placement: {observed:?}"
+        );
+
+        // A pid wearing the wrong start-time cookie is a stranger, and
+        // a stranger's masks must be refused, not returned.
+        assert!(
+            observed_placement(own_pid, own_ticks ^ 1).is_err(),
+            "an identity mismatch must refuse the observation"
         );
     }
 

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -332,6 +332,84 @@ pub fn restrict_daemon_from(vpp_cores: &[u16]) -> Result<usize, String> {
     Ok(edited)
 }
 
+/// A thread pinned to at most this many CPUs is *placement*; anything
+/// wider is a scheduling pool. One CPU is VPP's own shape — it pins its
+/// main thread to `main-core` and each worker to its `corelist-workers`
+/// CPU (vlib/threads.c, `pthread_setaffinity_np`) — and two tolerates
+/// an operator pairing a thread with a sibling. VPP's helper threads
+/// either inherit the main thread's pin (counted, harmlessly, as
+/// main-core again) or run unpinned across the host, and treating a
+/// wide inherited mask as placement would vacate the daemon from
+/// everywhere.
+#[cfg(target_os = "linux")]
+const PINNED_WIDTH_MAX: i32 = 2;
+
+/// The CPUs a running VPP's pinned threads occupy, observed from
+/// `/proc/<pid>/task` — never remembered from a record.
+///
+/// This is how an ADOPTED VPP's cores are learned. Observation rather
+/// than a state-file record is load-bearing, not a style choice: the
+/// recorded placement this replaced produced a review finding for
+/// every lifecycle that could outdate it (stale after a supervised
+/// respawn, wrong across an upgrade from a file predating the field,
+/// and an upgrade guard whose refusal left the box an unsupervised
+/// VPP as its only forwarding tier). The live masks cannot go stale
+/// and survive an operator retuning the process by hand.
+///
+/// Affinity is a per-thread attribute and `sched_getaffinity` reads
+/// any tid's mask (the getter carries no privilege gate, and this
+/// daemon is root regardless). An empty answer means no thread is
+/// pinned narrowly enough to be placement; an `Err` means the process
+/// could not be inspected at all. The caller must treat both as
+/// "observe failed, fall back to the derived map with a warning" —
+/// never as "pinned nowhere, nothing to vacate".
+#[cfg(target_os = "linux")]
+pub fn observed_placement(pid: i32) -> Result<Vec<u16>, String> {
+    let task_dir = format!("/proc/{pid}/task");
+    let tasks = std::fs::read_dir(&task_dir).map_err(|e| format!("{task_dir}: {e}"))?;
+    let mut cores: Vec<u16> = Vec::new();
+    for entry in tasks.flatten() {
+        let Some(tid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<libc::pid_t>().ok())
+        else {
+            continue;
+        };
+        let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            libc::sched_getaffinity(tid, std::mem::size_of::<libc::cpu_set_t>(), &mut mask)
+        };
+        if rc != 0 {
+            let err = std::io::Error::last_os_error();
+            if mask_too_small(&err) {
+                return Err(format!(
+                    "this host's CPU mask is wider than a fixed cpu_set_t ({} CPUs) can \
+                     express, so the adopted VPP's placement cannot be read: {err}",
+                    libc::CPU_SETSIZE
+                ));
+            }
+            continue; // thread exited between readdir and here
+        }
+        if unsafe { libc::CPU_COUNT(&mask) } > PINNED_WIDTH_MAX {
+            continue;
+        }
+        for cpu in 0..libc::CPU_SETSIZE as usize {
+            if unsafe { libc::CPU_ISSET(cpu, &mask) } && !cores.contains(&(cpu as u16)) {
+                cores.push(cpu as u16);
+            }
+        }
+    }
+    cores.sort_unstable();
+    Ok(cores)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn observed_placement(_pid: i32) -> Result<Vec<u16>, String> {
+    // Non-Linux never has a VPP to observe.
+    Err("thread affinity is not readable on this platform".into())
+}
+
 // There is deliberately **no** inverse of `restrict_daemon_from`.
 //
 // A CPU affinity mask is per-process state, and every path that stops
@@ -438,6 +516,48 @@ mod affinity_tests {
         let rc =
             unsafe { libc::sched_setaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &before) };
         assert_eq!(rc, 0);
+    }
+
+    /// Observation reads placement from the threads themselves: a
+    /// narrowly pinned thread's CPU is reported, a wide default mask
+    /// is not. Exercised against this very process, which is exactly
+    /// how production reads an adopted VPP — same procfs walk, same
+    /// syscall, different pid.
+    #[test]
+    fn observed_placement_reports_pinned_threads_and_ignores_wide_ones() {
+        use std::sync::mpsc::channel;
+
+        let _serialised = lock_affinity();
+        let before = current_mask();
+        let allowed: Vec<usize> = (0..libc::CPU_SETSIZE as usize)
+            .filter(|&c| unsafe { libc::CPU_ISSET(c, &before) })
+            .collect();
+        if allowed.len() < 4 {
+            return; // every mask here would read as "pinned"
+        }
+        let (a, b) = (allowed[0], allowed[1]);
+
+        let (pinned_tx, pinned_rx) = channel();
+        let (done_tx, done_rx) = channel();
+        let child = std::thread::spawn(move || {
+            set_mask(&[a]); // pid 0: this thread only
+            pinned_tx.send(()).expect("announce the pin");
+            done_rx.recv().expect("hold the pin until observed");
+        });
+        pinned_rx.recv().expect("child pinned before observing");
+
+        let observed = observed_placement(std::process::id() as i32).expect("observe self");
+        done_tx.send(()).expect("release the child");
+        child.join().expect("child joined");
+
+        assert!(
+            observed.contains(&(a as u16)),
+            "the pinned thread's CPU is the placement: {observed:?}"
+        );
+        assert!(
+            !observed.contains(&(b as u16)),
+            "a CPU held only by wide-mask threads is not placement: {observed:?}"
+        );
     }
 
     /// A thread created while the scan is running is still restricted.

--- a/crates/modules/vpp-offload/src/resources.rs
+++ b/crates/modules/vpp-offload/src/resources.rs
@@ -121,26 +121,6 @@ pub struct ResourceState {
     /// newer than this field.)
     #[serde(default)]
     pub expected_routes: u64,
-    /// The CPUs VPP's threads were placed on — main plus every worker,
-    /// as one flat set.
-    ///
-    /// Recorded for the same reason as `expected_routes`, and it is the
-    /// same failure one variable over: VPP fixes thread placement **at
-    /// start**, so a daemon restart that re-derives the map from a
-    /// CHANGED online CPU set (a core offlined for thermal reasons, or
-    /// administratively) computes cores the surviving VPP is not on.
-    /// The daemon would then vacate the wrong CPUs and leave the real
-    /// worker sharing one with a resync burst — silently restoring the
-    /// preemption this whole mechanism exists to remove, and doing it
-    /// only on an adoption, which is where it is hardest to notice.
-    ///
-    /// `serde(default)` for the reason the field above carries it: a
-    /// file written before this existed must still parse, since
-    /// `detach --all` reads the same struct and a parse error would
-    /// wedge the release door. An empty set simply means "nothing
-    /// recorded", and the derived map stands alone.
-    #[serde(default)]
-    pub vpp_cores: Vec<u16>,
     /// Hugepages reserved at attach: (pool bytes, page count).
     /// `(0, 0)` = attach found a sufficient pre-existing reservation
     /// and owns nothing (release then leaves reservations alone).
@@ -208,7 +188,6 @@ impl ResourceState {
         Self {
             version: STATE_VERSION,
             expected_routes: 0,
-            vpp_cores: Vec::new(),
             hugepage_pool_bytes: 0,
             hugepage_pages: 0,
             hugepage_prior_pages: 0,


### PR DESCRIPTION
## What the shadow found, and what this replaces

The `vpp_cores` upgrade guard from #149 refused this attach outright:

```
ERROR the state file records a running VPP but not the CPUs it was placed on
```

The first commit fixed the immediate defect (the guard checked whether the record **named** a process, not whether it was **running**). The second goes to the root: the placement record is deleted entirely, replaced by observation.

**Why the record had to go.** It produced a finding for every lifecycle that could outdate it — findings 20, 21/22, 23 on #149, and then this refusal, which review missed and hardware caught on first contact. That is this project's own recorded defect class: *state written when an effect was requested rather than observed*. And the refusal's remedy was worse than its disease — it left the shadow with no daemon, an unsupervised VPP as the only forwarding tier, and MCAM rules nothing would tear down if that VPP died, to guard against one possible ~5 s resync-burst preemption.

**What replaces it.** The record was only needed for adoption, and there the placement is directly observable: VPP pins its main thread to `main-core` and each worker to its corelist CPU at start ([vlib/threads.c](https://github.com/FDio/vpp/blob/master/src/vlib/threads.c), `pthread_setaffinity_np`), so the live per-thread affinity masks under `/proc/<pid>/task` **are** the placement. `cores::observed_placement` reads them — threads pinned to ≤2 CPUs count; wider masks are scheduling pools — and `bring_up` vacates derived ∪ observed after adoption settles whose cores they are. Spawned VPPs (first attach or supervised respawn) land on the derived map, already in the vacate set, so nothing needs remembering.

Observation cannot go stale, survives operator retuning, needs no upgrade guard, and adopts the shadow's currently-running VPP without killing it. Unobservable placement **degrades** (warn, vacate derived only) instead of refusing: degraded protection beats an unsupervised dataplane.

**Deleted:** `ResourceState::vpp_cores`, the `spawn_cores` plumbing through `FileStore`/`ResourceOwner`, the `process_changed` write, `acquire`'s fifth parameter, and the refusal. Old state files carrying the field still parse (serde ignores unknown fields). Net: the #149-round-20-through-23 sub-feature is gone rather than patched a fifth time.

Also confirmed by the run that found this: the enforcement mechanism itself works on hardware — `daemon threads restricted away from VPP's cores threads=3 vacated=[16, 17]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)