### PR TITLE
fix(vpp-offload): unsteer before reading an adopted VPP's FIB

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -267,6 +267,15 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         .as_ref()
         .map(|_| std::sync::Arc::new(packetframe_common::fib::TableCompleteness::new()));
 
+    // Whether the feed's BGP/BMP session is up right now, written by
+    // the session owner inside the fast-path controller and read by
+    // vpp-offload's deferred-reconciliation gate. Same wiring rule as
+    // completeness: one object, both tiers, built only when both exist.
+    #[cfg(feature = "vpp-offload")]
+    let feed_session = feed
+        .as_ref()
+        .map(|_| std::sync::Arc::new(packetframe_common::fib::FeedSession::new()));
+
     let mut modules: Vec<(String, Box<dyn Module>)> = Vec::new();
     for section in &config.modules {
         match section.name.as_str() {
@@ -280,6 +289,10 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 #[cfg(feature = "vpp-offload")]
                 if let Some(c) = &completeness {
                     m.set_completeness(c.clone());
+                }
+                #[cfg(feature = "vpp-offload")]
+                if let Some(h) = &feed_session {
+                    m.set_feed_session(h.clone());
                 }
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }
@@ -297,6 +310,9 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 m.set_allowlist(allowlist.clone());
                 if let Some(c) = &completeness {
                     m.set_completeness(c.clone());
+                }
+                if let Some(h) = &feed_session {
+                    m.set_feed_session(h.clone());
                 }
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
             }

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -355,6 +355,41 @@ impl TableCompleteness {
     }
 }
 
+/// Whether the route feed's transport session is up right now —
+/// written by whichever session owner feeds the mirror (the BGP
+/// listener or the BMP station), read by consumers that must
+/// distinguish "the source finished loading" from "the source is gone
+/// and left its last answer standing".
+///
+/// Out-of-band of the route-event stream on purpose: the BGP listener
+/// deliberately does NOT wipe the mirror on session loss — stale
+/// forwarding while bird restarts beats an empty table — so session
+/// lifecycle cannot be inferred downstream from route events, and a
+/// count of mirror routes says nothing about liveness (review
+/// finding: neighbour-synthesized local routes alone can number in
+/// the hundreds, so no husk-size bound works either).
+#[derive(Debug, Default)]
+pub struct FeedSession(std::sync::atomic::AtomicBool);
+
+impl FeedSession {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The session owner's report. `true` only while a session is
+    /// actually established — for BGP, after the OPEN exchange; set
+    /// back to `false` the moment the connection handler returns,
+    /// including on hold-timer expiry, which is what bounds how long
+    /// a hung session can keep this stale.
+    pub fn set_up(&self, up: bool) {
+        self.0.store(up, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn is_up(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
 #[cfg(test)]
 mod peer_id_tests {
     use super::*;

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -377,6 +377,17 @@ impl RouteController {
                 );
             }
             None => {
+                // No external feed means no session that could be down:
+                // the mirror's content — local-prefix and neighbour
+                // state — IS this deployment's whole world, and it is
+                // resident the moment the resolver runs. Raised once
+                // and never lowered, deliberately: leaving the handle
+                // at its default "down" made every release clause
+                // unsatisfiable after a daemon restart, parking a
+                // steered adoption forever (review finding).
+                if let Some(h) = &feed_session {
+                    h.set_up(true);
+                }
                 info!(
                     "RouteController started: NetlinkNeighborResolver + FibProgrammer \
                      (no route source, `route-source` not configured)"

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -115,6 +115,16 @@ pub struct RouteController {
     integrity: Option<SharedSnapshot>,
 }
 
+/// The handles a second forwarding tier registers before attach — how
+/// complete the mirror is, and whether the feed's transport session is
+/// up. One struct because they are created together (the loader),
+/// stored together (both modules), and consumed together (here).
+#[derive(Default)]
+pub struct SecondTierSignals {
+    pub completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    pub feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
+}
+
 impl RouteController {
     /// Build and start the controller. `bpffs_root` is the same
     /// `global.bpffs_root` path the loader pins maps under; the
@@ -133,8 +143,12 @@ impl RouteController {
         fallback_default: Option<FallbackDefaultSpec>,
         fdb_pin_chains: std::collections::HashMap<u32, (u32, u16)>,
         route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
-        completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+        signals: SecondTierSignals,
     ) -> Result<Self, ControllerError> {
+        let SecondTierSignals {
+            completeness,
+            feed_session,
+        } = signals;
         // Dedicated runtime. `worker_threads(2)` keeps task count to
         // what Phase 3 actually needs; the resolver, programmer, and
         // BMP station are all I/O-bound so CPU is never the limit.
@@ -255,6 +269,7 @@ impl RouteController {
                     let mut backoff = LISTENER_BACKOFF_INITIAL;
                     loop {
                         let mut station = BmpStation::new(listen, prog.clone(), shut.clone())
+                            .with_feed_session(feed_session.clone())
                             .with_stall_gate(stall.clone())
                             .with_peer_acl(peer_acl_for_spawn.clone());
                         if require_loc_rib {
@@ -313,6 +328,7 @@ impl RouteController {
                 // v0.2.2: same retry-with-backoff pattern as BmpStation
                 // above. See that comment for rationale.
                 let mut cfg = BgpListenerConfig::new(listen, local_as, peer_as, router_id);
+                cfg.session = feed_session.clone();
                 cfg.peer_acl = peer_acl;
                 cfg.expected_peer_ip = expected_peer_ip;
                 // Capture the auth-posture fields before the spawn

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -398,12 +398,13 @@ impl BgpListener {
             tokio::time::interval(Duration::from_secs(effective_hold.max(3) as u64 / 3));
         keepalive_tick.tick().await; // skip immediate fire
         let mut hold_deadline = Instant::now() + Duration::from_secs(effective_hold as u64);
-        // Established: OPENs exchanged, our KEEPALIVE sent. Everything
-        // before this point was handshake, and every exit below runs
-        // through the accept loop's set_up(false).
-        if let Some(sess) = &self.cfg.session {
-            sess.set_up(true);
-        }
+        // Deliberately NOT live yet: OPEN proves the SESSION, not the
+        // table. A session that establishes and then delays its first
+        // UPDATE would read as live-and-quiet, and two seconds of
+        // pre-stream quiet releases the second tier's gate onto a
+        // mirror holding only local routes (review finding). Liveness
+        // raises at the InitiationComplete heuristic below — the same
+        // initial-RIB-settled definition the BMP path uses.
         let mut last_update: Option<Instant> = None;
         let mut init_complete_fired = false;
         let mut quiescence_tick = tokio::time::interval(Duration::from_secs(1));
@@ -476,6 +477,16 @@ impl BgpListener {
                                         "InitiationComplete fired"
                                     );
                                     init_complete_fired = true;
+                                    // The initial RIB has settled: the
+                                    // mirror now holds what this session
+                                    // has to give, which is what "live"
+                                    // must mean to the second tier's
+                                    // release gate. Every session exit
+                                    // still runs through the accept
+                                    // loop's set_up(false).
+                                    if let Some(sess) = &self.cfg.session {
+                                        sess.set_up(true);
+                                    }
                                 }
                             }
                         }

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -427,7 +427,10 @@ impl BgpListener {
                         Some(m) => {
                             // Any inbound traffic resets hold.
                             hold_deadline = Instant::now() + Duration::from_secs(effective_hold as u64);
-                            self.process_msg(m, peer_id, peer_asn_observed, &mut last_update, &mut updates_seen).await;
+                            if let Err(e) = self.process_msg(m, peer_id, peer_asn_observed, &mut last_update, &mut updates_seen).await {
+                                reader.abort();
+                                return Err(e);
+                            }
                         }
                         None => {
                             // Reader exited, surface the result.
@@ -496,6 +499,12 @@ impl BgpListener {
         }
     }
 
+    /// `Err` is session-fatal: the caller must tear the connection
+    /// down. It was `()` until a review pass caught the oversized-
+    /// UPDATE arm logging "closing session" while only returning from
+    /// this helper — the connection lived on, quiesced, fired
+    /// InitiationComplete, and marked a feed LIVE whose last UPDATE
+    /// had been thrown away whole.
     async fn process_msg(
         &self,
         msg: BgpMessage,
@@ -503,7 +512,7 @@ impl BgpListener {
         peer_asn: u32,
         last_update: &mut Option<Instant>,
         updates_seen: &mut usize,
-    ) {
+    ) -> Result<(), RouteSourceError> {
         match msg {
             BgpMessage::Open(_) => {
                 // Spurious post-handshake OPEN, bird shouldn't do
@@ -514,12 +523,17 @@ impl BgpListener {
                 // Hold timer reset already happened; no further work.
             }
             BgpMessage::Notification(n) => {
-                // BgpError is a typed enum (MessageHeaderError,
-                // OpenError, UpdateError, HoldTimerExpired, Cease, ...);
-                // log the Debug repr, operator can grep on it.
-                warn!(error = ?n.error, "received NOTIFICATION; closing session");
-                // Reader will see EOF after bird closes; that path
-                // emits Resync via the accept loop.
+                // Session-fatal for real, not just in the log line: a
+                // NOTIFICATION ends the session per RFC 4271, and while
+                // bird usually closes the TCP right after (the reader
+                // would see EOF), waiting on the peer's close leaves a
+                // window where the connection quiesces, settles, and
+                // reports a feed live that its peer has already
+                // renounced.
+                return Err(RouteSourceError::recoverable(format!(
+                    "received NOTIFICATION ({:?}); closing session",
+                    n.error
+                )));
             }
             BgpMessage::Update(update) => {
                 *last_update = Some(Instant::now());
@@ -552,12 +566,13 @@ impl BgpListener {
                     // attacker-shaped UPDATE to just keep adding to
                     // the per-message budget. Close, emit Resync,
                     // let the peer reconnect.
-                    warn!(
-                        elems = elems.len(),
-                        cap = MAX_ELEMS_PER_UPDATE,
-                        "BGP UPDATE elem count exceeds per-message cap; closing session"
-                    );
-                    return;
+                    return Err(RouteSourceError::recoverable(format!(
+                        "BGP UPDATE fanned out to {} elems (cap {}); closing session — a \
+                         skipped UPDATE must not leave a session that later settles and \
+                         reports a feed live with that UPDATE's prefixes missing",
+                        elems.len(),
+                        MAX_ELEMS_PER_UPDATE
+                    )));
                 }
                 for elem in elems {
                     let event = match elem_to_route_event(&elem, peer_id, fallback_nh) {
@@ -570,6 +585,7 @@ impl BgpListener {
                 }
             }
         }
+        Ok(())
     }
 }
 

--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -167,6 +167,10 @@ pub struct BgpListenerConfig {
     /// checks are the only identity binding available in the
     /// absence of TCP-MD5 / TCP-AO.
     pub expected_peer_ip: Option<IpAddr>,
+    /// Session-liveness handle, reported to the second tier. See
+    /// [`packetframe_common::fib::FeedSession`] for why this travels
+    /// out-of-band of the route events.
+    pub session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
 }
 
 impl BgpListenerConfig {
@@ -179,6 +183,7 @@ impl BgpListenerConfig {
             hold_time: DEFAULT_HOLD_TIME,
             peer_acl: Vec::new(),
             expected_peer_ip: None,
+            session: None,
         }
     }
 }
@@ -287,6 +292,14 @@ impl BgpListener {
                             } else {
                                 info!("BGP client disconnected cleanly");
                             }
+                            // However the session ended — clean close,
+                            // NOTIFICATION, hold-timer expiry — it is
+                            // down now, and the hold timer above is what
+                            // bounds how long a hung session could have
+                            // kept the flag stale.
+                            if let Some(sess) = &self.cfg.session {
+                                sess.set_up(false);
+                            }
                             if let Err(e) = self
                                 .prog_handle
                                 .apply_route_event(RouteEvent::Resync)
@@ -385,6 +398,12 @@ impl BgpListener {
             tokio::time::interval(Duration::from_secs(effective_hold.max(3) as u64 / 3));
         keepalive_tick.tick().await; // skip immediate fire
         let mut hold_deadline = Instant::now() + Duration::from_secs(effective_hold as u64);
+        // Established: OPENs exchanged, our KEEPALIVE sent. Everything
+        // before this point was handshake, and every exit below runs
+        // through the accept loop's set_up(false).
+        if let Some(sess) = &self.cfg.session {
+            sess.set_up(true);
+        }
         let mut last_update: Option<Instant> = None;
         let mut init_complete_fired = false;
         let mut quiescence_tick = tokio::time::interval(Duration::from_secs(1));

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -146,6 +146,14 @@ pub struct BmpStation {
     /// peers all die empties its Loc-RIB through RM withdrawals rather
     /// than going silent, which the mirror then reflects honestly.
     saw_rm: std::sync::atomic::AtomicBool,
+    /// Whether this connection has EVER sent a PeerUp. An emitter that
+    /// speaks peer lifecycle gets peer-set semantics: when its last
+    /// monitored peer goes down, the feed is down, however many RM
+    /// frames were streamed before — a sticky RM bit would disable the
+    /// peer-set transition for every mode, not just the Loc-RIB
+    /// streams that lack notifications (review finding). `saw_rm`
+    /// attests liveness only for connections that never spoke PeerUp.
+    saw_peer_up: std::sync::atomic::AtomicBool,
 }
 
 /// Re-export for callers building the station.
@@ -177,6 +185,7 @@ impl BmpStation {
             session: None,
             up_peers: std::sync::Mutex::new(std::collections::HashSet::new()),
             saw_rm: std::sync::atomic::AtomicBool::new(false),
+            saw_peer_up: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -285,6 +294,8 @@ impl BmpStation {
                             self.up_peers.lock().expect("up_peers lock").clear();
                             self.saw_rm
                                 .store(false, std::sync::atomic::Ordering::Relaxed);
+                            self.saw_peer_up
+                                .store(false, std::sync::atomic::Ordering::Relaxed);
                             if let Some(sess) = &self.session {
                                 sess.set_up(false);
                             } else {
@@ -351,8 +362,19 @@ impl BmpStation {
                                     .as_secs() as i64;
                                 self.last_rm_unix.store(unix, Ordering::Relaxed);
                                 self.saw_rm.store(true, Ordering::Relaxed);
-                                if let Some(sess) = &self.session {
-                                    sess.set_up(true);
+                                // An RM frame attests the feed only for
+                                // a connection that does not speak peer
+                                // lifecycle; on one that does, straggler
+                                // frames after the last PeerDown must
+                                // not resurrect a down feed.
+                                let peers_speak =
+                                    self.saw_peer_up.load(Ordering::Relaxed);
+                                let peers_up =
+                                    !self.up_peers.lock().expect("up_peers lock").is_empty();
+                                if !peers_speak || peers_up {
+                                    if let Some(sess) = &self.session {
+                                        sess.set_up(true);
+                                    }
                                 }
                             }
                             // Loc-RIB safety check happens inside
@@ -429,6 +451,8 @@ impl BmpStation {
                 self.up_peers.lock().expect("up_peers lock").clear();
                 self.saw_rm
                     .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.saw_peer_up
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 if let Some(sess) = &self.session {
                     sess.set_up(false);
                 }
@@ -457,6 +481,8 @@ impl BmpStation {
                 {
                     warn!(?peer_id, error = %e, "PeerUp dispatch failed");
                 }
+                self.saw_peer_up
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
                 let mut up = self.up_peers.lock().expect("up_peers lock");
                 up.insert(peer_id);
                 if let Some(sess) = &self.session {
@@ -479,7 +505,13 @@ impl BmpStation {
                 }
                 let mut up = self.up_peers.lock().expect("up_peers lock");
                 up.remove(&peer_id);
-                if up.is_empty() && !self.saw_rm.load(std::sync::atomic::Ordering::Relaxed) {
+                // Peer-lifecycle emitters get peer-set semantics: last
+                // peer down = feed down, RM history notwithstanding.
+                // Only a connection that never spoke PeerUp may lean on
+                // its RM stream (the Loc-RIB case).
+                let rm_attests = !self.saw_peer_up.load(std::sync::atomic::Ordering::Relaxed)
+                    && self.saw_rm.load(std::sync::atomic::Ordering::Relaxed);
+                if up.is_empty() && !rm_attests {
                     if let Some(sess) = &self.session {
                         sess.set_up(false);
                     }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -139,12 +139,15 @@ pub struct BmpStation {
     /// Whether this connection has delivered a RouteMonitoring frame.
     /// RFC 9069 Loc-RIB streams need not send PeerUp for the synthetic
     /// Loc-RIB instance (review finding — and Loc-RIB is precisely the
-    /// mode `require-loc-rib` documents), so for them the RM stream
-    /// itself is the liveness evidence: it is the thing that delivers
-    /// the table. The handle is up while EITHER a monitored peer is up
-    /// or this connection has streamed RM; an emitter whose upstream
-    /// peers all die empties its Loc-RIB through RM withdrawals rather
-    /// than going silent, which the mirror then reflects honestly.
+    /// mode `require-loc-rib` documents), so for them the stream itself
+    /// is the liveness evidence — but only once it has SETTLED: the
+    /// raise happens at InitiationComplete, the station's definition of
+    /// initial-stream readiness, never on the first frame (review
+    /// finding: a dump stalling after frame one would otherwise read
+    /// as live-quiet-loaded for up to the read timeout). This flag's
+    /// remaining job is the peer-set arbitration below: a connection
+    /// that streamed RM without ever speaking PeerUp keeps its
+    /// liveness across an incidental PeerDown.
     saw_rm: std::sync::atomic::AtomicBool,
     /// Whether this connection has EVER sent a PeerUp. An emitter that
     /// speaks peer lifecycle gets peer-set semantics: when its last
@@ -361,21 +364,17 @@ impl BmpStation {
                                     .unwrap_or_default()
                                     .as_secs() as i64;
                                 self.last_rm_unix.store(unix, Ordering::Relaxed);
+                                // Deliberately NOT a liveness raise: a
+                                // single frame proves the stream began,
+                                // not that the initial dump landed — a
+                                // dump that stalls after frame one would
+                                // otherwise read as a live, quiet, loaded
+                                // feed for up to the read timeout (review
+                                // finding). Liveness for a Loc-RIB stream
+                                // raises at InitiationComplete below —
+                                // the station's own definition of
+                                // initial-stream readiness.
                                 self.saw_rm.store(true, Ordering::Relaxed);
-                                // An RM frame attests the feed only for
-                                // a connection that does not speak peer
-                                // lifecycle; on one that does, straggler
-                                // frames after the last PeerDown must
-                                // not resurrect a down feed.
-                                let peers_speak =
-                                    self.saw_peer_up.load(Ordering::Relaxed);
-                                let peers_up =
-                                    !self.up_peers.lock().expect("up_peers lock").is_empty();
-                                if !peers_speak || peers_up {
-                                    if let Some(sess) = &self.session {
-                                        sess.set_up(true);
-                                    }
-                                }
                             }
                             // Loc-RIB safety check happens inside
                             // process_msg; a violation returns Err and
@@ -418,6 +417,27 @@ impl BmpStation {
                             {
                                 warn!(error = %e, "InitiationComplete dispatch failed");
                             } else {
+                                // The station's own definition of
+                                // initial-stream readiness, and therefore
+                                // where a Loc-RIB stream becomes LIVE for
+                                // the second tier: the dump has quiesced,
+                                // so the mirror now holds what the
+                                // emitter has. Guarded like the RM raise
+                                // was: an emitter that speaks peer
+                                // lifecycle with no peer up stays down.
+                                let peers_speak = self
+                                    .saw_peer_up
+                                    .load(std::sync::atomic::Ordering::Relaxed);
+                                let peers_up = !self
+                                    .up_peers
+                                    .lock()
+                                    .expect("up_peers lock")
+                                    .is_empty();
+                                if !peers_speak || peers_up {
+                                    if let Some(sess) = &self.session {
+                                        sess.set_up(true);
+                                    }
+                                }
                                 info!(
                                     frames_parsed,
                                     quiescence_secs = INIT_COMPLETE_QUIESCENCE.as_secs(),

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -157,6 +157,15 @@ pub struct BmpStation {
     /// streams that lack notifications (review finding). `saw_rm`
     /// attests liveness only for connections that never spoke PeerUp.
     saw_peer_up: std::sync::atomic::AtomicBool,
+    /// Whether this connection's initial stream has settled
+    /// (InitiationComplete fired). Liveness raises pass through this:
+    /// a PeerUp that precedes a delayed initial dump proves a peer,
+    /// not a table, and raising on it let two seconds of pre-stream
+    /// quiet release the second tier's gate (review finding — the
+    /// same flaw the BGP and Loc-RIB paths shed, at the last raise
+    /// site that still had it). A PeerUp arriving AFTER settlement
+    /// raises immediately, which is the mid-session peer-join case.
+    initiated: std::sync::atomic::AtomicBool,
 }
 
 /// Re-export for callers building the station.
@@ -189,6 +198,7 @@ impl BmpStation {
             up_peers: std::sync::Mutex::new(std::collections::HashSet::new()),
             saw_rm: std::sync::atomic::AtomicBool::new(false),
             saw_peer_up: std::sync::atomic::AtomicBool::new(false),
+            initiated: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -298,6 +308,8 @@ impl BmpStation {
                             self.saw_rm
                                 .store(false, std::sync::atomic::Ordering::Relaxed);
                             self.saw_peer_up
+                                .store(false, std::sync::atomic::Ordering::Relaxed);
+                            self.initiated
                                 .store(false, std::sync::atomic::Ordering::Relaxed);
                             if let Some(sess) = &self.session {
                                 sess.set_up(false);
@@ -419,12 +431,14 @@ impl BmpStation {
                             } else {
                                 // The station's own definition of
                                 // initial-stream readiness, and therefore
-                                // where a Loc-RIB stream becomes LIVE for
-                                // the second tier: the dump has quiesced,
-                                // so the mirror now holds what the
-                                // emitter has. Guarded like the RM raise
-                                // was: an emitter that speaks peer
-                                // lifecycle with no peer up stays down.
+                                // where a stream becomes LIVE for the
+                                // second tier: the dump has quiesced, so
+                                // the mirror now holds what the emitter
+                                // has. Guarded like the RM raise was: an
+                                // emitter that speaks peer lifecycle
+                                // with no peer up stays down.
+                                self.initiated
+                                    .store(true, std::sync::atomic::Ordering::Relaxed);
                                 let peers_speak = self
                                     .saw_peer_up
                                     .load(std::sync::atomic::Ordering::Relaxed);
@@ -473,6 +487,8 @@ impl BmpStation {
                     .store(false, std::sync::atomic::Ordering::Relaxed);
                 self.saw_peer_up
                     .store(false, std::sync::atomic::Ordering::Relaxed);
+                self.initiated
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
                 if let Some(sess) = &self.session {
                     sess.set_up(false);
                 }
@@ -505,8 +521,13 @@ impl BmpStation {
                     .store(true, std::sync::atomic::Ordering::Relaxed);
                 let mut up = self.up_peers.lock().expect("up_peers lock");
                 up.insert(peer_id);
-                if let Some(sess) = &self.session {
-                    sess.set_up(true);
+                // Bookkeeping always; liveness only once the initial
+                // stream has settled. Before that, a peer is a promise
+                // of a table, not a table.
+                if self.initiated.load(std::sync::atomic::Ordering::Relaxed) {
+                    if let Some(sess) = &self.session {
+                        sess.set_up(true);
+                    }
                 }
             }
             BmpMessageBody::PeerDownNotification(_) => {

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -474,6 +474,21 @@ impl BmpStation {
                                     if let Some(sess) = &self.session {
                                         sess.set_up(true);
                                     }
+                                } else {
+                                    // Declined AND consumed: a peerless
+                                    // straggler frame is not testimony
+                                    // about any future epoch. Leaving
+                                    // the evidence cached let the next
+                                    // PeerUp settle on the very next
+                                    // tick, off a frame that predated
+                                    // the peer entirely (review
+                                    // finding, third pass at this
+                                    // hole). The new peer's dump must
+                                    // produce its own frames and its
+                                    // own quiescence.
+                                    self.saw_rm
+                                        .store(false, std::sync::atomic::Ordering::Relaxed);
+                                    last_route_monitoring = None;
                                 }
                             }
                         }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -128,6 +128,14 @@ pub struct BmpStation {
     /// Session-liveness handle, reported to the second tier. See
     /// [`packetframe_common::fib::FeedSession`].
     session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
+    /// Monitored peers currently up on this connection, by BMP PeerUp
+    /// and PeerDown. The liveness handle follows THIS set, never the
+    /// TCP transport: bird's monitoring connection stays established
+    /// while every BGP peer it monitors is down, and PeerDown has
+    /// already wiped their routes — reporting "up" on the socket alone
+    /// would let a second tier trust a mirror that just lost its feed
+    /// (review finding).
+    up_peers: std::sync::Mutex<std::collections::HashSet<PeerId>>,
 }
 
 /// Re-export for callers building the station.
@@ -157,6 +165,7 @@ impl BmpStation {
             require_loc_rib: false,
             peer_acl: Vec::new(),
             session: None,
+            up_peers: std::sync::Mutex::new(std::collections::HashSet::new()),
         }
     }
 
@@ -256,12 +265,13 @@ impl BmpStation {
                                 continue;
                             }
                             info!(%addr, "BMP client connected");
-                            if let Some(sess) = &self.session {
-                                sess.set_up(true);
-                            }
                             if let Err(e) = self.handle_connection(stream).await {
                                 warn!(error = %e, "BMP connection handler exited with error");
                             }
+                            // The connection ended, and per-peer state
+                            // ended with it: whatever PeerUps this
+                            // session delivered are no longer evidence.
+                            self.up_peers.lock().expect("up_peers lock").clear();
                             if let Some(sess) = &self.session {
                                 sess.set_up(false);
                             } else {
@@ -424,6 +434,11 @@ impl BmpStation {
                 {
                     warn!(?peer_id, error = %e, "PeerUp dispatch failed");
                 }
+                let mut up = self.up_peers.lock().expect("up_peers lock");
+                up.insert(peer_id);
+                if let Some(sess) = &self.session {
+                    sess.set_up(true);
+                }
             }
             BmpMessageBody::PeerDownNotification(_) => {
                 let pph = match &msg.per_peer_header {
@@ -438,6 +453,13 @@ impl BmpStation {
                     .await
                 {
                     warn!(?peer_id, error = %e, "PeerDown dispatch failed");
+                }
+                let mut up = self.up_peers.lock().expect("up_peers lock");
+                up.remove(&peer_id);
+                if up.is_empty() {
+                    if let Some(sess) = &self.session {
+                        sess.set_up(false);
+                    }
                 }
             }
             BmpMessageBody::RouteMonitoring(rm) => {

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -136,6 +136,16 @@ pub struct BmpStation {
     /// would let a second tier trust a mirror that just lost its feed
     /// (review finding).
     up_peers: std::sync::Mutex<std::collections::HashSet<PeerId>>,
+    /// Whether this connection has delivered a RouteMonitoring frame.
+    /// RFC 9069 Loc-RIB streams need not send PeerUp for the synthetic
+    /// Loc-RIB instance (review finding — and Loc-RIB is precisely the
+    /// mode `require-loc-rib` documents), so for them the RM stream
+    /// itself is the liveness evidence: it is the thing that delivers
+    /// the table. The handle is up while EITHER a monitored peer is up
+    /// or this connection has streamed RM; an emitter whose upstream
+    /// peers all die empties its Loc-RIB through RM withdrawals rather
+    /// than going silent, which the mirror then reflects honestly.
+    saw_rm: std::sync::atomic::AtomicBool,
 }
 
 /// Re-export for callers building the station.
@@ -166,6 +176,7 @@ impl BmpStation {
             peer_acl: Vec::new(),
             session: None,
             up_peers: std::sync::Mutex::new(std::collections::HashSet::new()),
+            saw_rm: std::sync::atomic::AtomicBool::new(false),
         }
     }
 
@@ -272,6 +283,8 @@ impl BmpStation {
                             // ended with it: whatever PeerUps this
                             // session delivered are no longer evidence.
                             self.up_peers.lock().expect("up_peers lock").clear();
+                            self.saw_rm
+                                .store(false, std::sync::atomic::Ordering::Relaxed);
                             if let Some(sess) = &self.session {
                                 sess.set_up(false);
                             } else {
@@ -337,6 +350,10 @@ impl BmpStation {
                                     .unwrap_or_default()
                                     .as_secs() as i64;
                                 self.last_rm_unix.store(unix, Ordering::Relaxed);
+                                self.saw_rm.store(true, Ordering::Relaxed);
+                                if let Some(sess) = &self.session {
+                                    sess.set_up(true);
+                                }
                             }
                             // Loc-RIB safety check happens inside
                             // process_msg; a violation returns Err and
@@ -409,6 +426,12 @@ impl BmpStation {
             }
             BmpMessageBody::TerminationMessage(_) => {
                 info!("BMP TERMINATION received from bird");
+                self.up_peers.lock().expect("up_peers lock").clear();
+                self.saw_rm
+                    .store(false, std::sync::atomic::Ordering::Relaxed);
+                if let Some(sess) = &self.session {
+                    sess.set_up(false);
+                }
             }
             BmpMessageBody::PeerUpNotification(_) => {
                 let pph = match &msg.per_peer_header {
@@ -456,7 +479,7 @@ impl BmpStation {
                 }
                 let mut up = self.up_peers.lock().expect("up_peers lock");
                 up.remove(&peer_id);
-                if up.is_empty() {
+                if up.is_empty() && !self.saw_rm.load(std::sync::atomic::Ordering::Relaxed) {
                     if let Some(sess) = &self.session {
                         sess.set_up(false);
                     }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -417,25 +417,41 @@ impl BmpStation {
                     }
                 }
                 _ = tick.tick() => {
-                    if init_complete_fired {
-                        continue;
-                    }
-                    if let Some(last) = last_route_monitoring {
-                        if last.elapsed() >= INIT_COMPLETE_QUIESCENCE {
-                            if let Err(e) = self
-                                .prog_handle
-                                .apply_route_event(RouteEvent::InitiationComplete)
-                                .await
-                            {
-                                warn!(error = %e, "InitiationComplete dispatch failed");
-                            } else {
-                                // The station's own definition of
-                                // initial-stream readiness, and therefore
-                                // where a stream becomes LIVE for the
-                                // second tier: the dump has quiesced, so
-                                // the mirror now holds what the emitter
-                                // has. Guarded like the RM raise was: an
-                                // emitter that speaks peer lifecycle
+                    // Settlement is per EPOCH, not per connection: when
+                    // the last monitored peer goes down, `initiated` and
+                    // `saw_rm` reset, and the NEXT peer's dump must
+                    // quiesce all over again before liveness returns —
+                    // a PeerUp on an already-settled connection was
+                    // raising ahead of that peer's own dump (review
+                    // finding). The InitiationComplete EVENT still
+                    // fires once per connection; the programmer's GC
+                    // semantics are per connection, and only the
+                    // liveness settlement re-arms.
+                    let settled = self.initiated.load(std::sync::atomic::Ordering::Relaxed);
+                    let rm_this_epoch = self.saw_rm.load(std::sync::atomic::Ordering::Relaxed);
+                    if !settled && rm_this_epoch {
+                        if let Some(last) = last_route_monitoring {
+                            if last.elapsed() >= INIT_COMPLETE_QUIESCENCE {
+                                if !init_complete_fired {
+                                    if let Err(e) = self
+                                        .prog_handle
+                                        .apply_route_event(RouteEvent::InitiationComplete)
+                                        .await
+                                    {
+                                        warn!(error = %e, "InitiationComplete dispatch failed");
+                                        continue;
+                                    }
+                                    info!(
+                                        frames_parsed,
+                                        quiescence_secs = INIT_COMPLETE_QUIESCENCE.as_secs(),
+                                        "InitiationComplete fired"
+                                    );
+                                    init_complete_fired = true;
+                                }
+                                // The stream (or this epoch's re-dump)
+                                // has quiesced: the mirror holds what
+                                // the emitter has. Guarded as always —
+                                // an emitter that speaks peer lifecycle
                                 // with no peer up stays down.
                                 self.initiated
                                     .store(true, std::sync::atomic::Ordering::Relaxed);
@@ -452,12 +468,6 @@ impl BmpStation {
                                         sess.set_up(true);
                                     }
                                 }
-                                info!(
-                                    frames_parsed,
-                                    quiescence_secs = INIT_COMPLETE_QUIESCENCE.as_secs(),
-                                    "InitiationComplete fired"
-                                );
-                                init_complete_fired = true;
                             }
                         }
                     }
@@ -556,6 +566,17 @@ impl BmpStation {
                     if let Some(sess) = &self.session {
                         sess.set_up(false);
                     }
+                    // The epoch ended with the last peer: whatever RM
+                    // settled BEFORE is no evidence about the next
+                    // peer's table, so settlement re-arms — the next
+                    // PeerUp records itself and waits for its own
+                    // dump's quiescence (review finding: an
+                    // already-settled connection re-raised on the new
+                    // PeerUp before that peer had streamed a frame).
+                    self.initiated
+                        .store(false, std::sync::atomic::Ordering::Relaxed);
+                    self.saw_rm
+                        .store(false, std::sync::atomic::Ordering::Relaxed);
                 }
             }
             BmpMessageBody::RouteMonitoring(rm) => {

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -452,9 +452,14 @@ impl BmpStation {
                                 // has quiesced: the mirror holds what
                                 // the emitter has. Guarded as always —
                                 // an emitter that speaks peer lifecycle
-                                // with no peer up stays down.
-                                self.initiated
-                                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                                // with no peer up stays down — and the
+                                // SETTLEMENT itself carries the same
+                                // guard: a peerless straggler frame
+                                // after the last PeerDown must not
+                                // prime the next epoch, or the next
+                                // PeerUp would raise off the cached
+                                // flag before its own dump arrived
+                                // (review finding).
                                 let peers_speak = self
                                     .saw_peer_up
                                     .load(std::sync::atomic::Ordering::Relaxed);
@@ -464,6 +469,8 @@ impl BmpStation {
                                     .expect("up_peers lock")
                                     .is_empty();
                                 if !peers_speak || peers_up {
+                                    self.initiated
+                                        .store(true, std::sync::atomic::Ordering::Relaxed);
                                     if let Some(sess) = &self.session {
                                         sess.set_up(true);
                                     }

--- a/crates/modules/fast-path/src/fib/route_source_bmp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bmp.rs
@@ -125,6 +125,9 @@ pub struct BmpStation {
     /// source IP must fall within at least one entry or the
     /// connection is dropped before the BMP framing starts.
     peer_acl: Vec<ipnet::IpNet>,
+    /// Session-liveness handle, reported to the second tier. See
+    /// [`packetframe_common::fib::FeedSession`].
+    session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
 }
 
 /// Re-export for callers building the station.
@@ -153,7 +156,18 @@ impl BmpStation {
             stall_gate: None,
             require_loc_rib: false,
             peer_acl: Vec::new(),
+            session: None,
         }
+    }
+
+    /// Report session liveness through `handle`. `None` reports to
+    /// nobody, which is every deployment without a second tier.
+    pub fn with_feed_session(
+        mut self,
+        handle: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
+    ) -> Self {
+        self.session = handle;
+        self
     }
 
     /// Attach the integrity checker's snapshot so `run()` spawns a
@@ -242,8 +256,14 @@ impl BmpStation {
                                 continue;
                             }
                             info!(%addr, "BMP client connected");
+                            if let Some(sess) = &self.session {
+                                sess.set_up(true);
+                            }
                             if let Err(e) = self.handle_connection(stream).await {
                                 warn!(error = %e, "BMP connection handler exited with error");
+                            }
+                            if let Some(sess) = &self.session {
+                                sess.set_up(false);
                             } else {
                                 info!("BMP client disconnected cleanly");
                             }

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -83,6 +83,8 @@ pub struct FastPathModule {
     route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
     #[cfg(target_os = "linux")]
     completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    #[cfg(target_os = "linux")]
+    feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
 }
 
 impl FastPathModule {
@@ -115,6 +117,17 @@ impl FastPathModule {
         handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
     ) {
         self.completeness = Some(handle);
+    }
+
+    /// Report the route feed's session liveness through `handle`, for
+    /// the second tier's release gating. Same constraint and caller as
+    /// [`Self::set_completeness`].
+    #[cfg(target_os = "linux")]
+    pub fn set_feed_session(
+        &mut self,
+        handle: std::sync::Arc<packetframe_common::fib::FeedSession>,
+    ) {
+        self.feed_session = Some(handle);
     }
 
     /// Snapshot of the current attach set for status reporting.
@@ -188,6 +201,7 @@ impl Module for FastPathModule {
             cfg,
             self.route_sink.clone(),
             self.completeness.clone(),
+            self.feed_session.clone(),
         )
     }
 

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1181,6 +1181,7 @@ pub fn attach(
     cfg: &ModuleConfig<'_>,
     route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
     completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
 ) -> ModuleResult<Vec<Attachment>> {
     // v0.2.5: load `finalize` first so its FD is available for the
     // MUTATION_PROGS[0] population below. Order matters: fast_path's
@@ -1636,7 +1637,10 @@ pub fn attach(
             fallback_default,
             fdb_pin_chains,
             route_sink,
-            completeness,
+            crate::fib::controller::SecondTierSignals {
+                completeness,
+                feed_session,
+            },
         )
         .map_err(|e| {
             ModuleError::other(MODULE_NAME, format!("RouteController start failed: {e}"))

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -157,6 +157,7 @@ pub fn bring_up(
     source: Box<dyn RouteSource + Send + Sync>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
+    feed_session: Option<Arc<packetframe_common::fib::FeedSession>>,
     budget: &McamBudget,
 ) -> Result<Attached, String> {
     // `require-table-complete on` with nothing publishing completeness
@@ -346,6 +347,7 @@ pub fn bring_up(
         &vpp_binary,
         steering,
         completeness,
+        feed_session,
         loopback,
     ) {
         Ok(attached) => Ok(attached),
@@ -416,6 +418,7 @@ fn finish(
     vpp_binary: &Path,
     steering: NtupleSteering,
     completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
+    feed_session: Option<Arc<packetframe_common::fib::FeedSession>>,
     loopback: packetframe_common::config::Ipv4Prefix,
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
@@ -672,6 +675,9 @@ fn finish(
         );
         if let Some(handle) = completeness {
             runtime.require_table_complete(handle);
+        }
+        if let Some(handle) = feed_session {
+            runtime.feed_session(handle);
         }
         let initial = match adopted {
             Some(p) => {

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -582,6 +582,10 @@ mod tests {
             self.calls.push("steer");
             Ok(())
         }
+        fn restore_steer(&mut self) -> Result<(), String> {
+            self.calls.push("steer");
+            Ok(())
+        }
         fn kill(&mut self) -> Disposition {
             self.calls.push("kill");
             self.kill_disposition.unwrap_or(Disposition::SafeToRelease)
@@ -1362,6 +1366,9 @@ mod tests {
                 Ok(())
             }
             fn steer(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn restore_steer(&mut self) -> Result<(), String> {
                 Ok(())
             }
             fn kill(&mut self) -> Disposition {

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -1293,6 +1293,15 @@ impl ConvergenceEngine {
         // process it was applied to.
         self.ledger.capacity()
     }
+
+    /// The route capacity in force — the high-water policy derived from
+    /// the operator's `expected-routes`. The pre-dump deferral floor is
+    /// computed from this, because at that point the adopted table's
+    /// size is unknowable: reading it is exactly the thing being
+    /// deferred.
+    pub fn route_capacity(&self) -> u64 {
+        self.ledger.capacity().high_water()
+    }
 }
 
 /// splitmix64. Deterministic successor so verify samples differ per pass

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -46,6 +46,11 @@ pub trait Effects {
     /// Install MCAM steering rules.
     fn steer(&mut self) -> Result<(), String>;
 
+    /// Re-install steering for the intact adoptee, bypassing the
+    /// completeness gate — see [`Action::RestoreSteer`] for why the
+    /// gate inverts on this one path.
+    fn restore_steer(&mut self) -> Result<(), String>;
+
     /// Whether the steering ledger currently names any rule in the NIC.
     ///
     /// Read after a failed [`Self::steer`] so the supervisor is *told*
@@ -186,6 +191,26 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                     out.events.push(Event::ConvergenceFailed);
                 }
             }
+            Action::RestoreSteer => out.events.push(match fx.restore_steer() {
+                Ok(()) => {
+                    tracing::info!(
+                        "steering RESTORED: the adopted VPP's intact FIB takes the traffic \
+                         back while the fallback is not ready"
+                    );
+                    Event::Steered
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        rules_remain = fx.steering_in_place(),
+                        "restore-steer failed; traffic stays on the eBPF tier"
+                    );
+                    out.failures.push((*action, e));
+                    Event::SteerFailed {
+                        rules_remain: fx.steering_in_place(),
+                    }
+                }
+            }),
             Action::Steer => out.events.push(match fx.steer() {
                 Ok(()) => {
                     // The one action that moves customer traffic between
@@ -270,6 +295,10 @@ mod tests {
             err_if(self.fail_unsteer, "ioctl refused")
         }
         fn steer(&mut self) -> Result<(), String> {
+            self.calls.push("steer");
+            err_if(self.fail_steer, "no free MCAM loc")
+        }
+        fn restore_steer(&mut self) -> Result<(), String> {
             self.calls.push("steer");
             err_if(self.fail_steer, "no free MCAM loc")
         }

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -368,6 +368,9 @@ pub struct VppOffloadModule {
     /// loader wires it, which it does only when a route authority
     /// exists; see [`Self::set_completeness`].
     completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    /// The feed's session-liveness handle, when the loader wired one;
+    /// see [`Self::set_feed_session`].
+    feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
     /// `Some` once supervision is running.
     attached: Option<bringup::Attached>,
     /// A teardown still running in the background after `detach` returned.
@@ -395,6 +398,7 @@ impl VppOffloadModule {
         Self {
             allowlist: std::sync::Arc::new(SharedAllowlist::default()),
             completeness: None,
+            feed_session: None,
             cfg: VppOffloadConfig::default(),
             state_dir: std::path::PathBuf::new(),
             source: None,
@@ -449,6 +453,21 @@ impl VppOffloadModule {
         handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
     ) {
         self.completeness = Some(handle);
+    }
+
+    /// Hand the module the feed's session-liveness handle.
+    ///
+    /// Read by the deferred adopted reconciliation: a small table's
+    /// release needs to know the session that fed the mirror is still
+    /// up, because no mirror-side count can distinguish a loaded small
+    /// table from the husk a dead session leaves behind (review
+    /// finding). Absent, the small-table release is simply off — the
+    /// capacity floor and the completeness authority still release.
+    pub fn set_feed_session(
+        &mut self,
+        handle: std::sync::Arc<packetframe_common::fib::FeedSession>,
+    ) {
+        self.feed_session = Some(handle);
     }
 
     /// Settle a finished background teardown and replace the provisional
@@ -725,6 +744,7 @@ impl Module for VppOffloadModule {
             source,
             &allowlist,
             self.completeness.clone(),
+            self.feed_session.clone(),
             &budget,
         ) {
             Ok(a) => a,

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -548,7 +548,15 @@ pub(super) mod sys {
                         req.fs = *stored;
                         Ok(())
                     }
-                    None => Err(std::io::Error::other("ENOENT: no rule at that location")),
+                    // `NotFound`, not a bare string: ENOENT is how the
+                    // real driver answers for an empty location, and
+                    // `delete` classifies on the error KIND — a fake
+                    // whose absent-rule error is unclassifiable would
+                    // hide exactly the branch the fake exists to test.
+                    None => Err(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        "ENOENT: no rule at that location",
+                    )),
                 },
                 ETHTOOL_SRXCLSRLDEL => {
                     if nic.undeletable.contains(&req.fs.location) {
@@ -556,7 +564,10 @@ pub(super) mod sys {
                     }
                     match nic.rules.remove(&key) {
                         Some(_) => Ok(()),
-                        None => Err(std::io::Error::other("ENOENT: no rule at that location")),
+                        None => Err(std::io::Error::new(
+                            std::io::ErrorKind::NotFound,
+                            "ENOENT: no rule at that location",
+                        )),
                     }
                 }
                 other => Err(std::io::Error::other(format!(
@@ -605,8 +616,26 @@ fn insert(iface: &str, rule: &SteerRule, vf_index: u32) -> Result<(), String> {
     Ok(())
 }
 
+/// What removing one rule actually did.
+enum Removal {
+    Removed,
+    /// The NIC answered ENOENT: no rule at that location. Absent IS
+    /// the removal's postcondition — nothing there is steering traffic
+    /// — so it counts as removed, not as a failure. The case is real,
+    /// not defensive: the UniFi controller wipes classifier state on
+    /// provisioning, so rules the ledger faithfully records can vanish
+    /// while the daemon is down. Treating that as a failed delete kept
+    /// the ledger populated forever — unsteer refused, the VF was
+    /// withheld, and the deferred adopted reconciliation waited on an
+    /// unsteer that could never be acknowledged (review finding).
+    ///
+    /// ENOENT only. EBUSY, EINVAL and the rest keep failing loudly:
+    /// they say nothing about whether a rule is still matching.
+    AlreadyAbsent,
+}
+
 /// Remove one rule by location.
-fn delete(iface: &str, location: u32) -> Result<(), String> {
+fn delete(iface: &str, location: u32) -> Result<Removal, String> {
     let mut req = Rxnfc {
         cmd: ETHTOOL_SRXCLSRLDEL,
         fs: RxFlowSpec {
@@ -615,8 +644,11 @@ fn delete(iface: &str, location: u32) -> Result<(), String> {
         },
         ..Rxnfc::default()
     };
-    sys::ethtool(iface, &mut req)
-        .map_err(|e| format!("deleting ntuple rule at loc {location}: {e}"))
+    match sys::ethtool(iface, &mut req) {
+        Ok(()) => Ok(Removal::Removed),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Removal::AlreadyAbsent),
+        Err(e) => Err(format!("deleting ntuple rule at loc {location}: {e}")),
+    }
 }
 
 /// The real [`crate::runtime::Steering`], replacing the placeholder.
@@ -659,9 +691,19 @@ impl NtupleSteering {
     fn remove_all(&mut self, victims: Vec<(String, u32)>) -> Vec<String> {
         let mut failed = Vec::new();
         for (iface, loc) in victims {
-            if let Err(e) = delete(&iface, loc) {
-                failed.push(format!("{iface} loc {loc}: {e}"));
-                self.installed.push((iface, loc));
+            match delete(&iface, loc) {
+                Ok(Removal::Removed) => {}
+                Ok(Removal::AlreadyAbsent) => tracing::info!(
+                    iface,
+                    loc,
+                    "ntuple rule was already gone — the controller wipes classifier \
+                     state on provisioning — and absent is what a removal is for, so \
+                     it counts as removed"
+                ),
+                Err(e) => {
+                    failed.push(format!("{iface} loc {loc}: {e}"));
+                    self.installed.push((iface, loc));
+                }
             }
         }
         failed
@@ -1045,6 +1087,28 @@ mod tests {
         let e = s.unsteer().expect_err("must refuse while rules remain");
         assert!(e.contains("must not be released"), "{e}");
         assert_eq!(s.installed().len(), 2, "still recorded after the refusal");
+    }
+
+    /// Rules the controller wiped behind the ledger's back are already
+    /// unsteered — `unsteer` must say so, not fail. The failing version
+    /// wedged the whole adopted pipeline: the ledger stayed populated,
+    /// every re-requested unsteer failed on the same ENOENT, and the
+    /// deferred reconciliation waited forever on an acknowledgement
+    /// that could never come (review finding on the pre-dump gate).
+    #[test]
+    fn vanished_rules_count_as_removed_not_as_failures() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], RuleSet::default());
+        // The state file remembers two rules; the NIC holds neither.
+        s.adopt_installed(vec![("eth0".into(), 1024), ("eth0".into(), 1025)]);
+
+        s.unsteer()
+            .expect("absent rules satisfy the removal's postcondition");
+        assert!(
+            s.installed().is_empty(),
+            "nothing may stay recorded when nothing is steering"
+        );
     }
 
     /// Adopted locations survive into `unsteer`.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -598,6 +598,35 @@ fn source_quiet_rate_per_sec(adopted: u64) -> u64 {
     (adopted / 1024).max(64)
 }
 
+/// The authority's CURRENT word, or `None` when no authority is
+/// configured: the cached verdict must still permit steering AND the
+/// report must still describe the mirror as it is now (its authority
+/// count against `mirror_now`, under the same drift bound the verdict
+/// itself enforces). One function because it has two callers — the
+/// release computation and the post-dump revalidation — and the review
+/// caught them drifting apart twice: first the /2 bound diverging from
+/// the policy, then the veto trusting the cached verdict while only
+/// the `complete` release recomputed (a stale Converged carried a
+/// since-shrunken mirror through the floor path for the length of the
+/// dump).
+fn authority_current(
+    completeness: &Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    mirror_now: u64,
+) -> Option<bool> {
+    completeness.as_ref().map(|h| {
+        h.verdict().permits_steering()
+            && h.latest().is_some_and(|r| {
+                let now_r = packetframe_common::fib::CompletenessReport {
+                    mirror_routes: mirror_now,
+                    ..r
+                };
+                now_r
+                    .drift()
+                    .is_some_and(|d| d <= packetframe_common::fib::STEER_MAX_DRIFT)
+            })
+    })
+}
+
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
 pub struct Runtime {
     core: Rc<RefCell<Core>>,
@@ -965,60 +994,24 @@ impl Observe for ObserveView {
                     //    SMALL_TABLE_QUIET_FOR), and the hold-length
                     //    quiet is what bounds a hung session going
                     //    stale at "up".
-                    // The completeness verdict is a REPORT — a snapshot
-                    // valid for up to STEER_MAX_REPORT_AGE — so it
-                    // attests liveness at report time, not now: a
-                    // PeerDown wipe inside that window would otherwise
-                    // ride a stale Converged onto an empty fallback
-                    // (review finding). Hence `live` here too, plus a
-                    // requirement that the CURRENT mirror would still
-                    // pass the SAME steering policy the report passed:
-                    // the report's authority count against today's
-                    // mirror, under the same drift bound. A /2 bound
-                    // here permitted a 50% collapse to ride a verdict
-                    // whose policy allows 1% (review finding).
+                    // The authority's CURRENT word gates every path:
+                    // the cached verdict alone let a stale Converged
+                    // carry a since-shrunken mirror through the floor
+                    // release for the length of the dump (review
+                    // finding). `authority_current` recomputes the
+                    // report against the mirror as it is now; None
+                    // means no authority is configured and the proxies
+                    // stand on their own.
+                    let authority = authority_current(&c.completeness, have);
+                    let veto = authority == Some(false);
                     let complete = live
                         && view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
-                        && c.completeness.as_ref().is_some_and(|h| {
-                            h.verdict().permits_steering()
-                                && h.latest().is_some_and(|r| {
-                                    let now_r = packetframe_common::fib::CompletenessReport {
-                                        mirror_routes: have,
-                                        ..r
-                                    };
-                                    now_r.drift().is_some_and(|d| {
-                                        d <= packetframe_common::fib::STEER_MAX_DRIFT
-                                    })
-                                })
-                        });
+                        && authority == Some(true);
                     let small_table_loaded = have > 0
                         && live
                         && view
                             .rate_quiet_for
                             .is_some_and(|q| q >= SMALL_TABLE_QUIET_FOR);
-                    // The floor answers SIZE and nothing else, so it
-                    // does not release alone: a small `expected-routes`
-                    // shrinks it beneath what neighbour-synthesized
-                    // routes can supply with the feed dead (capacity
-                    // 176 puts it at 11; review finding). Liveness is
-                    // the session's to answer on every path, the
-                    // completeness authority included — its report
-                    // proves bird was alive at REPORT time, and `live`
-                    // is what makes that claim current.
-                    // A configured authority that currently says NO is
-                    // a VETO, not a bystander: with the verdict
-                    // Incomplete, the mirror is KNOWN to be missing
-                    // more than the drift policy allows, and no count
-                    // or quiet proxy may out-vote that knowledge — a
-                    // live session whose load merely stalls for two
-                    // seconds past the floor would otherwise unsteer
-                    // onto a table the authority had already condemned
-                    // (review finding). No handle, no veto: birdless
-                    // deployments still release on the proxies.
-                    let veto = c
-                        .completeness
-                        .as_ref()
-                        .is_some_and(|h| !h.verdict().permits_steering());
                     let released =
                         !veto && ((view.released && live) || complete || small_table_loaded);
                     let unsteered = c.steering.installed().is_empty();
@@ -1148,18 +1141,8 @@ impl Observe for ObserveView {
                         // used for "the source still knows the table".
                         let mirror_settled =
                             have_now >= (have / 2).max(1) && dump_churn <= churn_budget;
-                        let authority_agrees = completeness.as_ref().is_none_or(|h| {
-                            h.verdict().permits_steering()
-                                && h.latest().is_some_and(|r| {
-                                    let now_r = packetframe_common::fib::CompletenessReport {
-                                        mirror_routes: have_now,
-                                        ..r
-                                    };
-                                    now_r.drift().is_some_and(|d| {
-                                        d <= packetframe_common::fib::STEER_MAX_DRIFT
-                                    })
-                                })
-                        });
+                        let authority_agrees =
+                            authority_current(completeness, have_now) != Some(false);
                         if !live_now || !mirror_settled || !authority_agrees {
                             tracing::warn!(
                                 adopted,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -324,9 +324,6 @@ struct Core {
 struct SourceGate {
     /// Minimum source size before quiescence even counts.
     floor: u64,
-    /// Mutations per second below which the source is quiet — see
-    /// [`source_quiet_rate_per_sec`].
-    quiet_rate: u64,
     /// The source's change counter at the previous check, for the
     /// activity rate. The COUNTER, not the table size: net size hides
     /// balanced churn and reads a shrinking source as quiet.
@@ -357,10 +354,9 @@ struct GateView {
 }
 
 impl SourceGate {
-    fn new(floor: u64, quiet_rate: u64, seq_baseline: u64) -> Self {
+    fn new(floor: u64, seq_baseline: u64) -> Self {
         Self {
             floor,
-            quiet_rate,
             last_seq: seq_baseline,
             last_check: None,
             quiet_since: None,
@@ -385,7 +381,22 @@ impl SourceGate {
     /// (review finding). Rebaselining continuously while down also
     /// covers the up-transition: the clock starts from the moment
     /// liveness returns.
-    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64, live: bool) -> GateView {
+    /// `quiet_rate` is supplied per observation, not stored, because
+    /// the honest basis DIFFERS by stage and time: the diff stage
+    /// scales it to the dumped table it protects, while the pre-dump
+    /// stage must scale it to the mirror AS OBSERVED — a
+    /// capacity-scaled rate let a 16M sizing call a steady 10k/s
+    /// reload quiet and release mid-load at the floor (review
+    /// finding). A rate frozen at construction cannot track a mirror
+    /// that is still growing.
+    fn observe(
+        &mut self,
+        now: std::time::Instant,
+        have: u64,
+        seq: u64,
+        live: bool,
+        quiet_rate: u64,
+    ) -> GateView {
         let activity_per_sec = match self.last_check {
             // A rate needs two observations; the first check only
             // baselines, and reports as loading — which a source
@@ -396,7 +407,7 @@ impl SourceGate {
                 seq.saturating_sub(self.last_seq).saturating_mul(1_000) / ms
             }
         };
-        let rate_quiet = live && activity_per_sec <= self.quiet_rate;
+        let rate_quiet = live && activity_per_sec <= quiet_rate;
         if !rate_quiet {
             self.rate_quiet_since = None;
         } else if self.rate_quiet_since.is_none() {
@@ -918,7 +929,9 @@ impl Observe for ObserveView {
                     mut restoring,
                 } => {
                     let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
-                    let view = gate.observe(now, have, seq, live);
+                    // Rate scaled to the mirror as observed — never
+                    // to capacity, which is a ceiling, not a table.
+                    let view = gate.observe(now, have, seq, live, source_quiet_rate_per_sec(have));
                     let want = gate.floor;
                     // Three ways the fallback proves itself ready,
                     // because the floor alone cannot: capacity is an
@@ -1111,7 +1124,15 @@ impl Observe for ObserveView {
                         let churn_budget =
                             source_quiet_rate_per_sec(have) * SOURCE_QUIET_FOR.as_secs();
                         let dump_churn = seq_now.saturating_sub(seq);
-                        let mirror_settled = have_now > 0 && dump_churn <= churn_budget;
+                        // Both bounds, because each covers the other's
+                        // small end: the absolute budget is 128
+                        // mutations at the 64/s floor, which is noise
+                        // for a 1M mirror and a 99% wipe for a
+                        // 100-route one (review finding). Half is the
+                        // same fraction the diff-stage floor has always
+                        // used for "the source still knows the table".
+                        let mirror_settled =
+                            have_now >= (have / 2).max(1) && dump_churn <= churn_budget;
                         let authority_agrees = completeness.as_ref().is_none_or(|h| {
                             h.verdict().permits_steering()
                                 && h.latest().is_some_and(|r| {
@@ -1161,7 +1182,9 @@ impl Observe for ObserveView {
                     // floor is measured against the DUMPED table, and
                     // nothing at this stage is steered), so quiet needs
                     // no liveness conditioning: pass live.
-                    let released = gate.observe(now, have, seq, true).released;
+                    let released = gate
+                        .observe(now, have, seq, true, source_quiet_rate_per_sec(adopted))
+                        .released;
                     if !released {
                         let want = gate.floor;
                         c.deferred_resync = Some(DeferredResync::AwaitingDiff { adopted, gate });
@@ -1394,7 +1417,7 @@ impl Effects for EffectsView {
                  resync"
             );
             c.deferred_resync = Some(DeferredResync::AwaitingFallback {
-                gate: SourceGate::new(floor, source_quiet_rate_per_sec(capacity), seq),
+                gate: SourceGate::new(floor, seq),
                 last_request: None,
                 restoring: false,
             });
@@ -1467,11 +1490,7 @@ impl Effects for EffectsView {
                     // the sole live route — the exact case the floor
                     // exists for (review finding). A populated
                     // adoption's floor is never satisfied by nothing.
-                    gate: SourceGate::new(
-                        (adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1),
-                        source_quiet_rate_per_sec(adopted),
-                        seq,
-                    ),
+                    gate: SourceGate::new((adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1), seq),
                 })
             }
         };

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1101,7 +1101,17 @@ impl Observe for ObserveView {
                         let dump_ms = dump_started.elapsed().as_millis().max(1) as u64;
                         let churn_per_sec =
                             seq_now.saturating_sub(seq).saturating_mul(1_000) / dump_ms;
-                        let mirror_settled = have_now > 0 && churn_per_sec <= gate.quiet_rate;
+                        // Bounded by the MIRROR being protected, never
+                        // by the sizing ceiling: gate.quiet_rate scales
+                        // with capacity, and a 16M-route sizing calls
+                        // 15.6k mutations/s quiet — ~78k routes lost
+                        // across a five-second dump would have read as
+                        // settled (review finding). The released
+                        // mirror's own scale is the honest yardstick,
+                        // the same arithmetic every other quiet bound
+                        // uses.
+                        let mirror_settled =
+                            have_now > 0 && churn_per_sec <= source_quiet_rate_per_sec(have);
                         let authority_agrees = completeness.as_ref().is_none_or(|h| {
                             h.verdict().permits_steering()
                                 && h.latest().is_some_and(|r| {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -332,6 +332,30 @@ struct SourceGate {
     /// while it is loading. Release requires this to have lasted
     /// [`SOURCE_QUIET_FOR`].
     quiet_since: Option<std::time::Instant>,
+    /// Since when the RATE alone has been quiet, floor ignored. The
+    /// pre-dump stage's alternate releases need quiet that the floor
+    /// cannot veto — they exist precisely for tables the floor is
+    /// wrong about.
+    rate_quiet_since: Option<std::time::Instant>,
+    /// The change counter when this gate was created, so
+    /// [`GateView::loaded_delta`] can report how much of a reload has
+    /// actually been observed.
+    seq_baseline: u64,
+}
+
+/// What one gate observation saw. `released` is the coupled
+/// floor-plus-quiescence verdict both stages share; the other fields
+/// serve the pre-dump stage's alternate releases, which must work
+/// exactly where the floor does not.
+#[derive(Debug, Clone, Copy)]
+struct GateView {
+    released: bool,
+    /// How long the rate alone has been quiet, floor ignored.
+    rate_quiet_for: Option<Duration>,
+    /// Change-counter advance since the gate was created — evidence a
+    /// reload actually happened, as opposed to a feed that never
+    /// delivered anything.
+    loaded_delta: u64,
 }
 
 impl SourceGate {
@@ -342,6 +366,8 @@ impl SourceGate {
             last_seq: seq_baseline,
             last_check: None,
             quiet_since: None,
+            rate_quiet_since: None,
+            seq_baseline,
         }
     }
 
@@ -354,7 +380,7 @@ impl SourceGate {
     /// per-call delta: the production loop caps its sleeps at 50 ms, so
     /// a per-call threshold shrinks with cadence until a full-speed
     /// reload classifies as quiet.
-    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64) -> bool {
+    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64) -> GateView {
         let activity_per_sec = match self.last_check {
             // A rate needs two observations; the first check only
             // baselines, and reports as loading — which a source
@@ -365,7 +391,13 @@ impl SourceGate {
                 seq.saturating_sub(self.last_seq).saturating_mul(1_000) / ms
             }
         };
-        let still_loading = have < self.floor || activity_per_sec > self.quiet_rate;
+        let rate_quiet = activity_per_sec <= self.quiet_rate;
+        if !rate_quiet {
+            self.rate_quiet_since = None;
+        } else if self.rate_quiet_since.is_none() {
+            self.rate_quiet_since = Some(now);
+        }
+        let still_loading = have < self.floor || !rate_quiet;
         if still_loading {
             self.quiet_since = None;
         } else if self.quiet_since.is_none() {
@@ -376,7 +408,11 @@ impl SourceGate {
             .is_some_and(|since| now.duration_since(since) >= SOURCE_QUIET_FOR);
         self.last_seq = seq;
         self.last_check = Some(now);
-        released
+        GateView {
+            released,
+            rate_quiet_for: self.rate_quiet_since.map(|s| now.duration_since(s)),
+            loaded_delta: seq.saturating_sub(self.seq_baseline),
+        }
     }
 }
 
@@ -425,13 +461,33 @@ impl DeferredResync {
 /// capacity. Before the dump the adopted table's size is unknowable —
 /// reading it is exactly what is being deferred — so the floor that
 /// keeps a dead or trickling source from triggering an unsteer needs
-/// another basis, and capacity is the honest one available: it derives
-/// from the operator's `expected-routes`, so it scales with the
-/// deployment instead of encoding this fleet's table. Sixteen keeps
-/// both failure modes far away: any real table passes under anything
-/// short of 16x oversizing, and a dead source — the case floors exist
-/// for — sits orders of magnitude below.
+/// another basis, and capacity is the one available: it derives from
+/// the operator's `expected-routes`, so it scales with the deployment
+/// instead of encoding this fleet's table.
+///
+/// Capacity is an UPPER sizing bound, though, so this floor is only
+/// one of three releases — a deployment whose real table sits below
+/// `capacity / 16` (the default sizing over a small table qualifies)
+/// would otherwise defer forever (review finding). The other two, in
+/// the `AwaitingFallback` arm: the completeness authority where a bird
+/// exists to compare against, and the observed-reload-plus-long-quiet
+/// clause under [`SMALL_TABLE_QUIET_FOR`].
 pub const FALLBACK_FLOOR_DIVISOR: u64 = 16;
+
+/// The pre-dump stage's small-table release: rate-quiet sustained this
+/// long, together with an observed full reload (the change counter
+/// advanced by at least the table size since the gate was created),
+/// counts as loaded even below the capacity floor. The DURATION is the
+/// load-bearing part: it must outlast the BGP hold time, because a
+/// feed that died or hung mid-load cannot stay quietly wrong longer
+/// than that — the session drops, the PeerDown wipe empties the
+/// mirror, and the wipe's own churn resets both quiet trackers.
+/// Default holds are 90 s and the fleet's feed negotiates 90; 150 s
+/// covers them with margin. A deployment that raises its hold beyond
+/// this should size `expected-routes` within 16x of its table or run
+/// `require-table-complete on`, both of which release without this
+/// clause.
+const SMALL_TABLE_QUIET_FOR: Duration = Duration::from_secs(150);
 
 /// How often a refused or unacknowledged unsteer is re-requested while
 /// the pre-dump stage waits. Paced because the gate re-checks every
@@ -822,8 +878,33 @@ impl Observe for ObserveView {
                     mut gate,
                     mut last_request,
                 } => {
-                    let released = gate.observe(now, have, seq);
+                    let view = gate.observe(now, have, seq);
                     let want = gate.floor;
+                    // Three ways the fallback proves itself ready,
+                    // because the floor alone cannot: capacity is an
+                    // upper sizing bound, so a real table below
+                    // capacity/16 would defer forever on it (review
+                    // finding).
+                    //  - the coupled floor+quiescence release, for
+                    //    tables within 16x of their sizing (the fleet);
+                    //  - the completeness authority, where a bird
+                    //    exists — the exact signal, and the same one
+                    //    `Effects::steer` gates on;
+                    //  - an observed full reload followed by quiet
+                    //    longer than the BGP hold time — see
+                    //    SMALL_TABLE_QUIET_FOR for why that duration
+                    //    makes "small and loaded" distinguishable from
+                    //    "died mid-load".
+                    let complete = view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
+                        && c.completeness
+                            .as_ref()
+                            .is_some_and(|h| h.verdict().permits_steering());
+                    let small_table_loaded = have > 0
+                        && view.loaded_delta >= have
+                        && view
+                            .rate_quiet_for
+                            .is_some_and(|q| q >= SMALL_TABLE_QUIET_FOR);
+                    let released = view.released || complete || small_table_loaded;
                     if !released {
                         c.deferred_resync =
                             Some(DeferredResync::AwaitingFallback { gate, last_request });
@@ -868,7 +949,7 @@ impl Observe for ObserveView {
                     c.deferred_resync = None;
                 }
                 DeferredResync::AwaitingDiff { adopted, mut gate } => {
-                    let released = gate.observe(now, have, seq);
+                    let released = gate.observe(now, have, seq).released;
                     if !released {
                         let want = gate.floor;
                         c.deferred_resync = Some(DeferredResync::AwaitingDiff { adopted, gate });

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -337,10 +337,6 @@ struct SourceGate {
     /// cannot veto — they exist precisely for tables the floor is
     /// wrong about.
     rate_quiet_since: Option<std::time::Instant>,
-    /// The change counter when this gate was created, so
-    /// [`GateView::loaded_delta`] can report how much of a reload has
-    /// actually been observed.
-    seq_baseline: u64,
 }
 
 /// What one gate observation saw. `released` is the coupled
@@ -352,10 +348,6 @@ struct GateView {
     released: bool,
     /// How long the rate alone has been quiet, floor ignored.
     rate_quiet_for: Option<Duration>,
-    /// Change-counter advance since the gate was created — evidence a
-    /// reload actually happened, as opposed to a feed that never
-    /// delivered anything.
-    loaded_delta: u64,
 }
 
 impl SourceGate {
@@ -367,7 +359,6 @@ impl SourceGate {
             last_check: None,
             quiet_since: None,
             rate_quiet_since: None,
-            seq_baseline,
         }
     }
 
@@ -411,7 +402,6 @@ impl SourceGate {
         GateView {
             released,
             rate_quiet_for: self.rate_quiet_since.map(|s| now.duration_since(s)),
-            loaded_delta: seq.saturating_sub(self.seq_baseline),
         }
     }
 }
@@ -470,24 +460,39 @@ impl DeferredResync {
 /// `capacity / 16` (the default sizing over a small table qualifies)
 /// would otherwise defer forever (review finding). The other two, in
 /// the `AwaitingFallback` arm: the completeness authority where a bird
-/// exists to compare against, and the observed-reload-plus-long-quiet
-/// clause under [`SMALL_TABLE_QUIET_FOR`].
+/// exists to compare against, and the small-table clause under
+/// [`SMALL_TABLE_QUIET_FOR`] / [`SMALL_TABLE_MIN_ROUTES`].
 pub const FALLBACK_FLOOR_DIVISOR: u64 = 16;
 
 /// The pre-dump stage's small-table release: rate-quiet sustained this
-/// long, together with an observed full reload (the change counter
-/// advanced by at least the table size since the gate was created),
-/// counts as loaded even below the capacity floor. The DURATION is the
-/// load-bearing part: it must outlast the BGP hold time, because a
-/// feed that died or hung mid-load cannot stay quietly wrong longer
-/// than that — the session drops, the PeerDown wipe empties the
-/// mirror, and the wipe's own churn resets both quiet trackers.
-/// Default holds are 90 s and the fleet's feed negotiates 90; 150 s
-/// covers them with margin. A deployment that raises its hold beyond
-/// this should size `expected-routes` within 16x of its table or run
+/// long, together with at least [`SMALL_TABLE_MIN_ROUTES`] in the
+/// mirror, counts as loaded even below the capacity floor. The
+/// DURATION is one of the two load-bearing parts: it must outlast the
+/// BGP hold time, because a feed that died or hung mid-load cannot
+/// stay quietly wrong longer than that — the session drops, the
+/// PeerDown wipe empties the mirror of everything the session carried,
+/// and the wipe's own churn resets the quiet tracker. Default holds
+/// are 90 s and the fleet's feed negotiates 90; 150 s covers them with
+/// margin. A deployment that raises its hold beyond this should size
+/// `expected-routes` within 16x of its table or run
 /// `require-table-complete on`, both of which release without this
 /// clause.
 const SMALL_TABLE_QUIET_FOR: Duration = Duration::from_secs(150);
+
+/// The other load-bearing part: what quiet-past-the-hold leaves behind
+/// after a session death is a mirror holding only what did NOT come
+/// from the session — neighbour-synthesized local routes, bounded by
+/// the hosts physically present on the box's L2s, i.e. dozens. No
+/// in-process signal can distinguish "watched a load" from "watched a
+/// wipe": the mirror starts empty every daemon start, so its content
+/// IS the observed mutations — a change-counter baseline is a
+/// tautology, and one taken at gate creation additionally missed
+/// whatever loaded before attach (review finding). An absolute
+/// minimum the husk cannot reach is the honest discriminator. A site
+/// with a genuine table under 128 routes releases through the floor
+/// instead, by sizing `expected-routes` at or under 2048 — whose
+/// floor, not coincidentally, is exactly 128.
+const SMALL_TABLE_MIN_ROUTES: u64 = 128;
 
 /// How often a refused or unacknowledged unsteer is re-requested while
 /// the pre-dump stage waits. Paced because the gate re-checks every
@@ -890,17 +895,16 @@ impl Observe for ObserveView {
                     //  - the completeness authority, where a bird
                     //    exists — the exact signal, and the same one
                     //    `Effects::steer` gates on;
-                    //  - an observed full reload followed by quiet
-                    //    longer than the BGP hold time — see
-                    //    SMALL_TABLE_QUIET_FOR for why that duration
-                    //    makes "small and loaded" distinguishable from
-                    //    "died mid-load".
+                    //  - a table past SMALL_TABLE_MIN_ROUTES that has
+                    //    been quiet longer than the BGP hold time — see
+                    //    the two constants for why that pair separates
+                    //    "small and loaded" from the synth-only husk a
+                    //    dead session leaves behind.
                     let complete = view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
                         && c.completeness
                             .as_ref()
                             .is_some_and(|h| h.verdict().permits_steering());
-                    let small_table_loaded = have > 0
-                        && view.loaded_delta >= have
+                    let small_table_loaded = have >= SMALL_TABLE_MIN_ROUTES
                         && view
                             .rate_quiet_for
                             .is_some_and(|q| q >= SMALL_TABLE_QUIET_FOR);

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1069,7 +1069,6 @@ impl Observe for ObserveView {
                             completeness,
                             ..
                         } = &mut *c;
-                        let dump_started = std::time::Instant::now();
                         let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
                         // Revalidate on the FAR side of the dump: it
                         // blocks this thread for seconds, and the world
@@ -1098,20 +1097,21 @@ impl Observe for ObserveView {
                         let live_now = feed_session.as_ref().is_some_and(|f| f.is_up());
                         let have_now = source.route_count();
                         let seq_now = source.change_seq();
-                        let dump_ms = dump_started.elapsed().as_millis().max(1) as u64;
-                        let churn_per_sec =
-                            seq_now.saturating_sub(seq).saturating_mul(1_000) / dump_ms;
-                        // Bounded by the MIRROR being protected, never
-                        // by the sizing ceiling: gate.quiet_rate scales
-                        // with capacity, and a 16M-route sizing calls
-                        // 15.6k mutations/s quiet — ~78k routes lost
-                        // across a five-second dump would have read as
-                        // settled (review finding). The released
-                        // mirror's own scale is the honest yardstick,
-                        // the same arithmetic every other quiet bound
-                        // uses.
-                        let mirror_settled =
-                            have_now > 0 && churn_per_sec <= source_quiet_rate_per_sec(have);
+                        // An ABSOLUTE budget for the whole dump, never
+                        // a dump-wide average: dividing by the dump's
+                        // duration let a withdrawal burst early in a
+                        // slow dump dilute into "settled" across the
+                        // idle seconds that followed (review finding —
+                        // twice: the first fix was claimed and never
+                        // landed, caught by the reviewer reading the
+                        // actual expression). The entire dump may see
+                        // at most what a legitimately quiet source
+                        // produces in one SOURCE_QUIET_FOR window,
+                        // scaled by the mirror being protected.
+                        let churn_budget =
+                            source_quiet_rate_per_sec(have) * SOURCE_QUIET_FOR.as_secs();
+                        let dump_churn = seq_now.saturating_sub(seq);
+                        let mirror_settled = have_now > 0 && dump_churn <= churn_budget;
                         let authority_agrees = completeness.as_ref().is_none_or(|h| {
                             h.verdict().permits_steering()
                                 && h.latest().is_some_and(|r| {
@@ -1128,7 +1128,8 @@ impl Observe for ObserveView {
                             tracing::warn!(
                                 adopted,
                                 live = live_now,
-                                churn_per_sec,
+                                dump_churn,
+                                churn_budget,
                                 have_now,
                                 "the feed changed while VPP's FIB was being dumped; holding \
                                  the diff — the adopted routes stay in the ledger and the \

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -299,25 +299,28 @@ struct Core {
     /// operator would see a stalled `pending_ops` with nothing saying
     /// why.
     last_drain_error: Option<String>,
-    /// `Some` while an adopted resync is deferred, holding the release
-    /// gate's state. Set by `start_resync` on EVERY adoption of a
-    /// populated FIB; cleared by `drain_batch` when the gate opens and
-    /// the diff actually begins. While set, the adopted VPP is left
-    /// exactly as found — steered, routes intact — because a diff
-    /// against a loading source is ~all withdrawals, and draining those
-    /// into a live dataplane is the drill-(d) blackhole (2026-08-07).
+    /// `Some` while an adopted reconciliation is deferred, holding the
+    /// release gate's state. Set by `start_resync` on every adoption
+    /// that has anything to protect; cleared by `drain_batch` when the
+    /// gate opens and the work actually begins. While set, the adopted
+    /// VPP is left exactly as found — routes intact, and on the steered
+    /// stage even its FIB unread — because a diff against a loading
+    /// source is ~all withdrawals (drill (d), 2026-08-07), and the dump
+    /// itself freezes VPP's workers (drill (d10), 2026-08-09). See
+    /// [`DeferredResync`] for the two stages.
     deferred_resync: Option<DeferredResync>,
 }
 
-/// Release-gate state for a deferred adopted resync. See
-/// [`ADOPTED_SOURCE_FLOOR_DIVISOR`] and [`SOURCE_QUIET_TICKS`] for the
-/// two conditions, and why both are load-bearing.
+/// The loaded-and-quiet release gate, shared by both deferral stages.
+/// See [`ADOPTED_SOURCE_FLOOR_DIVISOR`] for why the floor and the
+/// quiescence are BOTH load-bearing.
 #[derive(Debug, Clone, Copy)]
-struct DeferredResync {
-    /// Routes adopted from VPP's FIB — the diff's withdrawal universe.
-    adopted: u64,
-    /// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR`.
+struct SourceGate {
+    /// Minimum source size before quiescence even counts.
     floor: u64,
+    /// Mutations per second below which the source is quiet — see
+    /// [`source_quiet_rate_per_sec`].
+    quiet_rate: u64,
     /// The source's change counter at the previous check, for the
     /// activity rate. The COUNTER, not the table size: net size hides
     /// balanced churn and reads a shrinking source as quiet.
@@ -330,6 +333,111 @@ struct DeferredResync {
     /// [`SOURCE_QUIET_FOR`].
     quiet_since: Option<std::time::Instant>,
 }
+
+impl SourceGate {
+    fn new(floor: u64, quiet_rate: u64, seq_baseline: u64) -> Self {
+        Self {
+            floor,
+            quiet_rate,
+            last_seq: seq_baseline,
+            last_check: None,
+            quiet_since: None,
+        }
+    }
+
+    /// One paced observation; `true` once loaded-and-quiet has held for
+    /// [`SOURCE_QUIET_FOR`]. Both gates, in order: below the floor
+    /// nothing else matters, and above it only quiet SUSTAINED FOR A
+    /// DURATION counts — a loading feed passes through the floor by
+    /// construction (the floor-only version withdrew half a live table,
+    /// 2026-08-08), and "quiet" is a rate over elapsed time, never a
+    /// per-call delta: the production loop caps its sleeps at 50 ms, so
+    /// a per-call threshold shrinks with cadence until a full-speed
+    /// reload classifies as quiet.
+    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64) -> bool {
+        let activity_per_sec = match self.last_check {
+            // A rate needs two observations; the first check only
+            // baselines, and reports as loading — which a source
+            // this young almost certainly is.
+            None => u64::MAX,
+            Some(prev) => {
+                let ms = now.duration_since(prev).as_millis().max(1) as u64;
+                seq.saturating_sub(self.last_seq).saturating_mul(1_000) / ms
+            }
+        };
+        let still_loading = have < self.floor || activity_per_sec > self.quiet_rate;
+        if still_loading {
+            self.quiet_since = None;
+        } else if self.quiet_since.is_none() {
+            self.quiet_since = Some(now);
+        }
+        let released = self
+            .quiet_since
+            .is_some_and(|since| now.duration_since(since) >= SOURCE_QUIET_FOR);
+        self.last_seq = seq;
+        self.last_check = Some(now);
+        released
+    }
+}
+
+/// What a deferred adopted reconciliation is waiting for.
+#[derive(Debug, Clone, Copy)]
+enum DeferredResync {
+    /// A STEERED adoption: even the FIB DUMP is deferred. VPP processes
+    /// `ip_route_dump` with every worker parked in barrier sync — the
+    /// message is not mp-safe (`ip_api.c` marks `ip_route_add_del`
+    /// thread-safe but not the dump), so at the reference table the
+    /// dump is ~5.4 s of the NIC dropping frames no VPP counter sees
+    /// (drill (d10), shadow 2026-08-09; invariant across six prior runs
+    /// because every one of them ran this dump at attach). It may only
+    /// run against a VPP carrying no traffic. Once the source is loaded
+    /// and quiet — which means the eBPF tier is equally loaded, both
+    /// consuming the same mirror commits — the runtime asks the
+    /// supervisor to unsteer ([`Event::FallbackSettled`]) and dumps
+    /// only after the NIC ledger confirms the rules are gone.
+    /// `steer_wanted` survives the unsteer, so `VerifyPassed` re-steers
+    /// on the existing verified path.
+    AwaitingFallback {
+        gate: SourceGate,
+        /// When the unsteer was last requested, so a refused or
+        /// unacknowledged removal is re-asked every
+        /// [`UNSTEER_REQUEST_EVERY`] instead of on each 50 ms tick.
+        last_request: Option<std::time::Instant>,
+    },
+    /// An UNSTEERED adoption whose dump has already run — harmlessly,
+    /// because with no rules installed nothing is on VPP for the
+    /// barrier to stall. The DIFF is deferred until the source is
+    /// loaded and quiet, exactly the original gate: a diff against a
+    /// loading source is ~all withdrawals.
+    AwaitingDiff { adopted: u64, gate: SourceGate },
+}
+
+impl DeferredResync {
+    fn floor(&self) -> u64 {
+        match self {
+            DeferredResync::AwaitingFallback { gate, .. } => gate.floor,
+            DeferredResync::AwaitingDiff { gate, .. } => gate.floor,
+        }
+    }
+}
+
+/// Floor for the pre-dump stage, as a fraction of the ledger's route
+/// capacity. Before the dump the adopted table's size is unknowable —
+/// reading it is exactly what is being deferred — so the floor that
+/// keeps a dead or trickling source from triggering an unsteer needs
+/// another basis, and capacity is the honest one available: it derives
+/// from the operator's `expected-routes`, so it scales with the
+/// deployment instead of encoding this fleet's table. Sixteen keeps
+/// both failure modes far away: any real table passes under anything
+/// short of 16x oversizing, and a dead source — the case floors exist
+/// for — sits orders of magnitude below.
+pub const FALLBACK_FLOOR_DIVISOR: u64 = 16;
+
+/// How often a refused or unacknowledged unsteer is re-requested while
+/// the pre-dump stage waits. Paced because the gate re-checks every
+/// driver tick: asking on each one would emit an action per 50 ms at a
+/// NIC that just refused the last one.
+const UNSTEER_REQUEST_EVERY: Duration = Duration::from_secs(5);
 
 /// The adopted diff runs only when the source holds at least
 /// `adopted / ADOPTED_SOURCE_FLOOR_DIVISOR` routes **and** has been
@@ -522,7 +630,9 @@ impl Runtime {
             drain_error: c.last_drain_error.clone(),
             source_backlog: c.source.backlog(),
             steer_configured_ports: c.steering.configured_ports(),
-            resync_deferred: c.deferred_resync.map(|d| (c.source.route_count(), d.floor)),
+            resync_deferred: c
+                .deferred_resync
+                .map(|d| (c.source.route_count(), d.floor())),
         }
     }
 }
@@ -704,60 +814,82 @@ impl Observe for ObserveView {
         // coming diff reads the full mirror and covers them, and
         // applying a partial feed's withdrawals early is the exact
         // hazard being deferred.
-        if let Some(mut d) = c.deferred_resync {
+        if let Some(d) = c.deferred_resync {
             let have = c.source.route_count();
-            // Both gates, in order: below the floor nothing else
-            // matters, and above it only quiet SUSTAINED FOR A DURATION
-            // counts — a loading feed passes through the floor by
-            // construction (the floor-only version withdrew half a live
-            // table, 2026-08-08), and "quiet" is a rate over elapsed
-            // time, never a per-call delta: the production loop caps
-            // its sleeps at 50 ms, so a per-call threshold shrinks with
-            // cadence until a full-speed reload classifies as quiet.
             let seq = c.source.change_seq();
-            let activity_per_sec = match d.last_check {
-                // A rate needs two observations; the first check only
-                // baselines, and reports as loading — which a source
-                // this young almost certainly is.
-                None => u64::MAX,
-                Some(prev) => {
-                    let ms = now.duration_since(prev).as_millis().max(1) as u64;
-                    seq.saturating_sub(d.last_seq).saturating_mul(1_000) / ms
+            match d {
+                DeferredResync::AwaitingFallback {
+                    mut gate,
+                    mut last_request,
+                } => {
+                    let released = gate.observe(now, have, seq);
+                    let want = gate.floor;
+                    if !released {
+                        c.deferred_resync =
+                            Some(DeferredResync::AwaitingFallback { gate, last_request });
+                        return Ok(crate::driver::Drain::AwaitingSource { have, want });
+                    }
+                    if !c.steering.installed().is_empty() {
+                        // The fallback can carry the traffic now; ask the
+                        // supervisor to take it off VPP. Through the
+                        // machine, never `steering.unsteer()` from here:
+                        // the ledger persist and the `steered` fact live
+                        // with the executor, and a second unsteer path is
+                        // two owners for one NIC.
+                        let ask = last_request
+                            .is_none_or(|t| now.duration_since(t) >= UNSTEER_REQUEST_EVERY);
+                        if ask {
+                            c.pending.push(Event::FallbackSettled);
+                            last_request = Some(now);
+                        }
+                        c.deferred_resync =
+                            Some(DeferredResync::AwaitingFallback { gate, last_request });
+                        return Ok(crate::driver::Drain::AwaitingSource { have, want });
+                    }
+                    // Unsteered and quiet: the dump is free — nothing is
+                    // on VPP for the barrier to stall. The diff follows
+                    // immediately; the source this gate just called
+                    // loaded is the same one it reads.
+                    {
+                        let Core { engine, source, .. } = &mut *c;
+                        let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
+                        tracing::info!(
+                            have,
+                            adopted,
+                            "route source loaded and quiet and VPP unsteered; dumped its \
+                             FIB against no traffic and running the adopted resync diff"
+                        );
+                        let _plan = engine.begin_resync(source.as_ref());
+                        engine
+                            .program_neighbours(source.as_ref())
+                            .map(|_| ())
+                            .map_err(|e| e.to_string())?;
+                    }
+                    c.deferred_resync = None;
                 }
-            };
-            let still_loading =
-                have < d.floor || activity_per_sec > source_quiet_rate_per_sec(d.adopted);
-            if still_loading {
-                d.quiet_since = None;
-            } else if d.quiet_since.is_none() {
-                d.quiet_since = Some(now);
+                DeferredResync::AwaitingDiff { adopted, mut gate } => {
+                    let released = gate.observe(now, have, seq);
+                    if !released {
+                        let want = gate.floor;
+                        c.deferred_resync = Some(DeferredResync::AwaitingDiff { adopted, gate });
+                        return Ok(crate::driver::Drain::AwaitingSource { have, want });
+                    }
+                    tracing::info!(
+                        have,
+                        adopted,
+                        "route source loaded and quiet; running the adopted resync diff"
+                    );
+                    {
+                        let Core { engine, source, .. } = &mut *c;
+                        let _plan = engine.begin_resync(source.as_ref());
+                        engine
+                            .program_neighbours(source.as_ref())
+                            .map(|_| ())
+                            .map_err(|e| e.to_string())?;
+                    }
+                    c.deferred_resync = None;
+                }
             }
-            let released = d
-                .quiet_since
-                .is_some_and(|since| now.duration_since(since) >= SOURCE_QUIET_FOR);
-            d.last_seq = seq;
-            d.last_check = Some(now);
-            if !released {
-                c.deferred_resync = Some(d);
-                return Ok(crate::driver::Drain::AwaitingSource {
-                    have,
-                    want: d.floor,
-                });
-            }
-            tracing::info!(
-                have,
-                adopted = d.adopted,
-                "route source loaded and quiet; running the adopted resync diff"
-            );
-            {
-                let Core { engine, source, .. } = &mut *c;
-                let _plan = engine.begin_resync(source.as_ref());
-                engine
-                    .program_neighbours(source.as_ref())
-                    .map(|_| ())
-                    .map_err(|e| e.to_string())?;
-            }
-            c.deferred_resync = None;
         }
         // Live changes are pulled in FIRST, so a route learned while VPP
         // was already converged goes out in this same batch rather than
@@ -928,8 +1060,38 @@ impl Effects for EffectsView {
 
     fn start_resync(&mut self) -> Result<(), String> {
         let mut c = self.core.borrow_mut();
-        // Split borrow: the engine walks the source while both live in
-        // the same core.
+        // A steered start is necessarily a steered ADOPTION: rules
+        // reach the NIC only after a verify, which no fresh spawn has
+        // had, and inherited orphan rules are torn down before
+        // `StartRequested` is ever injected. It is also the one case
+        // where `adopt_vpp_fib` must NOT run yet: the dump parks every
+        // VPP worker in barrier sync (see
+        // `DeferredResync::AwaitingFallback`), and this VPP is the one
+        // carrying the traffic. Defer everything — the dump included —
+        // until the fallback tier can take over. The NIC ledger is the
+        // discriminator, not the supervisor's belief, because rules in
+        // the NIC are what puts packets on VPP.
+        if !c.steering.installed().is_empty() {
+            let capacity = c.engine.route_capacity();
+            let floor = (capacity / FALLBACK_FLOOR_DIVISOR).max(1);
+            let seq = c.source.change_seq();
+            tracing::info!(
+                floor,
+                "adopted VPP is steered, so reading its FIB waits: the dump freezes \
+                 every worker for seconds (ip_route_dump holds VPP's barrier). Once the \
+                 route source is loaded and quiet the eBPF tier takes the traffic, the \
+                 dump runs against an idle VPP, and steering returns after the verified \
+                 resync"
+            );
+            c.deferred_resync = Some(DeferredResync::AwaitingFallback {
+                gate: SourceGate::new(floor, source_quiet_rate_per_sec(capacity), seq),
+                last_request: None,
+            });
+            return Ok(());
+        }
+        // Unsteered: nothing is on VPP, so the dump's worker stall
+        // costs no packets. Split borrow: the engine walks the source
+        // while both live in the same core.
         let deferral = {
             let Core { engine, source, .. } = &mut *c;
             // BEFORE the diff, because the diff is what consumes it: the
@@ -949,15 +1111,13 @@ impl Effects for EffectsView {
             // finished loading, and a daemon restart is exactly when it
             // has not: the feed reconnects at startup and takes tens of
             // seconds to reload. Diffing an adopted ledger against that
-            // window queues ~everything as a withdrawal — against a
-            // live, possibly steered VPP (drill (d), 2026-08-07). EVERY
-            // adoption of a POPULATED FIB defers, even one whose source
-            // already looks complete — a count cannot say "complete",
-            // only the floor-plus-quiescence gate in `drain_batch` can,
-            // and an above-floor count at this instant is exactly what a
-            // half-finished reload looks like (2026-08-08). One path to
-            // the diff, ~1.5–3 s of deliberate patience on the path
-            // that used to skip it.
+            // window queues ~everything as a withdrawal (drill (d),
+            // 2026-08-07). EVERY adoption of a POPULATED FIB defers,
+            // even one whose source already looks complete — a count
+            // cannot say "complete", only the floor-plus-quiescence gate
+            // in `drain_batch` can, and an above-floor count at this
+            // instant is exactly what a half-finished reload looks like
+            // (2026-08-08).
             //
             // `adopted == 0` — a fresh spawn, or a survivor with an
             // empty FIB — starts immediately instead: there is no
@@ -988,7 +1148,7 @@ impl Effects for EffectsView {
                     "adopted resync deferred until the route source is loaded and quiet; \
                      the adopted FIB keeps forwarding untouched meanwhile"
                 );
-                Some(DeferredResync {
+                Some(DeferredResync::AwaitingDiff {
                     adopted,
                     // Clamped to 1: integer division floors adopted=1
                     // to zero, and a floor of zero lets a DEAD source
@@ -996,10 +1156,11 @@ impl Effects for EffectsView {
                     // the sole live route — the exact case the floor
                     // exists for (review finding). A populated
                     // adoption's floor is never satisfied by nothing.
-                    floor: (adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1),
-                    last_seq: seq,
-                    last_check: None,
-                    quiet_since: None,
+                    gate: SourceGate::new(
+                        (adopted / ADOPTED_SOURCE_FLOOR_DIVISOR).max(1),
+                        source_quiet_rate_per_sec(adopted),
+                        seq,
+                    ),
                 })
             }
         };

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -456,6 +456,13 @@ enum DeferredResync {
         /// the unsteer's pace window left traffic on a collapsing
         /// fallback for up to five seconds (review finding).
         last_request: Option<(SteerRequest, std::time::Instant)>,
+        /// True from the moment this deferral's unsteer is observed
+        /// complete until the gate re-releases: the revocation path
+        /// keeps re-asking on THIS flag, never on the ledger being
+        /// empty — a partial restore leaves rules in the ledger, and
+        /// gating on emptiness is what wedged half the allowlist on
+        /// the condemned fallback with no retry (review finding).
+        restoring: bool,
     },
     /// An UNSTEERED adoption whose dump has already run — harmlessly,
     /// because with no rules installed nothing is on VPP for the
@@ -908,6 +915,7 @@ impl Observe for ObserveView {
                 DeferredResync::AwaitingFallback {
                     mut gate,
                     mut last_request,
+                    mut restoring,
                 } => {
                     let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
                     let view = gate.observe(now, have, seq, live);
@@ -995,7 +1003,18 @@ impl Observe for ObserveView {
                         // that may be losing routes (review finding).
                         // Paced like the unsteer request; a refused
                         // steer is re-asked the same way.
-                        if unsteered {
+                        // `restoring` LATCHES on the first observation
+                        // of this deferral's unsteer having landed, and
+                        // the re-ask keys on the latch, never on the
+                        // ledger being empty: a PARTIAL restore leaves
+                        // rules in the ledger, and gating on emptiness
+                        // wedged half the allowlist on the condemned
+                        // fallback with no retry (review finding).
+                        // RestoreSteer is a reconcile, so re-asking
+                        // over an already-complete set is an idempotent
+                        // re-assert.
+                        if unsteered || restoring {
+                            restoring = true;
                             // Same-kind pacing only: the first
                             // revocation after an acknowledged unsteer
                             // goes out immediately.
@@ -1008,11 +1027,17 @@ impl Observe for ObserveView {
                                 last_request = Some((SteerRequest::Revoke, now));
                             }
                         }
-                        c.deferred_resync =
-                            Some(DeferredResync::AwaitingFallback { gate, last_request });
+                        c.deferred_resync = Some(DeferredResync::AwaitingFallback {
+                            gate,
+                            last_request,
+                            restoring,
+                        });
                         return Ok(crate::driver::Drain::AwaitingSource { have, want });
                     }
                     if !unsteered {
+                        // A re-release after a revocation cycle starts
+                        // the settle/unsteer sequence over.
+                        restoring = false;
                         // The fallback can carry the traffic now; ask the
                         // supervisor to take it off VPP. Through the
                         // machine, never `steering.unsteer()` from here:
@@ -1027,8 +1052,11 @@ impl Observe for ObserveView {
                             c.pending.push(Event::FallbackSettled);
                             last_request = Some((SteerRequest::Settle, now));
                         }
-                        c.deferred_resync =
-                            Some(DeferredResync::AwaitingFallback { gate, last_request });
+                        c.deferred_resync = Some(DeferredResync::AwaitingFallback {
+                            gate,
+                            last_request,
+                            restoring,
+                        });
                         return Ok(crate::driver::Drain::AwaitingSource { have, want });
                     }
                     // Unsteered and quiet: the dump is free — nothing is
@@ -1096,8 +1124,11 @@ impl Observe for ObserveView {
                                  the diff — the adopted routes stay in the ledger and the \
                                  reconciliation resumes when the source is ready again"
                             );
-                            c.deferred_resync =
-                                Some(DeferredResync::AwaitingFallback { gate, last_request });
+                            c.deferred_resync = Some(DeferredResync::AwaitingFallback {
+                                gate,
+                                last_request,
+                                restoring: true,
+                            });
                             return Ok(crate::driver::Drain::AwaitingSource { have, want });
                         }
                         tracing::info!(
@@ -1354,6 +1385,7 @@ impl Effects for EffectsView {
             c.deferred_resync = Some(DeferredResync::AwaitingFallback {
                 gate: SourceGate::new(floor, source_quiet_rate_per_sec(capacity), seq),
                 last_request: None,
+                restoring: false,
             });
             return Ok(());
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -289,6 +289,12 @@ struct Core {
     /// authority to compare against (the shadow has no bird of its own)
     /// and the operator owns the judgement instead.
     completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    /// The feed session-liveness handle: whether the BGP/BMP session
+    /// that fills the mirror is up RIGHT NOW, written by the session
+    /// owner in the fast-path controller. `None` when the wiring has no
+    /// second tier or a harness never set one; the small-table release
+    /// is then simply off.
+    feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
     /// Why the last drain failed, or `None` if the last one succeeded.
     ///
     /// Recorded here rather than left to the caller because the caller
@@ -460,39 +466,29 @@ impl DeferredResync {
 /// `capacity / 16` (the default sizing over a small table qualifies)
 /// would otherwise defer forever (review finding). The other two, in
 /// the `AwaitingFallback` arm: the completeness authority where a bird
-/// exists to compare against, and the small-table clause under
-/// [`SMALL_TABLE_QUIET_FOR`] / [`SMALL_TABLE_MIN_ROUTES`].
+/// exists to compare against, and the session-backed small-table
+/// clause under [`SMALL_TABLE_QUIET_FOR`].
 pub const FALLBACK_FLOOR_DIVISOR: u64 = 16;
 
-/// The pre-dump stage's small-table release: rate-quiet sustained this
-/// long, together with at least [`SMALL_TABLE_MIN_ROUTES`] in the
-/// mirror, counts as loaded even below the capacity floor. The
-/// DURATION is one of the two load-bearing parts: it must outlast the
-/// BGP hold time, because a feed that died or hung mid-load cannot
-/// stay quietly wrong longer than that — the session drops, the
-/// PeerDown wipe empties the mirror of everything the session carried,
-/// and the wipe's own churn resets the quiet tracker. Default holds
-/// are 90 s and the fleet's feed negotiates 90; 150 s covers them with
-/// margin. A deployment that raises its hold beyond this should size
-/// `expected-routes` within 16x of its table or run
-/// `require-table-complete on`, both of which release without this
-/// clause.
+/// The pre-dump stage's small-table release: the feed session is UP,
+/// the mirror is non-empty, and the rate has been quiet this long. The
+/// session handle is what three failed proxies were reaching for
+/// (capacity fractions, arrival deltas, absolute minimums - each a
+/// review finding): no mirror-side count can distinguish a loaded
+/// small table from the husk a dead session leaves behind, because
+/// neighbour-synthesized local routes alone can number in the
+/// hundreds. Liveness comes from the session owner instead, and quiet
+/// supplies the completion evidence.
+///
+/// The DURATION still matters: it must outlast the BGP hold time,
+/// because a HUNG session reads as up until the hold expires - the
+/// listener then closes it and reports down, which is what bounds how
+/// long "up" can be stale. Default holds are 90 s and the fleet feed
+/// negotiates 90; 150 s covers them with margin. A deployment that
+/// raises its hold beyond this should size `expected-routes` within
+/// 16x of its table or run `require-table-complete on`, both of which
+/// release without this clause.
 const SMALL_TABLE_QUIET_FOR: Duration = Duration::from_secs(150);
-
-/// The other load-bearing part: what quiet-past-the-hold leaves behind
-/// after a session death is a mirror holding only what did NOT come
-/// from the session — neighbour-synthesized local routes, bounded by
-/// the hosts physically present on the box's L2s, i.e. dozens. No
-/// in-process signal can distinguish "watched a load" from "watched a
-/// wipe": the mirror starts empty every daemon start, so its content
-/// IS the observed mutations — a change-counter baseline is a
-/// tautology, and one taken at gate creation additionally missed
-/// whatever loaded before attach (review finding). An absolute
-/// minimum the husk cannot reach is the honest discriminator. A site
-/// with a genuine table under 128 routes releases through the floor
-/// instead, by sizing `expected-routes` at or under 2048 — whose
-/// floor, not coincidentally, is exactly 128.
-const SMALL_TABLE_MIN_ROUTES: u64 = 128;
 
 /// How often a refused or unacknowledged unsteer is re-requested while
 /// the pre-dump stage waits. Paced because the gate re-checks every
@@ -576,6 +572,7 @@ impl Runtime {
         Self {
             core: Rc::new(RefCell::new(Core {
                 completeness: None,
+                feed_session: None,
                 engine,
                 process: None,
                 source,
@@ -631,6 +628,14 @@ impl Runtime {
         handle: std::sync::Arc<packetframe_common::fib::TableCompleteness>,
     ) {
         self.core.borrow_mut().completeness = Some(handle);
+    }
+
+    /// Attach the feed session-liveness handle. The small-table
+    /// release consults it, because no mirror-side count can
+    /// distinguish a loaded small table from the husk a dead session
+    /// leaves behind.
+    pub fn feed_session(&self, handle: std::sync::Arc<packetframe_common::fib::FeedSession>) {
+        self.core.borrow_mut().feed_session = Some(handle);
     }
 
     /// Point steering at a new set of ports and rules.
@@ -895,16 +900,19 @@ impl Observe for ObserveView {
                     //  - the completeness authority, where a bird
                     //    exists — the exact signal, and the same one
                     //    `Effects::steer` gates on;
-                    //  - a table past SMALL_TABLE_MIN_ROUTES that has
-                    //    been quiet longer than the BGP hold time — see
-                    //    the two constants for why that pair separates
-                    //    "small and loaded" from the synth-only husk a
-                    //    dead session leaves behind.
+                    //  - a non-empty mirror whose feed SESSION is up,
+                    //    quiet longer than the BGP hold time: the
+                    //    session handle is the liveness authority no
+                    //    mirror-side count could be (see
+                    //    SMALL_TABLE_QUIET_FOR), and the hold-length
+                    //    quiet is what bounds a hung session going
+                    //    stale at "up".
                     let complete = view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
                         && c.completeness
                             .as_ref()
                             .is_some_and(|h| h.verdict().permits_steering());
-                    let small_table_loaded = have >= SMALL_TABLE_MIN_ROUTES
+                    let small_table_loaded = have > 0
+                        && c.feed_session.as_ref().is_some_and(|f| f.is_up())
                         && view
                             .rate_quiet_for
                             .is_some_and(|q| q >= SMALL_TABLE_QUIET_FOR);

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -381,6 +381,21 @@ impl SourceGate {
     /// (review finding). Rebaselining continuously while down also
     /// covers the up-transition: the clock starts from the moment
     /// liveness returns.
+    /// Forget every piece of quiet evidence and restart the rate
+    /// baseline at `seq_now`. Called when a validation OUTSIDE the
+    /// gate rejects what the gate released — the post-dump churn
+    /// check — because reinserting an unchanged gate let the very
+    /// next tick average the rejected burst below the rate, keep the
+    /// pre-dump `quiet_since`, and re-release immediately: the
+    /// rejection undone one tick later (review finding). After this,
+    /// the source must establish a fresh sustained quiet interval.
+    fn rebaseline(&mut self, seq_now: u64) {
+        self.last_seq = seq_now;
+        self.last_check = None;
+        self.quiet_since = None;
+        self.rate_quiet_since = None;
+    }
+
     /// `quiet_rate` is supplied per observation, not stored, because
     /// the honest basis DIFFERS by stage and time: the diff stage
     /// scales it to the dumped table it protects, while the pre-dump
@@ -1156,6 +1171,7 @@ impl Observe for ObserveView {
                                  the diff — the adopted routes stay in the ledger and the \
                                  reconciliation resumes when the source is ready again"
                             );
+                            gate.rebaseline(seq_now);
                             c.deferred_resync = Some(DeferredResync::AwaitingFallback {
                                 gate,
                                 last_request,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -420,6 +420,14 @@ impl SourceGate {
     }
 }
 
+/// Which direction the deferral last asked the supervisor to move
+/// steering. See `DeferredResync::AwaitingFallback::last_request`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SteerRequest {
+    Settle,
+    Revoke,
+}
+
 /// What a deferred adopted reconciliation is waiting for.
 #[derive(Debug, Clone, Copy)]
 enum DeferredResync {
@@ -439,10 +447,15 @@ enum DeferredResync {
     /// on the existing verified path.
     AwaitingFallback {
         gate: SourceGate,
-        /// When the unsteer was last requested, so a refused or
-        /// unacknowledged removal is re-asked every
+        /// The last steering request and when it was made, so a
+        /// refused or unacknowledged transition is re-asked every
         /// [`UNSTEER_REQUEST_EVERY`] instead of on each 50 ms tick.
-        last_request: Option<std::time::Instant>,
+        /// The KIND is part of the record because opposite transitions
+        /// must not share a throttle: a revocation arriving just after
+        /// an acknowledged unsteer is the safety path, and waiting out
+        /// the unsteer's pace window left traffic on a collapsing
+        /// fallback for up to five seconds (review finding).
+        last_request: Option<(SteerRequest, std::time::Instant)>,
     },
     /// An UNSTEERED adoption whose dump has already run — harmlessly,
     /// because with no rules installed nothing is on VPP for the
@@ -983,11 +996,16 @@ impl Observe for ObserveView {
                         // Paced like the unsteer request; a refused
                         // steer is re-asked the same way.
                         if unsteered {
-                            let ask = last_request
-                                .is_none_or(|t| now.duration_since(t) >= UNSTEER_REQUEST_EVERY);
+                            // Same-kind pacing only: the first
+                            // revocation after an acknowledged unsteer
+                            // goes out immediately.
+                            let ask = last_request.is_none_or(|(kind, t)| {
+                                kind != SteerRequest::Revoke
+                                    || now.duration_since(t) >= UNSTEER_REQUEST_EVERY
+                            });
                             if ask {
                                 c.pending.push(Event::FallbackRevoked);
-                                last_request = Some(now);
+                                last_request = Some((SteerRequest::Revoke, now));
                             }
                         }
                         c.deferred_resync =
@@ -1001,11 +1019,13 @@ impl Observe for ObserveView {
                         // the ledger persist and the `steered` fact live
                         // with the executor, and a second unsteer path is
                         // two owners for one NIC.
-                        let ask = last_request
-                            .is_none_or(|t| now.duration_since(t) >= UNSTEER_REQUEST_EVERY);
+                        let ask = last_request.is_none_or(|(kind, t)| {
+                            kind != SteerRequest::Settle
+                                || now.duration_since(t) >= UNSTEER_REQUEST_EVERY
+                        });
                         if ask {
                             c.pending.push(Event::FallbackSettled);
-                            last_request = Some(now);
+                            last_request = Some((SteerRequest::Settle, now));
                         }
                         c.deferred_resync =
                             Some(DeferredResync::AwaitingFallback { gate, last_request });

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -957,12 +957,29 @@ impl Observe for ObserveView {
                     // proves bird was alive at REPORT time, and `live`
                     // is what makes that claim current.
                     let released = (view.released && live) || complete || small_table_loaded;
+                    let unsteered = c.steering.installed().is_empty();
                     if !released {
+                        // Revocation AFTER the unsteer was acknowledged
+                        // — the feed dropped in the window before the
+                        // dump. The adopted FIB is still whole (nothing
+                        // has touched it), so ask for the traffic back
+                        // rather than leaving it idle over a fallback
+                        // that may be losing routes (review finding).
+                        // Paced like the unsteer request; a refused
+                        // steer is re-asked the same way.
+                        if unsteered {
+                            let ask = last_request
+                                .is_none_or(|t| now.duration_since(t) >= UNSTEER_REQUEST_EVERY);
+                            if ask {
+                                c.pending.push(Event::FallbackRevoked);
+                                last_request = Some(now);
+                            }
+                        }
                         c.deferred_resync =
                             Some(DeferredResync::AwaitingFallback { gate, last_request });
                         return Ok(crate::driver::Drain::AwaitingSource { have, want });
                     }
-                    if !c.steering.installed().is_empty() {
+                    if !unsteered {
                         // The fallback can carry the traffic now; ask the
                         // supervisor to take it off VPP. Through the
                         // machine, never `steering.unsteer()` from here:

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1021,26 +1021,57 @@ impl Observe for ObserveView {
                             completeness,
                             ..
                         } = &mut *c;
+                        let dump_started = std::time::Instant::now();
                         let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
                         // Revalidate on the FAR side of the dump: it
-                        // blocks this thread for seconds, and a feed
-                        // that collapsed mid-walk would hand the diff a
-                        // husk — whose withdrawals destroy the intact
-                        // FIB just read, with traffic already on the
-                        // incomplete fallback (review finding). The
-                        // deferral is KEPT on refusal: the ledger now
-                        // holds the dumped FIB (the dump is a no-op on
-                        // a populated ledger), the revocation path
+                        // blocks this thread for seconds, and the world
+                        // it re-checks is the MIRROR, not just the
+                        // transport — a live BGP soft reload withdraws
+                        // and reannounces with the session up and a
+                        // cached verdict still permitting, and a diff
+                        // snapshotted in that trough queues withdrawals
+                        // that destroy the intact FIB just read (review
+                        // finding, twice: liveness alone was the first
+                        // version's check). Three current facts must
+                        // hold:
+                        //  - the session is still up;
+                        //  - the mirror moved during the dump at no
+                        //    more than the gate's own quiet rate — any
+                        //    faster and the quiet that released us is
+                        //    retroactively false;
+                        //  - a configured authority's report, recomputed
+                        //    against the mirror AS IT IS NOW, still
+                        //    permits.
+                        // The deferral is KEPT on refusal: the ledger
+                        // holds the dumped FIB (the dump no-ops on a
+                        // populated ledger), the revocation path
                         // re-steers, and a later release diffs against
                         // a recovered source.
                         let live_now = feed_session.as_ref().is_some_and(|f| f.is_up());
-                        let veto_now = completeness
-                            .as_ref()
-                            .is_some_and(|h| !h.verdict().permits_steering());
-                        if !live_now || veto_now {
+                        let have_now = source.route_count();
+                        let seq_now = source.change_seq();
+                        let dump_ms = dump_started.elapsed().as_millis().max(1) as u64;
+                        let churn_per_sec =
+                            seq_now.saturating_sub(seq).saturating_mul(1_000) / dump_ms;
+                        let mirror_settled = have_now > 0 && churn_per_sec <= gate.quiet_rate;
+                        let authority_agrees = completeness.as_ref().is_none_or(|h| {
+                            h.verdict().permits_steering()
+                                && h.latest().is_some_and(|r| {
+                                    let now_r = packetframe_common::fib::CompletenessReport {
+                                        mirror_routes: have_now,
+                                        ..r
+                                    };
+                                    now_r.drift().is_some_and(|d| {
+                                        d <= packetframe_common::fib::STEER_MAX_DRIFT
+                                    })
+                                })
+                        });
+                        if !live_now || !mirror_settled || !authority_agrees {
                             tracing::warn!(
                                 adopted,
                                 live = live_now,
+                                churn_per_sec,
+                                have_now,
                                 "the feed changed while VPP's FIB was being dumped; holding \
                                  the diff — the adopted routes stay in the ledger and the \
                                  reconciliation resumes when the source is ready again"
@@ -1176,6 +1207,23 @@ impl Effects for EffectsView {
     fn unsteer(&mut self) -> Result<(), String> {
         let mut c = self.core.borrow_mut();
         let outcome = c.steering.unsteer();
+        c.record_steering();
+        outcome
+    }
+
+    fn restore_steer(&mut self) -> Result<(), String> {
+        // NO completeness gate, deliberately — the one divergence from
+        // `steer`, and the whole reason this method exists. The gate
+        // protects traffic from a VPP synced off an incomplete MIRROR;
+        // the adoptee's FIB was never built from the mirror, and a
+        // verdict condemning the mirror is precisely when traffic
+        // belongs back on the intact adoptee rather than on the
+        // fallback the verdict condemned (review finding: the gate
+        // blocked the restoration exactly when its verdict caused the
+        // revocation). Reachable only through Action::RestoreSteer,
+        // which only (AdoptedResyncing, FallbackRevoked) emits.
+        let mut c = self.core.borrow_mut();
+        let outcome = c.steering.steer();
         c.record_steering();
         outcome
     }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -956,7 +956,22 @@ impl Observe for ObserveView {
                     // completeness authority included — its report
                     // proves bird was alive at REPORT time, and `live`
                     // is what makes that claim current.
-                    let released = (view.released && live) || complete || small_table_loaded;
+                    // A configured authority that currently says NO is
+                    // a VETO, not a bystander: with the verdict
+                    // Incomplete, the mirror is KNOWN to be missing
+                    // more than the drift policy allows, and no count
+                    // or quiet proxy may out-vote that knowledge — a
+                    // live session whose load merely stalls for two
+                    // seconds past the floor would otherwise unsteer
+                    // onto a table the authority had already condemned
+                    // (review finding). No handle, no veto: birdless
+                    // deployments still release on the proxies.
+                    let veto = c
+                        .completeness
+                        .as_ref()
+                        .is_some_and(|h| !h.verdict().permits_steering());
+                    let released =
+                        !veto && ((view.released && live) || complete || small_table_loaded);
                     let unsteered = c.steering.installed().is_empty();
                     if !released {
                         // Revocation AFTER the unsteer was acknowledged
@@ -997,12 +1012,43 @@ impl Observe for ObserveView {
                         return Ok(crate::driver::Drain::AwaitingSource { have, want });
                     }
                     // Unsteered and quiet: the dump is free — nothing is
-                    // on VPP for the barrier to stall. The diff follows
-                    // immediately; the source this gate just called
-                    // loaded is the same one it reads.
+                    // on VPP for the barrier to stall.
                     {
-                        let Core { engine, source, .. } = &mut *c;
+                        let Core {
+                            engine,
+                            source,
+                            feed_session,
+                            completeness,
+                            ..
+                        } = &mut *c;
                         let adopted = engine.adopt_vpp_fib().map_err(|e| e.to_string())?;
+                        // Revalidate on the FAR side of the dump: it
+                        // blocks this thread for seconds, and a feed
+                        // that collapsed mid-walk would hand the diff a
+                        // husk — whose withdrawals destroy the intact
+                        // FIB just read, with traffic already on the
+                        // incomplete fallback (review finding). The
+                        // deferral is KEPT on refusal: the ledger now
+                        // holds the dumped FIB (the dump is a no-op on
+                        // a populated ledger), the revocation path
+                        // re-steers, and a later release diffs against
+                        // a recovered source.
+                        let live_now = feed_session.as_ref().is_some_and(|f| f.is_up());
+                        let veto_now = completeness
+                            .as_ref()
+                            .is_some_and(|h| !h.verdict().permits_steering());
+                        if !live_now || veto_now {
+                            tracing::warn!(
+                                adopted,
+                                live = live_now,
+                                "the feed changed while VPP's FIB was being dumped; holding \
+                                 the diff — the adopted routes stay in the ledger and the \
+                                 reconciliation resumes when the source is ready again"
+                            );
+                            c.deferred_resync =
+                                Some(DeferredResync::AwaitingFallback { gate, last_request });
+                            return Ok(crate::driver::Drain::AwaitingSource { have, want });
+                        }
                         tracing::info!(
                             have,
                             adopted,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -907,16 +907,26 @@ impl Observe for ObserveView {
                     //    SMALL_TABLE_QUIET_FOR), and the hold-length
                     //    quiet is what bounds a hung session going
                     //    stale at "up".
+                    let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
                     let complete = view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
                         && c.completeness
                             .as_ref()
                             .is_some_and(|h| h.verdict().permits_steering());
                     let small_table_loaded = have > 0
-                        && c.feed_session.as_ref().is_some_and(|f| f.is_up())
+                        && live
                         && view
                             .rate_quiet_for
                             .is_some_and(|q| q >= SMALL_TABLE_QUIET_FOR);
-                    let released = view.released || complete || small_table_loaded;
+                    // The floor answers SIZE and nothing else, so it
+                    // does not release alone: a small `expected-routes`
+                    // shrinks it beneath what neighbour-synthesized
+                    // routes can supply with the feed dead (capacity
+                    // 176 puts it at 11; review finding). Liveness is
+                    // the session's to answer on every path — only the
+                    // completeness authority substitutes, because a
+                    // mirror that MATCHES bird's count has bird alive
+                    // in the comparison itself.
+                    let released = (view.released && live) || complete || small_table_loaded;
                     if !released {
                         c.deferred_resync =
                             Some(DeferredResync::AwaitingFallback { gate, last_request });

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -908,10 +908,22 @@ impl Observe for ObserveView {
                     //    quiet is what bounds a hung session going
                     //    stale at "up".
                     let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
-                    let complete = view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
-                        && c.completeness
-                            .as_ref()
-                            .is_some_and(|h| h.verdict().permits_steering());
+                    // The completeness verdict is a REPORT — a snapshot
+                    // valid for up to STEER_MAX_REPORT_AGE — so it
+                    // attests liveness at report time, not now: a
+                    // PeerDown wipe inside that window would otherwise
+                    // ride a stale Converged onto an empty fallback
+                    // (review finding). Hence `live` here too, plus a
+                    // sanity bound that the mirror the report described
+                    // has not collapsed since — half, not equality,
+                    // because legitimate churn between checker runs
+                    // must not invalidate the authority.
+                    let complete = live
+                        && view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
+                        && c.completeness.as_ref().is_some_and(|h| {
+                            h.verdict().permits_steering()
+                                && h.latest().is_some_and(|r| have >= r.mirror_routes / 2)
+                        });
                     let small_table_loaded = have > 0
                         && live
                         && view
@@ -922,10 +934,10 @@ impl Observe for ObserveView {
                     // shrinks it beneath what neighbour-synthesized
                     // routes can supply with the feed dead (capacity
                     // 176 puts it at 11; review finding). Liveness is
-                    // the session's to answer on every path — only the
-                    // completeness authority substitutes, because a
-                    // mirror that MATCHES bird's count has bird alive
-                    // in the comparison itself.
+                    // the session's to answer on every path, the
+                    // completeness authority included — its report
+                    // proves bird was alive at REPORT time, and `live`
+                    // is what makes that claim current.
                     let released = (view.released && live) || complete || small_table_loaded;
                     if !released {
                         c.deferred_resync =

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -377,7 +377,15 @@ impl SourceGate {
     /// per-call delta: the production loop caps its sleeps at 50 ms, so
     /// a per-call threshold shrinks with cadence until a full-speed
     /// reload classifies as quiet.
-    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64) -> GateView {
+    /// `live` conditions BOTH quiet trackers: quiet accumulated while
+    /// the feed was down is not evidence of anything — a dead session
+    /// is perfectly quiet — and without the reset, the first OPEN or
+    /// BMP frame after an outage would release instantly on stale
+    /// quiet, before the fresh session had streamed a single route
+    /// (review finding). Rebaselining continuously while down also
+    /// covers the up-transition: the clock starts from the moment
+    /// liveness returns.
+    fn observe(&mut self, now: std::time::Instant, have: u64, seq: u64, live: bool) -> GateView {
         let activity_per_sec = match self.last_check {
             // A rate needs two observations; the first check only
             // baselines, and reports as loading — which a source
@@ -388,7 +396,7 @@ impl SourceGate {
                 seq.saturating_sub(self.last_seq).saturating_mul(1_000) / ms
             }
         };
-        let rate_quiet = activity_per_sec <= self.quiet_rate;
+        let rate_quiet = live && activity_per_sec <= self.quiet_rate;
         if !rate_quiet {
             self.rate_quiet_since = None;
         } else if self.rate_quiet_since.is_none() {
@@ -888,7 +896,8 @@ impl Observe for ObserveView {
                     mut gate,
                     mut last_request,
                 } => {
-                    let view = gate.observe(now, have, seq);
+                    let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
+                    let view = gate.observe(now, have, seq, live);
                     let want = gate.floor;
                     // Three ways the fallback proves itself ready,
                     // because the floor alone cannot: capacity is an
@@ -907,22 +916,31 @@ impl Observe for ObserveView {
                     //    SMALL_TABLE_QUIET_FOR), and the hold-length
                     //    quiet is what bounds a hung session going
                     //    stale at "up".
-                    let live = c.feed_session.as_ref().is_some_and(|f| f.is_up());
                     // The completeness verdict is a REPORT — a snapshot
                     // valid for up to STEER_MAX_REPORT_AGE — so it
                     // attests liveness at report time, not now: a
                     // PeerDown wipe inside that window would otherwise
                     // ride a stale Converged onto an empty fallback
                     // (review finding). Hence `live` here too, plus a
-                    // sanity bound that the mirror the report described
-                    // has not collapsed since — half, not equality,
-                    // because legitimate churn between checker runs
-                    // must not invalidate the authority.
+                    // requirement that the CURRENT mirror would still
+                    // pass the SAME steering policy the report passed:
+                    // the report's authority count against today's
+                    // mirror, under the same drift bound. A /2 bound
+                    // here permitted a 50% collapse to ride a verdict
+                    // whose policy allows 1% (review finding).
                     let complete = live
                         && view.rate_quiet_for.is_some_and(|q| q >= SOURCE_QUIET_FOR)
                         && c.completeness.as_ref().is_some_and(|h| {
                             h.verdict().permits_steering()
-                                && h.latest().is_some_and(|r| have >= r.mirror_routes / 2)
+                                && h.latest().is_some_and(|r| {
+                                    let now_r = packetframe_common::fib::CompletenessReport {
+                                        mirror_routes: have,
+                                        ..r
+                                    };
+                                    now_r.drift().is_some_and(|d| {
+                                        d <= packetframe_common::fib::STEER_MAX_DRIFT
+                                    })
+                                })
                         });
                     let small_table_loaded = have > 0
                         && live
@@ -983,7 +1001,11 @@ impl Observe for ObserveView {
                     c.deferred_resync = None;
                 }
                 DeferredResync::AwaitingDiff { adopted, mut gate } => {
-                    let released = gate.observe(now, have, seq).released;
+                    // The diff stage has no session requirement (its
+                    // floor is measured against the DUMPED table, and
+                    // nothing at this stage is steered), so quiet needs
+                    // no liveness conditioning: pass live.
+                    let released = gate.observe(now, have, seq, true).released;
                     if !released {
                         let want = gate.floor;
                         c.deferred_resync = Some(DeferredResync::AwaitingDiff { adopted, gate });

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -213,6 +213,13 @@ impl Capacity {
         Self { high_water_routes }
     }
 
+    /// The high-water route count this policy enforces. Exposed for the
+    /// pre-dump deferral floor, which needs a table-scale number at a
+    /// moment when the adopted table itself cannot yet be read.
+    pub fn high_water(&self) -> u64 {
+        self.high_water_routes
+    }
+
     fn has_headroom(&self, installed: u64) -> bool {
         installed < self.high_water_routes
     }

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -150,6 +150,15 @@ pub enum Event {
     /// 2026-08-09). Meaningful only while an adopted resync is
     /// deferred; every other state ignores it as stale.
     FallbackSettled,
+    /// The inverse: readiness was REVOKED after the unsteer had
+    /// already been acknowledged — the feed dropped in the window
+    /// between the acknowledgement and the FIB dump. The adopted
+    /// VPP's FIB is still intact (nothing has touched it yet), so the
+    /// safe recovery is to put traffic BACK on it and return to
+    /// waiting, rather than leaving it idle while the fallback loses
+    /// routes underneath the traffic (review finding). Meaningful
+    /// only in `AdoptedResyncing`; elsewhere it is stale.
+    FallbackRevoked,
     /// The binary API answered.
     ApiUp,
     /// The pending map drained to empty.
@@ -510,6 +519,26 @@ impl Supervisor {
                 } else {
                     vec![]
                 }
+            }
+            // The window between the unsteer acknowledgement and the
+            // dump: the fallback stopped being ready, the adopted FIB
+            // is still whole — re-steer it. `steer_wanted` was set at
+            // adoption; a refused steer (the completeness gate, say)
+            // lands in the catch-all and the runtime re-asks, paced.
+            (AdoptedResyncing, FallbackRevoked) => {
+                if !self.steered && self.steer_wanted {
+                    vec![Action::Steer]
+                } else {
+                    vec![]
+                }
+            }
+            // The acknowledgement for that re-steer. Without this arm
+            // the catch-all would swallow it and the machine would
+            // believe traffic still on the fallback — suppressing the
+            // Unsteer that the next gate release owes.
+            (AdoptedResyncing, Event::Steered) => {
+                self.steered = true;
+                vec![]
             }
 
             // --- converging ---
@@ -916,6 +945,31 @@ mod tests {
         assert!(fresh.on(Event::FallbackSettled).is_empty());
         fresh.on(Event::StartRequested);
         assert!(fresh.on(Event::FallbackSettled).is_empty());
+    }
+
+    /// The revocation window: unsteer acknowledged, then the fallback
+    /// stops being ready before the dump — the intact adopted FIB gets
+    /// the traffic back.
+    #[test]
+    fn revoked_readiness_re_steers_the_intact_adopted_vpp() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        assert_eq!(s.on(Event::FallbackSettled), vec![Action::Unsteer]);
+        s.on(Event::Unsteered);
+        assert_eq!(
+            s.on(Event::FallbackRevoked),
+            vec![Action::Steer],
+            "an unsteered adoption with a revoked fallback takes traffic back"
+        );
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::AdoptedResyncing, "still converging");
+        assert!(
+            s.on(Event::FallbackRevoked).is_empty(),
+            "already steered again; nothing to do"
+        );
+        // And the next release still owes an Unsteer, because the
+        // re-steer was acknowledged into `steered`.
+        assert_eq!(s.on(Event::FallbackSettled), vec![Action::Unsteer]);
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -535,11 +535,29 @@ impl Supervisor {
             // adoption; a refused steer (the completeness gate, say)
             // lands in the catch-all and the runtime re-asks, paced.
             (AdoptedResyncing, FallbackRevoked) => {
-                if !self.steered && self.steer_wanted {
+                // On `steer_wanted` alone, NOT `!steered`: a partial
+                // restore leaves rules in the NIC and `steered` true —
+                // and gating on unsteered-ness is what wedged half the
+                // allowlist on the condemned fallback with no retry
+                // (review finding). `RestoreSteer` is a reconcile, so
+                // re-asking over an already-complete set is a cheap
+                // idempotent re-assert, the same move the UniFi wipe
+                // recovery leans on.
+                if self.steer_wanted {
                     vec![Action::RestoreSteer]
                 } else {
                     vec![]
                 }
+            }
+            // A restoration that failed part-way: some rules are in
+            // the NIC, some are not. Recorded exactly as reported —
+            // `steered` must reflect whether ANYTHING diverts traffic,
+            // or the next teardown skips the Unsteer it owes — and the
+            // runtime's paced FallbackRevoked keeps re-asking until
+            // the reconcile completes.
+            (AdoptedResyncing, SteerFailed { rules_remain }) => {
+                self.steered = rules_remain;
+                vec![]
             }
             // The acknowledgement for that re-steer. Without this arm
             // the catch-all would swallow it and the machine would
@@ -973,9 +991,18 @@ mod tests {
         );
         s.on(Event::Steered);
         assert_eq!(s.state(), State::AdoptedResyncing, "still converging");
-        assert!(
-            s.on(Event::FallbackRevoked).is_empty(),
-            "already steered again; nothing to do"
+        assert_eq!(
+            s.on(Event::FallbackRevoked),
+            vec![Action::RestoreSteer],
+            "re-asking over a complete set is an idempotent re-assert — gating on \
+             unsteered-ness is what wedged a PARTIAL restore forever"
+        );
+        // A partial failure records the truth and stays retryable.
+        s.on(Event::SteerFailed { rules_remain: true });
+        assert_eq!(
+            s.on(Event::FallbackRevoked),
+            vec![Action::RestoreSteer],
+            "rules half-in must keep retrying the reconcile"
         );
         // And the next release still owes an Unsteer, because the
         // re-steer was acknowledged into `steered`.

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -312,6 +312,15 @@ pub enum Event {
 /// and "restart then unsteer" differ by an outage.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Action {
+    /// Re-install steering for an adopted VPP whose reconciliation was
+    /// revoked after the unsteer — WITHOUT the completeness gate that
+    /// [`Action::Steer`] runs through. The gate protects traffic from
+    /// a VPP synced off an incomplete MIRROR; the adoptee's FIB was
+    /// never built from the mirror, and a condemning verdict is
+    /// exactly when traffic belongs back on it (review finding: the
+    /// gate blocked the restoration precisely when its verdict caused
+    /// the revocation).
+    RestoreSteer,
     /// Remove MCAM rules. First in any teardown.
     Unsteer,
     /// Kill the process if it is still alive.
@@ -527,7 +536,7 @@ impl Supervisor {
             // lands in the catch-all and the runtime re-asks, paced.
             (AdoptedResyncing, FallbackRevoked) => {
                 if !self.steered && self.steer_wanted {
-                    vec![Action::Steer]
+                    vec![Action::RestoreSteer]
                 } else {
                     vec![]
                 }
@@ -958,8 +967,9 @@ mod tests {
         s.on(Event::Unsteered);
         assert_eq!(
             s.on(Event::FallbackRevoked),
-            vec![Action::Steer],
-            "an unsteered adoption with a revoked fallback takes traffic back"
+            vec![Action::RestoreSteer],
+            "an unsteered adoption with a revoked fallback takes traffic back, \
+             ungated — the veto that revoked it must not block the restore"
         );
         s.on(Event::Steered);
         assert_eq!(s.state(), State::AdoptedResyncing, "still converging");

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -140,6 +140,16 @@ pub enum Event {
     Adopted {
         steered: bool,
     },
+    /// The runtime's deferred adopted reconciliation reports that the
+    /// route source is loaded and quiet. The eBPF tier consumes the
+    /// same mirror commits, so it is equally loaded — meaning it can
+    /// carry the traffic while VPP's FIB is read. And it must:
+    /// `ip_route_dump` is not mp-safe, so VPP processes it with every
+    /// worker parked in barrier sync — ~5.4 s of the NIC dropping
+    /// frames no counter sees, at the reference table (shadow,
+    /// 2026-08-09). Meaningful only while an adopted resync is
+    /// deferred; every other state ignores it as stale.
+    FallbackSettled,
     /// The binary API answered.
     ApiUp,
     /// The pending map drained to empty.
@@ -482,6 +492,24 @@ impl Supervisor {
                 // correctly-forwarding dataplane to do it.
                 self.state = if steered { AdoptedResyncing } else { Syncing };
                 vec![Action::AttachDevices, Action::StartResync]
+            }
+
+            // --- rule 3, refined by measurement ---
+            // Adoption still never tears steering down just to resync —
+            // but READING the adopted FIB stalls it: the dump holds
+            // VPP's worker barrier for seconds. So once the runtime
+            // reports the fallback tier loaded and quiet, unsteering
+            // FIRST is what keeps packets flowing, and the dump runs
+            // against a VPP carrying nothing. `steer_wanted` was set at
+            // adoption and survives, so `VerifyPassed` re-steers on the
+            // existing verified path; `steered` clears only on the
+            // `Unsteered` acknowledgement, as everywhere else.
+            (AdoptedResyncing, FallbackSettled) => {
+                if self.steered {
+                    vec![Action::Unsteer]
+                } else {
+                    vec![]
+                }
             }
 
             // --- converging ---
@@ -858,6 +886,36 @@ mod tests {
             vec![Action::AttachDevices, Action::StartResync],
             "device attach must precede the resync"
         );
+    }
+
+    #[test]
+    fn fallback_settled_unsteers_only_a_steered_adopted_resync() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        assert_eq!(s.state(), State::AdoptedResyncing);
+        assert_eq!(
+            s.on(Event::FallbackSettled),
+            vec![Action::Unsteer],
+            "a steered adoption is unsteered so the dump runs against an idle VPP"
+        );
+        // Until the acknowledgement arrives the request is re-askable,
+        // and after it the same event asks for nothing.
+        assert_eq!(s.on(Event::FallbackSettled), vec![Action::Unsteer]);
+        s.on(Event::Unsteered);
+        assert!(
+            s.on(Event::FallbackSettled).is_empty(),
+            "an acknowledged unsteer leaves nothing to ask for"
+        );
+        // The want survives for the re-steer after verify.
+        s.on(Event::SyncComplete);
+        s.on(Event::VerifyPassed);
+        assert_eq!(s.state(), State::Ready);
+
+        // Any state without a deferred adopted resync ignores it.
+        let mut fresh = Supervisor::new();
+        assert!(fresh.on(Event::FallbackSettled).is_empty());
+        fresh.on(Event::StartRequested);
+        assert!(fresh.on(Event::FallbackSettled).is_empty());
     }
 
     #[test]

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -196,6 +196,7 @@ fn a_fresh_attach_acquires_renders_and_supervises() {
         Box::new(Mirror),
         &ALLOW,
         None,
+        None,
         &McamBudget::default(),
     )
     .expect("bring-up");
@@ -315,6 +316,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         Box::new(Mirror),
         &ALLOW,
         None,
+        None,
         &McamBudget::default(),
     )
     .err()
@@ -329,6 +331,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -349,6 +352,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -403,6 +407,7 @@ fn a_failure_after_acquisition_releases_what_it_took() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -513,6 +518,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         Box::new(Mirror),
         &v6_only,
         None,
+        None,
         &McamBudget::default(),
     )
     .err()
@@ -538,6 +544,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     );
@@ -575,6 +582,7 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
         Box::new(Mirror),
         &ALLOW,
         None,
+        None,
         &McamBudget::default(),
     )
     .expect("first attach");
@@ -604,6 +612,7 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -656,6 +665,7 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
         Box::new(Mirror),
         &ALLOW,
         None,
+        None,
         &McamBudget::default(),
     )
     .expect("first attach");
@@ -687,6 +697,7 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -727,6 +738,7 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
         Box::new(Mirror),
         &ALLOW,
         None,
+        None,
         &McamBudget::default(),
     )
     .expect("first attach");
@@ -753,6 +765,7 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )
@@ -794,6 +807,7 @@ fn requiring_completeness_with_no_publisher_is_refused_at_attach() {
         &host.paths,
         Box::new(Mirror),
         &ALLOW,
+        None,
         None,
         &McamBudget::default(),
     )

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1454,6 +1454,7 @@ mod steered {
 
     pub type Log = Arc<Mutex<Vec<&'static str>>>;
     pub type SharedRoutes = Arc<Mutex<Vec<IpPrefix>>>;
+    pub type Session = Arc<packetframe_common::fib::FeedSession>;
 
     /// A steered adoption over a six-route VPP, mirror starting with
     /// `initial` routes, rules already in the NIC. The pre-dump floor
@@ -1464,7 +1465,7 @@ mod steered {
         name: &str,
         initial: &[IpPrefix],
         capacity: u64,
-    ) -> (Fake, SharedRoutes, Log, Runtime) {
+    ) -> (Fake, SharedRoutes, Log, Runtime, Session) {
         let fake = Fake::start_behaving(
             name,
             fake_vpp::Behaviour {
@@ -1483,7 +1484,11 @@ mod steered {
             }),
             capacity,
         );
-        (fake, shared, log, rt)
+        // Down until a test raises it, exactly like the real handle
+        // before the listener's first Established.
+        let session: Session = Arc::new(packetframe_common::fib::FeedSession::new());
+        rt.feed_session(session.clone());
+        (fake, shared, log, rt, session)
     }
 
     /// Adopt-steered, then confirm ticks below the release leave VPP
@@ -1601,7 +1606,8 @@ mod steered {
 /// steering returns only after the verified resync.
 #[test]
 fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
-    let (fake, shared, log, rt) = steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)], 160);
+    let (fake, shared, log, rt, _session) =
+        steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)], 160);
     let mut d = Driver::new();
     let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 40);
     assert_eq!(
@@ -1646,35 +1652,32 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
 
 /// The capacity floor is an UPPER sizing bound wearing a lower bound's
 /// hat, so it cannot be the only release (review finding): a deployment
-/// whose real table sits below capacity/16 — the default sizing over a
-/// small site — would defer forever. The small-table clause releases a
-/// mirror past SMALL_TABLE_MIN_ROUTES once it has been quiet longer
-/// than the BGP hold time: a session that died mid-load cannot stay
-/// quietly wrong past the hold (the PeerDown wipe empties it first),
-/// and the husk the wipe leaves cannot reach the minimum.
-///
-/// The mirror here starts PARTIALLY LOADED before the adoption is even
-/// injected — the loader starts the feed before vpp-offload attaches,
-/// so routes that predate the gate are the normal case, and a release
-/// condition counting only post-gate arrivals never fires (review
-/// finding, second round: `loaded_delta >= have` was exactly that).
+/// whose real table sits below capacity/16 - the default sizing over a
+/// small site - would defer forever. The small-table clause releases
+/// any non-empty mirror whose feed SESSION is up once it has been quiet
+/// longer than the BGP hold time. The session handle is the liveness
+/// authority no mirror-side count could be (three proxies fell to
+/// review: capacity fractions, arrival deltas, absolute minimums), so
+/// this works for a 100-route table as well as a 100k one, and no
+/// matter how much of the table loaded before the gate existed.
 #[test]
 fn a_small_table_releases_after_long_quiet_regardless_of_when_it_loaded() {
-    // Capacity 4096 → floor 256. The full table is 130 routes: past
-    // SMALL_TABLE_MIN_ROUTES (128), forever under the floor — only the
-    // small-table clause can release this.
+    // Capacity 4096 -> floor 256. The full table is 100 routes: under
+    // every count any proxy ever used - only session liveness plus
+    // long quiet can release this.
     let full: Vec<IpPrefix> = (0..4)
         .map(|i| fake_vpp::v4(0, i))
-        .chain((0..126).map(|i| fake_vpp::v4(1, i)))
+        .chain((0..96).map(|i| fake_vpp::v4(1, i)))
         .collect();
-    let (fake, shared, log, rt) = steered::fixture("steered-small", &full[..60], 4096);
+    let (fake, shared, log, rt, session) = steered::fixture("steered-small", &full[..60], 4096);
+    session.set_up(true);
     let mut d = Driver::new();
     let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
 
     // The rest of the load arrives after the gate exists.
     *shared.lock().unwrap() = full;
 
-    // 150 s of paced quiet at ≤250 ms a tick needs a real budget.
+    // 150 s of paced quiet at <=250 ms a tick needs a real budget.
     let (_, events) = steered::run_paced(&mut d, &rt, now, 8_192, |d| d.state() == State::Steered);
 
     assert_eq!(
@@ -1693,19 +1696,20 @@ fn a_small_table_releases_after_long_quiet_regardless_of_when_it_loaded() {
     );
 }
 
-/// A dead source releases nothing, ever: quiet is exactly what a feed
-/// that never loaded looks like, and unsteering onto an empty fallback
-/// is the original disaster. Neither does the husk a session death
-/// leaves behind — the handful of neighbour-synthesized routes that
-/// did not come from the session — however long it stays quiet: it
-/// cannot reach SMALL_TABLE_MIN_ROUTES. Held deferred with health
-/// degraded — stale-but-verified forwarding plus an alarm beats an
-/// outage.
+/// A dead source releases nothing, ever - and "dead" means the
+/// SESSION is down, not any particular mirror size. Local-prefix ARP
+/// scavenging can synthesize hundreds of routes with no bird behind
+/// them (review finding: up to 1024 hosts), so the husk left after a
+/// session death can dwarf any count threshold. With the session
+/// handle down, no amount of quiet releases: unsteering onto a
+/// fallback that lost its feed is the original disaster. Held deferred
+/// with health degraded - stale-but-verified forwarding plus an alarm
+/// beats an outage.
 #[test]
 fn a_dead_source_never_triggers_the_unsteer() {
-    let (fake, shared, log, rt) = steered::fixture("steered-dead", &[], 4096);
+    let (fake, shared, log, rt, session) = steered::fixture("steered-dead", &[], 4096);
     let mut d = Driver::new();
-    // Far past SMALL_TABLE_QUIET_FOR at ≤250 ms a tick, empty.
+    // Far past SMALL_TABLE_QUIET_FOR at <=250 ms a tick, empty.
     let mut now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 2_000);
     assert_eq!(
         d.state(),
@@ -1713,9 +1717,11 @@ fn a_dead_source_never_triggers_the_unsteer() {
         "an empty, silent source must hold the adoption deferred forever"
     );
 
-    // The session dies leaving the synth husk: eight local routes that
-    // never came from bird. Quiet past every window, still no release.
-    *shared.lock().unwrap() = (0..8).map(|i| fake_vpp::v4(3, i)).collect();
+    // The session died and left a LARGE husk: two hundred synthesized
+    // local routes that never came from bird. Quiet past every window,
+    // session down, still no release.
+    session.set_up(false);
+    *shared.lock().unwrap() = (0..200).map(|i| fake_vpp::v4(3, i)).collect();
     {
         let (mut obs, mut fx) = rt.views();
         for _ in 0..2_000 {
@@ -1732,7 +1738,7 @@ fn a_dead_source_never_triggers_the_unsteer() {
     assert_eq!(
         d.state(),
         State::AdoptedResyncing,
-        "a synth-only husk must not count as a loaded table"
+        "a session-less husk must not count as a loaded table, whatever its size"
     );
     assert!(
         log.lock().unwrap().is_empty(),
@@ -1741,7 +1747,7 @@ fn a_dead_source_never_triggers_the_unsteer() {
     );
     assert_eq!(
         rt.status().resync_deferred,
-        Some((8, 256)),
+        Some((200, 256)),
         "and the deferral must be visible, not silent"
     );
 }
@@ -1753,7 +1759,7 @@ fn a_dead_source_never_triggers_the_unsteer() {
 fn completeness_releases_a_below_floor_table_promptly() {
     use packetframe_common::fib::{CompletenessReport, TableCompleteness};
 
-    let (fake, shared, log, rt) = steered::fixture("steered-complete", &[], 160);
+    let (fake, shared, log, rt, _session) = steered::fixture("steered-complete", &[], 160);
     let handle = std::sync::Arc::new(TableCompleteness::new());
     rt.require_table_complete(handle.clone());
     let mut d = Driver::new();

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1386,20 +1386,12 @@ fn balanced_churn_is_not_quiescence() {
     assert_eq!(deletes, vec![([10, 0, 5, 0], 24)]);
 }
 
-/// The drill-(d10) regression (shadow, 2026-08-09): a steered adoption
-/// must not read VPP's FIB while traffic is on it. `ip_route_dump` is
-/// not mp-safe, so VPP parks every worker in barrier sync for the whole
-/// walk — ~5.4 s at the reference table, dropped at the NIC where no
-/// counter sees it, and invariant across six drill runs because every
-/// one of them ran the dump at attach. The sequence under test:
-/// nothing touches VPP until the source is loaded and quiet; then the
-/// supervisor unsteers FIRST; the dump runs against an idle VPP; and
-/// steering returns only after the verified resync.
-#[test]
-fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
+/// Fixtures shared by the steered-adoption tests below.
+mod steered {
+    use super::*;
     use std::sync::{Arc, Mutex};
 
-    struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
+    pub struct SharedMirror(pub Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
@@ -1421,9 +1413,9 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
 
     /// A NIC that acknowledges both directions and remembers the order
     /// they happened in — the ordering IS the property under test.
-    struct RecordingSteering {
-        rules: Vec<(String, u32)>,
-        log: Arc<Mutex<Vec<&'static str>>>,
+    pub struct RecordingSteering {
+        pub rules: Vec<(String, u32)>,
+        pub log: Arc<Mutex<Vec<&'static str>>>,
     }
     impl packetframe_vpp_offload::runtime::Steering for RecordingSteering {
         fn configured_ports(&self) -> usize {
@@ -1450,8 +1442,8 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
         }
     }
 
-    // The surviving VPP forwards six routes.
-    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+    /// The surviving VPP forwards six routes.
+    pub const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
         ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
         ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
         ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
@@ -1459,53 +1451,66 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
         ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
         ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
     ];
-    let fake = Fake::start_behaving(
-        "steered-adopt",
-        fake_vpp::Behaviour {
-            existing_routes: EXISTING,
-            ..Default::default()
-        },
-    );
-    // The feed has delivered one route so far — far below the floor.
-    let shared = Arc::new(Mutex::new(vec![fake_vpp::v4(0, 0)]));
-    let log: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
-    // Capacity 160 → a pre-dump floor of 160/16 = 10. That the floor is
-    // 10 and not 6/2 = 3 is itself evidence: 3 would mean the adopted
-    // table had been READ, which is the stall this test forbids.
-    let rt = runtime_custom(
-        &fake,
-        Box::new(SharedMirror(shared.clone())),
-        Box::new(RecordingSteering {
-            rules: vec![("eth4".into(), 1)],
-            log: log.clone(),
-        }),
-        160,
-    );
-    let mut d = Driver::new();
-    let t0 = Instant::now();
 
-    {
-        let (mut obs, _) = rt.views();
-        use packetframe_vpp_offload::driver::Observe as _;
-        assert!(obs.api_ready(), "the fake must answer the handshake");
-    }
-    {
-        let (_, mut fx) = rt.views();
-        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
-    }
-    assert_eq!(d.state(), State::AdoptedResyncing);
-    rt.set_steered(true);
+    pub type Log = Arc<Mutex<Vec<&'static str>>>;
+    pub type SharedRoutes = Arc<Mutex<Vec<IpPrefix>>>;
 
-    // Below the floor: VPP must be left exactly as found — steered,
-    // FIB unread, no route ops, no unsteer request.
-    let mut now = t0;
-    {
+    /// A steered adoption over a six-route VPP, mirror starting with
+    /// `initial` routes, rules already in the NIC. Capacity 160 makes
+    /// the pre-dump floor 160/16 = 10 — and that the floor is 10 and
+    /// not 6/2 = 3 is itself evidence the adopted table has not been
+    /// READ, which is the stall these tests forbid.
+    pub fn fixture(name: &str, initial: &[IpPrefix]) -> (Fake, SharedRoutes, Log, Runtime) {
+        let fake = Fake::start_behaving(
+            name,
+            fake_vpp::Behaviour {
+                existing_routes: EXISTING,
+                ..Default::default()
+            },
+        );
+        let shared: SharedRoutes = Arc::new(Mutex::new(initial.to_vec()));
+        let log: Log = Arc::new(Mutex::new(Vec::new()));
+        let rt = runtime_custom(
+            &fake,
+            Box::new(SharedMirror(shared.clone())),
+            Box::new(RecordingSteering {
+                rules: vec![("eth4".into(), 1)],
+                log: log.clone(),
+            }),
+            160,
+        );
+        (fake, shared, log, rt)
+    }
+
+    /// Adopt-steered, then confirm ticks below the release leave VPP
+    /// exactly as found: no route op, no steering transition.
+    pub fn adopt_and_hold(
+        d: &mut Driver,
+        rt: &Runtime,
+        fake: &Fake,
+        log: &Log,
+        t0: Instant,
+        ticks: usize,
+    ) -> Instant {
+        {
+            let (mut obs, _) = rt.views();
+            use packetframe_vpp_offload::driver::Observe as _;
+            assert!(obs.api_ready(), "the fake must answer the handshake");
+        }
+        {
+            let (_, mut fx) = rt.views();
+            d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+        }
+        assert_eq!(d.state(), State::AdoptedResyncing);
+        rt.set_steered(true);
+
+        let mut now = t0;
         let (mut obs, mut fx) = rt.views();
-        for _ in 0..40 {
+        for _ in 0..ticks {
             let t = d.tick(now, &mut obs, &mut fx);
             assert!(
                 !t.events.contains(&Event::SyncComplete),
-                "nothing may complete while the source loads: {:?}",
+                "nothing may complete while the fallback is unproven: {:?}",
                 t.events
             );
             for e in rt.take_pending() {
@@ -1516,39 +1521,100 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
                 .unwrap_or(Duration::from_millis(100))
                 .max(Duration::from_millis(1));
         }
+        assert!(
+            log.lock().unwrap().is_empty(),
+            "no steering transition below the release: {:?}",
+            log.lock().unwrap()
+        );
+        let touched: Vec<_> = fake
+            .drain_events()
+            .into_iter()
+            .filter_map(|e| match e {
+                fake_vpp::Event::Route(r) => Some(r),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            touched.is_empty(),
+            "no route op may reach a steered VPP before the unsteer: {touched:?}"
+        );
+        now
     }
+
+    /// `run_until` with a caller-chosen bound, for stop conditions that
+    /// legitimately need many paced ticks (the 150 s small-table quiet).
+    pub fn run_paced(
+        d: &mut Driver,
+        rt: &Runtime,
+        mut now: Instant,
+        max_ticks: usize,
+        stop: impl Fn(&Driver) -> bool,
+    ) -> (Instant, Vec<Event>) {
+        let (mut obs, mut fx) = rt.views();
+        let mut seen = Vec::new();
+        for _ in 0..max_ticks {
+            if stop(d) {
+                return (now, seen);
+            }
+            let t = d.tick(now, &mut obs, &mut fx);
+            seen.extend(t.events.clone());
+            for e in rt.take_pending() {
+                let it = d.inject(now, e, &mut fx);
+                seen.extend(it.events);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+        panic!("loop did not reach the stop condition; events: {seen:?}");
+    }
+
+    /// The withdrawals the fake saw, sorted for a stable comparison.
+    pub fn deletes(fake: &Fake) -> Vec<([u8; 4], u8)> {
+        let mut v: Vec<_> = fake
+            .drain_events()
+            .into_iter()
+            .filter_map(|e| match e {
+                fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+                _ => None,
+            })
+            .collect();
+        v.sort_unstable();
+        v
+    }
+}
+
+/// The drill-(d10) regression (shadow, 2026-08-09): a steered adoption
+/// must not read VPP's FIB while traffic is on it. `ip_route_dump` is
+/// not mp-safe, so VPP parks every worker in barrier sync for the whole
+/// walk — ~5.4 s at the reference table, dropped at the NIC where no
+/// counter sees it, and invariant across six drill runs because every
+/// one of them ran the dump at attach. The sequence under test: nothing
+/// touches VPP until the source is loaded and quiet; then the
+/// supervisor unsteers FIRST; the dump runs against an idle VPP; and
+/// steering returns only after the verified resync.
+#[test]
+fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
+    let (fake, shared, log, rt) = steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)]);
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 40);
     assert_eq!(
         rt.status().resync_deferred,
         Some((1, 10)),
         "the floor must be capacity-derived (160/16), not adopted-derived (6/2) — \
          an adopted-derived floor means the FIB was read while steered"
     );
-    assert!(
-        log.lock().unwrap().is_empty(),
-        "no steering transition below the floor: {:?}",
-        log.lock().unwrap()
-    );
-    let touched: Vec<_> = fake
-        .drain_events()
-        .into_iter()
-        .filter_map(|e| match e {
-            fake_vpp::Event::Route(r) => Some(r),
-            _ => None,
-        })
-        .collect();
-    assert!(
-        touched.is_empty(),
-        "no route op may reach a steered VPP before the unsteer: {touched:?}"
-    );
 
-    // The feed finishes: twelve routes, one of VPP's six (10.0.5.0/24)
-    // genuinely withdrawn while packetframe was down.
-    *shared.lock().unwrap() = (0..5)
+    // The feed finishes: twelve routes, two of VPP's six genuinely
+    // withdrawn while packetframe was down.
+    *shared.lock().unwrap() = (0..4)
         .map(|i| fake_vpp::v4(0, i))
-        .chain((0..7).map(|i| fake_vpp::v4(1, i)))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
         .collect();
 
-    let (_, events) = run_until(&mut d, &rt, now, |d| d.state() == State::Steered);
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
 
     // The order is the contract: traffic left VPP before its FIB was
     // read, and returned only through the verified path.
@@ -1565,19 +1631,96 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
         rt.status().resync_deferred.is_none(),
         "the deferral must clear when the reconciliation runs"
     );
-    // And the diff withdrew exactly the one prefix the source dropped —
+    // And the diff withdrew exactly the prefixes the source dropped —
     // proof the dump ran and seeded the withdrawal universe.
-    let deletes: Vec<_> = fake
-        .drain_events()
-        .into_iter()
-        .filter_map(|e| match e {
-            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
-            _ => None,
-        })
-        .collect();
     assert_eq!(
-        deletes,
-        vec![([10, 0, 5, 0], 24)],
-        "one withdrawal for the one prefix the source really dropped"
+        steered::deletes(&fake),
+        vec![([10, 0, 4, 0], 24), ([10, 0, 5, 0], 24)],
+        "two withdrawals for the two prefixes the source really dropped"
     );
+}
+
+/// The capacity floor is an UPPER sizing bound wearing a lower bound's
+/// hat, so it cannot be the only release (review finding): a deployment
+/// whose real table sits below capacity/16 — the default sizing over a
+/// small site — would defer forever. The small-table clause releases on
+/// an observed full reload plus quiet sustained past the BGP hold time,
+/// which is what makes "small and loaded" distinguishable from "died
+/// mid-load": a dead session cannot stay quietly wrong longer than the
+/// hold — the PeerDown wipe empties the mirror first.
+#[test]
+fn a_small_table_releases_after_a_full_reload_and_long_quiet() {
+    let (fake, shared, log, rt) = steered::fixture("steered-small", &[]);
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
+
+    // The whole table this site has: four routes — forever below the
+    // floor of ten.
+    *shared.lock().unwrap() = (0..4).map(|i| fake_vpp::v4(0, i)).collect();
+
+    // 150 s of paced quiet at ≤250 ms a tick needs a real budget.
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 8_192, |d| d.state() == State::Steered);
+
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer", "steer"],
+        "the small-table release must follow the same unsteer-first sequence"
+    );
+    assert!(
+        events.contains(&Event::SyncComplete) && events.contains(&Event::VerifyPassed),
+        "{events:?}"
+    );
+    assert_eq!(
+        steered::deletes(&fake),
+        vec![([10, 0, 4, 0], 24), ([10, 0, 5, 0], 24)],
+        "the reconciliation still withdraws what the small table lacks"
+    );
+}
+
+/// A dead source releases nothing, ever: quiet is exactly what a feed
+/// that never loaded looks like, and unsteering onto an empty fallback
+/// is the original disaster. Held deferred with health degraded —
+/// stale-but-verified forwarding plus an alarm beats an outage.
+#[test]
+fn a_dead_source_never_triggers_the_unsteer() {
+    let (fake, _shared, log, rt) = steered::fixture("steered-dead", &[]);
+    let mut d = Driver::new();
+    // Far past SMALL_TABLE_QUIET_FOR at ≤250 ms a tick.
+    let _ = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 2_000);
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "an empty, silent source must hold the adoption deferred forever"
+    );
+    assert_eq!(
+        rt.status().resync_deferred,
+        Some((0, 10)),
+        "and the deferral must be visible, not silent"
+    );
+}
+
+/// Where a bird exists, completeness is the exact readiness signal —
+/// the same one `Effects::steer` gates on — and it releases a table the
+/// capacity floor is wrong about without waiting out the hold time.
+#[test]
+fn completeness_releases_a_below_floor_table_promptly() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+    let (fake, shared, log, rt) = steered::fixture("steered-complete", &[]);
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
+
+    *shared.lock().unwrap() = (0..4).map(|i| fake_vpp::v4(0, i)).collect();
+    handle.publish(CompletenessReport {
+        authority_routes: 4,
+        mirror_routes: 4,
+        at: std::time::Instant::now(),
+    });
+
+    // Well under the 150 s small-table wait: the authority short-cuts.
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
+    assert_eq!(log.lock().unwrap().as_slice(), &["unsteer", "steer"]);
+    assert!(events.contains(&Event::VerifyPassed), "{events:?}");
 }

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1456,11 +1456,15 @@ mod steered {
     pub type SharedRoutes = Arc<Mutex<Vec<IpPrefix>>>;
 
     /// A steered adoption over a six-route VPP, mirror starting with
-    /// `initial` routes, rules already in the NIC. Capacity 160 makes
-    /// the pre-dump floor 160/16 = 10 — and that the floor is 10 and
-    /// not 6/2 = 3 is itself evidence the adopted table has not been
+    /// `initial` routes, rules already in the NIC. The pre-dump floor
+    /// is `capacity / 16` — and that the floor is capacity-derived and
+    /// never 6/2 = 3 is itself evidence the adopted table has not been
     /// READ, which is the stall these tests forbid.
-    pub fn fixture(name: &str, initial: &[IpPrefix]) -> (Fake, SharedRoutes, Log, Runtime) {
+    pub fn fixture(
+        name: &str,
+        initial: &[IpPrefix],
+        capacity: u64,
+    ) -> (Fake, SharedRoutes, Log, Runtime) {
         let fake = Fake::start_behaving(
             name,
             fake_vpp::Behaviour {
@@ -1477,7 +1481,7 @@ mod steered {
                 rules: vec![("eth4".into(), 1)],
                 log: log.clone(),
             }),
-            160,
+            capacity,
         );
         (fake, shared, log, rt)
     }
@@ -1597,7 +1601,7 @@ mod steered {
 /// steering returns only after the verified resync.
 #[test]
 fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
-    let (fake, shared, log, rt) = steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)]);
+    let (fake, shared, log, rt) = steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)], 160);
     let mut d = Driver::new();
     let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 40);
     assert_eq!(
@@ -1643,20 +1647,32 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
 /// The capacity floor is an UPPER sizing bound wearing a lower bound's
 /// hat, so it cannot be the only release (review finding): a deployment
 /// whose real table sits below capacity/16 — the default sizing over a
-/// small site — would defer forever. The small-table clause releases on
-/// an observed full reload plus quiet sustained past the BGP hold time,
-/// which is what makes "small and loaded" distinguishable from "died
-/// mid-load": a dead session cannot stay quietly wrong longer than the
-/// hold — the PeerDown wipe empties the mirror first.
+/// small site — would defer forever. The small-table clause releases a
+/// mirror past SMALL_TABLE_MIN_ROUTES once it has been quiet longer
+/// than the BGP hold time: a session that died mid-load cannot stay
+/// quietly wrong past the hold (the PeerDown wipe empties it first),
+/// and the husk the wipe leaves cannot reach the minimum.
+///
+/// The mirror here starts PARTIALLY LOADED before the adoption is even
+/// injected — the loader starts the feed before vpp-offload attaches,
+/// so routes that predate the gate are the normal case, and a release
+/// condition counting only post-gate arrivals never fires (review
+/// finding, second round: `loaded_delta >= have` was exactly that).
 #[test]
-fn a_small_table_releases_after_a_full_reload_and_long_quiet() {
-    let (fake, shared, log, rt) = steered::fixture("steered-small", &[]);
+fn a_small_table_releases_after_long_quiet_regardless_of_when_it_loaded() {
+    // Capacity 4096 → floor 256. The full table is 130 routes: past
+    // SMALL_TABLE_MIN_ROUTES (128), forever under the floor — only the
+    // small-table clause can release this.
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..126).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, shared, log, rt) = steered::fixture("steered-small", &full[..60], 4096);
     let mut d = Driver::new();
     let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
 
-    // The whole table this site has: four routes — forever below the
-    // floor of ten.
-    *shared.lock().unwrap() = (0..4).map(|i| fake_vpp::v4(0, i)).collect();
+    // The rest of the load arrives after the gate exists.
+    *shared.lock().unwrap() = full;
 
     // 150 s of paced quiet at ≤250 ms a tick needs a real budget.
     let (_, events) = steered::run_paced(&mut d, &rt, now, 8_192, |d| d.state() == State::Steered);
@@ -1679,22 +1695,53 @@ fn a_small_table_releases_after_a_full_reload_and_long_quiet() {
 
 /// A dead source releases nothing, ever: quiet is exactly what a feed
 /// that never loaded looks like, and unsteering onto an empty fallback
-/// is the original disaster. Held deferred with health degraded —
-/// stale-but-verified forwarding plus an alarm beats an outage.
+/// is the original disaster. Neither does the husk a session death
+/// leaves behind — the handful of neighbour-synthesized routes that
+/// did not come from the session — however long it stays quiet: it
+/// cannot reach SMALL_TABLE_MIN_ROUTES. Held deferred with health
+/// degraded — stale-but-verified forwarding plus an alarm beats an
+/// outage.
 #[test]
 fn a_dead_source_never_triggers_the_unsteer() {
-    let (fake, _shared, log, rt) = steered::fixture("steered-dead", &[]);
+    let (fake, shared, log, rt) = steered::fixture("steered-dead", &[], 4096);
     let mut d = Driver::new();
-    // Far past SMALL_TABLE_QUIET_FOR at ≤250 ms a tick.
-    let _ = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 2_000);
+    // Far past SMALL_TABLE_QUIET_FOR at ≤250 ms a tick, empty.
+    let mut now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 2_000);
     assert_eq!(
         d.state(),
         State::AdoptedResyncing,
         "an empty, silent source must hold the adoption deferred forever"
     );
+
+    // The session dies leaving the synth husk: eight local routes that
+    // never came from bird. Quiet past every window, still no release.
+    *shared.lock().unwrap() = (0..8).map(|i| fake_vpp::v4(3, i)).collect();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..2_000 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "a synth-only husk must not count as a loaded table"
+    );
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "no steering transition on a dead source: {:?}",
+        log.lock().unwrap()
+    );
     assert_eq!(
         rt.status().resync_deferred,
-        Some((0, 10)),
+        Some((8, 256)),
         "and the deferral must be visible, not silent"
     );
 }
@@ -1706,7 +1753,7 @@ fn a_dead_source_never_triggers_the_unsteer() {
 fn completeness_releases_a_below_floor_table_promptly() {
     use packetframe_common::fib::{CompletenessReport, TableCompleteness};
 
-    let (fake, shared, log, rt) = steered::fixture("steered-complete", &[]);
+    let (fake, shared, log, rt) = steered::fixture("steered-complete", &[], 160);
     let handle = std::sync::Arc::new(TableCompleteness::new());
     rt.require_table_complete(handle.clone());
     let mut d = Driver::new();

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -52,7 +52,12 @@ impl RouteSource for Mirror {
     }
 }
 
-fn runtime_with_source(fake: &Fake, source: Box<dyn RouteSource>) -> Runtime {
+fn runtime_custom(
+    fake: &Fake,
+    source: Box<dyn RouteSource>,
+    steering: Box<dyn packetframe_vpp_offload::runtime::Steering>,
+    capacity: u64,
+) -> Runtime {
     let engine = ConvergenceEngine::new(
         &fake.path,
         vec![PortAttach {
@@ -63,7 +68,7 @@ fn runtime_with_source(fake: &Fake, source: Box<dyn RouteSource>) -> Runtime {
             pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
         }],
         vec!["eth4".into()],
-        1_000_000,
+        capacity,
         FamilyPolicy::V4Only,
         packetframe_common::config::Ipv4Prefix {
             addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
@@ -73,12 +78,16 @@ fn runtime_with_source(fake: &Fake, source: Box<dyn RouteSource>) -> Runtime {
     Runtime::new(
         engine,
         source,
-        Box::new(SteeringUnavailable),
+        steering,
         Box::new(NullStore),
         Box::new(NoResources),
         "/usr/bin/vpp",
         "/tmp/startup.conf",
     )
+}
+
+fn runtime_with_source(fake: &Fake, source: Box<dyn RouteSource>) -> Runtime {
+    runtime_custom(fake, source, Box::new(SteeringUnavailable), 1_000_000)
 }
 
 fn runtime_for(fake: &Fake, n_routes: u8) -> Runtime {
@@ -1375,4 +1384,200 @@ fn balanced_churn_is_not_quiescence() {
         })
         .collect();
     assert_eq!(deletes, vec![([10, 0, 5, 0], 24)]);
+}
+
+/// The drill-(d10) regression (shadow, 2026-08-09): a steered adoption
+/// must not read VPP's FIB while traffic is on it. `ip_route_dump` is
+/// not mp-safe, so VPP parks every worker in barrier sync for the whole
+/// walk — ~5.4 s at the reference table, dropped at the NIC where no
+/// counter sees it, and invariant across six drill runs because every
+/// one of them ran the dump at attach. The sequence under test:
+/// nothing touches VPP until the source is loaded and quiet; then the
+/// supervisor unsteers FIRST; the dump runs against an idle VPP; and
+/// steering returns only after the verified resync.
+#[test]
+fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
+    use std::sync::{Arc, Mutex};
+
+    struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
+    impl RouteSource for SharedMirror {
+        fn route_count(&self) -> u64 {
+            let mut n = 0u64;
+            self.for_each_route(&mut |_, _| n += 1);
+            n
+        }
+        fn change_seq(&self) -> u64 {
+            self.route_count()
+        }
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in self.0.lock().unwrap().iter() {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+
+    /// A NIC that acknowledges both directions and remembers the order
+    /// they happened in — the ordering IS the property under test.
+    struct RecordingSteering {
+        rules: Vec<(String, u32)>,
+        log: Arc<Mutex<Vec<&'static str>>>,
+    }
+    impl packetframe_vpp_offload::runtime::Steering for RecordingSteering {
+        fn configured_ports(&self) -> usize {
+            1
+        }
+        fn steer(&mut self) -> Result<(), String> {
+            self.log.lock().unwrap().push("steer");
+            self.rules = vec![("eth4".into(), 1)];
+            Ok(())
+        }
+        fn unsteer(&mut self) -> Result<(), String> {
+            self.log.lock().unwrap().push("unsteer");
+            self.rules.clear();
+            Ok(())
+        }
+        fn installed(&self) -> Vec<(String, u32)> {
+            self.rules.clone()
+        }
+        fn retarget(
+            &mut self,
+            _ports: Vec<(String, u32)>,
+            _plan: packetframe_vpp_offload::steer::RuleSet,
+        ) {
+        }
+    }
+
+    // The surviving VPP forwards six routes.
+    const EXISTING: &[([u8; 4], u8, u32, bool)] = &[
+        ([10, 0, 0, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 1, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 2, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 3, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 4, 0], 24, ASSIGNED_INDEX, true),
+        ([10, 0, 5, 0], 24, ASSIGNED_INDEX, true),
+    ];
+    let fake = Fake::start_behaving(
+        "steered-adopt",
+        fake_vpp::Behaviour {
+            existing_routes: EXISTING,
+            ..Default::default()
+        },
+    );
+    // The feed has delivered one route so far — far below the floor.
+    let shared = Arc::new(Mutex::new(vec![fake_vpp::v4(0, 0)]));
+    let log: Arc<Mutex<Vec<&'static str>>> = Arc::new(Mutex::new(Vec::new()));
+    // Capacity 160 → a pre-dump floor of 160/16 = 10. That the floor is
+    // 10 and not 6/2 = 3 is itself evidence: 3 would mean the adopted
+    // table had been READ, which is the stall this test forbids.
+    let rt = runtime_custom(
+        &fake,
+        Box::new(SharedMirror(shared.clone())),
+        Box::new(RecordingSteering {
+            rules: vec![("eth4".into(), 1)],
+            log: log.clone(),
+        }),
+        160,
+    );
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: true }, &mut fx);
+    }
+    assert_eq!(d.state(), State::AdoptedResyncing);
+    rt.set_steered(true);
+
+    // Below the floor: VPP must be left exactly as found — steered,
+    // FIB unread, no route ops, no unsteer request.
+    let mut now = t0;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..40 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "nothing may complete while the source loads: {:?}",
+                t.events
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert_eq!(
+        rt.status().resync_deferred,
+        Some((1, 10)),
+        "the floor must be capacity-derived (160/16), not adopted-derived (6/2) — \
+         an adopted-derived floor means the FIB was read while steered"
+    );
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "no steering transition below the floor: {:?}",
+        log.lock().unwrap()
+    );
+    let touched: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        touched.is_empty(),
+        "no route op may reach a steered VPP before the unsteer: {touched:?}"
+    );
+
+    // The feed finishes: twelve routes, one of VPP's six (10.0.5.0/24)
+    // genuinely withdrawn while packetframe was down.
+    *shared.lock().unwrap() = (0..5)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..7).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+
+    let (_, events) = run_until(&mut d, &rt, now, |d| d.state() == State::Steered);
+
+    // The order is the contract: traffic left VPP before its FIB was
+    // read, and returned only through the verified path.
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer", "steer"],
+        "unsteer must precede the dump and the re-steer must be the last transition"
+    );
+    assert!(
+        events.contains(&Event::SyncComplete) && events.contains(&Event::VerifyPassed),
+        "the reconciliation must actually run once unsteered: {events:?}"
+    );
+    assert!(
+        rt.status().resync_deferred.is_none(),
+        "the deferral must clear when the reconciliation runs"
+    );
+    // And the diff withdrew exactly the one prefix the source dropped —
+    // proof the dump ran and seeded the withdrawal universe.
+    let deletes: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) if !r.is_add => Some((r.addr, r.len)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        deletes,
+        vec![([10, 0, 5, 0], 24)],
+        "one withdrawal for the one prefix the source really dropped"
+    );
 }

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1677,9 +1677,28 @@ fn a_met_floor_without_a_live_session_stays_deferred() {
     );
     let _ = shared;
 
-    // The session comes up: the very same mirror is now evidence, and
-    // the ordinary floor release proceeds.
+    // The session comes up. The very same mirror is now evidence — but
+    // not INSTANTLY: quiet accumulated while the feed was down attests
+    // nothing, so the clock restarts at the up-transition (review
+    // finding: without the reset, the first OPEN after an outage
+    // released on stale quiet before a single route had arrived).
     session.set_up(true);
+    let mut now = now;
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..4 {
+            let _t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += Duration::from_millis(100);
+        }
+    }
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "the up-transition must restart the quiet clock, not release on stale quiet"
+    );
     let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
     assert_eq!(log.lock().unwrap().as_slice(), &["unsteer", "steer"]);
     assert!(events.contains(&Event::VerifyPassed), "{events:?}");

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1850,6 +1850,115 @@ fn an_incomplete_verdict_vetoes_every_proxy_release() {
     assert!(events.contains(&Event::VerifyPassed), "{events:?}");
 }
 
+/// The veto-driven revocation: the authority turns Incomplete after
+/// the unsteer landed. The restoration steer must BYPASS the
+/// completeness gate - a plain steer refuses on exactly the verdict
+/// that caused the revocation, which parked traffic forever on the
+/// condemned fallback while the intact adoptee idled (review finding).
+#[test]
+fn a_condemning_verdict_cannot_block_its_own_revocations_restore() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, _shared, log, rt, session) = steered::fixture("steered-veto-restore", &full, 160);
+    session.set_up(true);
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    handle.publish(CompletenessReport {
+        authority_routes: 12,
+        mirror_routes: 12,
+        at: std::time::Instant::now(),
+    });
+    let mut d = Driver::new();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(Instant::now(), Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // Tick until the unsteer lands, then the authority condemns the
+    // mirror before the dump tick.
+    let mut now = Instant::now();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..512 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            let unsteer_landed = log.lock().unwrap().as_slice() == ["unsteer"];
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+            if unsteer_landed {
+                break;
+            }
+        }
+    }
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer"],
+        "window reached"
+    );
+    handle.publish(CompletenessReport {
+        authority_routes: 1000,
+        mirror_routes: 12,
+        at: std::time::Instant::now(),
+    });
+
+    // The veto revokes; the restore must go through DESPITE the
+    // verdict - that is the entire point of the ungated action.
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..512 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+            if log.lock().unwrap().len() == 2 {
+                break;
+            }
+        }
+    }
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer", "steer"],
+        "the condemning verdict must not block the restoration it caused"
+    );
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "steered again, still waiting"
+    );
+    let touched: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        touched.is_empty(),
+        "no dump, no diff under the veto: {touched:?}"
+    );
+}
+
 /// The revocation window: the gate released, the unsteer was
 /// acknowledged - and the feed dropped before the dump ran. The
 /// adopted FIB is still whole, so the traffic goes BACK onto it

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1959,6 +1959,48 @@ fn a_condemning_verdict_cannot_block_its_own_revocations_restore() {
     );
 }
 
+/// A still-valid Converged report must not carry a mirror that has
+/// SINCE shrunk past the drift policy through the floor release: the
+/// authority's word is recomputed against the mirror as it is now, on
+/// every path, not just the completeness release (review finding: the
+/// veto trusted the cached verdict while only `complete` recomputed).
+#[test]
+fn a_stale_convergence_cannot_carry_a_shrunken_mirror() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, shared, log, rt, session) = steered::fixture("steered-shrunk", &full, 160);
+    session.set_up(true);
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    // The authority saw twelve of twelve — and then the mirror lost
+    // one route while the report stayed fresh and Converged. Eleven
+    // still clears the floor of ten; the drift (1/12) does not clear
+    // the 1% policy, and that must gate the FLOOR path too.
+    handle.publish(CompletenessReport {
+        authority_routes: 12,
+        mirror_routes: 12,
+        at: std::time::Instant::now(),
+    });
+    shared.lock().unwrap().pop();
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 400);
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "a shrunken mirror under a stale Converged must not release"
+    );
+
+    // The route returns: the authority's recomputed word agrees again.
+    shared.lock().unwrap().push(fake_vpp::v4(1, 7));
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
+    assert_eq!(log.lock().unwrap().as_slice(), &["unsteer", "steer"]);
+    assert!(events.contains(&Event::VerifyPassed), "{events:?}");
+}
+
 /// The revocation window: the gate released, the unsteer was
 /// acknowledged - and the feed dropped before the dump ran. The
 /// adopted FIB is still whole, so the traffic goes BACK onto it

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -2013,10 +2013,14 @@ fn a_revoked_fallback_re_steers_the_intact_adopted_vpp() {
     );
     session.set_up(false);
 
-    // The revocation path: traffic back on the intact VPP, no dump.
+    // The revocation path: traffic back on the intact VPP, no dump —
+    // and IMMEDIATELY: the safety restoration must not wait out the
+    // preceding unsteer request's pace window (review finding: the
+    // shared throttle held it ~5 s while PeerDown emptied the
+    // fallback). Three ticks is transport, not throttle.
     {
         let (mut obs, mut fx) = rt.views();
-        for _ in 0..512 {
+        for _ in 0..3 {
             let t = d.tick(now, &mut obs, &mut fx);
             for e in rt.take_pending() {
                 d.inject(now, e, &mut fx);

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1806,6 +1806,112 @@ fn a_dead_source_never_triggers_the_unsteer() {
     );
 }
 
+/// The revocation window: the gate released, the unsteer was
+/// acknowledged - and the feed dropped before the dump ran. The
+/// adopted FIB is still whole, so the traffic goes BACK onto it
+/// (review finding: parking here left traffic on a fallback that a
+/// BMP PeerDown was simultaneously emptying). When readiness returns,
+/// the ordinary cycle resumes from the top.
+#[test]
+fn a_revoked_fallback_re_steers_the_intact_adopted_vpp() {
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, _shared, log, rt, session) = steered::fixture("steered-revoke", &full, 160);
+    session.set_up(true);
+    let mut d = Driver::new();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(Instant::now(), Event::Adopted { steered: true }, &mut fx);
+    }
+    rt.set_steered(true);
+
+    // Tick until the unsteer lands, then IMMEDIATELY drop the session
+    // - the dump must not run on the next tick.
+    let mut now = Instant::now();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..512 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            let unsteer_landed = log.lock().unwrap().as_slice() == ["unsteer"];
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+            if unsteer_landed {
+                break;
+            }
+        }
+    }
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer"],
+        "window reached"
+    );
+    session.set_up(false);
+
+    // The revocation path: traffic back on the intact VPP, no dump.
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..512 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+            if log.lock().unwrap().len() == 2 {
+                break;
+            }
+        }
+    }
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer", "steer"],
+        "revoked readiness must put traffic back on the adopted VPP"
+    );
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "still waiting, steered again"
+    );
+    let touched: Vec<_> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|e| match e {
+            fake_vpp::Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        touched.is_empty(),
+        "the dump and diff must not have run against the revoked window: {touched:?}"
+    );
+
+    // Readiness returns: the ordinary cycle completes from the top.
+    session.set_up(true);
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["unsteer", "steer", "unsteer", "steer"],
+        "the resumed cycle repeats the full sequence"
+    );
+    assert!(events.contains(&Event::VerifyPassed), "{events:?}");
+}
+
 /// Where a bird exists, completeness is the exact readiness signal -
 /// but a report is a snapshot, so it releases only alongside CURRENT
 /// session liveness (review finding: a PeerDown wipe inside the

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1806,6 +1806,50 @@ fn a_dead_source_never_triggers_the_unsteer() {
     );
 }
 
+/// A configured authority that says Incomplete VETOES the proxies: a
+/// met floor and a live, quiet session must not out-vote a verdict
+/// that the mirror is missing more than the drift policy allows
+/// (review finding: a load stalling two seconds past the floor would
+/// otherwise unsteer onto a table the authority had condemned). The
+/// same state releases the moment the authority agrees.
+#[test]
+fn an_incomplete_verdict_vetoes_every_proxy_release() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, _shared, log, rt, session) = steered::fixture("steered-veto", &full, 160);
+    session.set_up(true);
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    // The authority knows the world is ~1000 routes; the mirror holds
+    // twelve. Floor met, session live, quiet - and condemned.
+    handle.publish(CompletenessReport {
+        authority_routes: 1000,
+        mirror_routes: 12,
+        at: std::time::Instant::now(),
+    });
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 400);
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "an Incomplete verdict must hold every proxy release"
+    );
+
+    // The authority agrees: the ordinary release proceeds.
+    handle.publish(CompletenessReport {
+        authority_routes: 12,
+        mirror_routes: 12,
+        at: std::time::Instant::now(),
+    });
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
+    assert_eq!(log.lock().unwrap().as_slice(), &["unsteer", "steer"]);
+    assert!(events.contains(&Event::VerifyPassed), "{events:?}");
+}
+
 /// The revocation window: the gate released, the unsteer was
 /// acknowledged - and the feed dropped before the dump ran. The
 /// adopted FIB is still whole, so the traffic goes BACK onto it

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1787,18 +1787,21 @@ fn a_dead_source_never_triggers_the_unsteer() {
     );
 }
 
-/// Where a bird exists, completeness is the exact readiness signal —
-/// the same one `Effects::steer` gates on — and it releases a table the
-/// capacity floor is wrong about without waiting out the hold time.
+/// Where a bird exists, completeness is the exact readiness signal -
+/// but a report is a snapshot, so it releases only alongside CURRENT
+/// session liveness (review finding: a PeerDown wipe inside the
+/// report's validity window must not ride a stale Converged onto an
+/// empty fallback). With both in hand it releases a table the capacity
+/// floor is wrong about without waiting out the hold time.
 #[test]
 fn completeness_releases_a_below_floor_table_promptly() {
     use packetframe_common::fib::{CompletenessReport, TableCompleteness};
 
-    let (fake, shared, log, rt, _session) = steered::fixture("steered-complete", &[], 160);
+    let (fake, shared, log, rt, session) = steered::fixture("steered-complete", &[], 160);
     let handle = std::sync::Arc::new(TableCompleteness::new());
     rt.require_table_complete(handle.clone());
     let mut d = Driver::new();
-    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
+    let mut now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 20);
 
     *shared.lock().unwrap() = (0..4).map(|i| fake_vpp::v4(0, i)).collect();
     handle.publish(CompletenessReport {
@@ -1806,6 +1809,28 @@ fn completeness_releases_a_below_floor_table_promptly() {
         mirror_routes: 4,
         at: std::time::Instant::now(),
     });
+
+    // A Converged report with the session DOWN is a snapshot of a
+    // world that may have ended - it must not release by itself.
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..200 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "a cached Converged without current liveness must not release"
+    );
+    session.set_up(true);
 
     // Well under the 150 s small-table wait: the authority short-cuts.
     let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1606,8 +1606,9 @@ mod steered {
 /// steering returns only after the verified resync.
 #[test]
 fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
-    let (fake, shared, log, rt, _session) =
+    let (fake, shared, log, rt, session) =
         steered::fixture("steered-adopt", &[fake_vpp::v4(0, 0)], 160);
+    session.set_up(true);
     let mut d = Driver::new();
     let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 40);
     assert_eq!(
@@ -1648,6 +1649,40 @@ fn a_steered_adoption_unsteers_before_reading_vpps_fib() {
         vec![([10, 0, 4, 0], 24), ([10, 0, 5, 0], 24)],
         "two withdrawals for the two prefixes the source really dropped"
     );
+}
+
+/// The floor answers SIZE and nothing else, so meeting it must not
+/// release alone (review finding): a small `expected-routes` shrinks
+/// the floor beneath what neighbour-synthesized local routes supply
+/// with the feed dead, and unsteering onto those is the blackhole
+/// every round of this gate has been about. Liveness is the session
+/// handle to answer, on the floor path too — and turning the session
+/// on is exactly what lets the same state release.
+#[test]
+fn a_met_floor_without_a_live_session_stays_deferred() {
+    // Capacity 160 -> floor 10; twelve routes meet it. The session is
+    // down: this mirror is a husk, however comfortably it clears the
+    // floor.
+    let full: Vec<IpPrefix> = (0..4)
+        .map(|i| fake_vpp::v4(0, i))
+        .chain((0..8).map(|i| fake_vpp::v4(1, i)))
+        .collect();
+    let (fake, shared, log, rt, session) = steered::fixture("steered-floor-dead", &full, 160);
+    let mut d = Driver::new();
+    let now = steered::adopt_and_hold(&mut d, &rt, &fake, &log, Instant::now(), 400);
+    assert_eq!(
+        d.state(),
+        State::AdoptedResyncing,
+        "a met floor with a dead session must stay deferred"
+    );
+    let _ = shared;
+
+    // The session comes up: the very same mirror is now evidence, and
+    // the ordinary floor release proceeds.
+    session.set_up(true);
+    let (_, events) = steered::run_paced(&mut d, &rt, now, 512, |d| d.state() == State::Steered);
+    assert_eq!(log.lock().unwrap().as_slice(), &["unsteer", "steer"]);
+    assert!(events.contains(&Event::VerifyPassed), "{events:?}");
 }
 
 /// The capacity floor is an UPPER sizing bound wearing a lower bound's


### PR DESCRIPTION
## The 5.4 s drill-(d) gap, root-caused

Seven drill runs chased a metronomic 5.38–5.46 s outage on every adopted attach. It survived three FIB-door fixes (#146–#148), the resync deferral (#145), and the daemon affinity restriction (#149/#150) — because it was none of them. With the shadow's clock finally synced, run d10 placed the gap exactly over the attach's binary-API phase, and VPP's source confirmed the mechanism: **`ip_route_dump` is not mp-safe** ([ip_api.c](https://github.com/FDio/vpp/blob/master/src/vnet/ip/ip_api.c) marks `ip_route_add_del` thread-safe, not the dump), so VPP processes it with **every worker parked in barrier sync** while the handler walks the FIB and streams 1.05M details in one invocation ([VPP binary API docs](https://fd.io/docs/vpp/v2101/gettingstarted/developers/binary_api_support.html), [known packet-loss thread](https://lists.fd.io/g/vpp-dev/topic/packet_loss_on_use_of_api/10642131)). ~5.4 s of frozen workers, rings overflowing at the NIC where no VPP counter looks. The same capture measured the mp-safe 250k-route diff at ~0.1 s — the control group was in the data all along.

## The fix: make the dump harmless instead of cheaper

No VPP patches (we don't fork), and moving the dump around doesn't help — workers freeze whenever it runs. But the architecture already owns a place to put the traffic while it runs: the eBPF tier, fed by the same mirror commits the gate just declared loaded.

**Rule 3 refined, not repealed.** Adoption still never tears steering down *to resync*. But a **steered** adoption now defers everything — the dump included — behind the existing floor+quiescence gate; then:

```
wait source loaded+quiet → Event::FallbackSettled → Action::Unsteer
→ dump against an idle VPP → diff → drain → verify → re-steer (existing verified path)
```

`steer_wanted` is set at adoption and survives the unsteer, so `VerifyPassed → Action::Steer` needs no new bookkeeping — d10's own log shows that path working. An **unsteered** adoption keeps today's shape exactly: with no rules installed, the barrier stalls a VPP carrying nothing.

The pre-dump floor can't derive from the adopted count (reading it is the thing being deferred), so it derives from the ledger's route capacity — operator-declared `expected-routes` / 16 — which scales with the deployment and keeps the dead-source case orders of magnitude below it.

## Shape

- `DeferredResync` is now a two-stage enum (`AwaitingFallback` → `AwaitingDiff`) with the gate arithmetic in one `SourceGate`, so the stages cannot drift.
- One new supervisor event, `FallbackSettled`, meaningful only in `AdoptedResyncing`; every other state ignores it as stale. Unsteer requests are paced (5 s) so a refusing NIC isn't asked every 50 ms tick.
- The dump gate reads the **NIC ledger** (`steering.installed()`), not the supervisor's belief — rules in the NIC are what puts packets on VPP.

## Tests

- End-to-end regression (`a_steered_adoption_unsteers_before_reading_vpps_fib`): below the floor, no route op reaches VPP, no steering transition, and the reported floor is capacity-derived — which is itself proof the FIB went unread (an adopted-derived floor would mean the dump ran). Then exactly `[unsteer, steer]` in order, with `SyncComplete`/`VerifyPassed` between and the one genuine withdrawal applied.
- Supervisor unit test for the new event in every state.
- Existing deferral tests unchanged and passing — the unsteered path is bit-identical to before.

Expected on hardware: drill (d)'s restart half drops from a 5.4 s outage to two ~ms steering flips, with traffic riding the eBPF tier for the reconciliation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)