### PR TITLE
fix(fast-path): BGP liveness raises when the stream starts, not when it goes silent

### DIFF
--- a/crates/modules/fast-path/src/fib/route_source_bgp.rs
+++ b/crates/modules/fast-path/src/fib/route_source_bgp.rs
@@ -403,8 +403,16 @@ impl BgpListener {
         // UPDATE would read as live-and-quiet, and two seconds of
         // pre-stream quiet releases the second tier's gate onto a
         // mirror holding only local routes (review finding). Liveness
-        // raises at the InitiationComplete heuristic below — the same
-        // initial-RIB-settled definition the BMP path uses.
+        // raises on the FIRST UPDATE of the session — the stream has
+        // started, which is all "live" must attest. It must NOT wait
+        // for post-stream silence: a live DFZ feed never pauses five
+        // seconds (measured on the shadow, 2026-08-09 — 91 minutes of
+        // session, zero InitiationComplete firings, the reconciliation
+        // wedged behind a silence that cannot come). Whether the load
+        // has FINISHED is the release gate's question, and its
+        // mirror-scaled rate answers it: an initial load runs orders
+        // of magnitude above the quiet rate, so live-but-loading can
+        // never release early.
         let mut last_update: Option<Instant> = None;
         let mut init_complete_fired = false;
         let mut quiescence_tick = tokio::time::interval(Duration::from_secs(1));
@@ -480,16 +488,6 @@ impl BgpListener {
                                         "InitiationComplete fired"
                                     );
                                     init_complete_fired = true;
-                                    // The initial RIB has settled: the
-                                    // mirror now holds what this session
-                                    // has to give, which is what "live"
-                                    // must mean to the second tier's
-                                    // release gate. Every session exit
-                                    // still runs through the accept
-                                    // loop's set_up(false).
-                                    if let Some(sess) = &self.cfg.session {
-                                        sess.set_up(true);
-                                    }
                                 }
                             }
                         }
@@ -538,6 +536,14 @@ impl BgpListener {
             BgpMessage::Update(update) => {
                 *last_update = Some(Instant::now());
                 *updates_seen += 1;
+                if *updates_seen == 1 {
+                    // The stream has started; see the handshake note
+                    // for why this — and not post-stream silence — is
+                    // where the session becomes live.
+                    if let Some(sess) = &self.cfg.session {
+                        sess.set_up(true);
+                    }
+                }
                 let now_unix = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .unwrap_or_default()


### PR DESCRIPTION
## Hardware falsified the settle rule within hours

Drill d11 delivered a perfect capture — 150,000/150,000, worst gap 0.098 s — and a wedge behind it: the unsteer→dump→re-steer cycle never ran. The deferral was waiting on `live`, and `live` was waiting on the round-twelve settle rule: five seconds with no UPDATEs after the last one. **A live DFZ feed never pauses five seconds.** Measured on the shadow: session connected 20:56:22, table loaded by ~20:57, and at 22:27 — 91 minutes later — `InitiationComplete fired` count was zero. VPP forwarded a table frozen at attach the whole time, with health honestly reporting the deferral and nothing able to release it.

## The fix

`live` now means **the stream has started**: the handle raises on the session's first UPDATE.

- The counterexample that motivated round twelve stays closed: a session that establishes and then delays its first UPDATE has sent no UPDATE, and is not live.
- Whether the load has **finished** was never the listener's question. The release gate answers it with its mirror-scaled quiet rate: an initial load runs orders of magnitude above steady churn and reads as loud until it actually ends, live or not. Silence-based settling in the listener was compensation for the capacity-scaled rates that #151 round eighteen removed at the root.
- The `InitiationComplete` event is unchanged (programmer semantics); only the liveness raise moves.
- The BMP path's 1 s quiescence heuristic has the same latent exposure on continuously-churning emitters; it is not the fleet path and is flagged for the follow-up configuration-narrowing PR.

## Verification

Deploy to the shadow and restart the daemon over the steered VPP: the release should follow the source going rate-quiet (~40 s, as in every pre-#151-round-12 run), then unsteer → dump-against-idle → diff → verify → re-steer, under the same 500 pps capture. That run — not d11 — is the referee for the cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)