### PR TITLE
fix(vpp-offload): name a remedy the module will actually accept — and make the retry work

### DIFF
--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1797,9 +1797,11 @@ impl Effects for EffectsView {
                 return Err(format!(
                     "refusing to steer: {}. Traffic would be diverted into a table that \
                      cannot forward it, and a steered miss is dropped rather than falling \
-                     back to the kernel path. This retries on its own once the mirror \
-                     converges; `require-table-complete off` opts out where there is no \
-                     bird to compare against",
+                     back to the kernel path. NOTHING RETRIES THIS: the want is \
+                     remembered, but only a convergence or `packetframe reconfigure` \
+                     emits another steer, so re-run it once the mirror has caught up. \
+                     `require-table-complete off` opts out where there is no bird to \
+                     compare against",
                     verdict.describe()
                 ));
             }

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -855,7 +855,7 @@ fn apply_steering(
     req: &SteeringRequest,
 ) -> Result<(), String> {
     let state = driver.state();
-    if !matches!(state, State::Ready | State::Steered) {
+    if !state.accepts_steering_changes() {
         // Deliberately refused rather than queued. A steer request that
         // outlives a crash and fires against the replacement is not what
         // the operator asked for, and the replacement re-steers on its

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -870,6 +870,23 @@ fn apply_steering(
     runtime.retarget(req.ports.clone(), req.plan.clone());
 
     let steered = driver.supervisor().is_steered();
+    // INTENDED, not steered. The two differ in exactly the case an
+    // operator hits after a refusal: a steer that was asked for and
+    // failed leaves `steered == false` with the want remembered, so
+    // guarding on `steered` sent an unchanged-config `reconfigure`
+    // down the staging path — returning `Ok` without injecting
+    // anything. The advertised retry reported success and did nothing
+    // (review finding).
+    //
+    // `steer_intended()` is the predicate for this and says so: "a
+    // `steer on` port that has never yet steered and never failed to
+    // reads as not-wanted here. The distinction is real — one is the
+    // designed staging state, the other is a rollout that broke."
+    // `steer_wanted` is set only by adoption-while-steered, an explicit
+    // request, a death or wedge while steered, and a failed steer —
+    // never by config intent alone, so a first attach still waits for
+    // the operator's canary.
+    let intended = driver.supervisor().steer_intended();
     let event = if req.want_steer {
         // The config says steer, but that is not the same as the
         // operator asking for it NOW.
@@ -882,7 +899,7 @@ fn apply_steering(
         // updates the target and stops there. Diverting traffic as a side
         // effect of editing something else is precisely the decision this
         // module is not allowed to make.
-        if !steered && !req.lever_moved {
+        if !intended && !req.lever_moved {
             return Ok(());
         }
         // The same gate the automatic path uses, and applied on the same

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -854,13 +854,14 @@ impl StatusSnapshot {
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
                  not be. The rules outlived the request to remove them; `ethtool -n \
-                 <iface>` lists what is installed. Act rather than wait — while VPP is \
-                 not forwarding, that traffic is going to a VF nothing is servicing — but \
-                 remove only rules you can match to an `allow-prefix` from this config \
-                 steered at VPP's VF (`ethtool -N <iface> delete <loc>`). Targeting the \
-                 VF is not proof on its own, and after a restart this audit cannot prove \
-                 a slot still holds ours; deleting another rule breaks its traffic. \
-                 `packetframe reconfigure` also clears them wherever it is accepted",
+                 reconfigure` clears them BY LEDGER ENTRY and needs no identification, \
+                 so try it first; it reports its own reason if it will not run. Do not \
+                 wait for a convergence — while VPP is not forwarding, that traffic is \
+                 going to a VF nothing is servicing. Removing by hand (`ethtool -n \
+                 <iface>`, then `ethtool -N <iface> delete <loc>`) is the fallback where \
+                 reconfigure cannot run, and needs care: a rule for a prefix just removed \
+                 from the allowlist no longer matches this config, so the config is not \
+                 the test. The runbook has the field table",
                 self.steer_stray
             ));
         }
@@ -1622,8 +1623,8 @@ mod tests {
                 let msg = steering.message.as_deref().unwrap_or_default();
                 assert!(
                     msg.contains("ethtool -N <iface> delete <loc>"),
-                    "state {state:?}: a rule that is diverting traffic must always name \
-                     the removal that works from here: {msg}"
+                    "state {state:?}: the hand removal must still be named — it is the \
+                     fallback wherever `reconfigure` cannot run: {msg}"
                 );
                 assert!(
                     !msg.contains("only if it verifies clean"),
@@ -1632,12 +1633,12 @@ mod tests {
                      dropping that prefix, not merely losing the offload: {msg}"
                 );
                 assert!(
-                    msg.contains("`allow-prefix` from this config")
-                        && msg.contains("not proof on its own"),
-                    "state {state:?}: and must not hand them a categorical test the \
-                     audit itself does not have. The ring cookie names the VF, not the \
-                     owner — this module already learned that twice — so the line has \
-                     to name the conjunction and say it is not proof: {msg}"
+                    msg.contains("BY LEDGER ENTRY")
+                        && msg.contains("no longer matches this config"),
+                    "state {state:?}: lead with the repair that needs no identification, \
+                     and warn about the trap in the one that does — a rule for a prefix \
+                     just removed from the allowlist cannot match the current config, \
+                     which is exactly the stray an allowlist shrink produces: {msg}"
                 );
             }
         }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -766,9 +766,26 @@ impl StatusSnapshot {
         // reconcile.
         let remedy = if self.state.accepts_steering_changes() {
             "`packetframe reconfigure` reconciles either way"
+        } else if matches!(self.state, State::Stopped) {
+            // Nothing is running and nothing is trying to, so there is
+            // no convergence coming to fix this. Reachable and nasty:
+            // `StopRequested` assigns `Stopped` before knowing whether
+            // `Unsteer` succeeded, a refused removal keeps the rules in
+            // the ledger, and the final status is published either way
+            // — so this is precisely the snapshot that reports rules
+            // still diverting traffic into a VF whose VPP has just been
+            // killed. Telling that operator to wait would be the worst
+            // of the three answers (review finding).
+            "supervision has stopped, so nothing will reconcile this on its own: \
+             `packetframe detach --all` retries the teardown, and `ethtool -N <iface> \
+             delete <loc>` removes a rule by hand"
         } else {
-            "steering is reconciled automatically when this resync finishes and the FIB \
-             verifies; `packetframe reconfigure` is refused until then, and says so"
+            // A convergence is in flight or is coming (`Backoff` has no
+            // resync running yet, which is why this does not say "this
+            // resync").
+            "steering is reconciled automatically once the module converges again — the \
+             verify that ends a resync re-emits the steer; `packetframe reconfigure` is \
+             refused until then, and says so"
         };
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
@@ -1389,18 +1406,29 @@ mod tests {
                 .find(|s| s.name == SUBSYS_STEERING)
                 .expect("steering row");
             let msg = steering.message.as_deref().unwrap_or_default();
-            assert_eq!(
-                msg.contains("`packetframe reconfigure` reconciles"),
-                state.accepts_steering_changes(),
-                "state {state:?}: the line may name `reconfigure` as the fix only where \
-                 that command is accepted. Everywhere else it is refused, and an operator \
-                 following the health text gets 'not converged': {msg}"
-            );
-            if !state.accepts_steering_changes() {
-                assert!(
-                    msg.contains("reconciled automatically"),
-                    "state {state:?}: where the command is refused the line must say what \
-                     DOES happen — the verify that ends the resync re-emits the steer: {msg}"
+            // Three remedies, and exactly one may appear: run the
+            // command, wait for the convergence, or clean up by hand.
+            // Asserting the other two ABSENT is what makes this a
+            // classification rather than three independent contains().
+            let expected = if state.accepts_steering_changes() {
+                "`packetframe reconfigure` reconciles"
+            } else if matches!(state, State::Stopped) {
+                "supervision has stopped"
+            } else {
+                "reconciled automatically"
+            };
+            for marker in [
+                "`packetframe reconfigure` reconciles",
+                "supervision has stopped",
+                "reconciled automatically",
+            ] {
+                assert_eq!(
+                    msg.contains(marker),
+                    marker == expected,
+                    "state {state:?} must offer exactly the remedy that state admits, \
+                     and no other. `reconfigure` is refused outside Ready/Steered; a \
+                     convergence is coming everywhere except Stopped, where nothing \
+                     will ever reconcile this and the operator has to clean up: {msg}"
                 );
             }
         }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -854,13 +854,13 @@ impl StatusSnapshot {
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
                  not be. The rules outlived the request to remove them; `ethtool -n \
-                 <iface>` lists them, and ours are the ones whose action targets VPP's \
-                 VF. Delete those (`ethtool -N <iface> delete <loc>`) rather than waiting \
-                 — while VPP is not forwarding, that traffic is going to a VF nothing is \
-                 servicing. Check before removing: after a restart this audit cannot \
-                 always prove a location still holds OUR rule, and deleting another \
-                 breaks its traffic. `packetframe reconfigure` also clears them wherever \
-                 it is accepted",
+                 <iface>` lists what is installed. Act rather than wait — while VPP is \
+                 not forwarding, that traffic is going to a VF nothing is servicing — but \
+                 remove only rules you can match to an `allow-prefix` from this config \
+                 steered at VPP's VF (`ethtool -N <iface> delete <loc>`). Targeting the \
+                 VF is not proof on its own, and after a restart this audit cannot prove \
+                 a slot still holds ours; deleting another rule breaks its traffic. \
+                 `packetframe reconfigure` also clears them wherever it is accepted",
                 self.steer_stray
             ));
         }
@@ -1632,11 +1632,12 @@ mod tests {
                      dropping that prefix, not merely losing the offload: {msg}"
                 );
                 assert!(
-                    msg.contains("targets VPP's VF") && msg.contains("Check before removing"),
-                    "state {state:?}: and must not send them deleting blind — after a \
-                     restart the audit reports an occupied slot without proving it is \
-                     ours, and `ethtool -N ... delete` is destructive to whatever is \
-                     actually there: {msg}"
+                    msg.contains("`allow-prefix` from this config")
+                        && msg.contains("not proof on its own"),
+                    "state {state:?}: and must not hand them a categorical test the \
+                     audit itself does not have. The ring cookie names the VF, not the \
+                     owner — this module already learned that twice — so the line has \
+                     to name the conjunction and say it is not proof: {msg}"
                 );
             }
         }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -764,28 +764,47 @@ impl StatusSnapshot {
         // 2026-08-11). The repair does arrive on its own: the verify
         // that ends the resync re-emits the steer, and `steer` is a
         // reconcile.
+        // Four answers, because there are four situations and giving
+        // the wrong one sends an operator somewhere useless.
+        let cleanup = "`packetframe detach --all` retries the teardown, and `ethtool -N \
+                       <iface> delete <loc>` removes a rule by hand";
         let remedy = if self.state.accepts_steering_changes() {
-            "`packetframe reconfigure` reconciles either way"
+            "`packetframe reconfigure` reconciles either way".to_string()
         } else if matches!(self.state, State::Stopped) {
-            // Nothing is running and nothing is trying to, so there is
-            // no convergence coming to fix this. Reachable and nasty:
-            // `StopRequested` assigns `Stopped` before knowing whether
-            // `Unsteer` succeeded, a refused removal keeps the rules in
-            // the ledger, and the final status is published either way
-            // — so this is precisely the snapshot that reports rules
-            // still diverting traffic into a VF whose VPP has just been
-            // killed. Telling that operator to wait would be the worst
-            // of the three answers (review finding).
-            "supervision has stopped, so nothing will reconcile this on its own: \
-             `packetframe detach --all` retries the teardown, and `ethtool -N <iface> \
-             delete <loc>` removes a rule by hand"
+            // Nothing is running and nothing is trying to. Reachable and
+            // nasty: `StopRequested` assigns `Stopped` before knowing
+            // whether `Unsteer` succeeded, a refused removal keeps the
+            // rules in the ledger, and the final status is published
+            // either way — so this is precisely the snapshot reporting
+            // rules that still divert traffic into a VF whose VPP has
+            // just been killed (review finding).
+            format!("supervision has stopped, so nothing will reconcile this on its own: {cleanup}")
+        } else if !self.steer_configured {
+            // A convergence is coming and it will NOT clear these.
+            // `VerifyPassed` re-steers while `steered || steer_wanted`,
+            // and a refused `unsteer` deliberately keeps `steered` true
+            // — but `steer` refuses an empty target before reaching its
+            // stale-rule removal, also deliberately, because `Ok` there
+            // becomes `Event::Steered` and would report an offload
+            // carrying traffic it never saw. So a `steer off` whose
+            // removal failed retries that refusal on every convergence
+            // while the rules keep diverting traffic. The product gap is
+            // filed; what this line must not do is promise a repair that
+            // cannot happen (review finding).
+            format!(
+                "no port is configured to steer, so convergence cannot clear these — \
+                 `steer` refuses an empty target rather than report an offload it never \
+                 installed: {cleanup}"
+            )
         } else {
             // A convergence is in flight or is coming (`Backoff` has no
             // resync running yet, which is why this does not say "this
-            // resync").
+            // resync"), and the target it will reconcile to is non-empty,
+            // so its stale-rule removal covers whatever is left over.
             "steering is reconciled automatically once the module converges again — the \
              verify that ends a resync re-emits the steer; `packetframe reconfigure` is \
              refused until then, and says so"
+                .to_string()
         };
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
@@ -1386,50 +1405,62 @@ mod tests {
         }
 
         for state in states {
-            let led = ledger_with(10, 0, 0);
-            let mut snap = snap_of(
-                &steered_supervisor(),
-                &led,
-                ApiHealth::Answering {
-                    silent_for: Duration::from_millis(200),
-                },
-                verified(3),
-                ports_up(),
-            );
-            snap.state = state;
-            snap.steer_missing = 1;
-
-            let rep = snap.report();
-            let steering = rep
-                .subsystems
-                .iter()
-                .find(|s| s.name == SUBSYS_STEERING)
-                .expect("steering row");
-            let msg = steering.message.as_deref().unwrap_or_default();
-            // Three remedies, and exactly one may appear: run the
-            // command, wait for the convergence, or clean up by hand.
-            // Asserting the other two ABSENT is what makes this a
-            // classification rather than three independent contains().
-            let expected = if state.accepts_steering_changes() {
-                "`packetframe reconfigure` reconciles"
-            } else if matches!(state, State::Stopped) {
-                "supervision has stopped"
-            } else {
-                "reconciled automatically"
-            };
-            for marker in [
-                "`packetframe reconfigure` reconciles",
-                "supervision has stopped",
-                "reconciled automatically",
-            ] {
-                assert_eq!(
-                    msg.contains(marker),
-                    marker == expected,
-                    "state {state:?} must offer exactly the remedy that state admits, \
-                     and no other. `reconfigure` is refused outside Ready/Steered; a \
-                     convergence is coming everywhere except Stopped, where nothing \
-                     will ever reconcile this and the operator has to clean up: {msg}"
+            for steer_configured in [true, false] {
+                let led = ledger_with(10, 0, 0);
+                let mut snap = snap_of(
+                    &steered_supervisor(),
+                    &led,
+                    ApiHealth::Answering {
+                        silent_for: Duration::from_millis(200),
+                    },
+                    verified(3),
+                    ports_up(),
                 );
+                snap.state = state;
+                snap.steer_configured = steer_configured;
+                // Both clauses share the remedy, so set both and assert
+                // on the remedy alone.
+                snap.steer_missing = 1;
+                snap.steer_stray = 1;
+
+                let rep = snap.report();
+                let steering = rep
+                    .subsystems
+                    .iter()
+                    .find(|s| s.name == SUBSYS_STEERING)
+                    .expect("steering row");
+                let msg = steering.message.as_deref().unwrap_or_default();
+
+                // Exactly one of the four may appear. Asserting the
+                // other three ABSENT is what makes this a
+                // classification rather than four independent
+                // contains() that could all drift true.
+                let expected = if state.accepts_steering_changes() {
+                    "`packetframe reconfigure` reconciles"
+                } else if matches!(state, State::Stopped) {
+                    "supervision has stopped"
+                } else if !steer_configured {
+                    "no port is configured to steer"
+                } else {
+                    "reconciled automatically"
+                };
+                for marker in [
+                    "`packetframe reconfigure` reconciles",
+                    "supervision has stopped",
+                    "no port is configured to steer",
+                    "reconciled automatically",
+                ] {
+                    assert_eq!(
+                        msg.contains(marker),
+                        marker == expected,
+                        "state {state:?}, steer_configured={steer_configured}: the line \
+                         must offer exactly the remedy this situation admits. \
+                         `reconfigure` is refused outside Ready/Steered; a stopped \
+                         daemon reconciles nothing; and with no port configured to \
+                         steer, `steer` refuses the empty target before it would clear \
+                         the leftovers, so convergence cannot fix it either: {msg}"
+                    );
+                }
             }
         }
     }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -840,7 +840,6 @@ impl StatusSnapshot {
         //
         // So it names the removal that works from anywhere, always,
         // and never defers to a convergence.
-        let stray_remedy = "remove them with `ethtool -N <iface> delete <loc>` rather than                             wait — while VPP is not forwarding, that traffic is going to a                             VF nothing is servicing. `packetframe reconfigure` also clears                             them wherever it is accepted";
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
             // "Still occupied", not "still ours". Where the outgoing
@@ -854,7 +853,13 @@ impl StatusSnapshot {
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
                  not be. The rules outlived the request to remove them; `ethtool -n \
-                 <iface>` shows what is there. {stray_remedy}",
+                 <iface>` lists them, and ours are the ones whose action targets VPP's \
+                 VF. Delete those (`ethtool -N <iface> delete <loc>`) rather than waiting \
+                 — while VPP is not forwarding, that traffic is going to a VF nothing is \
+                 servicing. Check before removing: after a restart this audit cannot \
+                 always prove a location still holds OUR rule, and deleting another \
+                 breaks its traffic. `packetframe reconfigure` also clears them wherever \
+                 it is accepted",
                 self.steer_stray
             ));
         }
@@ -1515,6 +1520,57 @@ mod tests {
         }
     }
 
+    /// No health message contains a run of whitespace.
+    ///
+    /// Cheap guard for a class rather than an instance: `dfdc9b8`
+    /// shipped a remedy bound as `let x = "... \` + continuation`,
+    /// which rustfmt joined onto one line while KEEPING the source
+    /// indentation inside the literal — so the operator's line read
+    /// "rather than" followed by thirty spaces. Every assertion in
+    /// these tests matches a short fragment, and no fragment spanned
+    /// the gap, so all of them passed over it.
+    #[test]
+    fn no_health_message_carries_mangled_whitespace() {
+        for state in [
+            State::Backoff,
+            State::Ready,
+            State::Steered,
+            State::AdoptedResyncing,
+        ] {
+            for (missing, stray, unreadable) in [
+                (1usize, 0usize, None),
+                (0, 1, None),
+                (1, 1, Some("EIO: readback failed".to_string())),
+                (0, 0, Some("EIO: readback failed".to_string())),
+            ] {
+                let led = ledger_with(10, 0, 0);
+                let mut snap = snap_of(
+                    &steered_supervisor(),
+                    &led,
+                    ApiHealth::Answering {
+                        silent_for: Duration::from_millis(200),
+                    },
+                    verified(3),
+                    ports_up(),
+                );
+                snap.state = state;
+                snap.steer_missing = missing;
+                snap.steer_stray = stray;
+                snap.steer_audit_unreadable = unreadable.clone();
+
+                for sub in snap.report().subsystems {
+                    let Some(msg) = sub.message else { continue };
+                    assert!(
+                        !msg.contains("   "),
+                        "{} in {state:?} renders a whitespace run — a line an operator \
+                         reads at 3am, mangled by a source-formatting artefact: {msg:?}",
+                        sub.name
+                    );
+                }
+            }
+        }
+    }
+
     /// A stray rule never gets told to wait, in any state.
     ///
     /// The two complaints differ in what waiting costs. A MISSING rule
@@ -1573,6 +1629,13 @@ mod tests {
                     "state {state:?}: and must never defer to a convergence — with a \
                      refused unsteer the rules outlive the process, so waiting means \
                      dropping that prefix, not merely losing the offload: {msg}"
+                );
+                assert!(
+                    msg.contains("targets VPP's VF") && msg.contains("Check before removing"),
+                    "state {state:?}: and must not send them deleting blind — after a \
+                     restart the audit reports an occupied slot without proving it is \
+                     ours, and `ethtool -N ... delete` is destructive to whatever is \
+                     actually there: {msg}"
                 );
             }
         }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -752,6 +752,24 @@ impl StatusSnapshot {
         // pulling traffic OFF a port is the one case where "steering
         // healthy" is the most expensive possible answer (review
         // finding).
+        //
+        // The remedy depends on the lifecycle state, and saying so is
+        // the point. `packetframe reconfigure` reconciles steering only
+        // from a state that accepts steering changes; during an adopted
+        // resync it is refused. That is not a corner — a held deferral
+        // is the state this audit was written for, and on a box with no
+        // completeness authority it can hold indefinitely, so the line
+        // shipped promising a command that answers "not converged" in
+        // exactly the case it appears most (measured on the shadow,
+        // 2026-08-11). The repair does arrive on its own: the verify
+        // that ends the resync re-emits the steer, and `steer` is a
+        // reconcile.
+        let remedy = if self.state.accepts_steering_changes() {
+            "`packetframe reconfigure` reconciles either way"
+        } else {
+            "steering is reconciled automatically when this resync finishes and the FIB \
+             verifies; `packetframe reconfigure` is refused until then, and says so"
+        };
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
             // "Still occupied", not "still ours". Where the outgoing
@@ -765,7 +783,7 @@ impl StatusSnapshot {
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
                  not be. The rules outlived the request to remove them; `ethtool -n \
-                 <iface>` shows what is there and `packetframe reconfigure` clears them",
+                 <iface>` shows what is there, and {remedy}",
                 self.steer_stray
             ));
         }
@@ -775,7 +793,7 @@ impl StatusSnapshot {
                  longer match what was asked for, or were never installed — that traffic \
                  is on the eBPF tier. Something changed them out of band (a UniFi \
                  provisioning push does this), or the allowlist grew while the inherited \
-                 rules stayed as they were; `packetframe reconfigure` reconciles either way",
+                 rules stayed as they were; {remedy}",
                 self.steer_missing
             ));
         }
@@ -1304,6 +1322,88 @@ mod tests {
             msg.contains("cannot verify") && msg.contains("EIO"),
             "the line must say it could not check, and why: {msg}"
         );
+    }
+
+    /// The remedy the drift line names must be one the module accepts.
+    ///
+    /// Measured on the shadow 2026-08-11: an out-of-band `ethtool -N
+    /// eth1 delete 12` was detected in under 20 s and reported
+    /// `steering DEGRADED ... packetframe reconfigure reconciles either
+    /// way`. Running that command answered *"vpp-offload is
+    /// AdoptedResyncing, not converged — steering changes apply only
+    /// from Ready or Steered"*. The line pointed an operator at a wall,
+    /// in the very state the audit exists to report: an adopted
+    /// deferral, which on a box with no completeness authority holds
+    /// indefinitely.
+    ///
+    /// Asserted as an INVARIANT over every state rather than for the one
+    /// that bit us. The message and `apply_steering`'s gate now read the
+    /// same predicate, and this is what keeps them from drifting apart
+    /// again.
+    #[test]
+    fn the_drift_remedy_matches_the_gate_that_governs_it() {
+        let states = [
+            State::Stopped,
+            State::Backoff,
+            State::Starting,
+            State::Syncing,
+            State::Verifying,
+            State::Ready,
+            State::Steered,
+            State::AdoptedResyncing,
+        ];
+        // Tripwire: a new variant makes this match non-exhaustive, so it
+        // cannot be added without deciding what its drift line should
+        // tell an operator to do.
+        for s in states {
+            match s {
+                State::Stopped
+                | State::Backoff
+                | State::Starting
+                | State::Syncing
+                | State::Verifying
+                | State::Ready
+                | State::Steered
+                | State::AdoptedResyncing => {}
+            }
+        }
+
+        for state in states {
+            let led = ledger_with(10, 0, 0);
+            let mut snap = snap_of(
+                &steered_supervisor(),
+                &led,
+                ApiHealth::Answering {
+                    silent_for: Duration::from_millis(200),
+                },
+                verified(3),
+                ports_up(),
+            );
+            snap.state = state;
+            snap.steer_missing = 1;
+
+            let rep = snap.report();
+            let steering = rep
+                .subsystems
+                .iter()
+                .find(|s| s.name == SUBSYS_STEERING)
+                .expect("steering row");
+            let msg = steering.message.as_deref().unwrap_or_default();
+            assert_eq!(
+                msg.contains("`packetframe reconfigure` reconciles"),
+                state.accepts_steering_changes(),
+                "state {state:?}: the line may name `reconfigure` as the fix only where \
+                 that command is accepted. Everywhere else it is refused, and an operator \
+                 following the health text gets 'not converged': {msg}"
+            );
+            if !state.accepts_steering_changes() {
+                assert!(
+                    msg.contains("reconciled automatically"),
+                    "state {state:?}: where the command is refused the line must say what \
+                     DOES happen — the verify that ends the resync re-emits the steer: {msg}"
+                );
+            }
+        }
     }
 
     /// Rules still steering a port the config turned OFF degrade it.

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -812,9 +812,10 @@ impl StatusSnapshot {
             // resync running yet, which is why this does not say "this
             // resync"), and the target it will reconcile to is non-empty,
             // so its stale-rule removal covers whatever is left over.
-            "steering is reconciled automatically once the module converges again — the \
-             verify that ends a resync re-emits the steer; `packetframe reconfigure` is \
-             refused until then, and says so"
+            "steering is re-applied by the next convergence — the verify that ends it \
+             emits the steer. That steer passes the completeness gate too and can be \
+             refused there, and nothing retries afterwards, so if this line outlives the \
+             convergence, `packetframe reconfigure` is the retry"
                 .to_string()
         };
         let mut clauses: Vec<String> = Vec::new();
@@ -1453,13 +1454,13 @@ mod tests {
                 } else if !steer_configured {
                     "no port is configured to steer"
                 } else {
-                    "reconciled automatically"
+                    "re-applied by the next convergence"
                 };
                 for marker in [
                     "`packetframe reconfigure` re-applies steering",
                     "supervision has stopped",
                     "no port is configured to steer",
-                    "reconciled automatically",
+                    "re-applied by the next convergence",
                 ] {
                     assert_eq!(
                         msg.contains(marker),

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -853,15 +853,15 @@ impl StatusSnapshot {
                 "{} location(s) the ledger names are still occupied by rules this config \
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
-                 not be. The rules outlived the request to remove them; `ethtool -n \
-                 reconfigure` clears them BY LEDGER ENTRY and needs no identification, \
-                 so try it first; it reports its own reason if it will not run. Do not \
-                 wait for a convergence — while VPP is not forwarding, that traffic is \
-                 going to a VF nothing is servicing. Removing by hand (`ethtool -n \
-                 <iface>`, then `ethtool -N <iface> delete <loc>`) is the fallback where \
-                 reconfigure cannot run, and needs care: a rule for a prefix just removed \
-                 from the allowlist no longer matches this config, so the config is not \
-                 the test. The runbook has the field table",
+                 not be. The rules outlived the request to remove them. `packetframe \
+                 reconfigure` removes exactly the locations the ledger names, so nothing \
+                 has to be identified by eye — but it deletes BY LOCATION, so it can no \
+                 more prove they still hold OUR rules than this audit can. Do not wait \
+                 for a convergence: while VPP is not forwarding, that traffic is going to \
+                 a VF nothing is servicing. Where reconfigure will not run, remove by \
+                 hand (`ethtool -n <iface>`, then `ethtool -N <iface> delete <loc>`); the \
+                 current allowlist is not the test, since the commonest stray is a prefix \
+                 just removed from it. The runbook has the field table",
                 self.steer_stray
             ));
         }
@@ -1522,6 +1522,93 @@ mod tests {
         }
     }
 
+    /// Every backticked command in a health message is well-formed.
+    ///
+    /// Twice in one PR a scripted edit shipped a broken operator
+    /// command — first a literal with thirty spaces in it, then
+    /// `` `ethtool -n reconfigure` `` where `` `packetframe
+    /// reconfigure` `` was meant — and both times every assertion
+    /// passed, because they all match short fragments and none spans
+    /// the damage. Matching fragments cannot show a command is intact.
+    ///
+    /// So: collect every backticked span these messages render and
+    /// require it to be one this module means to print. A new one has
+    /// to be added here deliberately, which is the point.
+    #[test]
+    fn every_backticked_command_is_one_we_meant_to_print() {
+        const ALLOWED: &[&str] = &[
+            "packetframe reconfigure",
+            "packetframe detach --all",
+            "ethtool -n <iface>",
+            "ethtool -N <iface> delete <loc>",
+            "steer",
+            "require-table-complete off",
+        ];
+        let mut seen: Vec<String> = Vec::new();
+        for state in [
+            State::Stopped,
+            State::Backoff,
+            State::Starting,
+            State::Syncing,
+            State::Verifying,
+            State::Ready,
+            State::Steered,
+            State::AdoptedResyncing,
+        ] {
+            for steer_configured in [true, false] {
+                for (missing, stray, unreadable) in [
+                    (1usize, 0usize, None),
+                    (0, 1, None),
+                    (1, 1, Some("EIO: readback failed".to_string())),
+                    (0, 0, Some("EIO: readback failed".to_string())),
+                    (0, 0, None),
+                ] {
+                    let led = ledger_with(10, 0, 0);
+                    let mut snap = snap_of(
+                        &steered_supervisor(),
+                        &led,
+                        ApiHealth::Answering {
+                            silent_for: Duration::from_millis(200),
+                        },
+                        verified(3),
+                        ports_up(),
+                    );
+                    snap.state = state;
+                    snap.steer_configured = steer_configured;
+                    snap.steer_missing = missing;
+                    snap.steer_stray = stray;
+                    snap.steer_audit_unreadable = unreadable.clone();
+
+                    for sub in snap.report().subsystems {
+                        let Some(msg) = sub.message else { continue };
+                        let mut rest = msg.as_str();
+                        while let Some(open) = rest.find('`') {
+                            rest = &rest[open + 1..];
+                            let Some(close) = rest.find('`') else { break };
+                            let span = &rest[..close];
+                            rest = &rest[close + 1..];
+                            if !seen.iter().any(|s| s == span) {
+                                seen.push(span.to_string());
+                            }
+                            assert!(
+                                ALLOWED.contains(&span),
+                                "{} in {state:?} prints `{span}`, which is not a command \
+                                 this module means to emit. Either it is mangled — the \
+                                 way `ethtool -n reconfigure` was — or it is new and \
+                                 belongs in ALLOWED. Full line: {msg}",
+                                sub.name
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        assert!(
+            seen.len() >= 4,
+            "the matrix must actually render commands, or this proves nothing: {seen:?}"
+        );
+    }
+
     /// No health message contains a run of whitespace.
     ///
     /// Cheap guard for a class rather than an instance: `dfdc9b8`
@@ -1633,8 +1720,8 @@ mod tests {
                      dropping that prefix, not merely losing the offload: {msg}"
                 );
                 assert!(
-                    msg.contains("BY LEDGER ENTRY")
-                        && msg.contains("no longer matches this config"),
+                    msg.contains("removes exactly the locations the ledger names")
+                        && msg.contains("current allowlist is not the test"),
                     "state {state:?}: lead with the repair that needs no identification, \
                      and warn about the trap in the one that does — a rule for a prefix \
                      just removed from the allowlist cannot match the current config, \

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -766,8 +766,13 @@ impl StatusSnapshot {
         // reconcile.
         // Four answers, because there are four situations and giving
         // the wrong one sends an operator somewhere useless.
-        let cleanup = "`packetframe detach --all` retries the teardown, and `ethtool -N \
-                       <iface> delete <loc>` removes a rule by hand";
+        // No shared cleanup string: the two arms below differ in
+        // whether the daemon is still running, and that is exactly what
+        // decides which command works. `loader::detach` refuses outright
+        // while a `packetframe run` pid exists — the daemon holds the
+        // bpf_link FDs — so telling a live module to run it is a second
+        // refusal (review finding). Factoring these together was a DRY
+        // move that erased the distinguishing fact.
         let remedy = if self.state.accepts_steering_changes() {
             // NAMES the repair; does not promise it will succeed. The
             // state gate this arm reads is not the only one — the steer
@@ -789,7 +794,10 @@ impl StatusSnapshot {
             // either way — so this is precisely the snapshot reporting
             // rules that still divert traffic into a VF whose VPP has
             // just been killed (review finding).
-            format!("supervision has stopped, so nothing will reconcile this on its own: {cleanup}")
+            "supervision has stopped, so nothing will reconcile this on its own: with the \
+             daemon exited, `packetframe detach --all` retries the teardown, and `ethtool \
+             -N <iface> delete <loc>` removes a rule by hand"
+                .to_string()
         } else if !self.steer_configured {
             // A convergence is coming and it will NOT clear these.
             // `VerifyPassed` re-steers while `steered || steer_wanted`,
@@ -802,11 +810,11 @@ impl StatusSnapshot {
             // while the rules keep diverting traffic. The product gap is
             // filed; what this line must not do is promise a repair that
             // cannot happen (review finding).
-            format!(
-                "no port is configured to steer, so convergence cannot clear these — \
-                 `steer` refuses an empty target rather than report an offload it never \
-                 installed: {cleanup}"
-            )
+            "no port is configured to steer, so convergence cannot clear these — `steer` \
+             refuses an empty target rather than report an offload it never installed. \
+             Remove them with `ethtool -N <iface> delete <loc>`; `packetframe detach \
+             --all` also retries the teardown, but refuses while this daemon is running"
+                .to_string()
         } else {
             // A convergence is in flight or is coming (`Backoff` has no
             // resync running yet, which is why this does not say "this
@@ -1471,6 +1479,19 @@ mod tests {
                          daemon reconciles nothing; and with no port configured to \
                          steer, `steer` refuses the empty target before it would clear \
                          the leftovers, so convergence cannot fix it either: {msg}"
+                    );
+                }
+                // The two cannot-self-repair arms must name a command
+                // that works from where they are. `loader::detach`
+                // refuses while a `packetframe run` daemon is live, and
+                // this arm is only reachable with the module running —
+                // so it has to lead with the deletion that works.
+                if expected == "no port is configured to steer" {
+                    assert!(
+                        msg.contains("refuses while this daemon is running")
+                            && msg.contains("ethtool -N"),
+                        "state {state:?}: reachable only under a live daemon, where \
+                         `detach` is refused outright: {msg}"
                     );
                 }
             }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -826,6 +826,21 @@ impl StatusSnapshot {
              convergence, `packetframe reconfigure` is the retry"
                 .to_string()
         };
+        // Stray rules do NOT share that remedy, and sharing it was a
+        // P1. The two complaints differ in what waiting costs: a
+        // MISSING rule means its prefix is on the eBPF tier, which
+        // forwards, so waiting out a convergence is free. A STRAY rule
+        // is diverting traffic INTO VPP — and `fail()` unsteers before
+        // it kills, precisely because "until the MCAM rules are gone,
+        // every steered packet is going to a VF nothing is servicing".
+        // When that unsteer is refused the rules stay and VPP dies
+        // anyway, so in `Backoff` the affected prefixes are being
+        // dropped while this line says to wait for a convergence that
+        // exponential backoff can push out indefinitely.
+        //
+        // So it names the removal that works from anywhere, always,
+        // and never defers to a convergence.
+        let stray_remedy = "remove them with `ethtool -N <iface> delete <loc>` rather than                             wait — while VPP is not forwarding, that traffic is going to a                             VF nothing is servicing. `packetframe reconfigure` also clears                             them wherever it is accepted";
         let mut clauses: Vec<String> = Vec::new();
         if self.steer_stray > 0 {
             // "Still occupied", not "still ours". Where the outgoing
@@ -839,7 +854,7 @@ impl StatusSnapshot {
                  does not ask for — a port it leaves unsteered, or prefixes dropped from \
                  the allowlist — so traffic may still be diverted into VPP that should \
                  not be. The rules outlived the request to remove them; `ethtool -n \
-                 <iface>` shows what is there, and {remedy}",
+                 <iface>` shows what is there. {stray_remedy}",
                 self.steer_stray
             ));
         }
@@ -1438,10 +1453,12 @@ mod tests {
                 );
                 snap.state = state;
                 snap.steer_configured = steer_configured;
-                // Both clauses share the remedy, so set both and assert
-                // on the remedy alone.
+                // MISSING only. Stray carries its own remedy now — a
+                // stray rule can be dropping traffic, so it never defers
+                // to a convergence — and mixing the two here would let
+                // either string satisfy the assertions below.
                 snap.steer_missing = 1;
-                snap.steer_stray = 1;
+                snap.steer_stray = 0;
 
                 let rep = snap.report();
                 let steering = rep
@@ -1494,6 +1511,69 @@ mod tests {
                          `detach` is refused outright: {msg}"
                     );
                 }
+            }
+        }
+    }
+
+    /// A stray rule never gets told to wait, in any state.
+    ///
+    /// The two complaints differ in what waiting costs. A MISSING rule
+    /// means its prefix is on the eBPF tier, which forwards — waiting
+    /// out a convergence is free. A STRAY rule is diverting traffic
+    /// INTO VPP, and `Supervisor::fail` unsteers before it kills for
+    /// exactly that reason: "until the MCAM rules are gone, every
+    /// steered packet is going to a VF nothing is servicing". A refused
+    /// unsteer leaves them installed and VPP dies anyway, so in
+    /// `Backoff` those prefixes are being dropped — while the shared
+    /// remedy told the operator to wait for a convergence that
+    /// exponential backoff can postpone indefinitely (review finding,
+    /// P1).
+    #[test]
+    fn a_stray_rule_is_never_told_to_wait() {
+        for state in [
+            State::Stopped,
+            State::Backoff,
+            State::Starting,
+            State::Syncing,
+            State::Verifying,
+            State::Ready,
+            State::Steered,
+            State::AdoptedResyncing,
+        ] {
+            for steer_configured in [true, false] {
+                let led = ledger_with(10, 0, 0);
+                let mut snap = snap_of(
+                    &steered_supervisor(),
+                    &led,
+                    ApiHealth::Answering {
+                        silent_for: Duration::from_millis(200),
+                    },
+                    verified(3),
+                    ports_up(),
+                );
+                snap.state = state;
+                snap.steer_configured = steer_configured;
+                snap.steer_stray = 1;
+                snap.steer_missing = 0;
+
+                let rep = snap.report();
+                let steering = rep
+                    .subsystems
+                    .iter()
+                    .find(|s| s.name == SUBSYS_STEERING)
+                    .expect("steering row");
+                let msg = steering.message.as_deref().unwrap_or_default();
+                assert!(
+                    msg.contains("ethtool -N <iface> delete <loc>"),
+                    "state {state:?}: a rule that is diverting traffic must always name \
+                     the removal that works from here: {msg}"
+                );
+                assert!(
+                    !msg.contains("re-applied by the next convergence"),
+                    "state {state:?}: and must never defer to a convergence — with a \
+                     refused unsteer the rules outlive the process, so waiting means \
+                     dropping that prefix, not merely losing the offload: {msg}"
+                );
             }
         }
     }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -820,10 +820,11 @@ impl StatusSnapshot {
             // resync running yet, which is why this does not say "this
             // resync"), and the target it will reconcile to is non-empty,
             // so its stale-rule removal covers whatever is left over.
-            "steering is re-applied by the next convergence — the verify that ends it \
-             emits the steer. That steer passes the completeness gate too and can be \
-             refused there, and nothing retries afterwards, so if this line outlives the \
-             convergence, `packetframe reconfigure` is the retry"
+            "a convergence re-applies steering only if it verifies clean — one that ends \
+             with routes withheld or unresolvable parks in the staging state and emits no \
+             steer at all, and a steer that IS emitted can still be refused by the \
+             completeness gate. Nothing retries after either, so if this line outlives \
+             the convergence, `packetframe reconfigure` is the retry"
                 .to_string()
         };
         // Stray rules do NOT share that remedy, and sharing it was a
@@ -1484,13 +1485,13 @@ mod tests {
                 } else if !steer_configured {
                     "no port is configured to steer"
                 } else {
-                    "re-applied by the next convergence"
+                    "only if it verifies clean"
                 };
                 for marker in [
                     "`packetframe reconfigure` re-applies steering",
                     "supervision has stopped",
                     "no port is configured to steer",
-                    "re-applied by the next convergence",
+                    "only if it verifies clean",
                 ] {
                     assert_eq!(
                         msg.contains(marker),
@@ -1625,7 +1626,7 @@ mod tests {
                      the removal that works from here: {msg}"
                 );
                 assert!(
-                    !msg.contains("re-applied by the next convergence"),
+                    !msg.contains("only if it verifies clean"),
                     "state {state:?}: and must never defer to a convergence — with a \
                      refused unsteer the rules outlive the process, so waiting means \
                      dropping that prefix, not merely losing the offload: {msg}"

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -769,7 +769,18 @@ impl StatusSnapshot {
         let cleanup = "`packetframe detach --all` retries the teardown, and `ethtool -N \
                        <iface> delete <loc>` removes a rule by hand";
         let remedy = if self.state.accepts_steering_changes() {
-            "`packetframe reconfigure` reconciles either way".to_string()
+            // NAMES the repair; does not promise it will succeed. The
+            // state gate this arm reads is not the only one — the steer
+            // path refuses again if the table is not complete enough to
+            // steer into — and predicting a command's outcome by
+            // re-deriving its preconditions here is a copy that drifts.
+            // It found a new precondition on each of four review rounds.
+            // What is always true, and all an operator needs: this is
+            // the command, and it reports its own reason when it
+            // refuses (review finding).
+            "`packetframe reconfigure` re-applies steering, and reports its own reason if \
+             it refuses — a table too incomplete to steer into is the usual one"
+                .to_string()
         } else if matches!(self.state, State::Stopped) {
             // Nothing is running and nothing is trying to. Reachable and
             // nasty: `StopRequested` assigns `Stopped` before knowing
@@ -1436,7 +1447,7 @@ mod tests {
                 // classification rather than four independent
                 // contains() that could all drift true.
                 let expected = if state.accepts_steering_changes() {
-                    "`packetframe reconfigure` reconciles"
+                    "`packetframe reconfigure` re-applies steering"
                 } else if matches!(state, State::Stopped) {
                     "supervision has stopped"
                 } else if !steer_configured {
@@ -1445,7 +1456,7 @@ mod tests {
                     "reconciled automatically"
                 };
                 for marker in [
-                    "`packetframe reconfigure` reconciles",
+                    "`packetframe reconfigure` re-applies steering",
                     "supervision has stopped",
                     "no port is configured to steer",
                     "reconciled automatically",

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -114,6 +114,29 @@ impl State {
     pub fn has_process(self) -> bool {
         !matches!(self, State::Stopped | State::Backoff)
     }
+
+    /// Whether a steering change can be applied from here.
+    ///
+    /// This is the state machine's own admission rule, not a fact about
+    /// the world derived from the state — which is what the NOTE below
+    /// forbids. `apply_steering` refuses anywhere else, because a steer
+    /// request that outlives a crash and fires against the replacement
+    /// is not what the operator asked for.
+    ///
+    /// It lives here because the health surface has to say the same
+    /// thing: the drift line names `packetframe reconfigure` as the
+    /// remedy, and during an adopted deferral that command is refused —
+    /// so the message and the gate must not be able to disagree. They
+    /// were two copies for one round and the message was wrong for half
+    /// the states it could appear in (measured on the shadow,
+    /// 2026-08-11).
+    ///
+    /// Deliberately NOT the same predicate as `nominal()`'s
+    /// arrived-check, which happens to test the same two variants today
+    /// for an unrelated reason.
+    pub fn accepts_steering_changes(self) -> bool {
+        matches!(self, State::Ready | State::Steered)
+    }
 }
 // NOTE: there is deliberately no `State::is_converging()`. Deriving
 // "a resync is in flight" from the lifecycle state is what broke rule

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1189,6 +1189,147 @@ impl packetframe_vpp_offload::runtime::Steering for SpySteering {
     }
 }
 
+/// Fails the first steer, then succeeds — the shape a refusal leaves
+/// behind (the completeness gate declining `Action::Steer`).
+struct FailFirstSteer {
+    log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    failed: bool,
+}
+
+impl packetframe_vpp_offload::runtime::Steering for FailFirstSteer {
+    fn missing_from_nic(&self) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
+        Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
+    }
+    fn configured_ports(&self) -> usize {
+        1
+    }
+    fn steer(&mut self) -> Result<(), String> {
+        if !self.failed {
+            self.failed = true;
+            self.log.lock().unwrap().push("steer-refused".into());
+            return Err("refusing to steer: the route mirror holds 3 of 10 routes".into());
+        }
+        self.log.lock().unwrap().push("steer".into());
+        Ok(())
+    }
+    fn unsteer(&mut self) -> Result<(), String> {
+        self.log.lock().unwrap().push("unsteer".into());
+        Ok(())
+    }
+    fn installed(&self) -> Vec<(String, u32)> {
+        Vec::new()
+    }
+    fn retarget(
+        &mut self,
+        _ports: Vec<(String, u32)>,
+        _plan: packetframe_vpp_offload::steer::RuleSet,
+    ) {
+    }
+}
+
+/// `reconfigure` must RETRY a steer that failed, not report success and
+/// do nothing.
+///
+/// A refused steer (the completeness gate, most often) leaves the
+/// supervisor in `Ready` with `steered == false` and the want
+/// remembered. The guard read `is_steered()`, so an unchanged-config
+/// `reconfigure` — which computes `lever_moved == false` — took the
+/// staging early-return and answered `Ok` without injecting anything.
+/// The retry the health line advertises reported success and left the
+/// offload down (review finding).
+///
+/// `steer_intended()` is the predicate that separates "never steered,
+/// waiting for the operator's canary" from "asked for and broken".
+#[test]
+fn a_reconfigure_retries_a_steer_that_was_refused() {
+    let fake = Fake::start("svc-retry-refused");
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+                }],
+                vec!["eth4".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(FailFirstSteer {
+                    log: std::sync::Arc::clone(&spy),
+                    failed: false,
+                }),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if svc.status().expect("published").state == State::Ready {
+            break;
+        }
+        assert!(Instant::now() < deadline, "did not reach Ready");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // The operator turns the lever; the steer is refused.
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .expect_err("the refusal is the operator's answer");
+    assert_eq!(
+        svc.status().expect("published").state,
+        State::Ready,
+        "a refused steer leaves traffic on the fallback tier"
+    );
+
+    // The blocker clears, and they re-run the SAME config — no lever
+    // movement, because there is nothing to move.
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+        .expect("the retry is accepted");
+
+    assert_eq!(
+        svc.status().expect("published").state,
+        State::Steered,
+        "the retry must actually steer — reporting Ok while doing nothing is worse \
+         than refusing, because the operator has no way to tell"
+    );
+    let seen = log.lock().unwrap().clone();
+    assert_eq!(
+        seen,
+        vec!["steer-refused".to_string(), "steer".to_string()],
+        "exactly one refusal and one successful retry: {seen:?}"
+    );
+}
+
 fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {
     let allow: Vec<IpPrefix> = (0..count).map(|i| fake_vpp::v4(0, i)).collect();
     packetframe_vpp_offload::steer::RuleSet::plan(

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -395,17 +395,22 @@ on a box with no completeness authority it can hold indefinitely. So in
 that state the line points at the convergence instead:
 
 ```text
-steering  DEGRADED — 1 steering rule(s) ... steering is re-applied by the
-                     next convergence — the verify that ends it emits the
-                     steer. That steer passes the completeness gate too
-                     and can be refused there, and nothing retries
-                     afterwards, so if this line outlives the
-                     convergence, `packetframe reconfigure` is the retry
+steering  DEGRADED — 1 steering rule(s) ... a convergence re-applies
+                     steering only if it verifies clean — one that ends
+                     with routes withheld or unresolvable parks in the
+                     staging state and emits no steer at all, and a steer
+                     that IS emitted can still be refused by the
+                     completeness gate. Nothing retries after either, so
+                     if this line outlives the convergence, `packetframe
+                     reconfigure` is the retry
 ```
 
-**Read that second sentence.** The verify that ends a resync does emit
-the steer, but that steer meets the completeness gate like any other,
-and a stale or negative verdict refuses it. After that the supervisor
+**Read that second sentence.** There are two ways the automatic path
+declines. A verify that ends `VerifyIncomplete` — routes withheld or
+unresolvable — parks in the staging state and emits no steer at all,
+deliberately: diverting traffic into a FIB with known holes is what
+that arm exists to prevent. And a steer that *is* emitted still meets
+the completeness gate, which a stale or negative verdict refuses. After that the supervisor
 settles in `Ready` with the want remembered and **nothing emits another
 steer** — verify does not recur in steady state. So this is not a
 promise that the drift clears itself; it is a statement about where the

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -488,12 +488,25 @@ steering  DEGRADED — 2 location(s) the ledger names are still occupied by
                      <the remedy for the current state, as above>
 ```
 
-Two ways to arrive here, and they read the same because the remedy is
-the same: a port turned `steer off` whose reconcile has not run, or an
-allowlist that lost a prefix while its rules stayed installed. Both mean
-traffic is being diverted that nobody asked for — the opposite complaint
-to the drift line above, and worth reading carefully, because the fix
-points the other way: these rules need REMOVING, not reinstalling.
+Two ways to arrive here: a port turned `steer off` whose reconcile has
+not run, or an allowlist that lost a prefix while its rules stayed
+installed. Both mean traffic is being diverted that nobody asked for —
+the opposite complaint to the drift line above, and the fix points the
+other way: these rules need REMOVING, not reinstalling.
+
+**Do not wait this one out.** A missing rule is a lost optimisation —
+its prefix is on the eBPF tier, which forwards. A stray rule is the
+reverse: it is pushing traffic *into* VPP. `Supervisor::fail` unsteers
+before it kills for exactly this reason ("until the MCAM rules are
+gone, every steered packet is going to a VF nothing is servicing"), so
+when that unsteer is refused the rules outlive the process and the
+affected prefixes are **dropped**, not merely deoptimised. Exponential
+backoff can postpone the next convergence indefinitely. Remove them:
+
+```bash
+ethtool -n eth1            # what is actually installed
+ethtool -N eth1 delete 12  # per location
+```
 
 "May", not "is", and the wording is deliberate. Where the port was
 turned off by a live `reconfigure` the audit still holds the outgoing

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -392,18 +392,29 @@ from `Ready` or `Steered`; during an adopted resync it is refused with
 *"vpp-offload is AdoptedResyncing, not converged"*. That is not a rare
 corner — a held deferral is exactly when this audit earns its keep, and
 on a box with no completeness authority it can hold indefinitely. So in
-that state the line says the repair happens on its own instead:
+that state the line points at the convergence instead:
 
 ```text
-steering  DEGRADED — 1 steering rule(s) ... steering is reconciled
-                     automatically when this resync finishes and the FIB
-                     verifies; `packetframe reconfigure` is refused until
-                     then, and says so
+steering  DEGRADED — 1 steering rule(s) ... steering is re-applied by the
+                     next convergence — the verify that ends it emits the
+                     steer. That steer passes the completeness gate too
+                     and can be refused there, and nothing retries
+                     afterwards, so if this line outlives the
+                     convergence, `packetframe reconfigure` is the retry
 ```
 
-Which is true: the verify that ends a resync re-emits the steer, and
-`steer` is a reconcile. Nothing is dropping meanwhile — the affected
-prefix is on the eBPF tier, which is where it belongs.
+**Read that second sentence.** The verify that ends a resync does emit
+the steer, but that steer meets the completeness gate like any other,
+and a stale or negative verdict refuses it. After that the supervisor
+settles in `Ready` with the want remembered and **nothing emits another
+steer** — verify does not recur in steady state. So this is not a
+promise that the drift clears itself; it is a statement about where the
+next attempt comes from. If the line is still there once the module
+reaches `Ready`, restore completeness (watch `fib-synced`) and run
+`packetframe reconfigure`.
+
+Nothing is dropping meanwhile — the affected prefix is on the eBPF
+tier, which is where it belongs.
 
 **The exception is a stopped daemon, and it is the one that matters.**
 If supervision has stopped — a teardown whose `unsteer` was refused,

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -635,14 +635,20 @@ mirror is short of the table and steering into it would blackhole
 whatever has not arrived — and a steered miss is dropped, where an
 unsteered one falls through to the kernel path.
 
-Nothing to do: it retries on its own. The refusal leaves the *want* set,
-so the next verify attempts the steer again, and by then the dump has
-usually finished. Watch the two counts converge:
+**It does not retry on its own** — a belief three operator-facing texts
+carried until 2026-08-11. The refusal leaves the *want* set, but the
+only two things that emit a steer are the verify at the end of a
+convergence and an explicit `packetframe reconfigure`; verify does not
+recur in steady state. So during a first convergence the dump usually
+finishes in time and the steer lands, and outside that you have to
+re-run it. Watch the two counts converge:
 
 ```bash
 birdc show route count
 packetframe status | grep -A6 'module health'
 ```
+
+Once they agree, `packetframe reconfigure` re-applies the steer.
 
 If it persists, the mirror is genuinely not keeping up and that is a
 fast-path problem, not a steering one — check the integrity checker's

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -426,11 +426,15 @@ killed are a blackhole, not a lost optimisation.
 ```text
 steering  DEGRADED — ... no port is configured to steer, so convergence
                      cannot clear these — `steer` refuses an empty target
-                     rather than report an offload it never installed:
-                     `packetframe detach --all` retries the teardown, and
-                     `ethtool -N <iface> delete <loc>` removes a rule by
-                     hand
+                     rather than report an offload it never installed.
+                     Remove them with `ethtool -N <iface> delete <loc>`;
+                     `packetframe detach --all` also retries the teardown,
+                     but refuses while this daemon is running
 ```
+
+Note the order: `detach` refuses outright while a `packetframe run`
+daemon exists (it holds the bpf_link FDs), so under a live module the
+`ethtool` deletion is the one that works.
 
 The module cannot repair this one on its own: it re-steers because a
 refused `unsteer` leaves it believing traffic is diverted, and then

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -508,20 +508,35 @@ when that unsteer is refused the rules outlive the process and the
 affected prefixes are **dropped**, not merely deoptimised. Exponential
 backoff can postpone the next convergence indefinitely.
 
-**Look before deleting.** The line gives a count, never the locations,
-so `ethtool -n` is on the path anyway — and after a restart the audit
-reports an occupied slot without being able to prove it still holds
-*our* rule (`installed_as` is only set by a successful steer in this
-process). Ours are the ones whose action targets VPP's VF:
+**Identify before deleting, and the VF alone will not identify.** The
+line gives a count, never the locations, so `ethtool -n` is on the path
+anyway — and after a restart the audit reports an occupied slot without
+being able to prove it still holds *our* rule (`installed_as` is set
+only by a successful steer in this process).
+
+A rule is this module's when **all** of these hold, not any one:
+
+| field | what ours looks like |
+|---|---|
+| `Dest IP addr` / `Src IP addr` | one of the `allow-prefix` lines in the config, with the other side `0.0.0.0 mask 255.255.255.255` |
+| `Action` | `Direct to VF <n>`, the VF this module owns |
+| `TOS` / `Protocol` / `L4 bytes` masks | all `0xff` / `0xffffffff` — ours constrain nothing else |
+
+The action alone is not proof: another rule can target the same VF
+while matching different traffic, and a *narrowed* copy of one of ours
+keeps the cookie too. That is why the audit compares the whole spec
+rather than the cookie, and why you should.
 
 ```bash
-ethtool -n eth1            # look: `Action: Direct to VF 0 queue 0` is ours
-ethtool -N eth1 delete 12  # then delete those locations, one at a time
+ethtool -n eth1            # read the fields, compare against the table
+ethtool -N eth1 delete 12  # only for locations you recognised
 ```
 
 Deleting a location that turned out to hold somebody else's classifier
 rule breaks its traffic, and unlike a wrong health line that is not
-recoverable by reading.
+recoverable by reading. If you cannot recognise it, leave it and say so
+in the incident notes — a stray rule that is not ours is not ours to
+remove.
 
 "May", not "is", and the wording is deliberate. Where the port was
 turned off by a live `reconfigure` the audit still holds the outgoing

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -414,6 +414,24 @@ steering  DEGRADED — ... supervision has stopped, so nothing will
 Take that one seriously: rules pointing at a VF whose VPP has been
 killed are a blackhole, not a lost optimisation.
 
+**The same applies when no port is configured to steer** — a full
+`steer off` whose removal was refused:
+
+```text
+steering  DEGRADED — ... no port is configured to steer, so convergence
+                     cannot clear these — `steer` refuses an empty target
+                     rather than report an offload it never installed:
+                     `packetframe detach --all` retries the teardown, and
+                     `ethtool -N <iface> delete <loc>` removes a rule by
+                     hand
+```
+
+The module cannot repair this one on its own: it re-steers because a
+refused `unsteer` leaves it believing traffic is diverted, and then
+refuses the empty target. Clean up by hand. (Tracked as a product gap;
+the module should reconcile an empty target through `unsteer` rather
+than retry a refusal.)
+
 **Two directions, one count.** The rules the ledger names are read back
 and compared field by field, so a deleted, replaced or narrowed rule is
 drift. And the rules the *current* target asks for are checked for a

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -501,12 +501,22 @@ before it kills for exactly this reason ("until the MCAM rules are
 gone, every steered packet is going to a VF nothing is servicing"), so
 when that unsteer is refused the rules outlive the process and the
 affected prefixes are **dropped**, not merely deoptimised. Exponential
-backoff can postpone the next convergence indefinitely. Remove them:
+backoff can postpone the next convergence indefinitely.
+
+**Look before deleting.** The line gives a count, never the locations,
+so `ethtool -n` is on the path anyway — and after a restart the audit
+reports an occupied slot without being able to prove it still holds
+*our* rule (`installed_as` is only set by a successful steer in this
+process). Ours are the ones whose action targets VPP's VF:
 
 ```bash
-ethtool -n eth1            # what is actually installed
-ethtool -N eth1 delete 12  # per location
+ethtool -n eth1            # look: `Action: Direct to VF 0 queue 0` is ours
+ethtool -N eth1 delete 12  # then delete those locations, one at a time
 ```
+
+Deleting a location that turned out to hold somebody else's classifier
+rule breaks its traffic, and unlike a wrong health line that is not
+recoverable by reading.
 
 "May", not "is", and the wording is deliberate. Where the port was
 turned off by a live `reconfigure` the audit still holds the outgoing

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -514,12 +514,19 @@ anyway — and after a restart the audit reports an occupied slot without
 being able to prove it still holds *our* rule (`installed_as` is set
 only by a successful steer in this process).
 
-**Try `packetframe reconfigure` first.** It clears stray rules *by
-ledger entry* — `steer` removes what the ledger holds and the target no
-longer wants — so it needs no identification at all and cannot delete
-somebody else's rule. Hand-deletion is the fallback for the two cases
-where it will not run: a stopped daemon, or no port configured to steer
-(the health line says which). It reports its own reason otherwise.
+**Try `packetframe reconfigure` first.** `steer` removes what the
+ledger holds and the target no longer wants, so it takes out exactly
+the recorded locations and you identify nothing by eye. Hand-deletion
+is the fallback for the two cases where it will not run: a stopped
+daemon, or no port configured to steer (the health line says which).
+
+It is *not* ownership-safe, and the distinction matters. The delete
+ioctl addresses a **location**, not a rule — neither `reconfigure` nor
+your own `ethtool -N` verifies what is sitting there first. What
+`reconfigure` buys is that the locations come from the record rather
+than from a judgement call, so it cannot touch a slot the ledger never
+claimed. If something replaced our rule at a claimed slot, both routes
+delete it.
 
 If you must identify by hand, a rule is this module's when **all** of
 these hold, not any one:

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -514,18 +514,38 @@ anyway — and after a restart the audit reports an occupied slot without
 being able to prove it still holds *our* rule (`installed_as` is set
 only by a successful steer in this process).
 
-A rule is this module's when **all** of these hold, not any one:
+**Try `packetframe reconfigure` first.** It clears stray rules *by
+ledger entry* — `steer` removes what the ledger holds and the target no
+longer wants — so it needs no identification at all and cannot delete
+somebody else's rule. Hand-deletion is the fallback for the two cases
+where it will not run: a stopped daemon, or no port configured to steer
+(the health line says which). It reports its own reason otherwise.
+
+If you must identify by hand, a rule is this module's when **all** of
+these hold, not any one:
 
 | field | what ours looks like |
 |---|---|
-| `Dest IP addr` / `Src IP addr` | one of the `allow-prefix` lines in the config, with the other side `0.0.0.0 mask 255.255.255.255` |
+| `Dest IP addr` / `Src IP addr` | a /24-ish prefix on one side, the other side `0.0.0.0 mask 255.255.255.255` |
 | `Action` | `Direct to VF <n>`, the VF this module owns |
 | `TOS` / `Protocol` / `L4 bytes` masks | all `0xff` / `0xffffffff` — ours constrain nothing else |
 
-The action alone is not proof: another rule can target the same VF
-while matching different traffic, and a *narrowed* copy of one of ours
-keeps the cookie too. That is why the audit compares the whole spec
+**The current `allow-prefix` list is NOT the test**, and this is the
+trap: the commonest stray is a prefix you just *removed* from the
+allowlist, whose rules are by definition absent from the config you are
+holding. Check the config's previous revision (or your change diff) for
+the prefix that was there an hour ago.
+
+The action alone is not proof either: another rule can target the same
+VF while matching different traffic, and a *narrowed* copy of one of
+ours keeps the cookie. That is why the audit compares the whole spec
 rather than the cookie, and why you should.
+
+**A cleaner route for a removed prefix**, if the module is live and
+accepting: put the prefix back, `reconfigure` so the module owns those
+rules again, then remove it and `reconfigure` a second time. The stale
+removal in `steer` takes them out properly, and nothing is identified
+by eye.
 
 ```bash
 ethtool -n eth1            # read the fields, compare against the table

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -371,7 +371,9 @@ steering  DEGRADED — 1 steering rule(s) this target asks for are missing
                      tier. Something changed them out of band (a UniFi
                      provisioning push does this), or the allowlist grew
                      while the inherited rules stayed as they were;
-                     `packetframe reconfigure` reconciles either way
+                     `packetframe reconfigure` re-applies steering, and
+                     reports its own reason if it refuses — a table too
+                     incomplete to steer into is the usual one
 ```
 
 It found the drift by asking the NIC, not by inferring it. **Measured on
@@ -380,8 +382,12 @@ adopted daemon was reported as `steering DEGRADED` within 20 s. Before
 the audit existed the same deletion went unnoticed for two minutes with
 `steering healthy` and no log line.
 
-**The remedy depends on the lifecycle state, and the line tells you
-which one applies.** `packetframe reconfigure` reconciles steering only
+**The line names the remedy that fits the situation, and there are
+four.** Note it never promises the command will succeed: steering
+passes two gates — the lifecycle state, and whether the table is
+complete enough to steer into — and `reconfigure` reports which one
+stopped it. What the line is for is telling you when the command is the
+wrong move entirely. `packetframe reconfigure` reconciles steering only
 from `Ready` or `Steered`; during an adopted resync it is refused with
 *"vpp-offload is AdoptedResyncing, not converged"*. That is not a rare
 corner — a held deferral is exactly when this audit earns its keep, and

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -374,7 +374,30 @@ steering  DEGRADED — 1 steering rule(s) this target asks for are missing
                      `packetframe reconfigure` reconciles either way
 ```
 
-It found the drift by asking the NIC, not by inferring it.
+It found the drift by asking the NIC, not by inferring it. **Measured on
+the shadow 2026-08-11**: `ethtool -N eth1 delete 12` against a steered,
+adopted daemon was reported as `steering DEGRADED` within 20 s. Before
+the audit existed the same deletion went unnoticed for two minutes with
+`steering healthy` and no log line.
+
+**The remedy depends on the lifecycle state, and the line tells you
+which one applies.** `packetframe reconfigure` reconciles steering only
+from `Ready` or `Steered`; during an adopted resync it is refused with
+*"vpp-offload is AdoptedResyncing, not converged"*. That is not a rare
+corner — a held deferral is exactly when this audit earns its keep, and
+on a box with no completeness authority it can hold indefinitely. So in
+that state the line says the repair happens on its own instead:
+
+```text
+steering  DEGRADED — 1 steering rule(s) ... steering is reconciled
+                     automatically when this resync finishes and the FIB
+                     verifies; `packetframe reconfigure` is refused until
+                     then, and says so
+```
+
+Which is true: the verify that ends the resync re-emits the steer, and
+`steer` is a reconcile. Nothing is dropping meanwhile — the affected
+prefix is on the eBPF tier, which is where it belongs.
 
 **Two directions, one count.** The rules the ledger names are read back
 and compared field by field, so a deleted, replaced or narrowed rule is
@@ -407,8 +430,8 @@ steering  DEGRADED — 2 location(s) the ledger names are still occupied by
                      unsteered, or prefixes dropped from the allowlist — so
                      traffic may still be diverted into VPP that should not
                      be. The rules outlived the request to remove them;
-                     `ethtool -n <iface>` shows what is there and
-                     `packetframe reconfigure` clears them
+                     `ethtool -n <iface>` shows what is there, and
+                     <the remedy for the current state, as above>
 ```
 
 Two ways to arrive here, and they read the same because the remedy is

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -395,9 +395,24 @@ steering  DEGRADED — 1 steering rule(s) ... steering is reconciled
                      then, and says so
 ```
 
-Which is true: the verify that ends the resync re-emits the steer, and
+Which is true: the verify that ends a resync re-emits the steer, and
 `steer` is a reconcile. Nothing is dropping meanwhile — the affected
 prefix is on the eBPF tier, which is where it belongs.
+
+**The exception is a stopped daemon, and it is the one that matters.**
+If supervision has stopped — a teardown whose `unsteer` was refused,
+say — the rules are still in the NIC, the VF is withheld, and *no
+convergence is coming*. The line says so and points at cleanup:
+
+```text
+steering  DEGRADED — ... supervision has stopped, so nothing will
+                     reconcile this on its own: `packetframe detach
+                     --all` retries the teardown, and `ethtool -N
+                     <iface> delete <loc>` removes a rule by hand
+```
+
+Take that one seriously: rules pointing at a VF whose VPP has been
+killed are a blackhole, not a lost optimisation.
 
 **Two directions, one count.** The rules the ledger names are read back
 and compared field by field, so a deleted, replaced or narrowed rule is


### PR DESCRIPTION
The steering drift line from #156 told operators ``packetframe reconfigure` reconciles either way`. On hardware it does not.

## What the shadow said

Deleted a rule out of band against a steered, adopted daemon:

```
10:22:21  ethtool -N eth1 delete 12
10:22:41  steering DEGRADED — 1 steering rule(s) ... `packetframe reconfigure` reconciles either way
10:24:49  # packetframe reconfigure
          RECONFIGURE FAILED
          vpp-offload is AdoptedResyncing, not converged — steering changes
          apply only from Ready or Steered
```

`apply_steering` gates on `Ready | Steered`. An adopted deferral is neither — and it is *the* state this audit was written for: on a box with no completeness authority the deferral can hold indefinitely, which is exactly when a stripped rule would otherwise go unnoticed. So the message was wrong in the case it appears in most.

## The fix

Both clauses pick their remedy from the same predicate the gate reads, `State::accepts_steering_changes`, so the health text and `apply_steering` cannot drift apart. Where the command is refused the line says what *does* happen:

> steering is reconciled automatically when this resync finishes and the FIB verifies; `packetframe reconfigure` is refused until then, and says so

Which is true — the verify that ends the resync re-emits the steer, and `steer` is a reconcile. Nothing is dropping meanwhile; the affected prefix is on the eBPF tier, which is where it belongs.

Deliberately **not** shared with `nominal()`, which tests the same two variants today for an unrelated reason (*arrived*, not *admits steering changes*). Collapsing them would couple two things that are free to diverge.

## Test

Asserted over **every** `State` rather than the one that bit us, with an exhaustive `match` as a tripwire so a new variant cannot be added without deciding what its drift line should say. Verified against a revert (`if true`), which fails on `Stopped` first.

714 tests green, clippy clean on host + cross targets.

## Note on how this was found

Only by running it. The gate in my notes — *"change a state machine's refusal conditions ⇒ grep the status messages"* — does not catch this direction: a **new message naming an existing command** whose refusal conditions I never checked. Same defect class, opposite direction.

Also banked from that session, unrelated to this diff: drift detection works on the **adopted** path against a real NIC (detected in <20 s, correct count, correct direction), and detection does not mutate the ledger — it still recorded `[15,14,13,12]` while the NIC held `13,14,15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)