### PR TITLE
docs+fix: the 2026-08-11 shadow session, and drift detection for the finding it produced

### DIFF
--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -671,7 +671,7 @@ fn drive_signal_loop(
         for sig in signals.pending() {
             match sig {
                 SIGHUP => {
-                    reconfigure_from_signal(
+                    let published = reconfigure_from_signal(
                         config_path,
                         state_dir,
                         modules,
@@ -679,8 +679,12 @@ fn drive_signal_loop(
                         #[cfg(feature = "vpp-offload")]
                         allowlist,
                     );
-                    // It just published; do not immediately publish again.
-                    next_poll = Instant::now() + MODULE_POLL_INTERVAL;
+                    // Only when it actually published: a rejected
+                    // reload refreshed nothing, and skipping the next
+                    // poll on its behalf ages the health file.
+                    if published == Published::Yes {
+                        next_poll = Instant::now() + MODULE_POLL_INTERVAL;
+                    }
                 }
                 SIGTERM | SIGINT => {
                     tracing::info!(signal = sig, "termination requested");
@@ -717,7 +721,7 @@ fn reconfigure_from_signal(
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
     module_gauges: &std::sync::Mutex<String>,
     #[cfg(feature = "vpp-offload")] allowlist: &packetframe_vpp_offload::SharedAllowlist,
-) {
+) -> Published {
     use packetframe_common::module::ModuleConfig;
 
     tracing::info!(config = %config_path.display(), "SIGHUP received; reconfiguring");
@@ -729,7 +733,7 @@ fn reconfigure_from_signal(
         Err(e) => {
             tracing::error!(error = %e, "SIGHUP config parse failed; keeping current config");
             write_reconfigure_marker(&marker_path, &format!("ERR parse: {e}"));
-            return;
+            return Published::No;
         }
     };
 
@@ -752,7 +756,7 @@ fn reconfigure_from_signal(
     if let Err(e) = new_config.validate_vpp_offload() {
         tracing::error!(error = %e, "SIGHUP config is unsafe to apply; keeping current config");
         write_reconfigure_marker(&marker_path, &format!("ERR validate: {e}"));
-        return;
+        return Published::No;
     }
 
     // Before the module loop, and for the WHOLE config rather than per
@@ -808,6 +812,21 @@ fn reconfigure_from_signal(
             &format!("ERR module: {}", failures.join("; ")),
         );
     }
+    Published::Yes
+}
+
+/// Whether a reconfigure attempt refreshed the health file.
+///
+/// A rejected reload returns before publishing anything, so the caller
+/// must NOT postpone its own poll on the strength of it — doing that
+/// let a bad config arriving just before a scheduled poll age health by
+/// nearly two intervals, and a config that kept failing suppress
+/// polling for as long as it kept failing (review finding).
+#[cfg(target_os = "linux")]
+#[derive(PartialEq, Eq)]
+enum Published {
+    Yes,
+    No,
 }
 
 /// Append a timestamp + status line to the reconfigure marker file.

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -670,13 +670,18 @@ fn drive_signal_loop(
     loop {
         for sig in signals.pending() {
             match sig {
-                SIGHUP => reconfigure_from_signal(
-                    config_path,
-                    state_dir,
-                    modules,
-                    #[cfg(feature = "vpp-offload")]
-                    allowlist,
-                ),
+                SIGHUP => {
+                    reconfigure_from_signal(
+                        config_path,
+                        state_dir,
+                        modules,
+                        module_gauges,
+                        #[cfg(feature = "vpp-offload")]
+                        allowlist,
+                    );
+                    // It just published; do not immediately publish again.
+                    next_poll = Instant::now() + MODULE_POLL_INTERVAL;
+                }
                 SIGTERM | SIGINT => {
                     tracing::info!(signal = sig, "termination requested");
                     return Ok(Termination::ExitPreserveAttach);
@@ -710,6 +715,7 @@ fn reconfigure_from_signal(
     config_path: &Path,
     state_dir: &Path,
     modules: &mut [(String, Box<dyn packetframe_common::module::Module>)],
+    module_gauges: &std::sync::Mutex<String>,
     #[cfg(feature = "vpp-offload")] allowlist: &packetframe_vpp_offload::SharedAllowlist,
 ) {
     use packetframe_common::module::ModuleConfig;
@@ -777,6 +783,22 @@ fn reconfigure_from_signal(
             failures.push(format!("{name}: {e}"));
         }
     }
+
+    // Refresh the health file BEFORE the marker, because the marker is
+    // what `packetframe reconfigure` is waiting on — so by the time it
+    // returns, `packetframe status` already reflects what just changed.
+    //
+    // Without this the two surfaces disagreed for up to
+    // MODULE_POLL_INTERVAL: on the shadow (2026-08-11) a reconfigure
+    // returned OK and logged `steering UP`, `ethtool` showed the rules
+    // in the NIC, and `status` still read `steer off (staging state)`
+    // from a five-second-old snapshot. An operator stepping a canary
+    // ladder reads `status` immediately after `reconfigure`; a rollout
+    // script does it faster than a human can.
+    //
+    // Same shape as the service's publish-before-answer rule, one layer
+    // up: publish the observation, then answer the caller.
+    crate::health::poll(state_dir, modules, module_gauges);
 
     if failures.is_empty() {
         write_reconfigure_marker(&marker_path, "OK");

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -941,9 +941,25 @@ impl crate::runtime::Steering for NtupleSteering {
             // The location is only a slot; what makes a rule ours is
             // its spec. So try the rule planned AT this location first,
             // and otherwise accept a match against ANY planned rule.
+            // Stamped with the location being CHECKED, not the one the
+            // rule was planned for. `matches` compares `location`, so an
+            // expectation built straight from a planned rule can never
+            // match an adopted slot — the planner chose a different one
+            // by construction. Without this the whole "any planned rule"
+            // arm was dead code for exactly the rules it was added to
+            // cover, and every adopted rule fell through to an ownership
+            // guess (review finding).
             let expected: Vec<RxFlowSpec> = match rule {
                 Some(r) => vec![flow_spec(r, vf)],
-                None => self.plan.rules.iter().map(|r| flow_spec(r, vf)).collect(),
+                None => self
+                    .plan
+                    .rules
+                    .iter()
+                    .map(|r| RxFlowSpec {
+                        location: *loc,
+                        ..flow_spec(r, vf)
+                    })
+                    .collect(),
             };
             let mut check = Rxnfc {
                 cmd: ETHTOOL_GRXCLSRULE,
@@ -955,26 +971,26 @@ impl crate::runtime::Steering for NtupleSteering {
             };
             match sys::ethtool(iface, &mut check) {
                 Ok(()) => {
-                    let ours = if rule.is_some() {
-                        // We know exactly what should be here, so
-                        // nothing weaker will do. In particular the
-                        // ownership fallback below must NOT apply: a
-                        // rule narrowed behind our back keeps our ring
-                        // cookie, and accepting it on that basis put
-                        // the narrowing hole straight back (caught by
-                        // `a_rule_narrowed_behind_our_back_is_reported_missing`
-                        // while making adopted rules auditable).
-                        expected.iter().any(|e| audit_matches(e, &check.fs))
-                    } else {
-                        // Adopted: no expectation at this location.
-                        // Any rule we currently plan is a strong match;
-                        // failing that, a rule pointing at our VF is
-                        // one of ours from a previous config, present
-                        // and awaiting the next reconcile — not missing.
-                        expected.iter().any(|e| audit_matches(e, &check.fs))
-                            || check.fs.ring_cookie == ring_cookie(vf)
-                    };
-                    if !ours {
+                    // ONE rule, both cases: does the NIC hold something
+                    // this target asked for?
+                    //
+                    // There used to be an ownership fallback here —
+                    // accept anything pointing at our VF when no
+                    // expectation matched — and it was a guess dressed
+                    // as a check. A rule narrowed or replaced behind our
+                    // back keeps the ring cookie, so it proved nothing
+                    // about the rule and swallowed the drift it existed
+                    // to catch (review finding).
+                    //
+                    // Its purpose was to spare an adopted rule from a
+                    // PREVIOUS config, which matches nothing planned
+                    // now. Those are reported too, deliberately: the NIC
+                    // is not holding what the current target says it
+                    // should, the remedy is the same `reconfigure`, and
+                    // it retires them. The health text says "missing or
+                    // no longer what we asked for" rather than "gone"
+                    // for exactly that reason.
+                    if !expected.iter().any(|e| audit_matches(e, &check.fs)) {
                         missing.push((iface.clone(), *loc));
                     }
                 }
@@ -1363,8 +1379,22 @@ mod tests {
             "inherited rules are present and ours; nothing is missing"
         );
 
-        // And the thing the audit exists for still fires on them.
+        // NARROWED, not deleted — the case an ownership check cannot
+        // see. A narrowed rule keeps our ring cookie, so accepting
+        // adopted rules on the strength of the cookie reported this as
+        // fine; the audit has to compare the spec against what the
+        // current target asks for, at the location being checked.
         let (iface, loc) = inherited[0].clone();
+        sys::narrow_behind_back(&iface, loc);
+        assert_eq!(
+            after.missing_from_nic().expect("read the NIC"),
+            vec![(iface.clone(), loc)],
+            "an inherited rule narrowed out of band must be reported — some of \
+             the traffic we believe is offloaded no longer is"
+        );
+
+        // And outright deletion of an inherited rule, which is what the
+        // hardware actually did on 2026-08-11.
         sys::remove_behind_back(&iface, loc);
         assert_eq!(
             after.missing_from_nic().expect("read the NIC"),

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -921,25 +921,30 @@ impl crate::runtime::Steering for NtupleSteering {
         for (iface, loc) in &self.installed {
             let vf = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v);
             let rule = self.plan.rules.iter().find(|r| r.location == *loc);
-            let (vf, rule) = match (vf, rule) {
-                (Some(v), Some(r)) => (v, r),
-                // No expected spec to compare against — an adopted
-                // location from a previous config, or a port no longer
-                // in the target. Unverifiable is not the same as
-                // missing, and reporting it would degrade health over
-                // the transient window between adoption and the first
-                // reconcile.
-                _ => continue,
+            let Some(vf) = vf else {
+                // A port that is no longer a member. Its rules are
+                // still adopted (they are in the NIC and this object is
+                // the only thing that will remove them), but nothing
+                // here can say what they should look like.
+                continue;
             };
-            // OCCUPANCY IS NOT ENOUGH. An insert at an occupied
-            // location REPLACES what is there, so a provisioning push
-            // or a stray `ethtool -N` can leave our slot full of
-            // somebody else's rule — still listed by GRXCLSRLALL,
-            // matching traffic we never asked for, while the ledger
-            // says ours is installed (review finding). Read the
-            // location back and compare the flow spec, exactly as
-            // `insert` does after every write and for the same reason.
-            let asked = flow_spec(rule, vf);
+            // ADOPTED LOCATIONS DO NOT APPEAR IN THE PLAN, so keying on
+            // the location alone audited nothing after a restart.
+            // `McamBudget::from_table` excludes every occupied slot when
+            // planning, and on an adopted start the occupants are our
+            // own rules — so the plan lands elsewhere and `bring_up`
+            // then restores the real locations from the state file. The
+            // first version skipped all of them, and the window it
+            // skipped is the adopted-resync deferral, which can hold
+            // indefinitely (review finding).
+            //
+            // The location is only a slot; what makes a rule ours is
+            // its spec. So try the rule planned AT this location first,
+            // and otherwise accept a match against ANY planned rule.
+            let expected: Vec<RxFlowSpec> = match rule {
+                Some(r) => vec![flow_spec(r, vf)],
+                None => self.plan.rules.iter().map(|r| flow_spec(r, vf)).collect(),
+            };
             let mut check = Rxnfc {
                 cmd: ETHTOOL_GRXCLSRULE,
                 fs: RxFlowSpec {
@@ -949,9 +954,30 @@ impl crate::runtime::Steering for NtupleSteering {
                 ..Rxnfc::default()
             };
             match sys::ethtool(iface, &mut check) {
-                Ok(()) if audit_matches(&asked, &check.fs) => {}
-                // Present but not ours.
-                Ok(()) => missing.push((iface.clone(), *loc)),
+                Ok(()) => {
+                    let ours = if rule.is_some() {
+                        // We know exactly what should be here, so
+                        // nothing weaker will do. In particular the
+                        // ownership fallback below must NOT apply: a
+                        // rule narrowed behind our back keeps our ring
+                        // cookie, and accepting it on that basis put
+                        // the narrowing hole straight back (caught by
+                        // `a_rule_narrowed_behind_our_back_is_reported_missing`
+                        // while making adopted rules auditable).
+                        expected.iter().any(|e| audit_matches(e, &check.fs))
+                    } else {
+                        // Adopted: no expectation at this location.
+                        // Any rule we currently plan is a strong match;
+                        // failing that, a rule pointing at our VF is
+                        // one of ours from a previous config, present
+                        // and awaiting the next reconcile — not missing.
+                        expected.iter().any(|e| audit_matches(e, &check.fs))
+                            || check.fs.ring_cookie == ring_cookie(vf)
+                    };
+                    if !ours {
+                        missing.push((iface.clone(), *loc));
+                    }
+                }
                 // Empty: ENOENT is how the driver answers for a
                 // location holding nothing.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
@@ -1284,6 +1310,67 @@ mod tests {
             vec![(iface, loc)],
             "a rule carrying a constraint we never asked for is not ours — some \
              of the traffic we believe is steered no longer is"
+        );
+    }
+
+    /// An ADOPTED rule is audited, even though its location is absent
+    /// from the startup plan.
+    ///
+    /// This is the production path and it defeated the first version
+    /// entirely. `McamBudget::from_table` excludes every occupied slot
+    /// when planning, so on an adopted start the plan avoids our own
+    /// rules and lands elsewhere; `bring_up` then restores the real
+    /// locations from the state file. Keying the audit on "is there a
+    /// planned rule AT this location" therefore skipped every inherited
+    /// rule — for the whole adopted-resync deferral, which can hold
+    /// indefinitely on a box with no completeness authority (review
+    /// finding, and exactly the state the shadow sat in on
+    /// 2026-08-11).
+    #[test]
+    fn an_adopted_rule_is_audited_though_the_plan_never_named_its_slot() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+
+        // The previous daemon: installs at the top of the table.
+        let mut before =
+            NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        before.steer().expect("first run installs");
+        let inherited = before.installed();
+        assert!(!inherited.is_empty());
+
+        // The new daemon plans against a table those rules occupy, so
+        // it necessarily chooses different slots — then adopts.
+        let budget = crate::steer::McamBudget::from_table(&rule_table("eth0").expect("table"));
+        let allow = vec![IpPrefix::V4 {
+            addr: [198, 18, 0, 0],
+            prefix_len: 24,
+        }];
+        let fresh_plan = RuleSet::plan(&allow, budget).expect("fits");
+        for r in &fresh_plan.rules {
+            assert!(
+                !inherited.iter().any(|(_, l)| *l == r.location),
+                "the fixture must reproduce the real path: planned slot {} \
+                 collides with an inherited one",
+                r.location
+            );
+        }
+        let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], fresh_plan);
+        after.adopt_installed(inherited.clone());
+
+        assert_eq!(
+            after.missing_from_nic().expect("read the NIC"),
+            Vec::new(),
+            "inherited rules are present and ours; nothing is missing"
+        );
+
+        // And the thing the audit exists for still fires on them.
+        let (iface, loc) = inherited[0].clone();
+        sys::remove_behind_back(&iface, loc);
+        assert_eq!(
+            after.missing_from_nic().expect("read the NIC"),
+            vec![(iface, loc)],
+            "an inherited rule deleted out of band must be reported, or the \
+             audit is blind for the entire adopted deferral"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -944,7 +944,7 @@ impl crate::runtime::Steering for NtupleSteering {
         }
     }
 
-    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+    fn missing_from_nic(&self) -> Result<crate::runtime::SteeringAudit, String> {
         let mut missing = Vec::new();
         let mut read_errors: Vec<String> = Vec::new();
         // Which planned rule each interface has already accounted for.
@@ -1074,14 +1074,17 @@ impl crate::runtime::Steering for NtupleSteering {
             // than adopting a clean one this audit never established.
             return Err(read_errors.join("; "));
         }
-        if !read_errors.is_empty() {
-            tracing::debug!(
-                errors = ?read_errors,
-                confirmed = missing.len(),
-                "steering audit was incomplete; reporting what it could read"
-            );
-        }
-        Ok(missing)
+        // Both facts travel together. Confirmed drift used to be
+        // returned alone with the read failures logged at debug, and the
+        // caller reads any `Ok` as a complete pass — so it cleared its
+        // "cannot verify" state and published the confirmed count as
+        // current, while whatever sat behind the unreadable locations
+        // stayed invisible (review finding). The count is a FLOOR
+        // whenever this is `Some`.
+        Ok(crate::runtime::SteeringAudit {
+            missing,
+            unreadable: (!read_errors.is_empty()).then(|| read_errors.join("; ")),
+        })
     }
 
     fn installed(&self) -> Vec<(String, u32)> {
@@ -1320,7 +1323,7 @@ mod tests {
         let installed = s.installed();
         assert!(!installed.is_empty(), "the fixture must install something");
         assert_eq!(
-            s.missing_from_nic().expect("read the NIC"),
+            audit(&s),
             Vec::new(),
             "a NIC that agrees with the ledger reports nothing missing"
         );
@@ -1330,7 +1333,7 @@ mod tests {
         sys::remove_behind_back(&iface, loc);
 
         assert_eq!(
-            s.missing_from_nic().expect("read the NIC"),
+            audit(&s),
             vec![(iface, loc)],
             "a rule the NIC no longer holds must be reported, or the offload \
              goes silently partial with health green"
@@ -1360,7 +1363,7 @@ mod tests {
         s.steer().expect("steer installs");
         let installed = s.installed();
         assert_eq!(
-            s.missing_from_nic().expect("read the NIC"),
+            audit(&s),
             Vec::new(),
             "our own rules must not read as drift"
         );
@@ -1369,7 +1372,7 @@ mod tests {
         sys::replace_behind_back(&iface, loc);
 
         assert_eq!(
-            s.missing_from_nic().expect("read the NIC"),
+            audit(&s),
             vec![(iface, loc)],
             "a location still OCCUPIED but holding a different rule is not ours, \
              and occupancy alone cannot tell the difference"
@@ -1395,7 +1398,7 @@ mod tests {
         sys::narrow_behind_back(&iface, loc);
 
         assert_eq!(
-            s.missing_from_nic().expect("read the NIC"),
+            audit(&s),
             vec![(iface, loc)],
             "a rule carrying a constraint we never asked for is not ours — some \
              of the traffic we believe is steered no longer is"
@@ -1447,7 +1450,7 @@ mod tests {
         after.adopt_installed(inherited.clone());
 
         assert_eq!(
-            after.missing_from_nic().expect("read the NIC"),
+            audit(&after),
             Vec::new(),
             "inherited rules are present and ours; nothing is missing"
         );
@@ -1460,7 +1463,7 @@ mod tests {
         let (iface, loc) = inherited[0].clone();
         sys::narrow_behind_back(&iface, loc);
         assert_eq!(
-            after.missing_from_nic().expect("read the NIC"),
+            audit(&after),
             vec![(iface.clone(), loc)],
             "an inherited rule narrowed out of band must be reported — some of \
              the traffic we believe is offloaded no longer is"
@@ -1470,7 +1473,7 @@ mod tests {
         // hardware actually did on 2026-08-11.
         sys::remove_behind_back(&iface, loc);
         assert_eq!(
-            after.missing_from_nic().expect("read the NIC"),
+            audit(&after),
             vec![(iface, loc)],
             "an inherited rule deleted out of band must be reported, or the \
              audit is blind for the entire adopted deferral"
@@ -1496,7 +1499,7 @@ mod tests {
             installed.len() >= 2,
             "the fixture needs at least two rules (src and dst) to duplicate one"
         );
-        assert_eq!(s.missing_from_nic().expect("read"), Vec::new());
+        assert_eq!(audit(&s), Vec::new());
 
         // Overwrite the first slot with a copy of the second's rule.
         let (iface, victim) = installed[0].clone();
@@ -1508,7 +1511,7 @@ mod tests {
         // which of the two greedy matching leaves unaccounted is an
         // artifact of iteration order — pinning it would be asserting
         // the implementation rather than the property.
-        let m = s.missing_from_nic().expect("read");
+        let m = audit(&s);
         assert_eq!(
             m.len(),
             1,
@@ -1541,12 +1544,26 @@ mod tests {
         sys::remove_behind_back(&iface, gone);
         sys::wedge_read(&[unreadable]);
 
+        let a = s
+            .missing_from_nic()
+            .expect("proven drift survives an unreadable peer");
         assert_eq!(
-            s.missing_from_nic()
-                .expect("proven drift survives an unreadable peer"),
+            a.missing,
             vec![(iface.clone(), gone)],
             "the confirmed missing rule must be reported even though another \
              location could not be read"
+        );
+        // And the pass must say it was INCOMPLETE. Reporting the drift
+        // alone made the caller clear its "cannot verify" state, so
+        // health published a floor as a current count while whatever
+        // sat behind the wedged location stayed invisible — the same
+        // stale-answer-as-fresh mistake one level down (review finding).
+        let why = a
+            .unreadable
+            .expect("a pass that could not read a location is not a complete one");
+        assert!(
+            why.contains(&unreadable.to_string()),
+            "and it must name what it could not read: {why}"
         );
 
         // But an audit that proved NOTHING and could not read must fail
@@ -1596,7 +1613,7 @@ mod tests {
         let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], grown);
         after.adopt_installed(inherited.clone());
 
-        let m = after.missing_from_nic().expect("read the NIC");
+        let m = audit(&after);
         assert_eq!(
             m.len(),
             owed,
@@ -1613,7 +1630,7 @@ mod tests {
         // replacement for one already counted.
         let (iface, loc) = inherited[0].clone();
         sys::remove_behind_back(&iface, loc);
-        let m = after.missing_from_nic().expect("read the NIC");
+        let m = audit(&after);
         assert_eq!(
             m.len(),
             owed + 1,
@@ -1738,6 +1755,23 @@ mod tests {
             vec![("eth0".to_string(), 1024), ("eth0".to_string(), 1025)],
             "the previous process's rules are now this one's to remove"
         );
+    }
+
+    /// The audit's findings, asserting the pass read everything it was
+    /// asked about.
+    ///
+    /// Every fixture below drives a NIC that answers, so an incomplete
+    /// pass means the fixture broke — and `missing` alone cannot say so,
+    /// which is the whole reason the audit reports both facts.
+    fn audit(s: &NtupleSteering) -> Vec<(String, u32)> {
+        use crate::runtime::Steering as _;
+        let a = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.unreadable, None,
+            "this fixture answers every readback; an incomplete pass here is a \
+             broken test, not a finding"
+        );
+        a.missing
     }
 
     fn plan_for(prefixes: &[[u8; 4]]) -> RuleSet {

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1060,7 +1060,7 @@ impl crate::runtime::Steering for NtupleSteering {
         // this target wants go", and what is left over once every
         // homeless rule has an answer is surplus.
         let mut empty: std::collections::HashMap<&str, Vec<u32>> = std::collections::HashMap::new();
-        let mut occupied: std::collections::HashMap<&str, Vec<u32>> =
+        let mut occupied: std::collections::HashMap<&str, Vec<(u32, RxFlowSpec)>> =
             std::collections::HashMap::new();
         let mut unreadable: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
@@ -1172,7 +1172,10 @@ impl crate::runtime::Steering for NtupleSteering {
                                      neither this target's nor the last one's"
                                 );
                             } else {
-                                occupied.entry(iface.as_str()).or_default().push(*loc);
+                                occupied
+                                    .entry(iface.as_str())
+                                    .or_default()
+                                    .push((*loc, check.fs));
                             }
                         }
                     }
@@ -1219,31 +1222,56 @@ impl crate::runtime::Steering for NtupleSteering {
         // Only reachable with a non-empty ledger — the caller skips the
         // audit otherwise — so this cannot fire on a port that has simply
         // never steered.
-        for (iface, _) in &self.ports {
+        for (iface, vf) in &self.ports {
             let taken = consumed.get(iface.as_str());
-            let homeless: Vec<u32> = self
+            let homeless: Vec<&SteerRule> = self
                 .plan
                 .rules
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| taken.is_none_or(|t| !t[*i]))
-                .map(|(_, r)| r.location)
+                .map(|(_, r)| r)
                 .collect();
             let mut slots = empty.remove(iface.as_str()).unwrap_or_default();
             let mut occupants = occupied.remove(iface.as_str()).unwrap_or_default();
             let mut unread = unreadable.get(iface.as_str()).copied().unwrap_or(0);
 
             // Give every homeless rule an answer to "where should you
-            // have been", cheapest evidence first: an EMPTY ledger slot
-            // says it plainly, an occupied one says the slot was taken
-            // over, and an unreadable one says we cannot tell. Each
-            // answer is consumed, so one deleted rule cannot count
-            // twice — once as the slot and once as the plan entry that
-            // slot was holding.
-            for planned in homeless {
-                if let Some(loc) = slots.pop() {
+            // have been". Each answer is consumed, so one damaged rule
+            // cannot count twice — once as the slot and once as the plan
+            // entry that slot was holding.
+            for rule in homeless {
+                // A DAMAGED VERSION OF THIS RULE, first: same addresses,
+                // same direction, same slot, but not what was asked for
+                // — narrowed, or overwritten by a copy of its sibling.
+                // That is one defect, and the useful location to name is
+                // the one the damage is at.
+                //
+                // Identity is what makes this pairing legitimate, and
+                // requiring it is the fix: popping ANY occupant let an
+                // unrelated surplus rule stand in as the explanation. A
+                // target moving from {A,B} to {B,C} then reported C
+                // missing and said nothing about A still diverting
+                // traffic the allowlist no longer covers — two
+                // independent facts, one of them silently consumed by
+                // the other (review finding).
+                let damaged = occupants.iter().position(|(loc, got)| {
+                    matches(
+                        &RxFlowSpec {
+                            location: *loc,
+                            ..flow_spec(rule, *vf)
+                        },
+                        got,
+                    )
+                });
+                if let Some(k) = damaged {
+                    let (loc, _) = occupants.remove(k);
                     missing.push((iface.clone(), loc));
-                } else if let Some(loc) = occupants.pop() {
+                } else if let Some(loc) = slots.pop() {
+                    // An empty ledger slot says it plainly: something
+                    // was installed here and is gone. No identity to
+                    // check — an empty slot has no contents — so this
+                    // stays a positional pairing.
                     missing.push((iface.clone(), loc));
                 } else if unread > 0 {
                     // Explained by a read that failed: not established,
@@ -1255,15 +1283,15 @@ impl crate::runtime::Steering for NtupleSteering {
                     // produces when the allowlist GREW while the daemon
                     // was down. Named by its planned slot, the only
                     // location it has.
-                    missing.push((iface.clone(), planned));
+                    missing.push((iface.clone(), rule.location));
                 }
             }
-            // Occupants left over: every rule this target asks for is
-            // accounted for, so these are not absences — they are rules
-            // the NIC still holds that the target no longer asks for.
-            // The allowlist shrinking is what produces them, and the
-            // remedy points the other way: remove, not install.
-            for loc in occupants {
+            // Occupants left over: rules the NIC still holds that this
+            // target does not ask for, and that are not a damaged copy
+            // of anything it does. The allowlist shrinking is what
+            // produces them, and the remedy points the other way:
+            // remove, not install.
+            for (loc, _) in occupants {
                 stray.push((iface.clone(), loc));
             }
         }
@@ -1895,6 +1923,72 @@ mod tests {
         let a = live.missing_from_nic().expect("read the NIC");
         assert_eq!(a.missing, Vec::new(), "{:?}", a.missing);
         assert_eq!(a.stray.len(), owed, "{:?}", a.stray);
+    }
+
+    /// Swapping one prefix for another is TWO facts, not one.
+    ///
+    /// The pairing that stops a single damaged rule being counted twice
+    /// was positional — any occupant could stand in as the explanation
+    /// for any homeless rule — so a target moving from `{A,B}` to
+    /// `{B,C}` reported C missing and silently consumed the independent
+    /// fact that A's rules still divert traffic the allowlist no longer
+    /// covers. One reconfigure fixes both, but an operator reading only
+    /// half of it does not know the rollback side happened at all
+    /// (review finding).
+    ///
+    /// Pairing now requires IDENTITY: an occupant explains a homeless
+    /// rule only when it is a damaged copy of that same rule — same
+    /// addresses, same direction, same slot.
+    #[test]
+    fn a_prefix_swapped_for_another_reports_both_sides() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        const A: [u8; 4] = [198, 18, 0, 0];
+        const B: [u8; 4] = [203, 0, 113, 0];
+        const C: [u8; 4] = [192, 0, 2, 0];
+
+        let mut before = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[A, B]));
+        before.steer().expect("installs A and B");
+        let inherited = before.installed();
+        let per_prefix = inherited.len() / 2;
+        assert!(per_prefix > 0);
+
+        // THE RESTART: config now says {B, C}; the NIC holds {A, B}.
+        let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[B, C]));
+        after.adopt_installed(inherited.clone());
+
+        let a = after.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.missing.len(),
+            per_prefix,
+            "C is not installed — that traffic is on the eBPF tier: {:?}",
+            a.missing
+        );
+        assert_eq!(
+            a.stray.len(),
+            per_prefix,
+            "AND A is still installed — that traffic is still going into VPP \
+             though the allowlist no longer covers it. Reporting only the first \
+             hides the rollback side entirely: {:?}",
+            a.stray
+        );
+        // The two must not name the same slots: they are different
+        // rules, in different places, needing opposite remedies.
+        assert!(
+            a.missing.iter().all(|m| !a.stray.contains(m)),
+            "missing {:?} and stray {:?} describe distinct locations",
+            a.missing,
+            a.stray
+        );
+
+        // THE LIVE RECONFIGURE: same swap through retarget, so the
+        // outgoing target is known. Same two facts.
+        let mut live = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[A, B]));
+        live.adopt_installed(inherited);
+        live.retarget(vec![("eth0".into(), 0)], plan_for(&[B, C]));
+        let a = live.missing_from_nic().expect("read the NIC");
+        assert_eq!(a.missing.len(), per_prefix, "{:?}", a.missing);
+        assert_eq!(a.stray.len(), per_prefix, "{:?}", a.stray);
     }
 
     /// An UNRELATED rule at a dropped port's slot is not our steering.

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1054,7 +1054,14 @@ impl crate::runtime::Steering for NtupleSteering {
         // many could not be read at all. Both consume nothing from the
         // plan, so both would otherwise read as "a planned rule with no
         // rule on the NIC" and be counted a second time.
-        let mut reported: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        // Ledger locations that hold nothing, and ones that hold
+        // something this target did not ask for. Neither is a complaint
+        // by itself: both are candidate ANSWERS to "where did the rule
+        // this target wants go", and what is left over once every
+        // homeless rule has an answer is surplus.
+        let mut empty: std::collections::HashMap<&str, Vec<u32>> = std::collections::HashMap::new();
+        let mut occupied: std::collections::HashMap<&str, Vec<u32>> =
+            std::collections::HashMap::new();
         let mut unreadable: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
 
@@ -1138,14 +1145,35 @@ impl crate::runtime::Steering for NtupleSteering {
                     });
                     match found {
                         Some(i) => taken[i] = true,
-                        // Present, but nothing this target asked for is
-                        // still unaccounted. Reported rather than
-                        // excused: an ownership check by ring cookie
-                        // was tried and is worthless, since a narrowed
-                        // or duplicated rule keeps the cookie.
+                        // Occupied by something this target does not
+                        // ask for. WHICH complaint that is cannot be
+                        // decided here: if a planned rule is left
+                        // homeless, this is the slot where it should
+                        // have been (drift — install it); if every
+                        // planned rule found a home, nothing is absent
+                        // and this is a surplus rule still diverting
+                        // traffic (remove it). The allowlist shrinking
+                        // produces the second, and calling it "missing"
+                        // sent the operator to reinstall a rule that
+                        // was not gone while removed-prefix traffic
+                        // stayed in VPP (review finding). Paired up
+                        // after the loop, when the homeless set is
+                        // known.
+                        //
+                        // Unless the outgoing target can disown it
+                        // outright, in which case it is not ours at
+                        // all and neither complaint applies.
                         None => {
-                            missing.push((iface.clone(), *loc));
-                            *reported.entry(iface.as_str()).or_default() += 1;
+                            if self.former_disowns(iface, *loc, &check.fs, &mut former_consumed) {
+                                tracing::debug!(
+                                    iface,
+                                    loc,
+                                    "a location this ledger names holds a rule that is \
+                                     neither this target's nor the last one's"
+                                );
+                            } else {
+                                occupied.entry(iface.as_str()).or_default().push(*loc);
+                            }
                         }
                     }
                 }
@@ -1155,8 +1183,7 @@ impl crate::runtime::Steering for NtupleSteering {
                 // rule the ledger names is already gone.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     if member.is_some() {
-                        missing.push((iface.clone(), *loc));
-                        *reported.entry(iface.as_str()).or_default() += 1;
+                        empty.entry(iface.as_str()).or_default().push(*loc);
                     }
                 }
                 // A read that failed says nothing about THIS rule, but
@@ -1194,22 +1221,50 @@ impl crate::runtime::Steering for NtupleSteering {
         // never steered.
         for (iface, _) in &self.ports {
             let taken = consumed.get(iface.as_str());
-            // A location that reported drift, and one that could not be
-            // read, each leave a planned rule unaccounted without meaning
-            // a second rule is absent. Subtract them, or one deleted rule
-            // counts twice: once as the empty slot, once as the plan
-            // entry that slot was holding.
-            let explained = reported.get(iface.as_str()).copied().unwrap_or(0)
-                + unreadable.get(iface.as_str()).copied().unwrap_or(0);
-            let unaccounted = self
+            let homeless: Vec<u32> = self
                 .plan
                 .rules
                 .iter()
                 .enumerate()
                 .filter(|(i, _)| taken.is_none_or(|t| !t[*i]))
-                .map(|(_, r)| r.location);
-            for location in unaccounted.skip(explained) {
-                missing.push((iface.clone(), location));
+                .map(|(_, r)| r.location)
+                .collect();
+            let mut slots = empty.remove(iface.as_str()).unwrap_or_default();
+            let mut occupants = occupied.remove(iface.as_str()).unwrap_or_default();
+            let mut unread = unreadable.get(iface.as_str()).copied().unwrap_or(0);
+
+            // Give every homeless rule an answer to "where should you
+            // have been", cheapest evidence first: an EMPTY ledger slot
+            // says it plainly, an occupied one says the slot was taken
+            // over, and an unreadable one says we cannot tell. Each
+            // answer is consumed, so one deleted rule cannot count
+            // twice — once as the slot and once as the plan entry that
+            // slot was holding.
+            for planned in homeless {
+                if let Some(loc) = slots.pop() {
+                    missing.push((iface.clone(), loc));
+                } else if let Some(loc) = occupants.pop() {
+                    missing.push((iface.clone(), loc));
+                } else if unread > 0 {
+                    // Explained by a read that failed: not established,
+                    // and `unreadable` on the audit says so.
+                    unread -= 1;
+                } else {
+                    // Nothing on this port can account for it, so it
+                    // was never installed — the shape a restart
+                    // produces when the allowlist GREW while the daemon
+                    // was down. Named by its planned slot, the only
+                    // location it has.
+                    missing.push((iface.clone(), planned));
+                }
+            }
+            // Occupants left over: every rule this target asks for is
+            // accounted for, so these are not absences — they are rules
+            // the NIC still holds that the target no longer asks for.
+            // The allowlist shrinking is what produces them, and the
+            // remedy points the other way: remove, not install.
+            for loc in occupants {
+                stray.push((iface.clone(), loc));
             }
         }
 
@@ -1780,6 +1835,66 @@ mod tests {
              alarming on them would cry wolf on every successful unsteer"
         );
         assert_eq!(a.missing, Vec::new(), "and eth0 is still untouched");
+    }
+
+    /// A prefix dropped from the allowlist leaves SURPLUS, not absence.
+    ///
+    /// The two complaints point opposite ways and the audit collapsed
+    /// them into one: after a shrink, every rule the target asks for is
+    /// on the NIC and the leftovers are rules for prefixes nobody asked
+    /// to steer any more. Calling those "missing" told an operator that
+    /// target traffic had fallen back to the eBPF tier — the opposite of
+    /// what happened, since the real problem is that removed-prefix
+    /// traffic is *still* being diverted into VPP (review finding).
+    ///
+    /// Both routes into the shrink are covered: a restart that adopts a
+    /// larger ledger than its plan (no outgoing target to compare
+    /// against), and a live reconfigure whose reconcile has not run.
+    #[test]
+    fn prefixes_dropped_from_the_allowlist_are_surplus_not_absence() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let both = plan_for(&[[198, 18, 0, 0], [203, 0, 113, 0]]);
+        let mut before = NtupleSteering::new(vec![("eth0".into(), 0)], both);
+        before.steer().expect("installs both prefixes");
+        let inherited = before.installed();
+
+        // THE RESTART: the config now allows one prefix, and the ledger
+        // comes off disk with rules for two. Nothing to compare the
+        // leftovers against but the plan itself.
+        let one = plan_for(&[[198, 18, 0, 0]]);
+        let owed = inherited.len() - one.rules.len();
+        assert!(owed > 0, "the fixture must shrink the target");
+        let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], one.clone());
+        after.adopt_installed(inherited.clone());
+
+        let a = after.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.missing,
+            Vec::new(),
+            "every rule this target asks for IS on the NIC — reporting absence \
+             sends an operator to reinstall what was never gone: {:?}",
+            a.missing
+        );
+        assert_eq!(
+            a.stray.len(),
+            owed,
+            "and the rules for the dropped prefix are still steering traffic \
+             into VPP, which is the complaint that needs making: {:?}",
+            a.stray
+        );
+
+        // THE LIVE RECONFIGURE: same shrink, reached by retarget, so the
+        // outgoing target is still known. Same verdict.
+        let mut live = NtupleSteering::new(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[198, 18, 0, 0], [203, 0, 113, 0]]),
+        );
+        live.adopt_installed(inherited);
+        live.retarget(vec![("eth0".into(), 0)], one);
+        let a = live.missing_from_nic().expect("read the NIC");
+        assert_eq!(a.missing, Vec::new(), "{:?}", a.missing);
+        assert_eq!(a.stray.len(), owed, "{:?}", a.stray);
     }
 
     /// An UNRELATED rule at a dropped port's slot is not our steering.

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -230,6 +230,38 @@ fn flow_spec(rule: &SteerRule, vf_index: u32) -> RxFlowSpec {
     fs
 }
 
+/// Whether a rule read back from the NIC is still ours in the sense the
+/// AUDIT cares about: same match, and no narrower.
+///
+/// [`matches`] deliberately compares only the bytes we set, because a
+/// driver may normalise fields we left zero and refusing a correctly
+/// installed rule would be worse than tolerating a cosmetic difference.
+/// That tolerance has a hole the audit cannot afford: a foreign rule
+/// that keeps our addresses and ring cookie while ADDING a protocol,
+/// TOS or L4 constraint compares equal, and quietly stops offloading
+/// some of the traffic we think is steered (review finding).
+///
+/// So this adds the whole MASK. The mask is what decides breadth — a
+/// value with no mask bits behind it constrains nothing, which is
+/// exactly why `matches` can ignore values — so comparing every mask
+/// byte catches a narrowing without inheriting the false-refusal risk.
+///
+/// Safe to be this strict because the NIC was asked. Reading our own
+/// four rules back on the shadow (2026-08-11) returned stored masks of
+/// zero for TOS, protocol and L4 bytes, on rules installed with those
+/// left zero — the driver invents nothing there. Note `ethtool -n`
+/// PRINTS masks complemented, so those read as `0xff`/`0xffffffff` on
+/// screen; the stored bytes are zero. Mistaking the display for the
+/// wire cost a merged PR once already (#134).
+///
+/// Separate from `matches` on purpose, and used only by the audit: a
+/// false positive here costs a Degraded health line, while the same
+/// false positive in `insert` refuses to steer traffic. Those are not
+/// worth the same and must not share a predicate.
+fn audit_matches(asked: &RxFlowSpec, got: &RxFlowSpec) -> bool {
+    matches(asked, got) && asked.m_u.hdata == got.m_u.hdata
+}
+
 /// Whether a rule read back from the NIC is the one we asked it to hold.
 ///
 /// Compares only what was set: a driver may normalise fields we left
@@ -517,6 +549,23 @@ pub(super) mod sys {
                 occupied,
             })
         })
+    }
+
+    /// Narrow the rule at `loc` — same addresses, same ring cookie, but
+    /// an added protocol constraint. What an out-of-band writer does
+    /// when it reuses our slot for something more specific: the slot
+    /// stays occupied and the addresses still match, so anything
+    /// comparing only those reports it as ours.
+    pub(crate) fn narrow_behind_back(iface: &str, loc: u32) {
+        NIC.with(|n| {
+            let mut nic = n.borrow_mut();
+            if let Some(fs) = nic.rules.get_mut(&(iface.to_string(), loc)) {
+                // `proto` lives at offset 14 of `ethtool_usrip4_spec`;
+                // a mask byte there is what makes the rule narrower.
+                fs.m_u.hdata[14] = 0xff;
+                fs.h_u.hdata[14] = 6; // TCP only
+            }
+        });
     }
 
     /// Overwrite a location with a DIFFERENT rule, the way an insert
@@ -900,7 +949,7 @@ impl crate::runtime::Steering for NtupleSteering {
                 ..Rxnfc::default()
             };
             match sys::ethtool(iface, &mut check) {
-                Ok(()) if matches(&asked, &check.fs) => {}
+                Ok(()) if audit_matches(&asked, &check.fs) => {}
                 // Present but not ours.
                 Ok(()) => missing.push((iface.clone(), *loc)),
                 // Empty: ENOENT is how the driver answers for a
@@ -1209,6 +1258,32 @@ mod tests {
             vec![(iface, loc)],
             "a location still OCCUPIED but holding a different rule is not ours, \
              and occupancy alone cannot tell the difference"
+        );
+    }
+
+    /// A rule NARROWED behind our back is drift, not a match.
+    ///
+    /// The subtle half of the same problem: the slot is occupied, the
+    /// addresses are ours, the cookie is ours — but an added protocol
+    /// mask means part of the traffic we believe is offloaded is not.
+    /// Comparing only the address bytes (what `insert`'s tolerance
+    /// permits, for good reasons of its own) reports this as fine.
+    #[test]
+    fn a_rule_narrowed_behind_our_back_is_reported_missing() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        let (iface, loc) = installed[0].clone();
+
+        sys::narrow_behind_back(&iface, loc);
+
+        assert_eq!(
+            s.missing_from_nic().expect("read the NIC"),
+            vec![(iface, loc)],
+            "a rule carrying a constraint we never asked for is not ours — some \
+             of the traffic we believe is steered no longer is"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -519,6 +519,23 @@ pub(super) mod sys {
         })
     }
 
+    /// Overwrite a location with a DIFFERENT rule, the way an insert
+    /// from outside this process does — inserts at an occupied location
+    /// replace rather than fail, so the slot stays listed while our
+    /// rule is gone.
+    pub(crate) fn replace_behind_back(iface: &str, loc: u32) {
+        NIC.with(|n| {
+            let mut nic = n.borrow_mut();
+            let mut foreign = super::RxFlowSpec {
+                location: loc,
+                ..super::RxFlowSpec::default()
+            };
+            // Anything that will not compare equal to ours.
+            foreign.ring_cookie = 0xDEAD_BEEF;
+            nic.rules.insert((iface.to_string(), loc), foreign);
+        });
+    }
+
     /// Drop a rule WITHOUT going through `delete` — what a UniFi
     /// provisioning push, a firmware event, or an operator with
     /// `ethtool -N <if> delete <loc>` does. Nothing tells the module.
@@ -851,25 +868,53 @@ impl crate::runtime::Steering for NtupleSteering {
     }
 
     fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
-        // One NIC read per INTERFACE, not per rule: `rule_table` is an
-        // ioctl pair (count, then enumerate), and the ledger holds two
-        // rules per allowlisted prefix on every steered port.
-        let mut seen: Vec<(String, Vec<u32>)> = Vec::new();
         let mut missing = Vec::new();
         for (iface, loc) in &self.installed {
-            let occupied = match seen.iter().find(|(i, _)| i == iface) {
-                Some((_, occ)) => occ,
-                None => {
-                    let table = rule_table(iface)?;
-                    seen.push((iface.clone(), table.occupied));
-                    &seen.last().expect("just pushed").1
-                }
+            let vf = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v);
+            let rule = self.plan.rules.iter().find(|r| r.location == *loc);
+            let (vf, rule) = match (vf, rule) {
+                (Some(v), Some(r)) => (v, r),
+                // No expected spec to compare against — an adopted
+                // location from a previous config, or a port no longer
+                // in the target. Unverifiable is not the same as
+                // missing, and reporting it would degrade health over
+                // the transient window between adoption and the first
+                // reconcile.
+                _ => continue,
             };
-            // Only OUR locations are checked. `occupied` lists whatever
-            // the NIC holds, anyone's — a rule we did not install is not
-            // our business and must not read as drift.
-            if !occupied.contains(loc) {
-                missing.push((iface.clone(), *loc));
+            // OCCUPANCY IS NOT ENOUGH. An insert at an occupied
+            // location REPLACES what is there, so a provisioning push
+            // or a stray `ethtool -N` can leave our slot full of
+            // somebody else's rule — still listed by GRXCLSRLALL,
+            // matching traffic we never asked for, while the ledger
+            // says ours is installed (review finding). Read the
+            // location back and compare the flow spec, exactly as
+            // `insert` does after every write and for the same reason.
+            let asked = flow_spec(rule, vf);
+            let mut check = Rxnfc {
+                cmd: ETHTOOL_GRXCLSRULE,
+                fs: RxFlowSpec {
+                    location: *loc,
+                    ..RxFlowSpec::default()
+                },
+                ..Rxnfc::default()
+            };
+            match sys::ethtool(iface, &mut check) {
+                Ok(()) if matches(&asked, &check.fs) => {}
+                // Present but not ours.
+                Ok(()) => missing.push((iface.clone(), *loc)),
+                // Empty: ENOENT is how the driver answers for a
+                // location holding nothing.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    missing.push((iface.clone(), *loc))
+                }
+                // Anything else says nothing about the rule, so it must
+                // not be reported as drift.
+                Err(e) => {
+                    return Err(format!(
+                        "reading back ntuple rule at loc {loc} on {iface}: {e}"
+                    ))
+                }
             }
         }
         Ok(missing)
@@ -1131,6 +1176,39 @@ mod tests {
             installed.len(),
             "detection must not mutate the ledger — repair is a separate, \
              operator-triggered step"
+        );
+    }
+
+    /// A location REPLACED by somebody else's rule is drift too.
+    ///
+    /// Occupancy was the first thing I checked, and it is not enough:
+    /// an insert at an occupied location replaces rather than fails, so
+    /// the slot stays in `GRXCLSRLALL` while our rule is gone —
+    /// steering health would have read Healthy over a NIC matching
+    /// traffic nobody asked it to (review finding). The audit compares
+    /// the flow spec, which is the same check `insert` makes after
+    /// every write.
+    #[test]
+    fn a_location_taken_over_by_another_rule_is_reported_missing() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        assert_eq!(
+            s.missing_from_nic().expect("read the NIC"),
+            Vec::new(),
+            "our own rules must not read as drift"
+        );
+
+        let (iface, loc) = installed[0].clone();
+        sys::replace_behind_back(&iface, loc);
+
+        assert_eq!(
+            s.missing_from_nic().expect("read the NIC"),
+            vec![(iface, loc)],
+            "a location still OCCUPIED but holding a different rule is not ours, \
+             and occupancy alone cannot tell the difference"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -956,6 +956,14 @@ impl crate::runtime::Steering for NtupleSteering {
         // source traffic had quietly lost its offload (review finding).
         let mut consumed: std::collections::HashMap<&str, Vec<bool>> =
             std::collections::HashMap::new();
+        // Per-interface tallies for the second direction below: how many
+        // of this interface's locations already reported drift, and how
+        // many could not be read at all. Both consume nothing from the
+        // plan, so both would otherwise read as "a planned rule with no
+        // rule on the NIC" and be counted a second time.
+        let mut reported: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        let mut unreadable: std::collections::HashMap<&str, usize> =
+            std::collections::HashMap::new();
 
         for (iface, loc) in &self.installed {
             let Some(vf) = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
@@ -1000,13 +1008,17 @@ impl crate::runtime::Steering for NtupleSteering {
                         // excused: an ownership check by ring cookie
                         // was tried and is worthless, since a narrowed
                         // or duplicated rule keeps the cookie.
-                        None => missing.push((iface.clone(), *loc)),
+                        None => {
+                            missing.push((iface.clone(), *loc));
+                            *reported.entry(iface.as_str()).or_default() += 1;
+                        }
                     }
                 }
                 // Empty: ENOENT is how the driver answers for a location
                 // holding nothing.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    missing.push((iface.clone(), *loc))
+                    missing.push((iface.clone(), *loc));
+                    *reported.entry(iface.as_str()).or_default() += 1;
                 }
                 // A read that failed says nothing about THIS rule, but
                 // it must not erase what the other reads proved. The
@@ -1014,7 +1026,45 @@ impl crate::runtime::Steering for NtupleSteering {
                 // entry, and the caller keeps its previous count on
                 // `Err` — so an EIO on the last rule hid drift already
                 // established on the first (review finding).
-                Err(e) => read_errors.push(format!("loc {loc} on {iface}: {e}")),
+                Err(e) => {
+                    read_errors.push(format!("loc {loc} on {iface}: {e}"));
+                    *unreadable.entry(iface.as_str()).or_default() += 1;
+                }
+            }
+        }
+
+        // The other direction. Everything above walks the LEDGER and asks
+        // whether the NIC still holds it, which cannot see a rule this
+        // target asks for that was never installed at all — the shape a
+        // restart produces whenever the allowlist grew while the daemon
+        // was down: the state file names the old rules, the plan names
+        // old and new, every old rule reads back clean, and the audit
+        // reports nothing while the new prefix has no NIC rule anywhere.
+        // That lasts as long as the adopted resync is deferred, which on
+        // a box with no completeness authority is indefinitely (review
+        // finding).
+        //
+        // Only reachable with a non-empty ledger — the caller skips the
+        // audit otherwise — so this cannot fire on a port that has simply
+        // never steered.
+        for (iface, _) in &self.ports {
+            let taken = consumed.get(iface.as_str());
+            // A location that reported drift, and one that could not be
+            // read, each leave a planned rule unaccounted without meaning
+            // a second rule is absent. Subtract them, or one deleted rule
+            // counts twice: once as the empty slot, once as the plan
+            // entry that slot was holding.
+            let explained = reported.get(iface.as_str()).copied().unwrap_or(0)
+                + unreadable.get(iface.as_str()).copied().unwrap_or(0);
+            let unaccounted = self
+                .plan
+                .rules
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| taken.is_none_or(|t| !t[*i]))
+                .map(|(_, r)| r.location);
+            for location in unaccounted.skip(explained) {
+                missing.push((iface.clone(), location));
             }
         }
 
@@ -1510,6 +1560,98 @@ mod tests {
             s2.missing_from_nic().is_err(),
             "a wholly unreadable NIC must not read as clean — the caller keeps \
              its previous verdict on Err"
+        );
+    }
+
+    /// A rule the target ASKS FOR that the NIC never got is missing too.
+    ///
+    /// The audit walked the ledger and asked the NIC about each entry,
+    /// which cannot see the other direction: restart a steered daemon
+    /// after the allowlist gained a prefix and the state file names only
+    /// the old rules. Every one of them reads back clean, so the audit
+    /// reported nothing while the new prefix had no NIC rule anywhere —
+    /// steering Healthy over an offload the config says is bigger than
+    /// it is, for as long as the adopted resync stays deferred (review
+    /// finding).
+    #[test]
+    fn a_rule_the_target_asks_for_that_was_never_installed_is_reported_missing() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+
+        // The previous daemon steered one prefix.
+        let mut before =
+            NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        before.steer().expect("first run installs");
+        let inherited = before.installed();
+        assert!(!inherited.is_empty());
+
+        // This one starts with a grown allowlist and adopts what the
+        // state file names — the old rules only.
+        let grown = plan_for(&[[198, 18, 0, 0], [203, 0, 113, 0]]);
+        let owed = grown.rules.len() - inherited.len();
+        assert!(
+            owed > 0,
+            "the fixture must ask for more rules than were inherited"
+        );
+        let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], grown);
+        after.adopt_installed(inherited.clone());
+
+        let m = after.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            m.len(),
+            owed,
+            "every planned rule with no rule on the NIC must be reported, or the \
+             newly allowlisted prefix is unsteered with health green: {m:?}"
+        );
+        assert!(
+            m.iter().all(|e| !inherited.contains(e)),
+            "the inherited rules ARE on the NIC — reporting them would be \
+             counting the same absence twice: {m:?}"
+        );
+
+        // And a deleted inherited rule is one more absence, not a
+        // replacement for one already counted.
+        let (iface, loc) = inherited[0].clone();
+        sys::remove_behind_back(&iface, loc);
+        let m = after.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            m.len(),
+            owed + 1,
+            "drift and an uninstalled rule are separate absences: {m:?}"
+        );
+        assert!(
+            m.contains(&(iface, loc)),
+            "including the slot the NIC no longer holds: {m:?}"
+        );
+    }
+
+    /// A read that FAILS must not be turned into an uninstalled rule.
+    ///
+    /// The second direction counts planned rules that no readback
+    /// accounted for — and a location the NIC would not answer for
+    /// accounts for nothing. Subtracting them is what keeps a wedged
+    /// read from manufacturing drift the audit never established, which
+    /// is the same "unverifiable treated as unconstrained" mistake this
+    /// audit has now made twice.
+    #[test]
+    fn a_wedged_read_is_not_reported_as_an_uninstalled_rule() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        assert!(installed.len() >= 2);
+        let (_, wedged) = installed[1].clone();
+
+        sys::wedge_read(&[wedged]);
+
+        let e = s
+            .missing_from_nic()
+            .expect_err("nothing was proven and a location could not be read");
+        assert!(
+            e.contains(&wedged.to_string()),
+            "the answer must be 'cannot verify', naming the location, rather than \
+             a fabricated missing rule: {e}"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -769,6 +769,21 @@ pub struct NtupleSteering {
     /// the rule gone. The state file's mirror of this is what lets a
     /// later `detach --all` remove rules this process did not install.
     installed: Vec<(String, u32)>,
+    /// The target this object steered BEFORE the last `retarget`.
+    ///
+    /// Kept for one purpose: a port the config just turned off leaves
+    /// `ports`, and its ledger entries then have no expectation to be
+    /// checked against — so "is this slot still ours" degenerated into
+    /// "is this slot occupied", which is the ownership guess this audit
+    /// has already been burned by twice. With the outgoing target in
+    /// hand a dropped port's rules get the same field-by-field
+    /// comparison as everything else.
+    ///
+    /// Only the LAST target, deliberately: a second retarget drops it,
+    /// and a port dropped two targets ago falls back to occupancy. That
+    /// is stated rather than fixed because the alternative is
+    /// accumulating every target this process ever held.
+    former: Option<(Vec<(String, u32)>, RuleSet)>,
 }
 
 impl NtupleSteering {
@@ -777,6 +792,7 @@ impl NtupleSteering {
             ports,
             plan,
             installed: Vec::new(),
+            former: None,
         }
     }
 
@@ -856,6 +872,52 @@ impl NtupleSteering {
                 "the state file named the same steering rule more than once; a \
                  location exists once on the NIC, so the ledger keeps it once"
             );
+        }
+    }
+
+    /// Can the outgoing target prove this slot is **not** ours?
+    ///
+    /// `true` only when the former target covered this interface AND
+    /// nothing it asked for matches what the NIC returned — that is
+    /// positive evidence the rule at this location belongs to somebody
+    /// else, so our own is already gone. `false` covers both "it is
+    /// ours" and "there is nothing to check against", which is why the
+    /// caller's message claims occupancy rather than ownership.
+    ///
+    /// One-to-one, like the member path: two locations holding a copy
+    /// of the same former rule cannot both be accounted for by it.
+    fn former_disowns(
+        &self,
+        iface: &str,
+        loc: u32,
+        got: &RxFlowSpec,
+        consumed: &mut std::collections::HashMap<String, Vec<bool>>,
+    ) -> bool {
+        let Some((ports, plan)) = &self.former else {
+            return false;
+        };
+        let Some(vf) = ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
+            return false;
+        };
+        let taken = consumed
+            .entry(iface.to_string())
+            .or_insert_with(|| vec![false; plan.rules.len()]);
+        let found = plan.rules.iter().enumerate().position(|(i, r)| {
+            !taken[i]
+                && audit_matches(
+                    &RxFlowSpec {
+                        location: loc,
+                        ..flow_spec(r, vf)
+                    },
+                    got,
+                )
+        });
+        match found {
+            Some(i) => {
+                taken[i] = true;
+                false
+            }
+            None => true,
         }
     }
 
@@ -1005,6 +1067,10 @@ impl crate::runtime::Steering for NtupleSteering {
         // them (review finding). That is the rollback path, where the
         // whole point is getting traffic OFF a port.
         let mut stray = Vec::new();
+        // One-to-one accounting for the outgoing target, same rule as
+        // `consumed` above and for the same reason.
+        let mut former_consumed: std::collections::HashMap<String, Vec<bool>> =
+            std::collections::HashMap::new();
 
         for (iface, loc) in &self.installed {
             // `None` = the current target does not steer this port.
@@ -1018,14 +1084,38 @@ impl crate::runtime::Steering for NtupleSteering {
                 ..Rxnfc::default()
             };
             match sys::ethtool(iface, &mut check) {
-                // Occupied on a port the target does not steer. Nothing
-                // here can say what the rule ought to look like — there
-                // is no VF index to build an expectation from — but the
-                // ledger names it and the slot is not empty, which is
-                // all "still steering a port that should be quiet"
-                // needs. Read rather than assumed, so a rule the
-                // controller already wiped is not reported as live.
-                Ok(()) if member.is_none() => stray.push((iface.clone(), *loc)),
+                // Occupied on a port the target does not steer.
+                //
+                // Occupancy alone is NOT ownership — the same mistake
+                // this audit made on the member path, where an insert
+                // at an occupied slot replaces rather than fails, so a
+                // location can be full of somebody else's rule. Where
+                // the outgoing target is still known, the readback gets
+                // the same field-by-field comparison as everything
+                // else, and a slot holding an unrelated rule is not
+                // reported: our rule is gone, which is what `steer off`
+                // asked for, and alarming on it would send an operator
+                // to `reconfigure` — which would delete the occupant
+                // (review finding).
+                //
+                // Where it is NOT known — a restart whose config
+                // dropped the port, so the state file is the only
+                // record — ownership cannot be established either way.
+                // Reported on occupancy there, and the health line says
+                // "occupied" rather than claiming the traffic is ours:
+                // silence is the worse error on the rollback path.
+                Ok(()) if member.is_none() => {
+                    if self.former_disowns(iface, *loc, &check.fs, &mut former_consumed) {
+                        tracing::debug!(
+                            iface,
+                            loc,
+                            "a location this ledger names on an unsteered port holds a \
+                             rule that is not ours; our rule is already gone"
+                        );
+                    } else {
+                        stray.push((iface.clone(), *loc));
+                    }
+                }
                 Ok(()) => {
                     let vf = member.expect("the arm above takes the non-member case");
                     let taken = consumed
@@ -1148,8 +1238,10 @@ impl crate::runtime::Steering for NtupleSteering {
     }
 
     fn retarget(&mut self, ports: Vec<(String, u32)>, plan: RuleSet) {
-        self.ports = ports;
-        self.plan = plan;
+        self.former = Some((
+            std::mem::replace(&mut self.ports, ports),
+            std::mem::replace(&mut self.plan, plan),
+        ));
     }
 }
 
@@ -1688,6 +1780,62 @@ mod tests {
              alarming on them would cry wolf on every successful unsteer"
         );
         assert_eq!(a.missing, Vec::new(), "and eth0 is still untouched");
+    }
+
+    /// An UNRELATED rule at a dropped port's slot is not our steering.
+    ///
+    /// Occupancy is not ownership — the mistake the member path was
+    /// burned by twice, reintroduced on the non-member path the moment
+    /// it was added: an insert at an occupied location replaces rather
+    /// than fails, so a slot the ledger names can hold somebody else's
+    /// rule while ours is already gone. Reporting that raises a rollback
+    /// alarm that is not happening, and sends an operator to
+    /// `reconfigure`, which would delete the occupant (review finding).
+    ///
+    /// Checkable here because the outgoing target is still known: the
+    /// readback gets the same field-by-field comparison as everything
+    /// else.
+    #[test]
+    fn an_unrelated_rule_on_a_dropped_port_is_not_our_steering() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let plan = plan_for(&[[198, 18, 0, 0]]);
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0), ("eth1".into(), 1)], plan.clone());
+        s.steer().expect("steer installs on both ports");
+        let eth1: Vec<(String, u32)> = s
+            .installed()
+            .into_iter()
+            .filter(|(i, _)| i == "eth1")
+            .collect();
+        assert!(eth1.len() >= 2, "the fixture needs two rules on eth1");
+
+        // `steer off` on eth1, reconcile refused — the round-13 state.
+        s.retarget(vec![("eth0".into(), 0)], plan);
+        assert_eq!(
+            s.missing_from_nic().expect("read").stray.len(),
+            eth1.len(),
+            "our own rules on the dropped port are still ours, and still there"
+        );
+
+        // Now somebody else takes one of those slots. Our rule at it is
+        // gone, which is what `steer off` asked for.
+        let (iface, taken) = eth1[0].clone();
+        sys::replace_behind_back(&iface, taken);
+
+        let a = s.missing_from_nic().expect("read");
+        assert!(
+            !a.stray.contains(&(iface.clone(), taken)),
+            "a slot holding a rule that is not ours is not our steering — \
+             reporting it would raise a rollback alarm for traffic nobody is \
+             diverting, and point `reconfigure` at somebody else's rule: {:?}",
+            a.stray
+        );
+        assert_eq!(
+            a.stray.len(),
+            eth1.len() - 1,
+            "and the rules that ARE still ours must still be reported: {:?}",
+            a.stray
+        );
     }
 
     /// A ledger naming one rule twice does not make a correct NIC drift.

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -996,14 +996,19 @@ impl crate::runtime::Steering for NtupleSteering {
         let mut unreadable: std::collections::HashMap<&str, usize> =
             std::collections::HashMap::new();
 
+        // Rules on a port the target no longer steers. Skipping them
+        // entirely was the bug: `retarget` drops a port the config just
+        // set `steer off`, and the reconcile that would clear its rules
+        // can refuse at the completeness gate and never run — so the
+        // ledger goes on naming rules that divert traffic on a port an
+        // operator asked to be quiet, and the audit looked straight past
+        // them (review finding). That is the rollback path, where the
+        // whole point is getting traffic OFF a port.
+        let mut stray = Vec::new();
+
         for (iface, loc) in &self.installed {
-            let Some(vf) = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
-                // A port that is no longer a member. Its rules are still
-                // adopted — they are in the NIC and this object is the
-                // only thing that will remove them — but nothing here
-                // can say what they should look like.
-                continue;
-            };
+            // `None` = the current target does not steer this port.
+            let member = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v);
             let mut check = Rxnfc {
                 cmd: ETHTOOL_GRXCLSRULE,
                 fs: RxFlowSpec {
@@ -1013,7 +1018,16 @@ impl crate::runtime::Steering for NtupleSteering {
                 ..Rxnfc::default()
             };
             match sys::ethtool(iface, &mut check) {
+                // Occupied on a port the target does not steer. Nothing
+                // here can say what the rule ought to look like — there
+                // is no VF index to build an expectation from — but the
+                // ledger names it and the slot is not empty, which is
+                // all "still steering a port that should be quiet"
+                // needs. Read rather than assumed, so a rule the
+                // controller already wiped is not reported as live.
+                Ok(()) if member.is_none() => stray.push((iface.clone(), *loc)),
                 Ok(()) => {
+                    let vf = member.expect("the arm above takes the non-member case");
                     let taken = consumed
                         .entry(iface.as_str())
                         .or_insert_with(|| vec![false; self.plan.rules.len()]);
@@ -1046,10 +1060,14 @@ impl crate::runtime::Steering for NtupleSteering {
                     }
                 }
                 // Empty: ENOENT is how the driver answers for a location
-                // holding nothing.
+                // holding nothing. Drift on a port the target steers;
+                // on one it does not, it is the desired outcome — the
+                // rule the ledger names is already gone.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                    missing.push((iface.clone(), *loc));
-                    *reported.entry(iface.as_str()).or_default() += 1;
+                    if member.is_some() {
+                        missing.push((iface.clone(), *loc));
+                        *reported.entry(iface.as_str()).or_default() += 1;
+                    }
                 }
                 // A read that failed says nothing about THIS rule, but
                 // it must not erase what the other reads proved. The
@@ -1059,7 +1077,13 @@ impl crate::runtime::Steering for NtupleSteering {
                 // established on the first (review finding).
                 Err(e) => {
                     read_errors.push(format!("loc {loc} on {iface}: {e}"));
-                    *unreadable.entry(iface.as_str()).or_default() += 1;
+                    // Tallied only for ports the target steers: the
+                    // subtraction below is against THIS port's planned
+                    // rules, and a port the target does not steer has
+                    // none.
+                    if member.is_some() {
+                        *unreadable.entry(iface.as_str()).or_default() += 1;
+                    }
                 }
             }
         }
@@ -1099,7 +1123,7 @@ impl crate::runtime::Steering for NtupleSteering {
             }
         }
 
-        if missing.is_empty() && !read_errors.is_empty() {
+        if missing.is_empty() && stray.is_empty() && !read_errors.is_empty() {
             // Nothing proven and the NIC would not answer: report the
             // failure so the caller keeps its previous verdict rather
             // than adopting a clean one this audit never established.
@@ -1114,6 +1138,7 @@ impl crate::runtime::Steering for NtupleSteering {
         // whenever this is `Some`.
         Ok(crate::runtime::SteeringAudit {
             missing,
+            stray,
             unreadable: (!read_errors.is_empty()).then(|| read_errors.join("; ")),
         })
     }
@@ -1609,6 +1634,60 @@ mod tests {
             "a wholly unreadable NIC must not read as clean — the caller keeps \
              its previous verdict on Err"
         );
+    }
+
+    /// A port dropped from the target is still audited, not ignored.
+    ///
+    /// `retarget` removes a port the config just set `steer off`, and
+    /// the reconcile that would clear its rules can refuse at the
+    /// completeness gate and never run. The audit skipped every ledger
+    /// entry whose interface was no longer a member, so rules kept
+    /// diverting traffic on a port an operator had asked to go quiet
+    /// while steering read Healthy — on the rollback path, where getting
+    /// traffic OFF a port is the entire point (review finding).
+    #[test]
+    fn a_port_the_target_no_longer_steers_is_still_audited() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let plan = plan_for(&[[198, 18, 0, 0]]);
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0), ("eth1".into(), 1)], plan.clone());
+        s.steer().expect("steer installs on both ports");
+        let a = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(a.missing, Vec::new());
+        assert_eq!(a.stray, Vec::new(), "both ports are in the target");
+
+        // `steer off` on eth1, and the reconciling steer never runs.
+        s.retarget(vec![("eth0".into(), 0)], plan);
+
+        let a = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.missing,
+            Vec::new(),
+            "eth0 still holds everything the target asks for"
+        );
+        let stray_ifaces: Vec<&str> = a.stray.iter().map(|(i, _)| i.as_str()).collect();
+        assert!(
+            !a.stray.is_empty() && stray_ifaces.iter().all(|i| *i == "eth1"),
+            "the rules still steering the port that was turned off must be \
+             reported — that is the rollback failing: {:?}",
+            a.stray
+        );
+
+        // But a rule that is already GONE from a dropped port is the
+        // desired outcome, not something to alarm about.
+        for (iface, loc) in s.installed() {
+            if iface == "eth1" {
+                sys::remove_behind_back(&iface, loc);
+            }
+        }
+        let a = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.stray,
+            Vec::new(),
+            "rules the NIC no longer holds are not still steering anything; \
+             alarming on them would cry wolf on every successful unsteer"
+        );
+        assert_eq!(a.missing, Vec::new(), "and eth0 is still untouched");
     }
 
     /// A ledger naming one rule twice does not make a correct NIC drift.

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -769,21 +769,30 @@ pub struct NtupleSteering {
     /// the rule gone. The state file's mirror of this is what lets a
     /// later `detach --all` remove rules this process did not install.
     installed: Vec<(String, u32)>,
-    /// The target this object steered BEFORE the last `retarget`.
+    /// The target the LEDGER was last installed under.
     ///
     /// Kept for one purpose: a port the config just turned off leaves
     /// `ports`, and its ledger entries then have no expectation to be
     /// checked against — so "is this slot still ours" degenerated into
     /// "is this slot occupied", which is the ownership guess this audit
-    /// has already been burned by twice. With the outgoing target in
-    /// hand a dropped port's rules get the same field-by-field
-    /// comparison as everything else.
+    /// has already been burned by twice. With the installed target in
+    /// hand those rules get the same field-by-field comparison as
+    /// everything else.
     ///
-    /// Only the LAST target, deliberately: a second retarget drops it,
-    /// and a port dropped two targets ago falls back to occupancy. That
-    /// is stated rather than fixed because the alternative is
-    /// accumulating every target this process ever held.
-    former: Option<(Vec<(String, u32)>, RuleSet)>,
+    /// Written by a SUCCESSFUL `steer` and by nothing else. The first
+    /// version recorded the outgoing target on every `retarget`, which
+    /// is the last thing *intended* rather than the last thing
+    /// installed — so two reconfigures whose reconcile was refused (the
+    /// completeness gate permits a second request from `Ready`) left it
+    /// describing a target that had never reached the NIC. The rules
+    /// actually there then matched nothing, were disowned as foreign,
+    /// and vanished from the audit entirely: not missing, not surplus,
+    /// not mentioned (review finding).
+    ///
+    /// `None` after a restart: the state file records locations, not
+    /// what they were installed to hold, so ownership falls back to
+    /// occupancy — see the non-member arm of `missing_from_nic`.
+    installed_as: Option<(Vec<(String, u32)>, RuleSet)>,
 }
 
 impl NtupleSteering {
@@ -792,7 +801,7 @@ impl NtupleSteering {
             ports,
             plan,
             installed: Vec::new(),
-            former: None,
+            installed_as: None,
         }
     }
 
@@ -877,7 +886,7 @@ impl NtupleSteering {
 
     /// Can the outgoing target prove this slot is **not** ours?
     ///
-    /// `true` only when the former target covered this interface AND
+    /// `true` only when the last install covered this interface AND
     /// nothing it asked for matches what the NIC returned — that is
     /// positive evidence the rule at this location belongs to somebody
     /// else, so our own is already gone. `false` covers both "it is
@@ -885,15 +894,15 @@ impl NtupleSteering {
     /// caller's message claims occupancy rather than ownership.
     ///
     /// One-to-one, like the member path: two locations holding a copy
-    /// of the same former rule cannot both be accounted for by it.
-    fn former_disowns(
+    /// of the same installed rule cannot both be accounted for by it.
+    fn install_disowns(
         &self,
         iface: &str,
         loc: u32,
         got: &RxFlowSpec,
         consumed: &mut std::collections::HashMap<String, Vec<bool>>,
     ) -> bool {
-        let Some((ports, plan)) = &self.former else {
+        let Some((ports, plan)) = &self.installed_as else {
             return false;
         };
         let Some(vf) = ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
@@ -1017,6 +1026,12 @@ impl crate::runtime::Steering for NtupleSteering {
                 }
             }
         }
+        // Here and nowhere else: the ledger now holds this target,
+        // confirmed rule by rule by the readback inside `insert`. An
+        // intent that never reached the NIC must not overwrite this —
+        // that is what made a second refused reconfigure disown rules
+        // that were really there.
+        self.installed_as = Some((self.ports.clone(), self.plan.clone()));
         Ok(())
     }
 
@@ -1076,7 +1091,7 @@ impl crate::runtime::Steering for NtupleSteering {
         let mut stray = Vec::new();
         // One-to-one accounting for the outgoing target, same rule as
         // `consumed` above and for the same reason.
-        let mut former_consumed: std::collections::HashMap<String, Vec<bool>> =
+        let mut installed_consumed: std::collections::HashMap<String, Vec<bool>> =
             std::collections::HashMap::new();
 
         for (iface, loc) in &self.installed {
@@ -1112,7 +1127,7 @@ impl crate::runtime::Steering for NtupleSteering {
                 // "occupied" rather than claiming the traffic is ours:
                 // silence is the worse error on the rollback path.
                 Ok(()) if member.is_none() => {
-                    if self.former_disowns(iface, *loc, &check.fs, &mut former_consumed) {
+                    if self.install_disowns(iface, *loc, &check.fs, &mut installed_consumed) {
                         tracing::debug!(
                             iface,
                             loc,
@@ -1164,7 +1179,8 @@ impl crate::runtime::Steering for NtupleSteering {
                         // outright, in which case it is not ours at
                         // all and neither complaint applies.
                         None => {
-                            if self.former_disowns(iface, *loc, &check.fs, &mut former_consumed) {
+                            if self.install_disowns(iface, *loc, &check.fs, &mut installed_consumed)
+                            {
                                 tracing::debug!(
                                     iface,
                                     loc,
@@ -1321,10 +1337,8 @@ impl crate::runtime::Steering for NtupleSteering {
     }
 
     fn retarget(&mut self, ports: Vec<(String, u32)>, plan: RuleSet) {
-        self.former = Some((
-            std::mem::replace(&mut self.ports, ports),
-            std::mem::replace(&mut self.plan, plan),
-        ));
+        self.ports = ports;
+        self.plan = plan;
     }
 }
 
@@ -1989,6 +2003,54 @@ mod tests {
         let a = live.missing_from_nic().expect("read the NIC");
         assert_eq!(a.missing.len(), per_prefix, "{:?}", a.missing);
         assert_eq!(a.stray.len(), per_prefix, "{:?}", a.stray);
+    }
+
+    /// A SECOND refused reconfigure must not disown what is really there.
+    ///
+    /// The reference for "is this rule ours" was the outgoing target,
+    /// recorded on every `retarget` — the last thing *intended*, not the
+    /// last thing installed. `apply_steering` accepts another request
+    /// from `Ready` after the completeness gate refuses one, so two
+    /// reconfigures in a row left that reference describing a target
+    /// which had never reached the NIC. The rules actually installed
+    /// then matched nothing, were disowned as foreign, and left the
+    /// audit altogether: not missing, not surplus, not mentioned
+    /// (review finding).
+    #[test]
+    fn rules_survive_two_reconfigures_whose_reconcile_never_ran() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        const A: [u8; 4] = [198, 18, 0, 0];
+        const B: [u8; 4] = [203, 0, 113, 0];
+        const C: [u8; 4] = [192, 0, 2, 0];
+
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[A]));
+        s.steer()
+            .expect("A is installed, and confirmed by readback");
+        let installed = s.installed().len();
+        assert!(installed > 0);
+
+        // Two reconfigures, neither reconciled — the supervisor refused
+        // both at the completeness gate, so `steer` never ran again and
+        // the NIC still holds A.
+        s.retarget(vec![("eth0".into(), 0)], plan_for(&[B]));
+        s.retarget(vec![("eth0".into(), 0)], plan_for(&[C]));
+
+        let a = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(
+            a.stray.len(),
+            installed,
+            "A's rules are still on the NIC and the allowlist no longer covers \
+             them — disowning them as foreign because an intermediate target \
+             never matched loses the fact entirely: {:?}",
+            a.stray
+        );
+        assert_eq!(
+            a.missing.len(),
+            s.plan.rules.len(),
+            "and C, which was never installed, is still absent: {:?}",
+            a.missing
+        );
     }
 
     /// An UNRELATED rule at a dropped port's slot is not our steering.

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -824,8 +824,39 @@ impl NtupleSteering {
     /// [`crate::resources::ResourceState::steer_rules`], written by
     /// [`crate::runtime::IdentityStore::steering_changed`] after every
     /// change. Both halves shipped in #127 with nothing between them.
+    ///
+    /// **Deduplicated on the way in.** The ledger is a set — a location
+    /// exists once on a NIC — and `steer` maintains that, but this
+    /// arrives from a JSON file on disk, which is a boundary: an older
+    /// build's unconditional append, or an edited file, can name a rule
+    /// twice. The audit matches one planned rule to one location, so the
+    /// second copy would find nothing left to match and report drift on
+    /// a NIC that is perfectly correct — Degraded forever, and
+    /// `reconfigure` would not clear it, since a duplicate is not stale
+    /// (it IS in the desired set) and the insert loop's set-check only
+    /// declines to add a THIRD copy. A false alarm with no remedy is
+    /// worse than no alarm: it is what teaches an operator to stop
+    /// reading the line.
+    ///
+    /// Fixed here rather than in the audit, deliberately. One planned
+    /// rule accounting for one location is the property that catches a
+    /// duplicated rule on the NIC itself; relaxing it to tolerate a
+    /// malformed ledger would trade a real check for a cosmetic one.
     pub fn adopt_installed(&mut self, installed: Vec<(String, u32)>) {
-        self.installed = installed;
+        let found = installed.len();
+        let mut seen = std::collections::HashSet::new();
+        self.installed = installed
+            .into_iter()
+            .filter(|e| seen.insert(e.clone()))
+            .collect();
+        if self.installed.len() < found {
+            tracing::info!(
+                dropped = found - self.installed.len(),
+                kept = self.installed.len(),
+                "the state file named the same steering rule more than once; a \
+                 location exists once on the NIC, so the ledger keeps it once"
+            );
+        }
     }
 
     /// What the NIC should hold, from the current ports and plan.
@@ -1577,6 +1608,59 @@ mod tests {
             s2.missing_from_nic().is_err(),
             "a wholly unreadable NIC must not read as clean — the caller keeps \
              its previous verdict on Err"
+        );
+    }
+
+    /// A ledger naming one rule twice does not make a correct NIC drift.
+    ///
+    /// The state file is JSON on disk, so what comes back is not
+    /// necessarily what this code wrote — an older build appended to the
+    /// ledger unconditionally (fixed in #128, see `steer`), and a file
+    /// can be edited. The audit gives one planned rule to one location,
+    /// so a second copy of an entry found nothing left to match and
+    /// reported drift against a NIC holding exactly what was asked for.
+    /// Degraded forever, too: `reconfigure` cannot clear it, because a
+    /// duplicate is not stale — it is in the desired set — and the
+    /// insert loop's set-check only declines to add a third copy.
+    #[test]
+    fn a_ledger_naming_one_rule_twice_is_read_as_naming_it_once() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut before =
+            NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        before.steer().expect("first run installs");
+        let inherited = before.installed();
+        assert!(inherited.len() >= 2);
+
+        // What an older build's ledger looks like: the supervisor
+        // re-asserts steering on a VPP it believes steered, and every
+        // re-assert appended the same slots again.
+        let mut doubled = inherited.clone();
+        doubled.extend(inherited.iter().cloned());
+
+        let mut after = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        after.adopt_installed(doubled);
+        assert_eq!(
+            after.installed(),
+            inherited,
+            "a location exists once on the NIC, so the ledger holds it once — and \
+             this is also what gets persisted back"
+        );
+        assert_eq!(
+            audit(&after),
+            Vec::new(),
+            "a NIC holding exactly what was asked for must not read as drift; a \
+             false alarm with no remedy is what teaches an operator to ignore the line"
+        );
+
+        // The dedup must not cost the audit its teeth: real drift behind
+        // a duplicated ledger is still drift.
+        let (iface, loc) = inherited[0].clone();
+        sys::remove_behind_back(&iface, loc);
+        assert_eq!(
+            audit(&after),
+            vec![(iface, loc)],
+            "and a rule that really is gone must still be reported"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -488,6 +488,7 @@ pub(super) mod sys {
         /// Locations whose insert must fail, modelling a full or
         /// otherwise refusing MCAM.
         uninsertable: Vec<u32>,
+        unreadable: Vec<u32>,
         /// How many locations this fake offers. Defaults to the measured
         /// hardware size rather than to zero, so a test that forgets to
         /// set it gets a plausible NIC instead of one with no table.
@@ -500,6 +501,7 @@ pub(super) mod sys {
                 rules: HashMap::new(),
                 undeletable: Vec::new(),
                 uninsertable: Vec::new(),
+                unreadable: Vec::new(),
                 table_size: super::FALLBACK_TABLE_SIZE,
             }
         }
@@ -522,6 +524,13 @@ pub(super) mod sys {
 
     pub(crate) fn wedge_insert(locations: &[u32]) {
         NIC.with(|n| n.borrow_mut().uninsertable = locations.to_vec());
+    }
+
+    /// Make GRXCLSRULE fail at these locations with something that is
+    /// NOT ENOENT — an EIO-shaped fault, which says nothing about
+    /// whether a rule is there.
+    pub(crate) fn wedge_read(locations: &[u32]) {
+        NIC.with(|n| n.borrow_mut().unreadable = locations.to_vec());
     }
 
     pub(crate) fn set_table_size(size: u32) {
@@ -549,6 +558,22 @@ pub(super) mod sys {
                 occupied,
             })
         })
+    }
+
+    /// Copy the rule at `from` over the one at `to`, keeping `to`'s
+    /// location. Both slots then hold the SAME match — which is what an
+    /// out-of-band writer does when it reuses our slot for a rule we
+    /// also happen to want elsewhere, and it leaves whatever `from`
+    /// used to match unoffloaded.
+    pub(crate) fn duplicate_behind_back(iface: &str, from: u32, to: u32) {
+        NIC.with(|n| {
+            let mut nic = n.borrow_mut();
+            if let Some(src) = nic.rules.get(&(iface.to_string(), from)).copied() {
+                let mut copy = src;
+                copy.location = to;
+                nic.rules.insert((iface.to_string(), to), copy);
+            }
+        });
     }
 
     /// Narrow the rule at `loc` — same addresses, same ring cookie, but
@@ -617,6 +642,9 @@ pub(super) mod sys {
                     // which is what makes re-asserting cheap.
                     nic.rules.insert(key, req.fs);
                     Ok(())
+                }
+                ETHTOOL_GRXCLSRULE if nic.unreadable.contains(&req.fs.location) => {
+                    Err(std::io::Error::other("EIO: readback failed"))
                 }
                 ETHTOOL_GRXCLSRULE => match nic.rules.get(&key) {
                     Some(stored) => {
@@ -918,48 +946,24 @@ impl crate::runtime::Steering for NtupleSteering {
 
     fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
         let mut missing = Vec::new();
+        let mut read_errors: Vec<String> = Vec::new();
+        // Which planned rule each interface has already accounted for.
+        // ONE-TO-ONE: a planned rule satisfies at most one location.
+        // Matching each location against "any planned rule"
+        // independently let a writer replace our source-prefix rule
+        // with a second copy of the destination-prefix one — both
+        // locations then matched something planned, both passed, and
+        // source traffic had quietly lost its offload (review finding).
+        let mut consumed: std::collections::HashMap<&str, Vec<bool>> =
+            std::collections::HashMap::new();
+
         for (iface, loc) in &self.installed {
-            let vf = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v);
-            let rule = self.plan.rules.iter().find(|r| r.location == *loc);
-            let Some(vf) = vf else {
-                // A port that is no longer a member. Its rules are
-                // still adopted (they are in the NIC and this object is
-                // the only thing that will remove them), but nothing
-                // here can say what they should look like.
+            let Some(vf) = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
+                // A port that is no longer a member. Its rules are still
+                // adopted — they are in the NIC and this object is the
+                // only thing that will remove them — but nothing here
+                // can say what they should look like.
                 continue;
-            };
-            // ADOPTED LOCATIONS DO NOT APPEAR IN THE PLAN, so keying on
-            // the location alone audited nothing after a restart.
-            // `McamBudget::from_table` excludes every occupied slot when
-            // planning, and on an adopted start the occupants are our
-            // own rules — so the plan lands elsewhere and `bring_up`
-            // then restores the real locations from the state file. The
-            // first version skipped all of them, and the window it
-            // skipped is the adopted-resync deferral, which can hold
-            // indefinitely (review finding).
-            //
-            // The location is only a slot; what makes a rule ours is
-            // its spec. So try the rule planned AT this location first,
-            // and otherwise accept a match against ANY planned rule.
-            // Stamped with the location being CHECKED, not the one the
-            // rule was planned for. `matches` compares `location`, so an
-            // expectation built straight from a planned rule can never
-            // match an adopted slot — the planner chose a different one
-            // by construction. Without this the whole "any planned rule"
-            // arm was dead code for exactly the rules it was added to
-            // cover, and every adopted rule fell through to an ownership
-            // guess (review finding).
-            let expected: Vec<RxFlowSpec> = match rule {
-                Some(r) => vec![flow_spec(r, vf)],
-                None => self
-                    .plan
-                    .rules
-                    .iter()
-                    .map(|r| RxFlowSpec {
-                        location: *loc,
-                        ..flow_spec(r, vf)
-                    })
-                    .collect(),
             };
             let mut check = Rxnfc {
                 cmd: ETHTOOL_GRXCLSRULE,
@@ -971,42 +975,61 @@ impl crate::runtime::Steering for NtupleSteering {
             };
             match sys::ethtool(iface, &mut check) {
                 Ok(()) => {
-                    // ONE rule, both cases: does the NIC hold something
-                    // this target asked for?
-                    //
-                    // There used to be an ownership fallback here —
-                    // accept anything pointing at our VF when no
-                    // expectation matched — and it was a guess dressed
-                    // as a check. A rule narrowed or replaced behind our
-                    // back keeps the ring cookie, so it proved nothing
-                    // about the rule and swallowed the drift it existed
-                    // to catch (review finding).
-                    //
-                    // Its purpose was to spare an adopted rule from a
-                    // PREVIOUS config, which matches nothing planned
-                    // now. Those are reported too, deliberately: the NIC
-                    // is not holding what the current target says it
-                    // should, the remedy is the same `reconfigure`, and
-                    // it retires them. The health text says "missing or
-                    // no longer what we asked for" rather than "gone"
-                    // for exactly that reason.
-                    if !expected.iter().any(|e| audit_matches(e, &check.fs)) {
-                        missing.push((iface.clone(), *loc));
+                    let taken = consumed
+                        .entry(iface.as_str())
+                        .or_insert_with(|| vec![false; self.plan.rules.len()]);
+                    // Candidates are stamped with the location being
+                    // CHECKED, not the one planned: `matches` compares
+                    // `location`, and on an adopted start the planner
+                    // chose different slots by construction, so an
+                    // unstamped expectation can never match.
+                    let found = self.plan.rules.iter().enumerate().position(|(i, r)| {
+                        !taken[i]
+                            && audit_matches(
+                                &RxFlowSpec {
+                                    location: *loc,
+                                    ..flow_spec(r, vf)
+                                },
+                                &check.fs,
+                            )
+                    });
+                    match found {
+                        Some(i) => taken[i] = true,
+                        // Present, but nothing this target asked for is
+                        // still unaccounted. Reported rather than
+                        // excused: an ownership check by ring cookie
+                        // was tried and is worthless, since a narrowed
+                        // or duplicated rule keeps the cookie.
+                        None => missing.push((iface.clone(), *loc)),
                     }
                 }
-                // Empty: ENOENT is how the driver answers for a
-                // location holding nothing.
+                // Empty: ENOENT is how the driver answers for a location
+                // holding nothing.
                 Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
                     missing.push((iface.clone(), *loc))
                 }
-                // Anything else says nothing about the rule, so it must
-                // not be reported as drift.
-                Err(e) => {
-                    return Err(format!(
-                        "reading back ntuple rule at loc {loc} on {iface}: {e}"
-                    ))
-                }
+                // A read that failed says nothing about THIS rule, but
+                // it must not erase what the other reads proved. The
+                // early `return Err` here discarded every confirmed
+                // entry, and the caller keeps its previous count on
+                // `Err` — so an EIO on the last rule hid drift already
+                // established on the first (review finding).
+                Err(e) => read_errors.push(format!("loc {loc} on {iface}: {e}")),
             }
+        }
+
+        if missing.is_empty() && !read_errors.is_empty() {
+            // Nothing proven and the NIC would not answer: report the
+            // failure so the caller keeps its previous verdict rather
+            // than adopting a clean one this audit never established.
+            return Err(read_errors.join("; "));
+        }
+        if !read_errors.is_empty() {
+            tracing::debug!(
+                errors = ?read_errors,
+                confirmed = missing.len(),
+                "steering audit was incomplete; reporting what it could read"
+            );
         }
         Ok(missing)
     }
@@ -1401,6 +1424,92 @@ mod tests {
             vec![(iface, loc)],
             "an inherited rule deleted out of band must be reported, or the \
              audit is blind for the entire adopted deferral"
+        );
+    }
+
+    /// Two locations holding the SAME rule is drift, not two matches.
+    ///
+    /// Each location was checked against "any planned rule"
+    /// independently, so replacing our source-prefix rule with a second
+    /// copy of the destination-prefix one passed twice — both slots
+    /// matched something we plan — while source traffic had silently
+    /// lost its offload (review finding). A planned rule can satisfy at
+    /// most one location.
+    #[test]
+    fn one_planned_rule_cannot_account_for_two_locations() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        assert!(
+            installed.len() >= 2,
+            "the fixture needs at least two rules (src and dst) to duplicate one"
+        );
+        assert_eq!(s.missing_from_nic().expect("read"), Vec::new());
+
+        // Overwrite the first slot with a copy of the second's rule.
+        let (iface, victim) = installed[0].clone();
+        let (_, survivor) = installed[1].clone();
+        sys::duplicate_behind_back(&iface, survivor, victim);
+
+        // Asserted as an INVARIANT, not as an identity. Once both slots
+        // hold the same match they are indistinguishable by content, so
+        // which of the two greedy matching leaves unaccounted is an
+        // artifact of iteration order — pinning it would be asserting
+        // the implementation rather than the property.
+        let m = s.missing_from_nic().expect("read");
+        assert_eq!(
+            m.len(),
+            1,
+            "exactly one slot must be unaccounted for — the prefix the \
+             overwritten rule used to match is no longer offloaded: {m:?}"
+        );
+        assert!(
+            m[0].0 == iface && (m[0].1 == victim || m[0].1 == survivor),
+            "and it must be one of the two duplicated slots: {m:?}"
+        );
+    }
+
+    /// A read that fails must not erase what the other reads proved.
+    ///
+    /// The audit used to `return Err` on the first unreadable location,
+    /// discarding every confirmed entry — and the caller keeps its
+    /// previous count on `Err`, so an EIO on one rule hid drift already
+    /// established on another, for another 30 s (review finding).
+    #[test]
+    fn audit_keeps_confirmed_drift_when_a_later_read_fails() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        assert!(installed.len() >= 2);
+        let (iface, gone) = installed[0].clone();
+        let (_, unreadable) = installed[1].clone();
+
+        sys::remove_behind_back(&iface, gone);
+        sys::wedge_read(&[unreadable]);
+
+        assert_eq!(
+            s.missing_from_nic()
+                .expect("proven drift survives an unreadable peer"),
+            vec![(iface.clone(), gone)],
+            "the confirmed missing rule must be reported even though another \
+             location could not be read"
+        );
+
+        // But an audit that proved NOTHING and could not read must fail
+        // rather than report a clean NIC it never established.
+        sys::reset();
+        let mut s2 = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s2.steer().expect("installs");
+        let all: Vec<u32> = s2.installed().iter().map(|(_, l)| *l).collect();
+        sys::wedge_read(&all);
+        assert!(
+            s2.missing_from_nic().is_err(),
+            "a wholly unreadable NIC must not read as clean — the caller keeps \
+             its previous verdict on Err"
         );
     }
 

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -519,6 +519,15 @@ pub(super) mod sys {
         })
     }
 
+    /// Drop a rule WITHOUT going through `delete` — what a UniFi
+    /// provisioning push, a firmware event, or an operator with
+    /// `ethtool -N <if> delete <loc>` does. Nothing tells the module.
+    pub(crate) fn remove_behind_back(iface: &str, loc: u32) {
+        NIC.with(|n| {
+            n.borrow_mut().rules.remove(&(iface.to_string(), loc));
+        });
+    }
+
     /// Every `(iface, loc)` the NIC currently holds, sorted — the
     /// ground truth a test compares the ledger against.
     pub(crate) fn rules() -> Vec<(String, u32)> {
@@ -841,6 +850,31 @@ impl crate::runtime::Steering for NtupleSteering {
         }
     }
 
+    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+        // One NIC read per INTERFACE, not per rule: `rule_table` is an
+        // ioctl pair (count, then enumerate), and the ledger holds two
+        // rules per allowlisted prefix on every steered port.
+        let mut seen: Vec<(String, Vec<u32>)> = Vec::new();
+        let mut missing = Vec::new();
+        for (iface, loc) in &self.installed {
+            let occupied = match seen.iter().find(|(i, _)| i == iface) {
+                Some((_, occ)) => occ,
+                None => {
+                    let table = rule_table(iface)?;
+                    seen.push((iface.clone(), table.occupied));
+                    &seen.last().expect("just pushed").1
+                }
+            };
+            // Only OUR locations are checked. `occupied` lists whatever
+            // the NIC holds, anyone's — a rule we did not install is not
+            // our business and must not read as drift.
+            if !occupied.contains(loc) {
+                missing.push((iface.clone(), *loc));
+            }
+        }
+        Ok(missing)
+    }
+
     fn installed(&self) -> Vec<(String, u32)> {
         self.installed.clone()
     }
@@ -1052,6 +1086,52 @@ mod tests {
         let e = s.steer().expect_err("must refuse");
         assert!(e.contains("nothing to steer"), "{e}");
         assert!(s.installed().is_empty());
+    }
+
+    /// A rule removed from the NIC behind our back is reported missing.
+    ///
+    /// Measured on the shadow 2026-08-11: `ethtool -N eth1 delete 12`
+    /// while steered left the NIC holding three of four rules, and two
+    /// minutes later `steering healthy` was still the answer — nothing
+    /// polls the NIC, and only `VerifyPassed` re-emits `Action::Steer`,
+    /// which does not recur in steady state. The traffic was fine (it
+    /// falls back to the eBPF tier, which is where it belongs); what was
+    /// lost was knowing.
+    ///
+    /// This is the detection half only. Repair stays manual — a plain
+    /// `reconfigure` reinstalls the missing rule, because `steer` is a
+    /// reconcile — so nothing here re-asserts anything, and a wrong
+    /// answer costs a health line rather than a forwarding decision.
+    #[test]
+    fn a_rule_deleted_behind_our_back_is_reported_missing() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("steer installs");
+        let installed = s.installed();
+        assert!(!installed.is_empty(), "the fixture must install something");
+        assert_eq!(
+            s.missing_from_nic().expect("read the NIC"),
+            Vec::new(),
+            "a NIC that agrees with the ledger reports nothing missing"
+        );
+
+        // Exactly what the provisioning push did.
+        let (iface, loc) = installed[0].clone();
+        sys::remove_behind_back(&iface, loc);
+
+        assert_eq!(
+            s.missing_from_nic().expect("read the NIC"),
+            vec![(iface, loc)],
+            "a rule the NIC no longer holds must be reported, or the offload \
+             goes silently partial with health green"
+        );
+        assert_eq!(
+            s.installed().len(),
+            installed.len(),
+            "detection must not mutate the ledger — repair is a separate, \
+             operator-triggered step"
+        );
     }
 
     /// A rule that would not delete STAYS recorded.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -185,6 +185,15 @@ impl ResourceRelease for NoResources {
 pub struct SteeringAudit {
     /// Rules the current target needs in the NIC that are not there.
     pub missing: Vec<(String, u32)>,
+    /// Rules the ledger still names on a port the current target does
+    /// **not** steer, confirmed still occupying their slot.
+    ///
+    /// The opposite complaint to `missing`, and the more urgent one: an
+    /// operator asked for a port to stop diverting and it has not. The
+    /// two are separate counts because they point opposite ways — one
+    /// says install, the other says remove — and a single number would
+    /// have to pick one story to tell.
+    pub stray: Vec<(String, u32)>,
     /// Why the pass was incomplete, if it was. The locations behind it
     /// were neither confirmed present nor confirmed missing, so
     /// `missing` is a floor rather than a count.
@@ -374,6 +383,10 @@ struct Core {
     /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
     last_steer_audit: Option<std::time::Instant>,
     steer_missing: usize,
+    /// Rules still steering a port the config asks to leave unsteered,
+    /// as of the last audit. Its own count because it points the other
+    /// way: `steer_missing` says install, this says remove.
+    steer_stray: usize,
     /// Why the last audit could not read the NIC, if it could not.
     ///
     /// Kept apart from `steer_missing` because they answer different
@@ -831,6 +844,7 @@ impl Runtime {
                 deferred_resync: None,
                 last_steer_audit: None,
                 steer_missing: 0,
+                steer_stray: 0,
                 steer_audit_error: None,
             })),
         }
@@ -952,6 +966,7 @@ impl Runtime {
             // off (review finding).
             if c.steering.installed().is_empty() {
                 c.steer_missing = 0;
+                c.steer_stray = 0;
                 c.steer_audit_error = None;
                 c.last_steer_audit = None;
             }
@@ -971,6 +986,14 @@ impl Runtime {
                             );
                         }
                         c.steer_missing = audit.missing.len();
+                        if !audit.stray.is_empty() && c.steer_stray != audit.stray.len() {
+                            tracing::warn!(
+                                stray = ?audit.stray,
+                                "rules are still steering a port this config asks to leave \
+                                 unsteered; `packetframe reconfigure` removes them"
+                            );
+                        }
+                        c.steer_stray = audit.stray.len();
                         // Taken from the audit rather than cleared: a
                         // pass that proved drift AND could not read the
                         // rest is an incomplete answer, and clearing
@@ -1016,6 +1039,7 @@ impl Runtime {
                 .deferred_resync
                 .map(|d| (c.source.route_count(), d.floor())),
             steer_missing: c.steer_missing,
+            steer_stray: c.steer_stray,
             steer_audit_error: c.steer_audit_error.clone(),
             authority: if c.completeness.is_none() {
                 AuthorityPosture::Absent
@@ -1095,6 +1119,9 @@ pub struct RuntimeStatus {
     /// How many rules the ledger names that the NIC no longer holds, as
     /// of the last audit. See [`STEER_AUDIT_EVERY`].
     pub steer_missing: usize,
+    /// Rules still steering a port the config leaves unsteered. See
+    /// [`SteeringAudit::stray`].
+    pub steer_stray: usize,
     /// Why the last steering audit could not read the NIC, if so.
     pub steer_audit_error: Option<String>,
 }
@@ -2253,6 +2280,7 @@ mod tests {
                 Ok(SteeringAudit {
                     missing: vec![("eth4".into(), 1024)],
                     unreadable: Some("loc 1025 on eth4: EIO".into()),
+                    ..SteeringAudit::clean()
                 })
             }
             fn configured_ports(&self) -> usize {
@@ -2319,7 +2347,7 @@ mod tests {
                 } else {
                     SteeringAudit {
                         missing: vec![("eth4".into(), 1024)],
-                        unreadable: None,
+                        ..SteeringAudit::clean()
                     }
                 })
             }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -196,6 +196,23 @@ pub trait Steering {
     /// persisted — see [`IdentityStore::steering_changed`]. A rule that
     /// would not come out is still diverting traffic, so the failure
     /// path is the one that most needs this recorded.
+    /// Rules the ledger names that the NIC no longer holds.
+    ///
+    /// DETECTION ONLY — it must not repair, and it must not touch the
+    /// ledger. A rule can leave the NIC without us: a UniFi
+    /// provisioning push, a firmware event, an operator with `ethtool
+    /// -N`. Nothing re-emits `Action::Steer` in steady state (only
+    /// `VerifyPassed` does, and verify does not recur), so the offload
+    /// goes silently partial with health green — measured on the shadow
+    /// 2026-08-11, still missing two minutes later with no log line.
+    ///
+    /// Kept observational on purpose. The traffic is not lost — it falls
+    /// back to the eBPF tier, which is where it belongs — so the cost of
+    /// a wrong answer here is a misleading health line, not a forwarding
+    /// decision. Repair stays the operator's `packetframe reconfigure`,
+    /// which reinstalls what is missing because `steer` is a reconcile.
+    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String>;
+
     fn installed(&self) -> Vec<(String, u32)>;
     /// Change what steering *should* be, without touching the NIC.
     ///
@@ -246,6 +263,9 @@ impl Steering for SteeringUnavailable {
     }
     fn unsteer(&mut self) -> Result<(), String> {
         Err("MCAM steering is unavailable in this runtime; cannot confirm rules removed".into())
+    }
+    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+        Ok(Vec::new())
     }
     fn installed(&self) -> Vec<(String, u32)> {
         Vec::new()
@@ -315,6 +335,10 @@ struct Core {
     /// itself freezes VPP's workers (drill (d10), 2026-08-09). See
     /// [`DeferredResync`] for the two stages.
     deferred_resync: Option<DeferredResync>,
+    /// When the NIC was last audited against the steering ledger, and
+    /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
+    last_steer_audit: Option<std::time::Instant>,
+    steer_missing: usize,
 }
 
 /// The loaded-and-quiet release gate, shared by both deferral stages.
@@ -762,6 +786,8 @@ impl Runtime {
                 last_store_error: None,
                 last_drain_error: None,
                 deferred_resync: None,
+                last_steer_audit: None,
+                steer_missing: 0,
             })),
         }
     }
@@ -860,6 +886,42 @@ impl Runtime {
     /// last API error, and any store failure from a path that could not
     /// refuse.
     pub fn status(&self) -> RuntimeStatus {
+        // Ask the NIC whether it still holds what the ledger claims,
+        // at most once per STEER_AUDIT_EVERY. Rate-limited on the REAL
+        // clock rather than the driven one: this is a hardware poll,
+        // not a supervision deadline, and pacing it off a clock a test
+        // can fast-forward would turn every driven tick into an ioctl.
+        //
+        // Detection only. Nothing here re-asserts, and the ledger is
+        // never touched — a wrong answer costs a health line, not a
+        // forwarding decision. Repair is the operator's `reconfigure`.
+        {
+            let mut c = self.core.borrow_mut();
+            let now = std::time::Instant::now();
+            let due = c
+                .last_steer_audit
+                .is_none_or(|t| now.duration_since(t) >= STEER_AUDIT_EVERY);
+            if due && !c.steering.installed().is_empty() {
+                c.last_steer_audit = Some(now);
+                match c.steering.missing_from_nic() {
+                    Ok(missing) => {
+                        if !missing.is_empty() && c.steer_missing != missing.len() {
+                            tracing::warn!(
+                                missing = ?missing,
+                                "steering rules the ledger names are gone from the NIC; \
+                                 traffic for them is on the eBPF tier. `packetframe \
+                                 reconfigure` reinstalls them"
+                            );
+                        }
+                        c.steer_missing = missing.len();
+                    }
+                    // A NIC we cannot read is not a NIC we can call
+                    // wrong. Keep the last answer rather than inventing
+                    // a clean one.
+                    Err(e) => tracing::debug!(error = %e, "steering audit could not read the NIC"),
+                }
+            }
+        }
         let c = self.core.borrow();
         RuntimeStatus {
             counts: c.engine.counts(),
@@ -875,6 +937,7 @@ impl Runtime {
             resync_deferred: c
                 .deferred_resync
                 .map(|d| (c.source.route_count(), d.floor())),
+            steer_missing: c.steer_missing,
             authority: if c.completeness.is_none() {
                 AuthorityPosture::Absent
             } else if matches!(
@@ -888,6 +951,16 @@ impl Runtime {
         }
     }
 }
+
+/// How often to ask the NIC whether it still holds the rules the ledger
+/// names.
+///
+/// Two ioctls per steered interface per interval, so 30 s is free even
+/// on a fully steered box. Sized against how long a silently-partial
+/// offload should be allowed to go unnoticed rather than against any
+/// hardware limit — on the shadow it went two minutes and would have
+/// gone indefinitely.
+const STEER_AUDIT_EVERY: Duration = Duration::from_secs(30);
 
 /// What the completeness authority can currently say, for the health
 /// text.
@@ -940,6 +1013,9 @@ pub struct RuntimeStatus {
     /// recommends the thing it already has, while a demoted one is
     /// waiting on something else entirely.
     pub authority: AuthorityPosture,
+    /// How many rules the ledger names that the NIC no longer holds, as
+    /// of the last audit. See [`STEER_AUDIT_EVERY`].
+    pub steer_missing: usize,
 }
 
 impl Core {
@@ -1909,6 +1985,9 @@ mod tests {
     }
 
     impl Steering for LedgerSteering {
+        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+            Ok(Vec::new())
+        }
         fn configured_ports(&self) -> usize {
             self.configured
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -891,7 +891,7 @@ impl Runtime {
     /// the supervision loop is the only caller precisely so that the two
     /// cannot be separated.
     pub fn retarget(&self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet) {
-        self.core.borrow_mut().steering.retarget(ports, plan);
+        self.core.borrow_mut().retarget(ports, plan);
     }
 
     /// The two trait views the driver's tick takes.
@@ -1211,6 +1211,23 @@ impl Core {
         let rules = self.steering.installed();
         let r = self.store.steering_changed(&rules);
         let _ = self.note_persist(r);
+    }
+
+    /// Point steering at a new target, and invalidate the cached audit.
+    ///
+    /// The audit answers "does the NIC hold what THIS target asks for",
+    /// so it is a function of two things — the ledger and the target —
+    /// and both have to invalidate it. Only the ledger did, and the
+    /// target can move on its own: `retarget` runs before the
+    /// reconciling steer, which can refuse at the completeness gate and
+    /// return without ever reaching `record_steering`. The answer to
+    /// the OLD question then stood for up to STEER_AUDIT_EVERY, and
+    /// `reconfigure` republishes status the moment it returns — so an
+    /// operator who had just been told the steer was refused could read
+    /// `steering healthy` in the same breath (review finding).
+    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet) {
+        self.steering.retarget(ports, plan);
+        self.last_steer_audit = None;
     }
 }
 
@@ -2273,6 +2290,78 @@ mod tests {
             Some("loc 1025 on eth4: EIO"),
             "and so must the fact that the pass was incomplete — without it the \
              floor is published as a current count and further drift is invisible"
+        );
+    }
+
+    /// Retargeting invalidates the cached audit, like a ledger change.
+    ///
+    /// The audit answers "does the NIC hold what THIS target asks for",
+    /// so both inputs must invalidate it — and only the ledger did.
+    /// `retarget` runs before the reconciling steer, which can refuse at
+    /// the completeness gate and return without reaching
+    /// `record_steering`, so the answer to the old question stood for up
+    /// to STEER_AUDIT_EVERY while `reconfigure` republished status
+    /// immediately (review finding).
+    ///
+    /// The rate limiter is the discriminator: a second `status()` must
+    /// NOT re-audit, and the one after the retarget must.
+    #[test]
+    fn retargeting_invalidates_the_cached_audit() {
+        /// Clean on the first pass, drifting on every one after — so a
+        /// re-audit is visible in the published count.
+        struct DriftsAfterFirstPass(std::cell::Cell<usize>);
+        impl Steering for DriftsAfterFirstPass {
+            fn missing_from_nic(&self) -> Result<SteeringAudit, String> {
+                let n = self.0.get();
+                self.0.set(n + 1);
+                Ok(if n == 0 {
+                    SteeringAudit::clean()
+                } else {
+                    SteeringAudit {
+                        missing: vec![("eth4".into(), 1024)],
+                        unreadable: None,
+                    }
+                })
+            }
+            fn configured_ports(&self) -> usize {
+                1
+            }
+            fn steer(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn unsteer(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            // Non-empty: the caller skips the audit on an empty ledger.
+            fn installed(&self) -> Vec<(String, u32)> {
+                vec![("eth4".into(), 1024)]
+            }
+            fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+        }
+
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(DriftsAfterFirstPass(std::cell::Cell::new(0))),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        assert_eq!(rt.status().steer_missing, 0, "the first pass reads clean");
+        assert_eq!(
+            rt.status().steer_missing,
+            0,
+            "and the second is served from the cache — without this the test \
+             would pass whether or not retarget invalidates anything"
+        );
+
+        rt.retarget(vec![("eth4".into(), 0)], crate::steer::RuleSet::default());
+        assert_eq!(
+            rt.status().steer_missing,
+            1,
+            "a new target must be asked about, not answered from the old \
+             question's cache"
         );
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -196,7 +196,10 @@ pub trait Steering {
     /// persisted — see [`IdentityStore::steering_changed`]. A rule that
     /// would not come out is still diverting traffic, so the failure
     /// path is the one that most needs this recorded.
-    /// Rules the ledger names that the NIC no longer holds.
+    /// Rules the NIC should be holding for the current target and is
+    /// not — both directions: ones the ledger names that are gone or
+    /// altered, and ones the target asks for that were never installed
+    /// (a restart after the allowlist grew inherits only the old set).
     ///
     /// DETECTION ONLY — it must not repair, and it must not touch the
     /// ledger. A rule can leave the NIC without us: a UniFi

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -339,6 +339,14 @@ struct Core {
     /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
     last_steer_audit: Option<std::time::Instant>,
     steer_missing: usize,
+    /// Why the last audit could not read the NIC, if it could not.
+    ///
+    /// Kept apart from `steer_missing` because they answer different
+    /// questions: that one is "how many are gone", this one is "the
+    /// answer is not known". Collapsing them let a NIC that stopped
+    /// answering keep publishing the last clean count, so steering read
+    /// Healthy while drift had become undetectable (review finding).
+    steer_audit_error: Option<String>,
 }
 
 /// The loaded-and-quiet release gate, shared by both deferral stages.
@@ -788,6 +796,7 @@ impl Runtime {
                 deferred_resync: None,
                 last_steer_audit: None,
                 steer_missing: 0,
+                steer_audit_error: None,
             })),
         }
     }
@@ -908,6 +917,7 @@ impl Runtime {
             // off (review finding).
             if c.steering.installed().is_empty() {
                 c.steer_missing = 0;
+                c.steer_audit_error = None;
                 c.last_steer_audit = None;
             }
             let due = c
@@ -917,6 +927,7 @@ impl Runtime {
                 c.last_steer_audit = Some(now);
                 match c.steering.missing_from_nic() {
                     Ok(missing) => {
+                        c.steer_audit_error = None;
                         if !missing.is_empty() && c.steer_missing != missing.len() {
                             tracing::warn!(
                                 missing = ?missing,
@@ -928,9 +939,16 @@ impl Runtime {
                         c.steer_missing = missing.len();
                     }
                     // A NIC we cannot read is not a NIC we can call
-                    // wrong. Keep the last answer rather than inventing
-                    // a clean one.
-                    Err(e) => tracing::debug!(error = %e, "steering audit could not read the NIC"),
+                    // wrong — the last count stands. But it is not a
+                    // NIC we can call RIGHT either, and publishing the
+                    // stale count alone let a persistently unreadable
+                    // NIC keep reporting the last clean answer forever
+                    // (review finding). Record the failure so health
+                    // can say the answer is unknown.
+                    Err(e) => {
+                        tracing::warn!(error = %e, "steering audit could not read the NIC");
+                        c.steer_audit_error = Some(e);
+                    }
                 }
             }
         }
@@ -950,6 +968,7 @@ impl Runtime {
                 .deferred_resync
                 .map(|d| (c.source.route_count(), d.floor())),
             steer_missing: c.steer_missing,
+            steer_audit_error: c.steer_audit_error.clone(),
             authority: if c.completeness.is_none() {
                 AuthorityPosture::Absent
             } else if matches!(
@@ -1028,6 +1047,8 @@ pub struct RuntimeStatus {
     /// How many rules the ledger names that the NIC no longer holds, as
     /// of the last audit. See [`STEER_AUDIT_EVERY`].
     pub steer_missing: usize,
+    /// Why the last steering audit could not read the NIC, if so.
+    pub steer_audit_error: Option<String>,
 }
 
 impl Core {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -898,6 +898,18 @@ impl Runtime {
         {
             let mut c = self.core.borrow_mut();
             let now = std::time::Instant::now();
+            // An EMPTY ledger claims nothing, so nothing can be
+            // missing from it. Clearing here rather than skipping is
+            // the fix for the obvious version of this: guarding the
+            // whole audit on a non-empty ledger meant an unsteer after
+            // a drift reading froze `steer_missing` at its last value
+            // and blocked every future audit, so status reported
+            // missing rules forever on a port that was deliberately
+            // off (review finding).
+            if c.steering.installed().is_empty() {
+                c.steer_missing = 0;
+                c.last_steer_audit = None;
+            }
             let due = c
                 .last_steer_audit
                 .is_none_or(|t| now.duration_since(t) >= STEER_AUDIT_EVERY);
@@ -1120,6 +1132,13 @@ impl Core {
     /// the NIC either way, and reporting the steer as failed would make
     /// the supervisor believe traffic is not diverted when it is.
     fn record_steering(&mut self) {
+        // The ledger just moved, so the cached audit describes a NIC
+        // that no longer exists. Invalidate rather than wait out the
+        // interval: a successful re-steer would otherwise keep
+        // reporting the drift it just repaired for up to
+        // STEER_AUDIT_EVERY, which is exactly the window an operator
+        // stepping a canary ladder is watching (review finding).
+        self.last_steer_audit = None;
         let rules = self.steering.installed();
         let r = self.store.steering_changed(&rules);
         let _ = self.note_persist(r);

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -172,6 +172,33 @@ impl ResourceRelease for NoResources {
     }
 }
 
+/// What one pass of the steering audit established.
+///
+/// Two facts rather than one, because they are independent: a pass can
+/// prove drift AND fail to read some of what it was asked about.
+/// Returning only the first published a partial answer as a complete
+/// one — the caller cleared its "cannot verify" state on any `Ok` — so
+/// health reported the confirmed count as current while more drift
+/// could have been sitting behind an unreadable location (review
+/// finding, the third instance of this shape in this audit).
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct SteeringAudit {
+    /// Rules the current target needs in the NIC that are not there.
+    pub missing: Vec<(String, u32)>,
+    /// Why the pass was incomplete, if it was. The locations behind it
+    /// were neither confirmed present nor confirmed missing, so
+    /// `missing` is a floor rather than a count.
+    pub unreadable: Option<String>,
+}
+
+impl SteeringAudit {
+    /// Everything the target asks for is present and correct, and the
+    /// whole of it was read.
+    pub fn clean() -> Self {
+        Self::default()
+    }
+}
+
 /// The MCAM steering seam ([`crate::ntuple::NtupleSteering`] is the
 /// real one: ETHTOOL_SRXCLSRLINS, ring_cookie `(vf+1)<<32`, loc
 /// budgeting).
@@ -214,7 +241,12 @@ pub trait Steering {
     /// a wrong answer here is a misleading health line, not a forwarding
     /// decision. Repair stays the operator's `packetframe reconfigure`,
     /// which reinstalls what is missing because `steer` is a reconcile.
-    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String>;
+    ///
+    /// `Err` means the pass established **nothing** — no count to adopt,
+    /// so the caller keeps its previous one. A pass that established
+    /// something while failing to read the rest is `Ok` with
+    /// [`SteeringAudit::unreadable`] set.
+    fn missing_from_nic(&self) -> Result<SteeringAudit, String>;
 
     fn installed(&self) -> Vec<(String, u32)>;
     /// Change what steering *should* be, without touching the NIC.
@@ -267,8 +299,8 @@ impl Steering for SteeringUnavailable {
     fn unsteer(&mut self) -> Result<(), String> {
         Err("MCAM steering is unavailable in this runtime; cannot confirm rules removed".into())
     }
-    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
-        Ok(Vec::new())
+    fn missing_from_nic(&self) -> Result<SteeringAudit, String> {
+        Ok(SteeringAudit::clean())
     }
     fn installed(&self) -> Vec<(String, u32)> {
         Vec::new()
@@ -929,17 +961,30 @@ impl Runtime {
             if due && !c.steering.installed().is_empty() {
                 c.last_steer_audit = Some(now);
                 match c.steering.missing_from_nic() {
-                    Ok(missing) => {
-                        c.steer_audit_error = None;
-                        if !missing.is_empty() && c.steer_missing != missing.len() {
+                    Ok(audit) => {
+                        if !audit.missing.is_empty() && c.steer_missing != audit.missing.len() {
                             tracing::warn!(
-                                missing = ?missing,
-                                "steering rules the ledger names are gone from the NIC; \
+                                missing = ?audit.missing,
+                                "steering rules this target needs are not in the NIC; \
                                  traffic for them is on the eBPF tier. `packetframe \
                                  reconfigure` reinstalls them"
                             );
                         }
-                        c.steer_missing = missing.len();
+                        c.steer_missing = audit.missing.len();
+                        // Taken from the audit rather than cleared: a
+                        // pass that proved drift AND could not read the
+                        // rest is an incomplete answer, and clearing
+                        // here published it as a complete one (review
+                        // finding). `None` is the only thing that says
+                        // the whole target was checked.
+                        if let Some(why) = &audit.unreadable {
+                            tracing::warn!(
+                                error = %why,
+                                confirmed = audit.missing.len(),
+                                "steering audit was incomplete; the count is a floor"
+                            );
+                        }
+                        c.steer_audit_error = audit.unreadable;
                     }
                     // A NIC we cannot read is not a NIC we can call
                     // wrong — the last count stands. But it is not a
@@ -2028,8 +2073,8 @@ mod tests {
     }
 
     impl Steering for LedgerSteering {
-        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
-            Ok(Vec::new())
+        fn missing_from_nic(&self) -> Result<SteeringAudit, String> {
+            Ok(SteeringAudit::clean())
         }
         fn configured_ports(&self) -> usize {
             self.configured
@@ -2171,6 +2216,63 @@ mod tests {
         assert!(
             rt.status().store_error.is_some(),
             "but the operator has to learn the record is stale — the next start cannot adopt"
+        );
+    }
+
+    /// An INCOMPLETE audit reaches status as both of its facts.
+    ///
+    /// The audit can prove drift and still fail to read the rest, and
+    /// the caller used to treat any `Ok` as a complete pass: it cleared
+    /// `steer_audit_error` and published the confirmed count as current,
+    /// so health said "1 rule missing" while more could have been
+    /// sitting behind the unreadable location and nothing said so
+    /// (review finding). The count is a floor whenever the pass was
+    /// partial, and the two travel together for that reason.
+    #[test]
+    fn an_incomplete_audit_publishes_its_count_and_its_gap() {
+        struct PartialAudit;
+        impl Steering for PartialAudit {
+            fn missing_from_nic(&self) -> Result<SteeringAudit, String> {
+                Ok(SteeringAudit {
+                    missing: vec![("eth4".into(), 1024)],
+                    unreadable: Some("loc 1025 on eth4: EIO".into()),
+                })
+            }
+            fn configured_ports(&self) -> usize {
+                1
+            }
+            fn steer(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn unsteer(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            // Non-empty: the caller skips the audit on an empty ledger.
+            fn installed(&self) -> Vec<(String, u32)> {
+                vec![("eth4".into(), 1024), ("eth4".into(), 1025)]
+            }
+            fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+        }
+
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(PartialAudit),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let st = rt.status();
+        assert_eq!(
+            st.steer_missing, 1,
+            "the drift the pass DID prove must be published"
+        );
+        assert_eq!(
+            st.steer_audit_error.as_deref(),
+            Some("loc 1025 on eth4: EIO"),
+            "and so must the fact that the pass was incomplete — without it the \
+             floor is published as a current count and further drift is invisible"
         );
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -99,6 +99,18 @@ const MAX_EPISODE_REASONS: usize = 8;
 /// `STOP_PATIENCE` to outlast an undead VPP, and the caller must not be
 /// blocked for it. What the caller gets instead is a snapshot that says
 /// the teardown is unfinished.
+///
+/// **The contract this is sized against is not met on hardware, and this
+/// constant is not what misses it.** `detach --all` measured **2.814 s**
+/// on the shadow (2026-08-11, ONE VF, live VPP holding 1.05M routes):
+/// pins came out in 1 ms, then ~2.80 s went on terminating VPP and
+/// rebinding the VF and restoring hugepages — work that happens after
+/// `stop()` has already returned within this budget. So `stop()` keeps
+/// its 900 ms promise while the operator-visible command takes about
+/// three times the published figure. Raising this would not help; the
+/// cost is in VPP's exit and the resource release, and the honest
+/// number is recorded in the runbook's measured table rather than
+/// papered over here.
 const DETACH_BUDGET: Duration = Duration::from_millis(900);
 
 /// How long [`SupervisionService::apply_steering`] waits for the loop to

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1021,6 +1021,7 @@ fn run_loop(
             rs.source_backlog,
             rs.steer_configured_ports > 0,
             rs.steer_missing,
+            rs.steer_audit_error.clone(),
         );
         let report = snap.report();
         let overall = report.overall;

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1020,8 +1020,11 @@ fn run_loop(
             rs.drain_error.clone(),
             rs.source_backlog,
             rs.steer_configured_ports > 0,
-            rs.steer_missing,
-            rs.steer_audit_error.clone(),
+            crate::status::SteerAudit {
+                missing: rs.steer_missing,
+                stray: rs.steer_stray,
+                unreadable: rs.steer_audit_error.clone(),
+            },
         );
         let report = snap.report();
         let overall = report.overall;

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1020,6 +1020,7 @@ fn run_loop(
             rs.drain_error.clone(),
             rs.source_backlog,
             rs.steer_configured_ports > 0,
+            rs.steer_missing,
         );
         let report = snap.report();
         let overall = report.overall;

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -260,6 +260,11 @@ pub struct StatusSnapshot {
     /// Rules the ledger names that the NIC no longer holds. See
     /// [`crate::runtime::RuntimeStatus::steer_missing`].
     pub steer_missing: usize,
+    /// Rules still steering a port the config leaves unsteered. See
+    /// [`crate::runtime::SteeringAudit::stray`]. Its own count because
+    /// it points the other way: `steer_missing` says install, this says
+    /// remove.
+    pub steer_stray: usize,
     /// Why the last steering audit could not read the NIC, if so. See
     /// [`crate::runtime::RuntimeStatus::steer_audit_error`].
     pub steer_audit_unreadable: Option<String>,
@@ -309,6 +314,19 @@ pub struct StatusSnapshot {
     pub source_backlog: u64,
 }
 
+/// The steering audit, as the health surface consumes it.
+///
+/// One parameter rather than three, because two of them are `usize`
+/// that point OPPOSITE ways — install versus remove — and adjacent
+/// positional counts of the same type are a transposition nothing would
+/// catch.
+#[derive(Debug, Default, Clone)]
+pub struct SteerAudit {
+    pub missing: usize,
+    pub stray: usize,
+    pub unreadable: Option<String>,
+}
+
 impl StatusSnapshot {
     /// Observe live state.
     ///
@@ -344,8 +362,7 @@ impl StatusSnapshot {
             // drift would be a claim. Zero here means "not observed",
             // and every caller of this form is a path with no steering
             // ledger to audit against.
-            0,
-            None,
+            SteerAudit::default(),
         )
     }
 
@@ -369,16 +386,16 @@ impl StatusSnapshot {
         drain_error: Option<String>,
         source_backlog: u64,
         steer_configured: bool,
-        steer_missing: usize,
-        steer_audit_unreadable: Option<String>,
+        audit: SteerAudit,
     ) -> Self {
         Self {
             state: sup.state(),
             steered: sup.is_steered(),
             steer_intended: sup.steer_intended(),
             steer_configured,
-            steer_missing,
-            steer_audit_unreadable,
+            steer_missing: audit.missing,
+            steer_stray: audit.stray,
+            steer_audit_unreadable: audit.unreadable,
             undead: sup.is_undead(),
             failures: sup.failures(),
             counts,
@@ -727,35 +744,53 @@ impl StatusSnapshot {
         // published the retained count as though it were current while
         // further drift had become invisible (review finding). So one
         // arm, and the message carries whichever facts are true.
-        let drift = (self.steer_missing > 0).then(|| {
-            format!(
+        //
+        // Three facts now, composed rather than matched. The third
+        // points the OTHER way: rules still steering a port the config
+        // asks to leave unsteered. It is named first when present,
+        // because that is the rollback lever failing — an operator
+        // pulling traffic OFF a port is the one case where "steering
+        // healthy" is the most expensive possible answer (review
+        // finding).
+        let mut clauses: Vec<String> = Vec::new();
+        if self.steer_stray > 0 {
+            clauses.push(format!(
+                "{} steering rule(s) are still diverting traffic on a port this config \
+                 leaves unsteered — the rules outlived the request to remove them, so \
+                 that port is still in VPP; `packetframe reconfigure` clears them, and \
+                 `ethtool -n <iface>` shows them",
+                self.steer_stray
+            ));
+        }
+        if self.steer_missing > 0 {
+            clauses.push(format!(
                 "{} steering rule(s) this target asks for are missing from the NIC, no \
                  longer match what was asked for, or were never installed — that traffic \
                  is on the eBPF tier. Something changed them out of band (a UniFi \
                  provisioning push does this), or the allowlist grew while the inherited \
                  rules stayed as they were; `packetframe reconfigure` reconciles either way",
                 self.steer_missing
-            )
-        });
-        let unverifiable = |why: &str| {
-            format!(
+            ));
+        }
+        if let Some(why) = &self.steer_audit_unreadable {
+            let unverifiable = format!(
                 "the NIC would not answer a rule readback ({why}), so rules may be \
                  removed or altered without this being visible; `ethtool -n <iface>` is \
                  the ground truth until it clears"
-            )
-        };
-        let message = match (drift, self.steer_audit_unreadable.as_deref()) {
-            (Some(drift), None) => Some(drift),
-            // Both: the count is real but STALE, and saying so is the
-            // whole point — an operator reading a count as current will
-            // fix that many rules and stop looking.
-            (Some(drift), Some(why)) => Some(format!(
-                "{drift}. That count is the last answer the NIC gave, not a current one: {}",
-                unverifiable(why)
-            )),
-            (None, Some(why)) => Some(format!("cannot verify steering: {}", unverifiable(why))),
-            (None, None) => None,
-        };
+            );
+            clauses.push(if clauses.is_empty() {
+                format!("cannot verify steering: {unverifiable}")
+            } else {
+                // The counts above are real but STALE, and saying so is
+                // the whole point — an operator reading a count as
+                // current will fix that many rules and stop looking.
+                format!(
+                    "and the count(s) above are the last answer the NIC gave, not current \
+                     ones: {unverifiable}"
+                )
+            });
+        }
+        let message = (!clauses.is_empty()).then(|| clauses.join(". "));
         if let Some(message) = message {
             return SubsystemHealth {
                 name: SUBSYS_STEERING.into(),
@@ -1264,6 +1299,48 @@ mod tests {
         );
     }
 
+    /// Rules still steering a port the config turned OFF degrade it.
+    ///
+    /// The opposite complaint to drift, and the one an operator is
+    /// least able to afford being wrong about: it means the rollback
+    /// lever did not take. Named first in the message for that reason,
+    /// and counted separately because a single number would have to
+    /// pick one story — install or remove — and this one says remove.
+    #[test]
+    fn rules_left_on_a_port_the_config_unsteered_degrade_it() {
+        let led = ledger_with(10, 0, 0);
+        let mut snap = snap_of(
+            &steered_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            verified(3),
+            ports_up(),
+        );
+        snap.steer_missing = 0;
+        snap.steer_stray = 2;
+
+        let rep = snap.report();
+        let steering = rep
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_STEERING)
+            .expect("steering row");
+        assert_eq!(
+            steering.state,
+            HealthState::Degraded,
+            "a port the config leaves unsteered that is still steering is not \
+             healthy, whatever the drift count says: {steering:?}"
+        );
+        let msg = steering.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains('2') && msg.contains("still diverting"),
+            "and the line must say which way the problem points — these rules \
+             need REMOVING, not reinstalling: {msg}"
+        );
+    }
+
     /// A RETAINED drift count must say it can no longer be checked.
     ///
     /// The two facts are independent — `Runtime::status` keeps the last
@@ -1304,7 +1381,7 @@ mod tests {
             "the proven drift must still be reported: {msg}"
         );
         assert!(
-            msg.contains("EIO") && msg.contains("not a current one"),
+            msg.contains("EIO") && msg.contains("not current ones"),
             "and so must the fact that the count is stale and further drift is \
              invisible — reporting only the count sends an operator to fix that \
              many rules and stop looking: {msg}"

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -260,6 +260,9 @@ pub struct StatusSnapshot {
     /// Rules the ledger names that the NIC no longer holds. See
     /// [`crate::runtime::RuntimeStatus::steer_missing`].
     pub steer_missing: usize,
+    /// Why the last steering audit could not read the NIC, if so. See
+    /// [`crate::runtime::RuntimeStatus::steer_audit_error`].
+    pub steer_audit_unreadable: Option<String>,
     pub undead: bool,
     pub failures: u32,
     pub counts: SinkCounts,
@@ -342,6 +345,7 @@ impl StatusSnapshot {
             // and every caller of this form is a path with no steering
             // ledger to audit against.
             0,
+            None,
         )
     }
 
@@ -366,6 +370,7 @@ impl StatusSnapshot {
         source_backlog: u64,
         steer_configured: bool,
         steer_missing: usize,
+        steer_audit_unreadable: Option<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -373,6 +378,7 @@ impl StatusSnapshot {
             steer_intended: sup.steer_intended(),
             steer_configured,
             steer_missing,
+            steer_audit_unreadable,
             undead: sup.is_undead(),
             failures: sup.failures(),
             counts,
@@ -723,6 +729,23 @@ impl StatusSnapshot {
                      they were inherited from an earlier config; `packetframe \
                      reconfigure` reconciles either way",
                     self.steer_missing
+                )),
+                last_success_age_seconds: None,
+            };
+        }
+        // Checked after proven drift and before everything else: a NIC
+        // that will not answer is not a NIC we can call healthy. The
+        // count alone kept publishing the last clean answer forever
+        // while drift had become undetectable — "cannot check" reported
+        // as "checked, fine" (review finding).
+        if let Some(why) = &self.steer_audit_unreadable {
+            return SubsystemHealth {
+                name: SUBSYS_STEERING.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "cannot verify steering: the NIC would not answer a rule readback \
+                     ({why}). Rules may have been removed or altered without this being \
+                     visible; `ethtool -n <iface>` is the ground truth until it clears"
                 )),
                 last_success_age_seconds: None,
             };
@@ -1184,6 +1207,49 @@ mod tests {
     /// Degraded rather than Unhealthy on purpose: the stripped traffic
     /// falls back to the eBPF tier, so nothing is dropping — the offload
     /// is just smaller than it claims.
+    /// A NIC that will not answer is not a healthy NIC.
+    ///
+    /// The audit keeps its previous count when a readback fails, which
+    /// is right — an unreadable NIC is not a wrong one. But publishing
+    /// only that count meant a persistently unreadable NIC kept
+    /// reporting the last clean answer forever, so steering read
+    /// Healthy while drift had become undetectable (review finding).
+    /// "Cannot check" and "checked, fine" must not print the same line.
+    #[test]
+    fn an_unreadable_steering_audit_is_not_healthy() {
+        let led = ledger_with(10, 0, 0);
+        let mut snap = snap_of(
+            &steered_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            verified(3),
+            ports_up(),
+        );
+        // Zero missing — the last audit that SUCCEEDED found nothing.
+        snap.steer_missing = 0;
+        snap.steer_audit_unreadable = Some("EIO: readback failed".into());
+
+        let rep = snap.report();
+        let steering = rep
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_STEERING)
+            .expect("steering row");
+        assert_eq!(
+            steering.state,
+            HealthState::Degraded,
+            "an audit that could not read the NIC must not present the previous \
+             clean count as current: {steering:?}"
+        );
+        let msg = steering.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains("cannot verify") && msg.contains("EIO"),
+            "the line must say it could not check, and why: {msg}"
+        );
+    }
+
     #[test]
     fn steering_rules_missing_from_the_nic_degrade_it() {
         let led = ledger_with(10, 0, 0);

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -257,6 +257,9 @@ pub struct StatusSnapshot {
     /// had just written `steer on` could not tell the config had been
     /// read at all.
     pub steer_configured: bool,
+    /// Rules the ledger names that the NIC no longer holds. See
+    /// [`crate::runtime::RuntimeStatus::steer_missing`].
+    pub steer_missing: usize,
     pub undead: bool,
     pub failures: u32,
     pub counts: SinkCounts,
@@ -334,6 +337,11 @@ impl StatusSnapshot {
             None,
             0,
             steer_configured,
+            // The shorthand has no NIC audit behind it; claiming zero
+            // drift would be a claim. Zero here means "not observed",
+            // and every caller of this form is a path with no steering
+            // ledger to audit against.
+            0,
         )
     }
 
@@ -357,12 +365,14 @@ impl StatusSnapshot {
         drain_error: Option<String>,
         source_backlog: u64,
         steer_configured: bool,
+        steer_missing: usize,
     ) -> Self {
         Self {
             state: sup.state(),
             steered: sup.is_steered(),
             steer_intended: sup.steer_intended(),
             steer_configured,
+            steer_missing,
             undead: sup.is_undead(),
             failures: sup.failures(),
             counts,
@@ -691,6 +701,31 @@ impl StatusSnapshot {
     }
 
     fn steering_health(&self) -> SubsystemHealth {
+        // Checked before the steered arm: "steered" is a fact about
+        // what we asked for, and this is a fact about what the NIC
+        // actually holds. A provisioning push can strip rules with
+        // nothing else noticing — measured on the shadow 2026-08-11,
+        // still missing two minutes later with `steering healthy` —
+        // and the answer an operator needs is not "steered" but "part
+        // of it is gone, and here is the one command that fixes it".
+        //
+        // DEGRADED, not Unhealthy: the stripped traffic falls back to
+        // the eBPF tier, which is where it belongs. Nothing is
+        // dropping; the offload is smaller than it claims.
+        if self.steer_missing > 0 {
+            return SubsystemHealth {
+                name: SUBSYS_STEERING.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "{} steering rule(s) the ledger names are gone from the NIC — that \
+                     traffic is on the eBPF tier. Something removed them out of band (a \
+                     UniFi provisioning push does this); `packetframe reconfigure` \
+                     reinstalls them",
+                    self.steer_missing
+                )),
+                last_success_age_seconds: None,
+            };
+        }
         let (state, message) = match (self.steered, self.steer_intended) {
             (true, _) => (HealthState::Healthy, None),
             // Intended but absent: a failed steer, or steering torn down
@@ -1135,6 +1170,57 @@ mod tests {
             ports,
             false,
         )
+    }
+
+    /// Rules missing from the NIC degrade steering, even while steered.
+    ///
+    /// The arm is checked BEFORE `steered`, because "steered" says what
+    /// we asked for and this says what the NIC actually holds. On the
+    /// shadow (2026-08-11) a rule deleted out of band left `steering
+    /// healthy` for two minutes with three of four rules installed; an
+    /// operator reading that line had no way to know.
+    ///
+    /// Degraded rather than Unhealthy on purpose: the stripped traffic
+    /// falls back to the eBPF tier, so nothing is dropping — the offload
+    /// is just smaller than it claims.
+    #[test]
+    fn steering_rules_missing_from_the_nic_degrade_it() {
+        let led = ledger_with(10, 0, 0);
+        let mut snap = snap_of(
+            &steered_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            verified(3),
+            ports_up(),
+        );
+        // Baseline: a NIC that agrees is healthy.
+        let base = snap.report();
+        let steering = base
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_STEERING)
+            .expect("steering row");
+        assert_eq!(steering.state, HealthState::Healthy, "{steering:?}");
+
+        snap.steer_missing = 1;
+        let rep = snap.report();
+        let steering = rep
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_STEERING)
+            .expect("steering row");
+        assert_eq!(
+            steering.state,
+            HealthState::Degraded,
+            "a NIC missing a rule the ledger names must not read healthy"
+        );
+        let msg = steering.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains("reconfigure"),
+            "the line has to name the one command that fixes it: {msg}"
+        );
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -723,11 +723,12 @@ impl StatusSnapshot {
                 name: SUBSYS_STEERING.into(),
                 state: HealthState::Degraded,
                 message: Some(format!(
-                    "{} steering rule(s) are missing from the NIC or no longer match \
-                     what was asked for — that traffic is on the eBPF tier. Something \
-                     changed them out of band (a UniFi provisioning push does this), or \
-                     they were inherited from an earlier config; `packetframe \
-                     reconfigure` reconciles either way",
+                    "{} steering rule(s) this target asks for are missing from the NIC, \
+                     no longer match what was asked for, or were never installed — that \
+                     traffic is on the eBPF tier. Something changed them out of band (a \
+                     UniFi provisioning push does this), or the allowlist grew while the \
+                     inherited rules stayed as they were; `packetframe reconfigure` \
+                     reconciles either way",
                     self.steer_missing
                 )),
                 last_success_age_seconds: None,

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -754,11 +754,17 @@ impl StatusSnapshot {
         // finding).
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
+            // "Still occupied", not "still ours". Where the outgoing
+            // target is known the audit proves ownership field by
+            // field; after a restart that dropped the port there is
+            // nothing to check against, and claiming the traffic is
+            // ours would be the ownership guess this audit keeps
+            // getting wrong. `ethtool -n` settles it either way.
             clauses.push(format!(
-                "{} steering rule(s) are still diverting traffic on a port this config \
-                 leaves unsteered — the rules outlived the request to remove them, so \
-                 that port is still in VPP; `packetframe reconfigure` clears them, and \
-                 `ethtool -n <iface>` shows them",
+                "{} location(s) the ledger names on a port this config leaves unsteered \
+                 are still occupied, so that port may still be diverting traffic into \
+                 VPP — the rules outlived the request to remove them; `ethtool -n \
+                 <iface>` shows what is there and `packetframe reconfigure` clears them",
                 self.steer_stray
             ));
         }
@@ -1335,9 +1341,15 @@ mod tests {
         );
         let msg = steering.message.as_deref().unwrap_or_default();
         assert!(
-            msg.contains('2') && msg.contains("still diverting"),
+            msg.contains('2') && msg.contains("may still be diverting"),
             "and the line must say which way the problem points — these rules \
              need REMOVING, not reinstalling: {msg}"
+        );
+        assert!(
+            !msg.contains("are still diverting"),
+            "without claiming ownership it cannot always prove: after a restart \
+             that dropped the port there is nothing left to check the readback \
+             against, and `ethtool -n` is what settles it: {msg}"
         );
     }
 

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -717,10 +717,11 @@ impl StatusSnapshot {
                 name: SUBSYS_STEERING.into(),
                 state: HealthState::Degraded,
                 message: Some(format!(
-                    "{} steering rule(s) the ledger names are gone from the NIC — that \
-                     traffic is on the eBPF tier. Something removed them out of band (a \
-                     UniFi provisioning push does this); `packetframe reconfigure` \
-                     reinstalls them",
+                    "{} steering rule(s) are missing from the NIC or no longer match \
+                     what was asked for — that traffic is on the eBPF tier. Something \
+                     changed them out of band (a UniFi provisioning push does this), or \
+                     they were inherited from an earlier config; `packetframe \
+                     reconfigure` reconciles either way",
                     self.steer_missing
                 )),
                 last_success_age_seconds: None,

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -761,9 +761,10 @@ impl StatusSnapshot {
             // ours would be the ownership guess this audit keeps
             // getting wrong. `ethtool -n` settles it either way.
             clauses.push(format!(
-                "{} location(s) the ledger names on a port this config leaves unsteered \
-                 are still occupied, so that port may still be diverting traffic into \
-                 VPP — the rules outlived the request to remove them; `ethtool -n \
+                "{} location(s) the ledger names are still occupied by rules this config \
+                 does not ask for — a port it leaves unsteered, or prefixes dropped from \
+                 the allowlist — so traffic may still be diverted into VPP that should \
+                 not be. The rules outlived the request to remove them; `ethtool -n \
                  <iface>` shows what is there and `packetframe reconfigure` clears them",
                 self.steer_stray
             ));
@@ -1341,7 +1342,7 @@ mod tests {
         );
         let msg = steering.message.as_deref().unwrap_or_default();
         assert!(
-            msg.contains('2') && msg.contains("may still be diverting"),
+            msg.contains('2') && msg.contains("may still be diverted"),
             "and the line must say which way the problem points — these rules \
              need REMOVING, not reinstalling: {msg}"
         );

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -718,36 +718,49 @@ impl StatusSnapshot {
         // DEGRADED, not Unhealthy: the stripped traffic falls back to
         // the eBPF tier, which is where it belongs. Nothing is
         // dropping; the offload is smaller than it claims.
-        if self.steer_missing > 0 {
+        //
+        // A NIC that will not answer is not healthy either, and the two
+        // facts are INDEPENDENT: `Runtime::status` retains the last count
+        // when a readback fails, so a nonzero count and an unreadable
+        // audit can both hold. Ordering them could not fix that —
+        // whichever arm ran first hid the other, and the first version
+        // published the retained count as though it were current while
+        // further drift had become invisible (review finding). So one
+        // arm, and the message carries whichever facts are true.
+        let drift = (self.steer_missing > 0).then(|| {
+            format!(
+                "{} steering rule(s) this target asks for are missing from the NIC, no \
+                 longer match what was asked for, or were never installed — that traffic \
+                 is on the eBPF tier. Something changed them out of band (a UniFi \
+                 provisioning push does this), or the allowlist grew while the inherited \
+                 rules stayed as they were; `packetframe reconfigure` reconciles either way",
+                self.steer_missing
+            )
+        });
+        let unverifiable = |why: &str| {
+            format!(
+                "the NIC would not answer a rule readback ({why}), so rules may be \
+                 removed or altered without this being visible; `ethtool -n <iface>` is \
+                 the ground truth until it clears"
+            )
+        };
+        let message = match (drift, self.steer_audit_unreadable.as_deref()) {
+            (Some(drift), None) => Some(drift),
+            // Both: the count is real but STALE, and saying so is the
+            // whole point — an operator reading a count as current will
+            // fix that many rules and stop looking.
+            (Some(drift), Some(why)) => Some(format!(
+                "{drift}. That count is the last answer the NIC gave, not a current one: {}",
+                unverifiable(why)
+            )),
+            (None, Some(why)) => Some(format!("cannot verify steering: {}", unverifiable(why))),
+            (None, None) => None,
+        };
+        if let Some(message) = message {
             return SubsystemHealth {
                 name: SUBSYS_STEERING.into(),
                 state: HealthState::Degraded,
-                message: Some(format!(
-                    "{} steering rule(s) this target asks for are missing from the NIC, \
-                     no longer match what was asked for, or were never installed — that \
-                     traffic is on the eBPF tier. Something changed them out of band (a \
-                     UniFi provisioning push does this), or the allowlist grew while the \
-                     inherited rules stayed as they were; `packetframe reconfigure` \
-                     reconciles either way",
-                    self.steer_missing
-                )),
-                last_success_age_seconds: None,
-            };
-        }
-        // Checked after proven drift and before everything else: a NIC
-        // that will not answer is not a NIC we can call healthy. The
-        // count alone kept publishing the last clean answer forever
-        // while drift had become undetectable — "cannot check" reported
-        // as "checked, fine" (review finding).
-        if let Some(why) = &self.steer_audit_unreadable {
-            return SubsystemHealth {
-                name: SUBSYS_STEERING.into(),
-                state: HealthState::Degraded,
-                message: Some(format!(
-                    "cannot verify steering: the NIC would not answer a rule readback \
-                     ({why}). Rules may have been removed or altered without this being \
-                     visible; `ethtool -n <iface>` is the ground truth until it clears"
-                )),
+                message: Some(message),
                 last_success_age_seconds: None,
             };
         }
@@ -1248,6 +1261,53 @@ mod tests {
         assert!(
             msg.contains("cannot verify") && msg.contains("EIO"),
             "the line must say it could not check, and why: {msg}"
+        );
+    }
+
+    /// A RETAINED drift count must say it can no longer be checked.
+    ///
+    /// The two facts are independent — `Runtime::status` keeps the last
+    /// count when a readback fails — so this combination is reachable and
+    /// was the one the previous fix left behind: proven drift returned
+    /// first and the unreadable audit went unmentioned, so an operator
+    /// read "1 rule missing, reconfigure fixes it", fixed one rule, and
+    /// had no way to know the audit had stopped being able to find the
+    /// rest. Ordering cannot fix it; whichever arm runs first hides the
+    /// other (review finding).
+    #[test]
+    fn a_retained_drift_count_says_it_is_no_longer_current() {
+        let led = ledger_with(10, 0, 0);
+        let mut snap = snap_of(
+            &steered_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            verified(3),
+            ports_up(),
+        );
+        // Drift was proven by an earlier audit; the NIC has since stopped
+        // answering, so the count stands but nothing can add to it.
+        snap.steer_missing = 1;
+        snap.steer_audit_unreadable = Some("EIO: readback failed".into());
+
+        let rep = snap.report();
+        let steering = rep
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_STEERING)
+            .expect("steering row");
+        assert_eq!(steering.state, HealthState::Degraded);
+        let msg = steering.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains('1') && msg.contains("eBPF tier"),
+            "the proven drift must still be reported: {msg}"
+        );
+        assert!(
+            msg.contains("EIO") && msg.contains("not a current one"),
+            "and so must the fact that the count is stale and further drift is \
+             invisible — reporting only the count sends an operator to fix that \
+             many rules and stop looking: {msg}"
         );
     }
 

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1418,6 +1418,10 @@ mod steered {
         pub log: Arc<Mutex<Vec<&'static str>>>,
     }
     impl packetframe_vpp_offload::runtime::Steering for RecordingSteering {
+        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+            // No NIC behind this double, so nothing can be missing from one.
+            Ok(Vec::new())
+        }
         fn configured_ports(&self) -> usize {
             1
         }

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1418,9 +1418,11 @@ mod steered {
         pub log: Arc<Mutex<Vec<&'static str>>>,
     }
     impl packetframe_vpp_offload::runtime::Steering for RecordingSteering {
-        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+        fn missing_from_nic(
+            &self,
+        ) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
             // No NIC behind this double, so nothing can be missing from one.
-            Ok(Vec::new())
+            Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
         }
         fn configured_ports(&self) -> usize {
             1

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -716,6 +716,10 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
 fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
     struct PanicOnSteer;
     impl packetframe_vpp_offload::runtime::Steering for PanicOnSteer {
+        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+            // No NIC behind this double, so nothing can be missing from one.
+            Ok(Vec::new())
+        }
         fn configured_ports(&self) -> usize {
             1
         }
@@ -1151,6 +1155,10 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
 struct SpySteering(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
 
 impl packetframe_vpp_offload::runtime::Steering for SpySteering {
+    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+        // No NIC behind this double, so nothing can be missing from one.
+        Ok(Vec::new())
+    }
     fn configured_ports(&self) -> usize {
         1
     }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -716,9 +716,11 @@ fn a_verdict_dies_with_its_process_but_its_reason_does_not() {
 fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
     struct PanicOnSteer;
     impl packetframe_vpp_offload::runtime::Steering for PanicOnSteer {
-        fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+        fn missing_from_nic(
+            &self,
+        ) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
             // No NIC behind this double, so nothing can be missing from one.
-            Ok(Vec::new())
+            Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
         }
         fn configured_ports(&self) -> usize {
             1
@@ -1155,9 +1157,9 @@ fn the_timeout_correction_survives_the_in_flight_tick() {
 struct SpySteering(std::sync::Arc<std::sync::Mutex<Vec<String>>>);
 
 impl packetframe_vpp_offload::runtime::Steering for SpySteering {
-    fn missing_from_nic(&self) -> Result<Vec<(String, u32)>, String> {
+    fn missing_from_nic(&self) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
         // No NIC behind this double, so nothing can be missing from one.
-        Ok(Vec::new())
+        Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
     }
     fn configured_ports(&self) -> usize {
         1

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -371,8 +371,23 @@ steering  DEGRADED — 1 steering rule(s) the ledger names are gone from the
                      does this); `packetframe reconfigure` reinstalls them
 ```
 
-It found the drift by asking the NIC, not by inferring it. **Detection
-only — it does not repair**, deliberately: re-asserting rules from a
+It found the drift by asking the NIC, not by inferring it.
+
+If the NIC will not answer the readback at all, that is reported too and
+is NOT the same line:
+
+```text
+steering  DEGRADED — cannot verify steering: the NIC would not answer a
+                     rule readback (EIO: ...). Rules may have been removed
+                     or altered without this being visible; `ethtool -n
+                     <iface>` is the ground truth until it clears
+```
+
+An audit that cannot read keeps its previous count — an unreadable NIC
+is not a wrong one — but it must not present that count as current.
+"Cannot check" and "checked, fine" are different answers.
+
+**Detection only — it does not repair**, deliberately: re-asserting rules from a
 background audit would put a second, unsupervised installation path
 beside `Action::Steer`, and the repair is one operator command.
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -399,6 +399,21 @@ An audit that cannot read keeps its previous count — an unreadable NIC
 is not a wrong one — but it must not present that count as current.
 "Cannot check" and "checked, fine" are different answers.
 
+The audit also reports the opposite complaint, and names it first:
+
+```text
+steering  DEGRADED — 2 steering rule(s) are still diverting traffic on a
+                     port this config leaves unsteered — the rules outlived
+                     the request to remove them, so that port is still in
+                     VPP; `packetframe reconfigure` clears them
+```
+
+That is the rollback lever not taking. A `steer off` whose reconcile was
+refused (the completeness gate) or whose deletes failed leaves the ledger
+naming rules on a port you asked to go quiet — and traffic keeps entering
+VPP there. It is a different remedy from the drift line above: those
+rules need REMOVING, not reinstalling.
+
 And when both hold — drift was proven, then the NIC stopped answering —
 the line says so, because a count read as current sends you to fix that
 many rules and stop looking:

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -402,13 +402,21 @@ is not a wrong one — but it must not present that count as current.
 The audit also reports the opposite complaint, and names it first:
 
 ```text
-steering  DEGRADED — 2 location(s) the ledger names on a port this config
-                     leaves unsteered are still occupied, so that port may
-                     still be diverting traffic into VPP — the rules
-                     outlived the request to remove them; `ethtool -n
-                     <iface>` shows what is there and `packetframe
-                     reconfigure` clears them
+steering  DEGRADED — 2 location(s) the ledger names are still occupied by
+                     rules this config does not ask for — a port it leaves
+                     unsteered, or prefixes dropped from the allowlist — so
+                     traffic may still be diverted into VPP that should not
+                     be. The rules outlived the request to remove them;
+                     `ethtool -n <iface>` shows what is there and
+                     `packetframe reconfigure` clears them
 ```
+
+Two ways to arrive here, and they read the same because the remedy is
+the same: a port turned `steer off` whose reconcile has not run, or an
+allowlist that lost a prefix while its rules stayed installed. Both mean
+traffic is being diverted that nobody asked for — the opposite complaint
+to the drift line above, and worth reading carefully, because the fix
+points the other way: these rules need REMOVING, not reinstalling.
 
 "May", not "is", and the wording is deliberate. Where the port was
 turned off by a live `reconfigure` the audit still holds the outgoing

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -358,16 +358,26 @@ count against the floor in the health text.
 
 ### Steering silently went partial — fewer rules in the NIC than the ledger thinks
 
-**Nothing detects this. Health stays green.** Measured 2026-08-11: a
-rule deleted out of band (`ethtool -N eth1 delete 12`) was still missing
-two minutes later, `steering healthy` throughout, not one line in the
-log. The ledger and the state file went on naming four rules while the
-NIC held three.
+**The module now detects this within 30 s and says so:**
 
-Why: nothing polls the NIC. The only thing that re-emits `Action::Steer`
-is `VerifyPassed`, and verify does not re-run in steady state — so a
-provisioning push, a firmware event, or anything else that clears MCAM
-entries leaves the offload **partially steered indefinitely**.
+```text
+steering  DEGRADED — 1 steering rule(s) the ledger names are gone from the
+                     NIC — that traffic is on the eBPF tier. Something
+                     removed them out of band (a UniFi provisioning push
+                     does this); `packetframe reconfigure` reinstalls them
+```
+
+It found the drift by asking the NIC, not by inferring it. **Detection
+only — it does not repair**, deliberately: re-asserting rules from a
+background audit would put a second, unsupervised installation path
+beside `Action::Steer`, and the repair is one operator command.
+
+Before that audit existed this went entirely unnoticed. Measured
+2026-08-11: a rule deleted out of band (`ethtool -N eth1 delete 12`) was
+still missing two minutes later, `steering healthy` throughout, not one
+line in the log — nothing polled the NIC, and the only thing that
+re-emits `Action::Steer` is `VerifyPassed`, which does not recur in
+steady state.
 
 What it costs: less than it sounds. Traffic for the stripped rule falls
 back to the **eBPF tier**, which is exactly where it belongs — this is a

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -399,6 +399,18 @@ An audit that cannot read keeps its previous count — an unreadable NIC
 is not a wrong one — but it must not present that count as current.
 "Cannot check" and "checked, fine" are different answers.
 
+And when both hold — drift was proven, then the NIC stopped answering —
+the line says so, because a count read as current sends you to fix that
+many rules and stop looking:
+
+```text
+steering  DEGRADED — 1 steering rule(s) ... reconfigure reconciles either
+                     way. That count is the last answer the NIC gave, not
+                     a current one: the NIC would not answer a rule
+                     readback (EIO: ...), so rules may be removed or
+                     altered without this being visible
+```
+
 **Detection only — it does not repair**, deliberately: re-asserting rules from a
 background audit would put a second, unsupervised installation path
 beside `Action::Steer`, and the repair is one operator command.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -402,11 +402,21 @@ is not a wrong one — but it must not present that count as current.
 The audit also reports the opposite complaint, and names it first:
 
 ```text
-steering  DEGRADED — 2 steering rule(s) are still diverting traffic on a
-                     port this config leaves unsteered — the rules outlived
-                     the request to remove them, so that port is still in
-                     VPP; `packetframe reconfigure` clears them
+steering  DEGRADED — 2 location(s) the ledger names on a port this config
+                     leaves unsteered are still occupied, so that port may
+                     still be diverting traffic into VPP — the rules
+                     outlived the request to remove them; `ethtool -n
+                     <iface>` shows what is there and `packetframe
+                     reconfigure` clears them
 ```
+
+"May", not "is", and the wording is deliberate. Where the port was
+turned off by a live `reconfigure` the audit still holds the outgoing
+target and proves ownership field by field. After a *restart* that
+dropped the port there is nothing left to check the readback against —
+the state file records locations, not what they should contain — so all
+that can be established is that the slot is occupied. `ethtool -n
+<iface>` settles it.
 
 That is the rollback lever not taking. A `steer off` whose reconcile was
 refused (the completeness gate) or whose deletes failed leaves the ledger

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -27,16 +27,20 @@ running badly.
 > rules than existed, and a mask "correction" that inverted a field
 > which had been right all along. Every one of them failed loudly, as
 > designed: nothing was installed, and the all-or-nothing unwind left the
-> port with zero rules each time. What is *still*
-> unproven is everything past installation: no steered packet has ever
-> reached VPP, because the only port available to test on carries
-> nothing the allowlist matches. Every rule
+> port with zero rules each time. Everything past installation is now
+> proven too, on the shadow: steered frames counted on `octeon0/0`
+> (2026-08-07), forwarded end to end through VPP's graph the same day,
+> and PMTUD answered correctly through a steered path. What remains
+> unproven is scale and reality — one VF, one wired port, and traffic we
+> generated ourselves. Every rule
 > insert is followed by an `ETHTOOL_GRXCLSRULE` readback and compared
 > field by field, precisely so a wrong `ethtool_rx_flow_spec` offset
 > fails loudly on first contact instead of installing a rule that
 > matches the wrong traffic while both tiers report healthy. Expect that
 > check to be the thing that fires first, and treat it as the module
-> working, not failing.
+> working, not failing. The same readback now runs every 30 s against
+> the ledger, so a rule removed or altered out of band shows up as
+> `steering DEGRADED` rather than as nothing at all.
 >
 > **Native XDP attach panics this vendor kernel.** Not a queue-leak
 > question, not something to re-test on an idle port. The version gate

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -360,18 +360,30 @@ count against the floor in the health text.
 
 ## Triage by symptom
 
-### Steering silently went partial — fewer rules in the NIC than the ledger thinks
+### Steering silently went partial — the NIC holds less than the config asks for
 
 **The module now detects this within 30 s and says so:**
 
 ```text
-steering  DEGRADED — 1 steering rule(s) the ledger names are gone from the
-                     NIC — that traffic is on the eBPF tier. Something
-                     removed them out of band (a UniFi provisioning push
-                     does this); `packetframe reconfigure` reinstalls them
+steering  DEGRADED — 1 steering rule(s) this target asks for are missing
+                     from the NIC, no longer match what was asked for, or
+                     were never installed — that traffic is on the eBPF
+                     tier. Something changed them out of band (a UniFi
+                     provisioning push does this), or the allowlist grew
+                     while the inherited rules stayed as they were;
+                     `packetframe reconfigure` reconciles either way
 ```
 
 It found the drift by asking the NIC, not by inferring it.
+
+**Two directions, one count.** The rules the ledger names are read back
+and compared field by field, so a deleted, replaced or narrowed rule is
+drift. And the rules the *current* target asks for are checked for a
+counterpart, so a rule that was never installed counts too — the shape a
+restart produces when the allowlist grew while the daemon was down: the
+state file names the old rules, they all read back clean, and the new
+prefix has no rule anywhere. One-directional, that read Healthy for as
+long as the adopted resync stayed deferred.
 
 If the NIC will not answer the readback at all, that is reported too and
 is NOT the same line:

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -11,12 +11,14 @@ running badly.
 
 > ## Read this before the first bring-up
 >
-> **No part of this module has ever run against a real VPP process.**
-> Every layer is unit-tested, `Module::attach` runs end to end against a
-> fixture sysfs and a fake VPP on a unix socket, and the convergence
-> budget was measured by a bench driving the same engine — but the
-> composition has never executed on hardware. Neither has any of the
-> three published failover numbers.
+> **This module has run against real VPP on the shadow, repeatedly.**
+> First bring-up 2026-08-05; first forwarded packet 2026-08-07; the five
+> acceptance drills and a restart-over-steered-VPP cycle through
+> 2026-08-09; `detach --all`, a cold bring-up and the steering-reconcile
+> checks on 2026-08-11. What has NOT happened is any of it on the
+> primary, or on more than one VF, or with real customer traffic — the
+> shadow's only wired port carries the interconnect, so every packet
+> that has ever traversed VPP here was one we generated.
 >
 > **The MCAM ioctl path has now met a NIC, and it took several rounds.**
 > First contact on 2026-08-05 found one real defect — the `loc` space
@@ -354,6 +356,93 @@ count against the floor in the health text.
 
 ## Triage by symptom
 
+### Steering silently went partial — fewer rules in the NIC than the ledger thinks
+
+**Nothing detects this. Health stays green.** Measured 2026-08-11: a
+rule deleted out of band (`ethtool -N eth1 delete 12`) was still missing
+two minutes later, `steering healthy` throughout, not one line in the
+log. The ledger and the state file went on naming four rules while the
+NIC held three.
+
+Why: nothing polls the NIC. The only thing that re-emits `Action::Steer`
+is `VerifyPassed`, and verify does not re-run in steady state — so a
+provisioning push, a firmware event, or anything else that clears MCAM
+entries leaves the offload **partially steered indefinitely**.
+
+What it costs: less than it sounds. Traffic for the stripped rule falls
+back to the **eBPF tier**, which is exactly where it belongs — this is a
+lost optimisation, not a lost packet. What you lose is the knowledge
+that it happened.
+
+**Detect** by comparing the two directly; they should match:
+
+```bash
+ethtool -n eth1 | grep -c '^Filter:'
+grep -o '"steer_rules".*' /var/lib/packetframe/state/vpp-offload.json
+```
+
+**Repair** with a plain reconfigure — no config change, no lever
+movement, no restart, no traffic impact:
+
+```bash
+packetframe reconfigure
+```
+
+That works because `steer` is a reconcile rather than an append: on a
+port that is already steered it re-installs whatever the target says is
+missing. (A reconfigure will *not* start steering a port that is
+unsteered — that still needs the lever.) Verified 2026-08-11: 3 rules →
+4, exit 0.
+
+**Run it after every UniFi provisioning push while a port is steered**,
+and check the count afterwards. A push on 2026-08-11 did not disturb the
+VF, hugepages or VPP — but it reconfigured a different interface, so it
+never tested this path.
+
+### A verified FIB is not a complete one
+
+`fib-synced healthy — N routes installed; verified on 64 probes` means
+the probes matched the mirror. It does **not** mean the table is whole.
+
+Measured 2026-08-11 on a cold bring-up: `healthy` at **11.4 s with
+110,724 routes** — about 10% of the table — with 64 probes passing,
+because verify samples the ledger and the ledger was small. The full
+table arrived by 61 s.
+
+That is safe on its own, because a first attach never steers itself:
+`steer on` in the config is a staging state until an operator moves the
+lever. The exposure is the operator who moves it early.
+
+**`require-table-complete on` is what closes it**, and it is not
+optional on a box with a bird:
+
+```
+module vpp-offload
+  require-table-complete on
+```
+
+With it, `steer` refuses while the mirror disagrees with bird's count,
+reports why, and retries itself once the mirror converges. Without it
+there is no gate at all — the refusal path is compiled out — and the
+canary ladder is the only thing between an early lever-move and traffic
+diverted into a 10%-loaded FIB. `off` is the documented opt-out for
+boxes with no bird to compare against (the shadow), not a default to
+leave alone.
+
+### `packetframe status` disagrees with what you just did
+
+`status` reads `module-health.json`, which the loader rewrites every
+**5 s**. `packetframe reconfigure` returning `OK` therefore does not
+mean `status` has caught up — for up to five seconds it will show the
+previous state. Measured 2026-08-11: reconfigure returned OK and logged
+`steering UP`, `ethtool` showed four rules, and `status` still read
+`steer off (staging state)`.
+
+The snapshot is honest about it — the header says `(pid N, Ms old)` —
+so read that age before believing a status line that contradicts an
+action you just took. `ethtool -n <iface>` is the ground truth for
+steering; the log line `steering UP:` is the ground truth for when.
+
 ### `packetframe status` says STALE
 
 The daemon is gone; VPP is not being supervised. Check whether VPP is
@@ -471,12 +560,19 @@ Be precise about this when reasoning about an incident.
 | PMTUD through a steered path | **PASS** | frag-needed, mtu 1300, sourced from 169.254.254.3, ×5. Gate 0b item 7 closed. |
 | Steered packets reaching VPP | **PASS** | gate 0b item 1 closed 2026-08-07: allowlisted frames counted on octeon0/0, non-allowlisted stayed on the kernel path. |
 | Restart health window | Degraded ~40–80 s | see the note below — the deferral and reconcile are visible by design. |
+| `detach --all` | **2.814 s** | 2026-08-11 shadow, ONE VF with a live VPP holding 1.05M routes. Misses the published <1 s; see below. Breakdown: pins removed in 1 ms, then 2.80 s terminating VPP + rebinding the VF + restoring hugepages. |
+| Interconnect blip during `detach --all` | **none** | same run, 5 Hz ping from the primary across the teardown: zero gaps >0.5 s, one 30 ms spike. Writing `sriov_numvfs=0` does not disturb the PF link. |
+| `ip_route_dump` at adoption | **7.04 s** for 1,054,548 routes | 2026-08-11, timed directly rather than inferred from a traffic gap. This is the barrier-sync freeze §the deferral exists to keep away from steered traffic. |
+| Adopted restart, UNSTEERED | ~53 s start→verified | 2026-08-11. Dump at +7 s, deferral held 32.8 s waiting for the mirror, diff+verify after. No traffic impact — nothing was steered. |
+| Cold bring-up (nothing running) | **11.4 s to `healthy`, ≤61 s to full table** | 2026-08-11. Read the caveat: `healthy` at 11.4 s meant **110,724 routes** — 10% of the table, verified clean. See "A verified FIB is not a complete one". |
+| `reconfigure` (lever move) | **0.215 s** | 2026-08-11, exit 0, writes `OK <ns>` to `last-reconfigure.timestamp`. |
+| Idle draw with VPP polling one worker | 33.56 W, 38/49/42 °C, fan 3780 RPM | 2026-08-11 shadow, chassis total — NOT a VPP attribution, no VPP-off baseline was taken. |
 
 **Published but never measured:**
 
 | number | status |
 |---|---|
-| `detach` < 1 s across N VFs | UNMEASURED — the last shadow item; relaxes to a documented best-effort bound if hardware says so |
+| `detach` across **more than one** VF | UNMEASURED — the single-VF case is measured above at 2.814 s. Nothing has torn down N>1 VFs, and the per-VF cost is unknown. |
 
 ### A planned restart looks Degraded for 40-80 seconds. Do not page on it.
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -442,16 +442,30 @@ leave alone.
 ### `packetframe status` disagrees with what you just did
 
 `status` reads `module-health.json`, which the loader rewrites every
-**5 s**. `packetframe reconfigure` returning `OK` therefore does not
-mean `status` has caught up — for up to five seconds it will show the
-previous state. Measured 2026-08-11: reconfigure returned OK and logged
-`steering UP`, `ethtool` showed four rules, and `status` still read
-`steer off (staging state)`.
+**5 s** — so it is a snapshot, and the header says how old:
+`(pid N, Ms old)`. Read that age before believing a line that
+contradicts something you just did.
 
-The snapshot is honest about it — the header says `(pid N, Ms old)` —
-so read that age before believing a status line that contradicts an
-action you just took. `ethtool -n <iface>` is the ground truth for
-steering; the log line `steering UP:` is the ground truth for when.
+**After a `reconfigure` it is not stale.** The SIGHUP handler refreshes
+the health file *before* writing the acknowledgement marker the CLI
+waits on, so by the time `packetframe reconfigure` returns, `status`
+already reflects the change. That was not true before 2026-08-11: a
+reconfigure returned OK and logged `steering UP`, `ethtool` showed the
+rules installed, and `status` still read `steer off (staging state)`
+from a five-second-old snapshot.
+
+Two cases where the age still matters:
+
+- **A rejected reload publishes nothing.** A config that fails to parse
+  or validate returns without refreshing, so `status` keeps whatever it
+  had until the next scheduled poll.
+- **Changes the module makes on its own** — a verify completing, a
+  process dying, steering torn down by trouble — land on the ordinary
+  5 s cadence, because nothing is waiting on them.
+
+Ground truth, when you need it rather than a snapshot: `ethtool -n
+<iface>` for what the NIC holds, and the `steering UP:` / `steering
+DOWN:` log lines for when it changed.
 
 ### `packetframe status` says STALE
 


### PR DESCRIPTION
First hardware session against merged #153/#154. Four findings; one of them warranted a code fix.

## Measured for the first time

| | result |
|---|---|
| `detach --all` | **2.814 s** (1 VF, live VPP w/ 1.05M routes) — **misses the published `<1 s`** |
| interconnect blip during that detach | **none** — zero ping gaps >0.5 s across the teardown |
| `ip_route_dump` at adoption | **7.04 s** for 1,054,548 routes — the barrier freeze, timed directly |
| adopted restart, unsteered | ~53 s start→verified (dump +7 s, deferral held 32.8 s) |
| cold bring-up | **11.4 s to `healthy`**, ≤61 s to full table |
| `reconfigure` (lever move) | 0.215 s, exit 0 |

## Findings

**1. `detach --all` misses its contract.** The cost is VPP's exit plus VF rebind plus hugepage restore — all *after* `stop()` returns, so `stop()` keeps its own 900 ms promise. `DETACH_BUDGET` is annotated rather than raised, since raising it wouldn't touch the real cost. The runbook's last UNMEASURED row becomes measured; the honest remaining unknown is N>1 VFs.

**2. Steering can go silently partial.** A rule deleted out of band was still missing two minutes later — `steering healthy`, no log line, ledger still claiming four. Nothing polls the NIC; only `VerifyPassed` re-emits `Action::Steer`, and verify doesn't recur in steady state. Impact is bounded: that traffic falls back to the eBPF tier, which is correct. What's lost is knowing. **A plain `reconfigure` repairs it** (3→4, no lever movement, no restart) because `steer` is a reconcile. Detection + remedy are now in triage, with instructions to run it after every provisioning push.

**3. A verified FIB is not a complete one.** Cold bring-up reported `healthy` at 110,724 routes — 10% of the table — with 64 probes passing, because verify samples the ledger. Safe alone (first attach never steers itself); the exposure is an early lever-move, and `require-table-complete on` is the only thing that refuses it.

**4. `status` lagged `reconfigure` by up to 5 s** — it reads `module-health.json`, rewritten on the loader's `MODULE_POLL_INTERVAL`, not the window the service publishes to. **Fixed**: the SIGHUP path refreshes health *before* writing the marker the CLI waits on. Same shape as the service's publish-before-answer rule, one layer up.

## Also

The runbook opened with *"No part of this module has ever run against a real VPP process"* — false since 2026-08-05, and the first thing an operator reads. Replaced with what has and hasn't run.

## Deliberately not included

Automatic NIC/ledger drift detection. It's an enhancement beyond the finding, needs new state through three layers, and the documented detect-and-repair works today. It wants its own PR with a failing test written first.

Local: workspace tests green ×2, clippy clean by exit code on host and all four Linux targets.