### PR TITLE
fix(vpp-offload): give a reconcile-to-empty an outcome, so `steer off` can finish

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -483,6 +483,7 @@ mod tests {
     use super::*;
     use crate::liveness::{PING_BUDGET, PING_INTERVAL, SYNC_PING_BUDGET};
     use crate::process::Disposition;
+    use crate::runtime::SteerOutcome;
     use crate::supervisor::Action;
 
     fn at(base: Instant, ms: u64) -> Instant {
@@ -578,13 +579,13 @@ mod tests {
             self.calls.push("unsteer");
             Ok(())
         }
-        fn steer(&mut self) -> Result<(), String> {
+        fn steer(&mut self) -> Result<SteerOutcome, String> {
             self.calls.push("steer");
-            Ok(())
+            Ok(SteerOutcome::Steered)
         }
-        fn restore_steer(&mut self) -> Result<(), String> {
+        fn restore_steer(&mut self) -> Result<SteerOutcome, String> {
             self.calls.push("steer");
-            Ok(())
+            Ok(SteerOutcome::Steered)
         }
         fn kill(&mut self) -> Disposition {
             self.calls.push("kill");
@@ -1365,11 +1366,11 @@ mod tests {
             fn unsteer(&mut self) -> Result<(), String> {
                 Ok(())
             }
-            fn steer(&mut self) -> Result<(), String> {
-                Ok(())
+            fn steer(&mut self) -> Result<SteerOutcome, String> {
+                Ok(SteerOutcome::Steered)
             }
-            fn restore_steer(&mut self) -> Result<(), String> {
-                Ok(())
+            fn restore_steer(&mut self) -> Result<SteerOutcome, String> {
+                Ok(SteerOutcome::Steered)
             }
             fn kill(&mut self) -> Disposition {
                 Disposition::SafeToRelease

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -26,6 +26,7 @@
 use std::time::Duration;
 
 use crate::process::Disposition;
+use crate::runtime::SteerOutcome;
 use crate::supervisor::{Action, Event};
 
 /// Everything the executor does to the world outside itself.
@@ -43,13 +44,15 @@ pub trait Effects {
     /// Remove MCAM steering rules. First in any teardown.
     fn unsteer(&mut self) -> Result<(), String>;
 
-    /// Install MCAM steering rules.
-    fn steer(&mut self) -> Result<(), String>;
+    /// Reconcile MCAM steering rules to the current target. `Ok` says
+    /// which side of the tier boundary that left the traffic on — see
+    /// [`SteerOutcome`].
+    fn steer(&mut self) -> Result<SteerOutcome, String>;
 
     /// Re-install steering for the intact adoptee, bypassing the
     /// completeness gate — see [`Action::RestoreSteer`] for why the
     /// gate inverts on this one path.
-    fn restore_steer(&mut self) -> Result<(), String>;
+    fn restore_steer(&mut self) -> Result<SteerOutcome, String>;
 
     /// Whether the steering ledger currently names any rule in the NIC.
     ///
@@ -192,12 +195,24 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                 }
             }
             Action::RestoreSteer => out.events.push(match fx.restore_steer() {
-                Ok(()) => {
+                Ok(SteerOutcome::Steered) => {
                     tracing::info!(
                         "steering RESTORED: the adopted VPP's intact FIB takes the traffic \
                          back while the fallback is not ready"
                     );
                     Event::Steered
+                }
+                // The config stopped asking for this port between the
+                // adoption and the revocation. Nothing to restore, and
+                // the reconcile has cleared the adoptee's inherited
+                // rules — which is the outcome, not a failure to
+                // produce the other one.
+                Ok(SteerOutcome::NothingToSteer) => {
+                    tracing::info!(
+                        "steering DOWN: no port is configured to steer, so the restore \
+                         removed the adopted rules instead of re-installing them"
+                    );
+                    Event::NothingToSteer
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -212,7 +227,7 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                 }
             }),
             Action::Steer => out.events.push(match fx.steer() {
-                Ok(()) => {
+                Ok(SteerOutcome::Steered) => {
                     // The one action that moves customer traffic between
                     // forwarding tiers. It had no log line at all until
                     // a shadow run came up steered with nothing in the
@@ -224,6 +239,21 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
                          tier remains the failover)"
                     );
                     Event::Steered
+                }
+                // A reconcile whose target asks for nothing. It is a
+                // SUCCESS and it moves traffic the other way, so it
+                // gets the acknowledgement that says so rather than
+                // `Event::Steered` — which would report an offload
+                // carrying traffic it had just stopped carrying — or an
+                // error, which is what left a refused `steer off`
+                // retrying a no-op while its rules kept diverting.
+                Ok(SteerOutcome::NothingToSteer) => {
+                    tracing::info!(
+                        "steering DOWN: no port is configured to steer, so the reconcile \
+                         removed what was left and installed nothing; traffic is on the \
+                         eBPF fast-path tier"
+                    );
+                    Event::NothingToSteer
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -279,6 +309,23 @@ mod tests {
         kill_disposition: Option<Disposition>,
         /// What the steering ledger reports after a failed steer.
         rules_remain: bool,
+        /// The target asks for no port, so a reconcile installs nothing
+        /// and removes whatever is left. Separate from `fail_steer`
+        /// because it is a SUCCESS that moves traffic the other way.
+        empty_target: bool,
+    }
+
+    impl Recorder {
+        fn steer_result(&self) -> Result<SteerOutcome, String> {
+            if self.fail_steer {
+                return Err("no free MCAM loc".into());
+            }
+            Ok(if self.empty_target {
+                SteerOutcome::NothingToSteer
+            } else {
+                SteerOutcome::Steered
+            })
+        }
     }
 
     impl Effects for Recorder {
@@ -294,13 +341,13 @@ mod tests {
             self.calls.push("unsteer");
             err_if(self.fail_unsteer, "ioctl refused")
         }
-        fn steer(&mut self) -> Result<(), String> {
+        fn steer(&mut self) -> Result<SteerOutcome, String> {
             self.calls.push("steer");
-            err_if(self.fail_steer, "no free MCAM loc")
+            self.steer_result()
         }
-        fn restore_steer(&mut self) -> Result<(), String> {
+        fn restore_steer(&mut self) -> Result<SteerOutcome, String> {
             self.calls.push("steer");
-            err_if(self.fail_steer, "no free MCAM loc")
+            self.steer_result()
         }
         fn kill(&mut self) -> Disposition {
             self.calls.push("kill");
@@ -500,6 +547,35 @@ mod tests {
         let mut r = Recorder::default();
         let out = execute(&[Action::Steer], &mut r);
         assert_eq!(out.events, vec![Event::Steered]);
+    }
+
+    /// A reconcile against a target that asks for nothing is a success
+    /// that moves traffic the OTHER way, and the acknowledgement has to
+    /// say which way.
+    ///
+    /// `Event::Steered` here would report an offload carrying traffic
+    /// the reconcile had just stopped carrying — and would set
+    /// `steered`, withholding the VF for rules that are no longer
+    /// there. The seam is the only place the distinction can be made:
+    /// by the time the supervisor sees an event, the outcome is a word.
+    #[test]
+    fn a_reconcile_to_an_empty_target_reports_nothing_to_steer() {
+        for action in [Action::Steer, Action::RestoreSteer] {
+            let mut r = Recorder {
+                empty_target: true,
+                ..Default::default()
+            };
+            let out = execute(&[action], &mut r);
+            assert_eq!(out.events, vec![Event::NothingToSteer], "{action:?}");
+            assert!(
+                !out.events.contains(&Event::Steered),
+                "{action:?}: nothing was steered"
+            );
+            assert!(
+                out.ok(),
+                "{action:?}: a reconcile that succeeded is not a failure"
+            );
+        }
     }
 
     /// A deterministic pipeline failure must not be left for the phase

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -30,6 +30,7 @@
 //! [`crate::steer::RuleSet::plan`] applies to the budget, enforced here
 //! against the NIC rather than against arithmetic.
 
+use crate::runtime::SteerOutcome;
 use crate::steer::{RuleSet, Side, SteerRule};
 
 /// `ETHTOOL_SRXCLSRLINS` — insert a classifier rule.
@@ -947,8 +948,27 @@ impl crate::runtime::Steering for NtupleSteering {
         self.ports.len()
     }
 
-    fn steer(&mut self) -> Result<(), String> {
-        if self.plan.rules.is_empty() {
+    fn steer(&mut self) -> Result<SteerOutcome, String> {
+        // Two ways to have nothing to install, and they are opposite
+        // events.
+        //
+        // No PORT is the operator's answer: every port is `steer off`,
+        // so the reconcile below removes whatever the previous target
+        // left and reports `NothingToSteer` — the NIC holds nothing and
+        // nothing is wanted. Refusing instead is what made the rollback
+        // unrecoverable: an `unsteer` the NIC declines leaves rules in
+        // `installed` and `steered` true, every later convergence
+        // re-emits `Action::Steer`, and a refusal here returns before
+        // the stale-rule removal that is the only thing that could
+        // clear them.
+        //
+        // Ports but no RULES is a fault, and still refuses. Somebody
+        // asked for a port to divert traffic and the allowlist or the
+        // MCAM budget produced nothing to divert it with; reporting
+        // that as a clean "nothing steered" would retire the want and
+        // hide a broken allowlist behind the same line a deliberate
+        // `steer off` prints.
+        if !self.ports.is_empty() && self.plan.rules.is_empty() {
             return Err(
                 "nothing to steer: the allowlist produced no rules for this NIC (see \
                  `packetframe feasibility`, capability `vpp.steering.budget`)"
@@ -1032,7 +1052,19 @@ impl crate::runtime::Steering for NtupleSteering {
         // that is what made a second refused reconfigure disown rules
         // that were really there.
         self.installed_as = Some((self.ports.clone(), self.plan.clone()));
-        Ok(())
+        // From the LEDGER, not from `ports.is_empty()`. The ledger is
+        // the postcondition the caller acts on — it is what
+        // `steering_in_place` reads and what the state file records —
+        // and every path that could leave it holding a rule under an
+        // empty target has already returned `Err` above. Saying
+        // "nothing is steered" while a location this object installed
+        // is still in the NIC is the one lie the release rules cannot
+        // survive.
+        Ok(if self.installed.is_empty() {
+            SteerOutcome::NothingToSteer
+        } else {
+            SteerOutcome::Steered
+        })
     }
 
     fn unsteer(&mut self) -> Result<(), String> {
@@ -1530,19 +1562,100 @@ mod tests {
         assert_eq!(after.free.first(), Some(&13), "the next free one is next");
     }
 
-    /// A plan with no rules refuses rather than reporting success.
+    /// A CONFIGURED port with no rules to install refuses rather than
+    /// reporting success.
     ///
-    /// `Ok` from `steer` becomes `Event::Steered`, which is what tells
-    /// the supervisor traffic is diverted — so a no-op that returned
-    /// `Ok` would put the module in `Steered` with nothing steered, and
-    /// health would report the offload carrying traffic it never saw.
+    /// Somebody asked for this port to divert traffic and the allowlist
+    /// or the MCAM budget produced nothing to divert it with. Neither
+    /// `Ok` answers that: `SteerOutcome::Steered` becomes
+    /// `Event::Steered` and puts the module in `Steered` with nothing
+    /// steered, so health reports the offload carrying traffic it never
+    /// saw; `SteerOutcome::NothingToSteer` retires the want and prints
+    /// the line a deliberate `steer off` prints, hiding a broken
+    /// allowlist behind it.
+    ///
+    /// The port list is what makes this the fault case — see
+    /// [`a_reconcile_to_an_empty_target_clears_the_nic_and_says_so`] for
+    /// the other emptiness, which is the operator's answer and not a
+    /// fault.
     #[test]
-    fn steering_an_empty_plan_is_refused() {
+    fn steering_a_configured_port_with_no_rules_is_refused() {
         use crate::runtime::Steering as _;
         let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], RuleSet::default());
         let e = s.steer().expect_err("must refuse");
         assert!(e.contains("nothing to steer"), "{e}");
         assert!(s.installed().is_empty());
+    }
+
+    /// The other emptiness: no port asks to steer, so the reconcile
+    /// removes what a previous target left and reports that it holds
+    /// nothing.
+    ///
+    /// `steer` is a reconcile, and an empty target is a legitimate
+    /// thing to reconcile to — it is where `steer off` lands. Refusing
+    /// it returned before the stale-rule removal, which is the only
+    /// thing that could clear the leftovers, so the rules a refused
+    /// `unsteer` had left in the NIC could never come out on their own.
+    #[test]
+    fn a_reconcile_to_an_empty_target_clears_the_nic_and_says_so() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        assert_eq!(
+            s.steer().expect("installs"),
+            SteerOutcome::Steered,
+            "rules in the NIC is the other outcome, and the two must not be confusable"
+        );
+        assert!(
+            !s.installed().is_empty(),
+            "the fixture must install something"
+        );
+
+        // Every port `steer off`.
+        s.retarget(Vec::new(), RuleSet::default());
+        assert_eq!(
+            s.steer()
+                .expect("an empty target is reconcilable, not a fault"),
+            SteerOutcome::NothingToSteer
+        );
+        assert!(s.installed().is_empty(), "the ledger must be empty too");
+        assert!(
+            sys::rule_table("eth0")
+                .expect("the fake answers")
+                .occupied
+                .is_empty(),
+            "the rules must be gone from the NIC, not merely forgotten by the ledger"
+        );
+    }
+
+    /// A rule the NIC will not delete still refuses, even under an
+    /// empty target.
+    ///
+    /// `NothingToSteer` is what releases the VF and retires the want, so
+    /// it may only be said when the NIC really holds nothing. This is
+    /// the half that must not be traded away to make the empty target
+    /// reconcilable.
+    #[test]
+    fn an_empty_target_still_refuses_while_a_rule_will_not_come_out() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+
+        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        s.steer().expect("installs");
+        let stuck: Vec<u32> = s.installed().iter().map(|(_, loc)| *loc).collect();
+        sys::wedge_delete(&stuck);
+
+        s.retarget(Vec::new(), RuleSet::default());
+        let e = s
+            .steer()
+            .expect_err("a rule that would not come out is still steering");
+        assert!(e.contains("could not be removed"), "{e}");
+        assert_eq!(
+            s.installed().len(),
+            stuck.len(),
+            "what would not come out stays in the ledger, or the VF is released under it"
+        );
     }
 
     /// A rule removed from the NIC behind our back is reported missing.
@@ -2523,5 +2636,182 @@ mod tests {
              a forwarding policy nobody chose"
         );
         assert!(s.installed().is_empty());
+    }
+    /// The rollback that could not finish: `steer off`, a removal the
+    /// NIC refuses, a crash, and a restart — and the module clears it
+    /// on the next convergence instead of retrying a no-op forever.
+    ///
+    /// Every step of this is deliberate behaviour somewhere else in the
+    /// subsystem, which is what made it a trap rather than a bug in any
+    /// one place:
+    ///
+    /// - a refused `unsteer` keeps its rules in `installed` and
+    ///   `steered` true, so the VF stays withheld while MCAM may still
+    ///   point at it ([`NtupleSteering::remove_all`]);
+    /// - a death while `steered` re-arms `steer_wanted`, so a restart
+    ///   nobody watched does not silently leave the offload off;
+    /// - `VerifyPassed` therefore re-steers, because
+    ///   `steer_intended()` is true.
+    ///
+    /// Composed, they used to meet a `steer` that refused an empty
+    /// target *before* its stale-rule removal — so the one action that
+    /// could have cleared the rules returned an error instead, on every
+    /// convergence, while the rules went on diverting traffic for a
+    /// port the operator had asked to stop steering.
+    ///
+    /// Drives the real supervisor and the real executor, because that
+    /// composition IS the defect: each half is correct alone.
+    #[test]
+    fn a_refused_unsteer_is_cleared_by_the_next_convergence() {
+        use crate::executor::{execute, Effects};
+        use crate::process::Disposition;
+        use crate::runtime::Steering as _;
+        use crate::supervisor::{Event, State, Supervisor};
+
+        /// The steering half of [`Effects`] over a real
+        /// `NtupleSteering`. Everything else succeeds silently: this
+        /// test is about which rules are in the NIC, and a process
+        /// double that could fail would only add ways to not reach the
+        /// convergence.
+        struct SteeringOnly(NtupleSteering);
+
+        impl Effects for SteeringOnly {
+            fn steer(&mut self) -> Result<SteerOutcome, String> {
+                self.0.steer()
+            }
+            fn restore_steer(&mut self) -> Result<SteerOutcome, String> {
+                self.0.steer()
+            }
+            fn unsteer(&mut self) -> Result<(), String> {
+                self.0.unsteer()
+            }
+            fn steering_in_place(&self) -> bool {
+                !self.0.installed().is_empty()
+            }
+            fn spawn(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn kill(&mut self) -> Disposition {
+                Disposition::SafeToRelease
+            }
+            fn attach_devices(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn start_resync(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn start_verify(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+            fn abort_convergence(&mut self) {}
+            fn arm_backoff(&mut self, _d: std::time::Duration) {}
+            fn release_resources(&mut self) -> Result<(), String> {
+                Ok(())
+            }
+        }
+
+        /// Apply one event and feed the executor's events back until
+        /// the two settle, exactly as the driver's tick does.
+        fn settle(sup: &mut Supervisor, fx: &mut SteeringOnly, event: Event) {
+            let mut pending = vec![event];
+            for _ in 0..16 {
+                if pending.is_empty() {
+                    return;
+                }
+                let mut next = Vec::new();
+                for e in pending.drain(..) {
+                    let actions = sup.on(e);
+                    next.extend(execute(&actions, fx).events);
+                }
+                pending = next;
+            }
+            panic!("the supervisor/executor seam did not settle");
+        }
+
+        fn nic_holds(iface: &str) -> Vec<u32> {
+            sys::rule_table(iface).expect("the fake answers").occupied
+        }
+
+        sys::reset();
+        let mut fx = SteeringOnly(NtupleSteering::new(
+            vec![("eth4".into(), 0)],
+            plan_for(&[[198, 18, 0, 0]]),
+        ));
+        let mut sup = Supervisor::new();
+
+        // 1. Converge, then the operator moves the canary lever. The
+        //    machine never steers a first attach on its own.
+        settle(&mut sup, &mut fx, Event::StartRequested);
+        settle(&mut sup, &mut fx, Event::Spawned);
+        settle(&mut sup, &mut fx, Event::ApiUp);
+        settle(&mut sup, &mut fx, Event::SyncComplete);
+        settle(&mut sup, &mut fx, Event::VerifyPassed);
+        settle(&mut sup, &mut fx, Event::SteerRequested);
+        assert_eq!(sup.state(), State::Steered);
+        let steered_locs = nic_holds("eth4");
+        assert!(!steered_locs.is_empty(), "the fixture must steer something");
+
+        // 2. `steer off` on every port, `packetframe reconfigure` — and
+        //    the NIC refuses to delete what it holds.
+        sys::wedge_delete(&steered_locs);
+        fx.0.retarget(Vec::new(), RuleSet::default());
+        settle(&mut sup, &mut fx, Event::UnsteerRequested);
+        assert!(
+            sup.is_steered(),
+            "a removal the NIC refused must keep `steered` true, or the VF is released \
+             under live rules"
+        );
+        assert_eq!(
+            nic_holds("eth4"),
+            steered_locs,
+            "the rules are still there — that is the premise of the rest of this test"
+        );
+
+        // 3. VPP dies. The teardown unsteers first, is refused again,
+        //    and the death re-arms the want because rules remain.
+        settle(&mut sup, &mut fx, Event::ProcessExited { status: None });
+        assert_eq!(sup.state(), State::Backoff);
+        assert!(sup.is_steered() && sup.steer_intended());
+
+        // 4. The NIC stops refusing. Nothing about the module changed —
+        //    a UniFi provisioning push or a firmware event clears
+        //    classifier state underneath us, and by design the module
+        //    is supposed to reconcile whatever it finds.
+        sys::wedge_delete(&[]);
+
+        // 5. The replacement comes up and verifies. THIS is where the
+        //    module used to re-enter its refusal: `steer_intended()` is
+        //    true, so `VerifyPassed` emits `Action::Steer`, and the
+        //    target is empty.
+        settle(&mut sup, &mut fx, Event::BackoffElapsed);
+        settle(&mut sup, &mut fx, Event::Spawned);
+        settle(&mut sup, &mut fx, Event::ApiUp);
+        settle(&mut sup, &mut fx, Event::SyncComplete);
+        settle(&mut sup, &mut fx, Event::VerifyPassed);
+
+        assert!(
+            nic_holds("eth4").is_empty(),
+            "the leftover rules must be GONE from the NIC: they divert traffic for a \
+             port the operator turned off, and no convergence after this one will look \
+             again. Still holding {:?}",
+            nic_holds("eth4")
+        );
+        assert!(
+            fx.0.installed().is_empty(),
+            "and gone from the ledger, which is what the state file persists and what \
+             releasing the VF is gated on"
+        );
+        assert!(
+            !sup.is_steered(),
+            "`steered` must clear, or every later teardown keeps withholding the VF for \
+             rules that are not there"
+        );
+        assert!(
+            !sup.steer_intended(),
+            "the want must retire too. `Unsteered` alone leaves it set — correct on the \
+             adopted path, wrong here — and the module would sit Degraded on `steering \
+             intended but not in place` with an empty config and nothing left to do"
+        );
+        assert_eq!(sup.state(), State::Ready, "membership without steering");
     }
 }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -208,6 +208,34 @@ impl SteeringAudit {
     }
 }
 
+/// Which side of the tier boundary a successful reconcile left the
+/// traffic on.
+///
+/// Two answers rather than a bare `Ok(())`, because a reconcile against
+/// an EMPTY target succeeds by removing everything, and "it worked" is
+/// the same word for both outcomes while the consequences are
+/// opposites. The executor turns this into the supervisor's
+/// acknowledgement, and the supervisor releases VFs and paints health
+/// on that acknowledgement — so collapsing the two reported an offload
+/// carrying traffic it had just stopped carrying.
+///
+/// The alternative — `Err` for the empty target, which is what shipped
+/// — is what wedged the rollback: a `steer off` whose `unsteer` the NIC
+/// refused leaves rules installed and `steered` true, every later
+/// convergence re-emits `Action::Steer`, and a `steer` that refuses
+/// before reaching its stale-rule removal can never clear them. The
+/// module retried a no-op error forever while the rules kept diverting
+/// traffic the operator had asked it to stop diverting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SteerOutcome {
+    /// Rules are confirmed in the NIC; allowlisted traffic is diverted.
+    Steered,
+    /// The target asks for no port, and the NIC now holds nothing —
+    /// including anything a previous target left behind. Traffic is on
+    /// the eBPF tier, and nothing is wanted.
+    NothingToSteer,
+}
+
 /// The MCAM steering seam ([`crate::ntuple::NtupleSteering`] is the
 /// real one: ETHTOOL_SRXCLSRLINS, ring_cookie `(vf+1)<<32`, loc
 /// budgeting).
@@ -220,8 +248,10 @@ impl SteeringAudit {
 /// lets [`Self::retarget`] change the target under a live port without
 /// a second code path.
 pub trait Steering {
-    /// Install the rules. `Ok` means they are confirmed in the NIC.
-    fn steer(&mut self) -> Result<(), String>;
+    /// Reconcile the NIC to the current target. `Ok` means the NIC now
+    /// holds exactly what the target asks for — which, for a target
+    /// that asks for nothing, means it holds nothing.
+    fn steer(&mut self) -> Result<SteerOutcome, String>;
     /// Remove the rules. `Ok` means they are confirmed gone — and only
     /// then, because the supervisor releases VFs on the strength of it.
     fn unsteer(&mut self) -> Result<(), String>;
@@ -302,7 +332,7 @@ impl Steering for SteeringUnavailable {
         0
     }
 
-    fn steer(&mut self) -> Result<(), String> {
+    fn steer(&mut self) -> Result<SteerOutcome, String> {
         Err("MCAM steering is unavailable in this runtime; port stays unsteered".into())
     }
     fn unsteer(&mut self) -> Result<(), String> {
@@ -1757,7 +1787,7 @@ impl Effects for EffectsView {
         outcome
     }
 
-    fn restore_steer(&mut self) -> Result<(), String> {
+    fn restore_steer(&mut self) -> Result<SteerOutcome, String> {
         // NO completeness gate, deliberately — the one divergence from
         // `steer`, and the whole reason this method exists. The gate
         // protects traffic from a VPP synced off an incomplete MIRROR;
@@ -1774,7 +1804,7 @@ impl Effects for EffectsView {
         outcome
     }
 
-    fn steer(&mut self) -> Result<(), String> {
+    fn steer(&mut self) -> Result<SteerOutcome, String> {
         let mut c = self.core.borrow_mut();
         // The completeness gate, HERE rather than at either caller.
         //
@@ -1791,7 +1821,17 @@ impl Effects for EffectsView {
         // `SteerFailed`, which leaves `steer_wanted` set, so the next
         // verify retries — and by then the dump has usually finished. No
         // rules are installed, so `rules_remain` is unaffected.
-        if let Some(handle) = &c.completeness {
+        //
+        // Not applied to an EMPTY target, and that exception is the
+        // whole of the gate's own logic turned round: it exists to stop
+        // traffic being diverted into a table that cannot forward it,
+        // and a reconcile against a target with no port diverts
+        // nothing — it only removes. Gating it refuses the one steer
+        // whose entire job is to take traffic OFF VPP, and does so
+        // precisely when the mirror is unhealthy, which is when the
+        // operator is most likely to be rolling back.
+        let diverts_traffic = c.steering.configured_ports() > 0;
+        if let Some(handle) = c.completeness.as_ref().filter(|_| diverts_traffic) {
             let verdict = handle.verdict();
             if !verdict.permits_steering() {
                 return Err(format!(
@@ -2126,11 +2166,11 @@ mod tests {
             self.configured
         }
 
-        fn steer(&mut self) -> Result<(), String> {
+        fn steer(&mut self) -> Result<SteerOutcome, String> {
             let (rules, ok) = self.next.take().unwrap_or_default();
             self.rules = rules;
             if ok {
-                Ok(())
+                Ok(SteerOutcome::Steered)
             } else {
                 Err("MCAM refused".into())
             }
@@ -2288,8 +2328,8 @@ mod tests {
             fn configured_ports(&self) -> usize {
                 1
             }
-            fn steer(&mut self) -> Result<(), String> {
-                Ok(())
+            fn steer(&mut self) -> Result<SteerOutcome, String> {
+                Ok(SteerOutcome::Steered)
             }
             fn unsteer(&mut self) -> Result<(), String> {
                 Ok(())
@@ -2356,8 +2396,8 @@ mod tests {
             fn configured_ports(&self) -> usize {
                 1
             }
-            fn steer(&mut self) -> Result<(), String> {
-                Ok(())
+            fn steer(&mut self) -> Result<SteerOutcome, String> {
+                Ok(SteerOutcome::Steered)
             }
             fn unsteer(&mut self) -> Result<(), String> {
                 Ok(())
@@ -2591,6 +2631,12 @@ mod tests {
 
         let steering = LedgerSteering {
             next: Some((vec![("eth4".into(), 1024)], true)),
+            // The gate applies to a target that ASKS for a port —
+            // that is the traffic it protects. A double that installs a
+            // rule while reporting nothing configured would exercise
+            // the empty-target bypass instead, and pass for the wrong
+            // reason.
+            configured: 1,
             ..Default::default()
         };
         let rt = Runtime::new(
@@ -2640,6 +2686,48 @@ mod tests {
         assert_eq!(rt.core.borrow().steering.installed().len(), 1);
     }
 
+    /// The gate does not block a reconcile that diverts nothing.
+    ///
+    /// It exists to keep traffic out of a table that cannot forward it.
+    /// A target with no port installs nothing and only removes, so
+    /// gating it refuses the one steer whose job is to take traffic OFF
+    /// VPP — and refuses it precisely when the mirror is unhealthy,
+    /// which is when an operator is most likely to be rolling back. The
+    /// rollback would then be unable to complete for the same reason it
+    /// was started.
+    #[test]
+    fn the_completeness_gate_does_not_block_an_empty_target() {
+        use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+        let steering = LedgerSteering {
+            // Reconciled to nothing, successfully: no port configured.
+            next: Some((Vec::new(), true)),
+            configured: 0,
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        let handle = std::sync::Arc::new(TableCompleteness::new());
+        rt.require_table_complete(handle.clone());
+        // The most condemning verdict there is.
+        handle.publish(CompletenessReport {
+            authority_routes: 1_000_000,
+            mirror_routes: 1,
+            at: std::time::Instant::now(),
+        });
+
+        let (_, mut fx) = rt.views();
+        fx.steer()
+            .expect("a reconcile that installs nothing has no traffic to protect");
+    }
+
     /// Without the handle the gate does not exist at all.
     ///
     /// `require-table-complete off` is a deployment with no authority to
@@ -2651,6 +2739,12 @@ mod tests {
     fn an_unset_gate_does_not_block_steering() {
         let steering = LedgerSteering {
             next: Some((vec![("eth4".into(), 1024)], true)),
+            // The gate applies to a target that ASKS for a port —
+            // that is the traffic it protects. A double that installs a
+            // rule while reporting nothing configured would exercise
+            // the empty-target bypass instead, and pass for the wrong
+            // reason.
+            configured: 1,
             ..Default::default()
         };
         let rt = Runtime::new(

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -799,21 +799,29 @@ impl StatusSnapshot {
              -N <iface> delete <loc>` removes a rule by hand"
                 .to_string()
         } else if !self.steer_configured {
-            // A convergence is coming and it will NOT clear these.
-            // `VerifyPassed` re-steers while `steered || steer_wanted`,
-            // and a refused `unsteer` deliberately keeps `steered` true
-            // — but `steer` refuses an empty target before reaching its
-            // stale-rule removal, also deliberately, because `Ok` there
-            // becomes `Event::Steered` and would report an offload
-            // carrying traffic it never saw. So a `steer off` whose
-            // removal failed retries that refusal on every convergence
-            // while the rules keep diverting traffic. The product gap is
-            // filed; what this line must not do is promise a repair that
-            // cannot happen (review finding).
-            "no port is configured to steer, so convergence cannot clear these — `steer` \
-             refuses an empty target rather than report an offload it never installed. \
-             Remove them with `ethtool -N <iface> delete <loc>`; `packetframe detach \
-             --all` also retries the teardown, but refuses while this daemon is running"
+            // A convergence DOES clear these, and for a while it did
+            // not. `VerifyPassed` re-steers while `steered ||
+            // steer_wanted`, and a refused `unsteer` deliberately keeps
+            // `steered` true — so a `steer off` whose removal the NIC
+            // declined re-emitted `Action::Steer` on every convergence.
+            // `steer` used to refuse an empty target outright, before
+            // reaching its stale-rule removal, because `Ok` had no way
+            // to say "nothing is steered" and would have become
+            // `Event::Steered`. The refusal repeated forever while the
+            // rules kept diverting. `SteerOutcome::NothingToSteer` is
+            // the vocabulary that was missing; the reconcile now removes
+            // them and the module retires the want.
+            //
+            // The manual removals stay named anyway. This arm is also
+            // reached from `Backoff`, where the next convergence is
+            // however long the exponential schedule says, and a stray
+            // rule is diverting traffic into a VF whose VPP is not
+            // running — that is not something to wait out.
+            "no port is configured to steer, so the next convergence reconciles the NIC to \
+             an empty target and removes these. Do not wait for it if VPP is not \
+             forwarding: `ethtool -N <iface> delete <loc>` removes a rule now, and \
+             `packetframe detach --all` retries the whole teardown once this daemon has \
+             exited"
                 .to_string()
         } else {
             // A convergence is in flight or is coming (`Backoff` has no
@@ -1501,21 +1509,23 @@ mod tests {
                          must offer exactly the remedy this situation admits. \
                          `reconfigure` is refused outside Ready/Steered; a stopped \
                          daemon reconciles nothing; and with no port configured to \
-                         steer, `steer` refuses the empty target before it would clear \
-                         the leftovers, so convergence cannot fix it either: {msg}"
+                         steer, the convergence reconciles to an empty target, which \
+                         is a different promise from the one the general arm makes: \
+                         {msg}"
                     );
                 }
-                // The two cannot-self-repair arms must name a command
-                // that works from where they are. `loader::detach`
-                // refuses while a `packetframe run` daemon is live, and
-                // this arm is only reachable with the module running —
-                // so it has to lead with the deletion that works.
+                // This arm names a convergence, but it is reached from
+                // `Backoff` too — where the next one is however long
+                // the exponential schedule says, and VPP is not
+                // forwarding meanwhile. So it must ALSO name a removal
+                // that works right now, and must not point at `detach`
+                // without saying that a live daemon refuses it.
                 if expected == "no port is configured to steer" {
                     assert!(
-                        msg.contains("refuses while this daemon is running")
-                            && msg.contains("ethtool -N"),
-                        "state {state:?}: reachable only under a live daemon, where \
-                         `detach` is refused outright: {msg}"
+                        msg.contains("ethtool -N") && msg.contains("once this daemon has exited"),
+                        "state {state:?}: waiting out a convergence is not always an \
+                         option here, and `loader::detach` is refused while this \
+                         daemon holds the bpf_link FDs: {msg}"
                     );
                 }
             }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -799,8 +799,8 @@ impl StatusSnapshot {
              -N <iface> delete <loc>` removes a rule by hand"
                 .to_string()
         } else if !self.steer_configured {
-            // A convergence DOES clear these, and for a while it did
-            // not. `VerifyPassed` re-steers while `steered ||
+            // A convergence CAN clear these now, and for a while none
+            // could. `VerifyPassed` re-steers while `steered ||
             // steer_wanted`, and a refused `unsteer` deliberately keeps
             // `steered` true — so a `steer off` whose removal the NIC
             // declined re-emitted `Action::Steer` on every convergence.
@@ -809,19 +809,33 @@ impl StatusSnapshot {
             // to say "nothing is steered" and would have become
             // `Event::Steered`. The refusal repeated forever while the
             // rules kept diverting. `SteerOutcome::NothingToSteer` is
-            // the vocabulary that was missing; the reconcile now removes
-            // them and the module retires the want.
+            // the vocabulary that was missing.
+            //
+            // CAN, not will, and the qualifier is the same one the arm
+            // below carries: only `VerifyPassed` emits the steer that
+            // carries the reconcile. `VerifyIncomplete` parks in `Ready`
+            // with no action at all, so a convergence that ends with
+            // routes withheld or unresolvable leaves these exactly where
+            // they are — and the promise this line made in its first
+            // draft was the very thing #157 was written to stop it
+            // doing (review finding). The state is not stuck: `Ready`
+            // takes the `reconfigure` arm above, and with no port asking
+            // to steer that reconcile removes rather than reinstalls.
             //
             // The manual removals stay named anyway. This arm is also
             // reached from `Backoff`, where the next convergence is
             // however long the exponential schedule says, and a stray
             // rule is diverting traffic into a VF whose VPP is not
             // running — that is not something to wait out.
-            "no port is configured to steer, so the next convergence reconciles the NIC to \
-             an empty target and removes these. Do not wait for it if VPP is not \
-             forwarding: `ethtool -N <iface> delete <loc>` removes a rule now, and \
-             `packetframe detach --all` retries the whole teardown once this daemon has \
-             exited"
+            "no port is configured to steer, so a convergence that verifies without \
+             withheld or unresolvable routes reconciles the NIC to an empty target and \
+             removes these. One that ends incomplete parks in the staging state and \
+             emits no steer at all, so nothing reconciles and this line outlives the \
+             convergence — `packetframe reconfigure` is then the retry, and with no port \
+             asking to steer it removes the rules rather than reinstalling any. Do not \
+             wait for either if VPP is not forwarding: `ethtool -N <iface> delete <loc>` \
+             removes a rule now, and `packetframe detach --all` retries the whole \
+             teardown once this daemon has exited"
                 .to_string()
         } else {
             // A convergence is in flight or is coming (`Backoff` has no

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -218,6 +218,28 @@ pub enum Event {
     ConvergenceFailed,
     /// Steering rules installed.
     Steered,
+    /// A reconcile ran against a target that asks for **no port**: the
+    /// NIC now holds nothing, and nothing is wanted.
+    ///
+    /// The third outcome of `Action::Steer`, and the one whose absence
+    /// made `steer off` unrecoverable. `steer` reconciles, so a target
+    /// with no port is a legitimate thing to reconcile to — but with
+    /// only `Steered` and `SteerFailed` to report it in, it had to
+    /// refuse, and it refused *before* the stale-rule removal. So an
+    /// `unsteer` the NIC declined (rules stay in the ledger, `steered`
+    /// stays true, the VF stays withheld — by design) left every later
+    /// convergence re-emitting `Action::Steer` into that same refusal,
+    /// with the rules still diverting traffic the operator had asked it
+    /// to stop diverting. Reported, but unfixable by the module.
+    ///
+    /// Distinct from [`Self::Unsteered`] in exactly one respect, and it
+    /// is the load-bearing one: this retires the WANT as well. An
+    /// `Unsteered` on the adopted path must leave `steer_wanted` set so
+    /// the next `VerifyPassed` re-steers; this one arrives from a
+    /// config that asks for nothing, so leaving the want set parks the
+    /// module in `steering intended but not in place` forever — the
+    /// same permanent-Degraded shape the shadow hit on 2026-08-07.
+    NothingToSteer,
     /// The process exited — from pidfd, not SIGCHLD, because adoption
     /// reparents the child and SIGCHLD would never arrive.
     ProcessExited {
@@ -786,6 +808,28 @@ impl Supervisor {
             // --- steering acknowledgements ---
             (_, Unsteered) => {
                 self.steered = false;
+                vec![]
+            }
+            // The reconcile found a target with no port, so the NIC
+            // holds nothing — and unlike `Unsteered`, this also says
+            // the CONFIG asks for nothing, which is the only thing
+            // entitled to retire the want.
+            //
+            // Retiring it is not cosmetic. `steer_wanted` is resurrected
+            // by every death or wedge that happens while `steered` is
+            // true (`if self.steered { self.steer_wanted = true }`),
+            // which is exactly the path a rollback takes when the NIC
+            // refuses the removal — so without this the module would
+            // clear the rules here and still read `steering intended
+            // but not in place`, Degraded, with nothing left to do
+            // about it.
+            //
+            // A catch-all like the other two acknowledgements: it
+            // describes what the NIC now holds, and that is true from
+            // whichever state asked.
+            (_, NothingToSteer) => {
+                self.steered = false;
+                self.steer_wanted = false;
                 vec![]
             }
             // Traffic is still diverted. `steered` stays true so the
@@ -1635,6 +1679,73 @@ mod tests {
         assert!(
             s.on(Event::StopRequested).contains(&Action::Unsteer),
             "every later teardown must keep trying, and keep withholding the VF"
+        );
+    }
+
+    /// The acknowledgement that gets a refused `steer off` unstuck —
+    /// and the one respect in which it differs from `Unsteered`.
+    ///
+    /// Both clear `steered`. Only this one clears the WANT, and it must:
+    /// a death or wedge while `steered` re-arms `steer_wanted`, which is
+    /// exactly the path a rollback takes when the NIC refuses the
+    /// removal. Leave the want set and the module has cleared the rules
+    /// and still reads `steering intended but not in place` — Degraded
+    /// forever against a config that asks for nothing, which is the
+    /// shape the shadow hit on 2026-08-07.
+    #[test]
+    fn a_reconcile_to_an_empty_target_retires_the_want_as_well() {
+        let mut s = running_and_steered();
+        // `steer off`, and the NIC refuses the removal.
+        s.on(Event::UnsteerRequested);
+        s.on(Event::UnsteerFailed);
+        // VPP dies with rules still installed, which re-arms the want.
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::UnsteerFailed);
+        assert!(
+            s.steer_intended(),
+            "the premise: a death while steered re-arms the want, so the next verify \
+             re-steers"
+        );
+
+        // The replacement verifies, and the reconcile finds no port.
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+        assert_eq!(
+            s.on(Event::VerifyPassed),
+            vec![Action::Steer],
+            "this is the steer that used to hit the refusal"
+        );
+
+        s.on(Event::NothingToSteer);
+        assert!(!s.is_steered());
+        assert!(
+            !s.steer_intended(),
+            "a config that asks for no port is the one thing entitled to retire the want"
+        );
+        assert!(
+            s.on(Event::VerifyPassed).is_empty(),
+            "and no later convergence re-enters the loop"
+        );
+    }
+
+    /// `Unsteered` must NOT retire the want — the difference that makes
+    /// `NothingToSteer` a separate event rather than a second call site.
+    ///
+    /// The adopted path unsteers deliberately, to read the adoptee's FIB
+    /// without holding VPP's worker barrier for seconds. `steer_wanted`
+    /// is what puts traffic back afterwards.
+    #[test]
+    fn a_plain_unsteer_leaves_the_want_for_the_re_steer() {
+        let mut s = Supervisor::new();
+        s.on(Event::Adopted { steered: true });
+        s.on(Event::FallbackSettled);
+        s.on(Event::Unsteered);
+        assert!(!s.is_steered());
+        assert!(
+            s.steer_intended(),
+            "the adopted resync unsteers to read the FIB, and the want is what re-steers \
+             it once the verify passes"
         );
     }
 

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -1729,6 +1729,55 @@ mod tests {
         );
     }
 
+    /// The limit of that repair: only `VerifyPassed` carries it.
+    ///
+    /// `Action::Steer` is what runs the reconcile, and
+    /// `VerifyIncomplete` deliberately emits none — diverting traffic
+    /// into a FIB with known holes is the thing that arm exists to
+    /// prevent. So a convergence that ends with routes withheld or
+    /// unresolvable leaves the leftover rules exactly where they are.
+    ///
+    /// Pinned rather than fixed. Closing it would mean emitting
+    /// `Action::Steer` here, and nothing the supervisor can see
+    /// separates "leftover rules under a config that asks for nothing"
+    /// from "rules we want and are about to re-assert": `steer_wanted`
+    /// is re-armed by the very death that precedes the restart. The
+    /// emptiness is only knowable in `steer` itself, which is why the
+    /// outcome lives there — so for a CONFIGURED target this arm would
+    /// divert traffic into the incomplete FIB, which is the regression
+    /// it was written to stop. The escape is the operator's:
+    /// `VerifyIncomplete` parks in `Ready`, where `reconfigure` is
+    /// accepted and removes the rules, and the health line says so
+    /// rather than promising a convergence that may not come.
+    #[test]
+    fn an_incomplete_verify_does_not_reconcile_an_empty_target() {
+        let mut s = running_and_steered();
+        s.on(Event::UnsteerRequested);
+        s.on(Event::UnsteerFailed);
+        s.on(Event::ProcessExited { status: None });
+        s.on(Event::UnsteerFailed);
+        s.on(Event::BackoffElapsed);
+        s.on(Event::ApiUp);
+        s.on(Event::SyncComplete);
+
+        assert_eq!(
+            s.on(Event::VerifyIncomplete),
+            Vec::new(),
+            "no steer, so no reconcile — the rules stay in the NIC"
+        );
+        assert!(
+            s.is_steered(),
+            "and the module still believes them installed, which is what keeps the VF \
+             withheld"
+        );
+        assert_eq!(
+            s.state(),
+            State::Ready,
+            "the way out is `reconfigure`, which this state accepts"
+        );
+        assert!(s.state().accepts_steering_changes());
+    }
+
     /// `Unsteered` must NOT retire the want — the difference that makes
     /// `NothingToSteer` a separate event rather than a second call site.
     ///

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1427,10 +1427,10 @@ mod steered {
         fn configured_ports(&self) -> usize {
             1
         }
-        fn steer(&mut self) -> Result<(), String> {
+        fn steer(&mut self) -> Result<packetframe_vpp_offload::runtime::SteerOutcome, String> {
             self.log.lock().unwrap().push("steer");
             self.rules = vec![("eth4".into(), 1)];
-            Ok(())
+            Ok(packetframe_vpp_offload::runtime::SteerOutcome::Steered)
         }
         fn unsteer(&mut self) -> Result<(), String> {
             self.log.lock().unwrap().push("unsteer");

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -726,7 +726,7 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
             1
         }
 
-        fn steer(&mut self) -> Result<(), String> {
+        fn steer(&mut self) -> Result<packetframe_vpp_offload::runtime::SteerOutcome, String> {
             panic!("supervision loop panic, on purpose");
         }
         fn unsteer(&mut self) -> Result<(), String> {
@@ -1165,9 +1165,9 @@ impl packetframe_vpp_offload::runtime::Steering for SpySteering {
         1
     }
 
-    fn steer(&mut self) -> Result<(), String> {
+    fn steer(&mut self) -> Result<packetframe_vpp_offload::runtime::SteerOutcome, String> {
         self.0.lock().unwrap().push("steer".into());
-        Ok(())
+        Ok(packetframe_vpp_offload::runtime::SteerOutcome::Steered)
     }
     fn unsteer(&mut self) -> Result<(), String> {
         self.0.lock().unwrap().push("unsteer".into());
@@ -1203,14 +1203,14 @@ impl packetframe_vpp_offload::runtime::Steering for FailFirstSteer {
     fn configured_ports(&self) -> usize {
         1
     }
-    fn steer(&mut self) -> Result<(), String> {
+    fn steer(&mut self) -> Result<packetframe_vpp_offload::runtime::SteerOutcome, String> {
         if !self.failed {
             self.failed = true;
             self.log.lock().unwrap().push("steer-refused".into());
             return Err("refusing to steer: the route mirror holds 3 of 10 routes".into());
         }
         self.log.lock().unwrap().push("steer".into());
-        Ok(())
+        Ok(packetframe_vpp_offload::runtime::SteerOutcome::Steered)
     }
     fn unsteer(&mut self) -> Result<(), String> {
         self.log.lock().unwrap().push("unsteer".into());

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -440,12 +440,18 @@ killed are a blackhole, not a lost optimisation.
 as of the `SteerOutcome::NothingToSteer` fix it does repair itself:
 
 ```text
-steering  DEGRADED — ... no port is configured to steer, so the next
-                     convergence reconciles the NIC to an empty target and
-                     removes these. Do not wait for it if VPP is not
-                     forwarding: `ethtool -N <iface> delete <loc>` removes
-                     a rule now, and `packetframe detach --all` retries the
-                     whole teardown once this daemon has exited
+steering  DEGRADED — ... no port is configured to steer, so a convergence
+                     that verifies without withheld or unresolvable routes
+                     reconciles the NIC to an empty target and removes
+                     these. One that ends incomplete parks in the staging
+                     state and emits no steer at all, so nothing reconciles
+                     and this line outlives the convergence — `packetframe
+                     reconfigure` is then the retry, and with no port asking
+                     to steer it removes the rules rather than reinstalling
+                     any. Do not wait for either if VPP is not forwarding:
+                     `ethtool -N <iface> delete <loc>` removes a rule now,
+                     and `packetframe detach --all` retries the whole
+                     teardown once this daemon has exited
 ```
 
 `steer` is a reconcile, and a target with no port is a legitimate thing
@@ -453,6 +459,15 @@ to reconcile to: the stale-rule removal runs, the rules come out, and the
 outcome lands as `Event::NothingToSteer` — which clears `steered` *and*
 retires the want, so the module settles in `Ready` with `steer off
 (staging state)`.
+
+**Read the second sentence here too.** `Action::Steer` is what carries
+that reconcile, and only `VerifyPassed` emits it. A convergence ending
+`VerifyIncomplete` parks in `Ready` with no action at all, so the
+leftover rules stay. That is not a stuck state — `Ready` accepts
+`packetframe reconfigure`, and with no port configured to steer the
+reconcile removes the rules rather than reinstalling any — but it does
+mean "wait for the convergence" is the wrong instinct if the health line
+is still there once the module reaches `Ready`.
 
 It did not always. `steer` used to refuse an empty target outright,
 before reaching that removal, because `Ok` had no way to say "nothing is

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -436,27 +436,40 @@ steering  DEGRADED — ... supervision has stopped, so nothing will
 Take that one seriously: rules pointing at a VF whose VPP has been
 killed are a blackhole, not a lost optimisation.
 
-**The same applies when no port is configured to steer** — a full
-`steer off` whose removal was refused:
+**A full `steer off` whose removal was refused reads differently**, and
+as of the `SteerOutcome::NothingToSteer` fix it does repair itself:
 
 ```text
-steering  DEGRADED — ... no port is configured to steer, so convergence
-                     cannot clear these — `steer` refuses an empty target
-                     rather than report an offload it never installed.
-                     Remove them with `ethtool -N <iface> delete <loc>`;
-                     `packetframe detach --all` also retries the teardown,
-                     but refuses while this daemon is running
+steering  DEGRADED — ... no port is configured to steer, so the next
+                     convergence reconciles the NIC to an empty target and
+                     removes these. Do not wait for it if VPP is not
+                     forwarding: `ethtool -N <iface> delete <loc>` removes
+                     a rule now, and `packetframe detach --all` retries the
+                     whole teardown once this daemon has exited
 ```
 
-Note the order: `detach` refuses outright while a `packetframe run`
-daemon exists (it holds the bpf_link FDs), so under a live module the
-`ethtool` deletion is the one that works.
+`steer` is a reconcile, and a target with no port is a legitimate thing
+to reconcile to: the stale-rule removal runs, the rules come out, and the
+outcome lands as `Event::NothingToSteer` — which clears `steered` *and*
+retires the want, so the module settles in `Ready` with `steer off
+(staging state)`.
 
-The module cannot repair this one on its own: it re-steers because a
-refused `unsteer` leaves it believing traffic is diverted, and then
-refuses the empty target. Clean up by hand. (Tracked as a product gap;
-the module should reconcile an empty target through `unsteer` rather
-than retry a refusal.)
+It did not always. `steer` used to refuse an empty target outright,
+before reaching that removal, because `Ok` had no way to say "nothing is
+steered" and would have become `Event::Steered` — an offload reported as
+carrying traffic it never saw. Meanwhile a refused `unsteer` leaves
+`steered` true by design, a death while steered re-arms the want, and
+`VerifyPassed` re-steers on the want: so every convergence re-entered the
+same refusal and the rules diverted traffic forever, for a port the
+operator had turned off.
+
+Do not simply wait for the convergence, though. This line is also
+reachable from `Backoff`, where the next one is however long the
+exponential schedule says and VPP is not forwarding meanwhile — rules
+pointing at a VF whose VPP is down are a blackhole. `detach` refuses
+outright while a `packetframe run` daemon exists (it holds the bpf_link
+FDs), so under a live module the `ethtool` deletion is the one that
+works right now.
 
 **Two directions, one count.** The rules the ledger names are read back
 and compared field by field, so a deleted, replaced or narrowed rule is


### PR DESCRIPTION
## The stuck state

Found reviewing #157. A `steer off` whose `unsteer` the NIC refuses could never be cleared by the module — it retried a no-op error forever while the rules kept diverting traffic for a port the operator had asked it to stop steering.

Every step is deliberate behaviour somewhere else in the subsystem, which is what made it a trap rather than a bug in any one place:

1. `steer off` on every port + `reconfigure` retargets to an empty target and emits `Action::Unsteer`.
2. `unsteer()` fails on at least one rule. By design the rules stay in `installed`, `steered` stays true, and the VF is withheld — a rule that would not come out is still steering traffic.
3. VPP dies. `fail()` unsteers first (refused again), and the death re-arms `steer_wanted`, because a restart nobody watched should not silently leave the offload off.
4. The replacement verifies. `steer_intended()` is true, so `VerifyPassed` emits `Action::Steer` — into a `steer` that refused an empty target **before** reaching its stale-rule removal. Every convergence re-entered the same refusal.

## Why the obvious fix is wrong

Making `steer()` clear the stale rules and return `Ok` for an empty target does not work: `Ok` becomes `Event::Steered`, which tells the supervisor traffic is diverted. `ntuple::tests::steering_an_empty_plan_is_refused` asserted exactly that — "a no-op that returned `Ok` would put the module in `Steered` with nothing steered, and health would report the offload carrying traffic it never saw."

The refusal was correct given the vocabulary available. What was missing was a third outcome.

## The shape chosen

`Steering::steer` now returns `Result<SteerOutcome, String>`, and the executor maps `Ok(SteerOutcome::NothingToSteer)` to a new `Event::NothingToSteer`.

I considered the alternative suggested in review — have the supervisor emit `Action::Unsteer` rather than `Action::Steer` when the target is empty — and rejected it. The supervisor is a pure state machine with no view of the target; it would need a shadow copy of a fact `NtupleSteering` already owns, initialised at three sites (retarget, attach, and the `InheritedSteering { still_configured }` path that already carries config intent) and free to drift from the real thing at each. This module's own comments are a record of what derived state costs here. `steer` is the one routine responsible for every rule that ever reaches the NIC; keeping the answer there keeps one source of truth.

`NothingToSteer` also **retires the want**, which `Unsteered` deliberately does not — the adopted path unsteers to read the adoptee's FIB and needs `steer_wanted` to put traffic back afterwards. Without that the module would clear the rules and still read `steering intended but not in place`: Degraded forever against a config asking for nothing, the same shape the shadow hit on 2026-08-07.

## Two things that fall out

- **Ports configured with an empty PLAN still refuses.** That is a broken allowlist or an exhausted MCAM budget; reporting it as a clean "nothing steered" would retire the want and hide it behind the line a deliberate `steer off` prints. The emptiness that means "the operator asked for nothing" is the *port* list, not the rule list. The old test survives as `steering_a_configured_port_with_no_rules_is_refused`.
- **The completeness gate no longer applies to an empty target.** It exists to keep traffic out of a table that cannot forward it. A reconcile that installs nothing has no traffic to protect, and gating it refused the one steer whose job is to take traffic *off* VPP — precisely when the mirror is unhealthy, which is when an operator is most likely to be rolling back.

## Tests

`ntuple::tests::a_refused_unsteer_is_cleared_by_the_next_convergence` drives the whole sequence — steer, `steer off` retarget, refused unsteer (`wedge_delete`), process death, restart, `VerifyPassed` — through the real `Supervisor`, the real `execute()`, and a real `NtupleSteering` over the in-memory NIC, because that composition *is* the defect; each half is correct alone. Against the previous code it fails on the NIC still holding both rules:

```
the leftover rules must be GONE from the NIC: they divert traffic for a port
the operator turned off, and no convergence after this one will look again.
Still holding [14, 15]
```

Also added: the two `NtupleSteering` outcomes and the still-refused stuck-rule case; the executor mapping for both `Steer` and `RestoreSteer`; the supervisor arm, paired with a test that `Unsteered` must *not* retire the want; and the gate bypass. Two existing gate-test doubles installed a rule while reporting `configured_ports() == 0` — they now declare the port they steer, or they would exercise the bypass and pass for the wrong reason.

## Docs

The `!steer_configured` remedy from #157 and its runbook section described the unfixable state. Both now describe the repair — while still naming the manual `ethtool -N` deletion, because that line is also reachable from `Backoff`, where the next convergence is however long the exponential schedule says and the rules point at a VF whose VPP is down.

## Verification

`make test` and `make lint` are green. The vpp-offload integration tests (`tests/vpp_*.rs`) run on this host and pass; the qemu matrix is CI's. Nothing here is platform-gated — the Linux split lives inside `sys::ethtool`, below everything touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)