### PR TITLE
fix(vpp-offload): retry a wanted steer once the gate that refused it clears

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -123,7 +123,8 @@ pub trait Observe {
     /// Send a ping and read its reply.
     fn ping(&mut self) -> Result<(), String>;
 
-    /// Whether a steer would get past the module's own gates right now.
+    /// Whether the module has any reason of its own to refuse or defer
+    /// a steer right now.
     ///
     /// Read only when a wanted steer is missing (see
     /// [`Supervisor::steer_retry_pending`]) and only as often as
@@ -131,12 +132,20 @@ pub trait Observe {
     /// but not an ioctl.
     ///
     /// It must answer for **every** gate the steer path applies, or the
-    /// retry becomes a way around one of them. Both refuse for the same
+    /// retry becomes a way around one of them. Two refuse for the same
     /// reason from opposite ends: the completeness verdict says the
     /// route mirror is not yet the table, and the ledger's counts say
     /// what we hold has not all reached VPP. Diverting traffic on either
     /// blackholes exactly the prefixes that are missing, and a steered
     /// miss is dropped rather than falling through to the eBPF tier.
+    ///
+    /// And one thing that is not a gate at all but disqualifies the
+    /// moment just as thoroughly: a source backlog. Neither gate can
+    /// see changes the engine has not pulled yet — the ledger has not
+    /// classified them and the mirror already counts them — so the
+    /// implementation owes that check too. The driver's own
+    /// `Drain::Idle` proof does not cover it either; see
+    /// `Driver::poll_steer_retry`.
     fn steer_permitted(&mut self) -> bool;
 
     /// Drain **one bounded batch** of pending routes.

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -253,6 +253,11 @@ impl Driver {
         let before = self.sup.state();
         let mut events = Vec::new();
         let mut more_to_drain = false;
+        // Whether THIS tick's drain proved the engine has nothing left to
+        // send. The steer retry's precondition — see `poll_steer_retry`.
+        // False until a drain says so, so a tick that did not drain at
+        // all, or whose drain failed, cannot be read as proof.
+        let mut drain_proved_idle = false;
         // Whether the API was already up **at entry**. Captured here
         // because the block below may arm the detector during this very
         // tick, and every observation in this loop reads the state as it
@@ -337,7 +342,7 @@ impl Driver {
                     // drain can say so, which is why this is observed
                     // rather than assumed after issuing StartResync.
                     Ok(Drain::Idle) if resyncing => events.push(Event::SyncComplete),
-                    Ok(Drain::Idle) => {}
+                    Ok(Drain::Idle) => drain_proved_idle = true,
                     Ok(Drain::More) => more_to_drain = true,
                     // Deliberate waiting, not progress and not
                     // completion. The phase deadline is pushed forward
@@ -381,7 +386,7 @@ impl Driver {
             }
 
             events.extend(self.poll_liveness(now, obs));
-            events.extend(self.poll_steer_retry(now, obs));
+            events.extend(self.poll_steer_retry(now, drain_proved_idle, obs));
         }
 
         let mut tick = self.apply(now, events, fx);
@@ -492,16 +497,42 @@ impl Driver {
     /// [`STEER_RETRY_EVERY`] is what stops a steer that keeps failing
     /// for its own reasons from being re-attempted every tick.
     ///
-    /// One thing it deliberately does NOT do: rescue a want whose target
-    /// is empty. `steer` refuses that before it reaches its stale-rule
-    /// removal, so such a retry could only fail — but every supported
-    /// path that empties the target also clears the want, and the case
-    /// where it does not (a `steer off` whose unsteer was refused) needs
-    /// a teardown outcome meaning "reconciled to nothing steered", which
-    /// is filed separately rather than smuggled in here.
-    fn poll_steer_retry(&mut self, now: Instant, obs: &mut dyn Observe) -> Vec<Event> {
+    /// `drained_idle` is this tick's proof that the engine has nothing
+    /// left to send, and it is a PRECONDITION, not a nicety. The
+    /// ledger's counts are the other gate's evidence and they can be
+    /// clean over deltas VPP never received: `RouteFeed::drain_changes`
+    /// removes the batch from the mirror, and `Engine::apply_changes`
+    /// returns on a failed `send_neighbour` **before** queuing that
+    /// batch's routes — so nothing is left `installing`,
+    /// `blocks_first_steer()` says fine, and a steer here would divert
+    /// traffic into a FIB missing exactly those prefixes (review
+    /// finding, PR #160). A drain that did not run, or ran and failed,
+    /// proves nothing, so neither may pass for proof.
+    ///
+    /// It also subsumes the ordinary in-flight case — `Drain::More`
+    /// means routes are on the wire — which the counts already covered.
+    /// The error case is the one they get wrong.
+    ///
+    /// One thing this deliberately does NOT do: rescue a want whose
+    /// target is empty. `steer` refuses that before it reaches its
+    /// stale-rule removal, so such a retry could only fail — but every
+    /// supported path that empties the target also clears the want, and
+    /// the case where it does not (a `steer off` whose unsteer was
+    /// refused) needs a teardown outcome meaning "reconciled to nothing
+    /// steered", which is filed separately rather than smuggled in here.
+    fn poll_steer_retry(
+        &mut self,
+        now: Instant,
+        drained_idle: bool,
+        obs: &mut dyn Observe,
+    ) -> Vec<Event> {
         if !self.sup.steer_retry_pending() {
             self.last_steer_retry = None;
+            return Vec::new();
+        }
+        if !drained_idle {
+            // Nothing recorded: this is a missing proof, not a spent
+            // attempt, so the tick that does prove it acts immediately.
             return Vec::new();
         }
         if self
@@ -1505,6 +1536,62 @@ mod tests {
             "{attempts} attempts in {window:?} — the interval is not pacing anything"
         );
         assert!(d.supervisor().steer_retry_pending(), "still outstanding");
+    }
+
+    /// A tick whose drain failed is not proof of anything, and must not
+    /// be steered over.
+    ///
+    /// The completeness verdict and the ledger's counts are the two
+    /// gates, and a failed drain can leave BOTH looking clean over
+    /// deltas VPP never received: `drain_changes` takes the batch out of
+    /// the mirror, and `apply_changes` returns on a failed
+    /// `send_neighbour` before queuing that batch's routes, so nothing
+    /// is left `installing` to notice. Steering there diverts traffic
+    /// into a FIB missing exactly those prefixes — and unlike the
+    /// unsteered case, a steered miss is dropped (review finding, PR
+    /// #160).
+    #[test]
+    fn a_failed_drain_holds_the_retry_until_one_succeeds() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            ..Default::default()
+        };
+        refused_canary(t0, &mut d, &mut w, &mut fx);
+
+        // Both gates now say yes — and the drain says it could not talk
+        // to VPP, which is the fact that outranks them.
+        w.steer_permitted = true;
+        w.drain_fails = true;
+        fx.steer_fails = false;
+        fx.calls.clear();
+        for ms in (100..10_000).step_by(250) {
+            d.tick(at(t0, ms), &mut w, &mut fx);
+        }
+        assert!(
+            !fx.calls.contains(&"steer"),
+            "a drain that failed cannot show the FIB is current: {:?}",
+            fx.calls
+        );
+        assert!(
+            d.supervisor().steer_retry_pending(),
+            "and the want is still outstanding, not discarded"
+        );
+
+        // The transport comes back and a drain reports the queue empty.
+        // That is the proof, and it is acted on at once — the withheld
+        // ticks must not have counted as attempts.
+        w.drain_fails = false;
+        let t = d.tick(at(t0, 10_100), &mut w, &mut fx);
+        assert!(
+            t.events.contains(&Event::SteerUnblocked),
+            "a proven-idle drain releases it immediately: {:?}",
+            t.events
+        );
+        assert_eq!(d.state(), State::Steered);
     }
 
     /// A port that never asked to steer is not steered by a gate that

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -540,6 +540,27 @@ impl Driver {
             // attempt, so the tick that does prove it acts immediately.
             return Vec::new();
         }
+        // And VPP has to be answering. `Drain::Idle` does not say so: an
+        // empty pending map sends nothing at all, so in steady state
+        // that `Ok` is reached without touching the socket. The two
+        // proofs are about different things — one that the FIB is
+        // current, one that there is a VPP behind it — and steering
+        // needs both.
+        //
+        // `answered_last_probe`, not `is_wedged`: the silence budget
+        // tolerates two missed pings so jitter cannot cost a restart,
+        // and that tolerance is exactly the window this would otherwise
+        // steer into. `Wedged` has not fired yet, so nothing takes the
+        // rules back off until it does (review finding, PR #160). It is
+        // read after `poll_liveness` has run this tick, so a ping that
+        // failed a moment ago already counts.
+        if !self
+            .detector
+            .as_ref()
+            .is_some_and(|d| d.answered_last_probe())
+        {
+            return Vec::new();
+        }
         if self
             .last_steer_retry
             .is_some_and(|t| now.duration_since(t) < STEER_RETRY_EVERY)
@@ -1597,6 +1618,76 @@ mod tests {
             "a proven-idle drain releases it immediately: {:?}",
             t.events
         );
+        assert_eq!(d.state(), State::Steered);
+    }
+
+    /// Nor may it steer into a VPP that has stopped answering.
+    ///
+    /// The gap this closes is between the first unanswered ping and
+    /// `Wedged`: the budget deliberately tolerates two missed pings so
+    /// jitter cannot cost a restart, and in steady state `Drain::Idle`
+    /// is reached without touching the socket — an empty pending map
+    /// sends nothing — so neither the drain proof nor the wedge
+    /// detector objects. Rules installed in that window put packets on
+    /// a VF whose VPP is already gone, and nothing takes them off until
+    /// the budget expires (review finding, PR #160).
+    #[test]
+    fn a_silent_api_holds_the_retry_until_it_answers_again() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            ..Default::default()
+        };
+        refused_canary(t0, &mut d, &mut w, &mut fx);
+        w.steer_permitted = true;
+        fx.steer_fails = false;
+
+        // VPP stops answering, and the FIRST tick after the refusal is
+        // one where a ping is due — otherwise the retry fires on the
+        // last pong, which is at most one ping interval old and is
+        // exactly as fresh as this loop can ever be.
+        //
+        // From there, stay INSIDE the silence budget measured from that
+        // pong at ~t0. That tolerated window is the whole premise: no
+        // `Wedged`, nothing torn down, and the drain still reports idle
+        // because there is nothing to send.
+        w.ping_fails = true;
+        fx.calls.clear();
+        let mut ms = PING_INTERVAL.as_millis() as u64;
+        while Duration::from_millis(ms) < PING_BUDGET {
+            let t = d.tick(at(t0, ms), &mut w, &mut fx);
+            assert!(
+                !t.events.contains(&Event::Wedged),
+                "the premise is the tolerated window, before any teardown: {:?}",
+                t.events
+            );
+            ms += 100;
+        }
+        assert!(w.pings > 0, "a ping must actually have gone unanswered");
+        assert!(
+            !fx.calls.contains(&"steer"),
+            "steering into an API that is not answering puts packets on a VF whose \
+             VPP is already gone: {:?}",
+            fx.calls
+        );
+        assert!(d.supervisor().steer_retry_pending(), "still wanted");
+
+        // It answers again. The pong lands before the wedge check on the
+        // same tick, so a recovery at the moment the next ping is due
+        // both clears the silence and releases the retry.
+        w.ping_fails = false;
+        let mut steered = false;
+        for step in 0..8 {
+            let t = d.tick(at(t0, ms + step * 100), &mut w, &mut fx);
+            if t.events.contains(&Event::SteerUnblocked) {
+                steered = true;
+                break;
+            }
+        }
+        assert!(steered, "a recovered API must release it: {:?}", fx.calls);
         assert_eq!(d.state(), State::Steered);
     }
 

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -57,6 +57,25 @@ use std::time::{Duration, Instant};
 /// here, so the cadence lives in the driver, not in every caller.
 pub const API_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
+/// How often a wanted-but-absent steer may be re-attempted.
+///
+/// The pacing half of [`Event::SteerUnblocked`]. The trigger is the
+/// gates opening, not this timer — but "the gates are open" is a level,
+/// not an edge, and a steer can also fail for reasons no gate knows
+/// about (the NIC refusing an insert). Without a floor between
+/// attempts, a steer that keeps failing under an open gate would be
+/// retried on every tick, which in steady state is every ping interval.
+///
+/// 30 s, matching `runtime::STEER_AUDIT_EVERY`, which paces the
+/// other periodic ethtool traffic on this path for the same reason: a
+/// handful of ioctls per steered interface is free at that cadence, and
+/// the number is sized against how long a silently-unsteered offload
+/// should be allowed to persist rather than against any hardware limit.
+/// It bounds the wait only for a RE-attempt — entering the
+/// wanted-but-absent state arms nothing, so the first look happens on
+/// the next tick.
+pub const STEER_RETRY_EVERY: Duration = Duration::from_secs(30);
+
 use crate::executor::{execute, Effects, Outcome};
 use crate::liveness::{budget_for, WedgeDetector};
 use crate::schedule::Schedule;
@@ -104,6 +123,22 @@ pub trait Observe {
     /// Send a ping and read its reply.
     fn ping(&mut self) -> Result<(), String>;
 
+    /// Whether a steer would get past the module's own gates right now.
+    ///
+    /// Read only when a wanted steer is missing (see
+    /// [`Supervisor::steer_retry_pending`]) and only as often as
+    /// [`STEER_RETRY_EVERY`] allows, so it may cost a lock and a count —
+    /// but not an ioctl.
+    ///
+    /// It must answer for **every** gate the steer path applies, or the
+    /// retry becomes a way around one of them. Both refuse for the same
+    /// reason from opposite ends: the completeness verdict says the
+    /// route mirror is not yet the table, and the ledger's counts say
+    /// what we hold has not all reached VPP. Diverting traffic on either
+    /// blackholes exactly the prefixes that are missing, and a steered
+    /// miss is dropped rather than falling through to the eBPF tier.
+    fn steer_permitted(&mut self) -> bool;
+
     /// Drain **one bounded batch** of pending routes.
     ///
     /// Bounded is the contract, not an implementation detail. A blocking
@@ -150,6 +185,13 @@ pub struct Driver {
     /// once: counting VPP's startup as silence would declare a wedge
     /// before it ever had a chance to reply.
     detector: Option<WedgeDetector>,
+    /// When the last wanted-but-absent steer was re-attempted.
+    ///
+    /// Cleared the moment nothing is outstanding, so the interval bounds
+    /// re-attempts *within* one outstanding steer rather than punishing
+    /// the next one: a refusal that arrives a minute after the last
+    /// success is looked at on the very next tick.
+    last_steer_retry: Option<Instant>,
 }
 
 impl Default for Driver {
@@ -165,6 +207,7 @@ impl Driver {
             sched: Schedule::new(),
             reconnect_wanted: false,
             detector: None,
+            last_steer_retry: None,
         }
     }
 
@@ -338,6 +381,7 @@ impl Driver {
             }
 
             events.extend(self.poll_liveness(now, obs));
+            events.extend(self.poll_steer_retry(now, obs));
         }
 
         let mut tick = self.apply(now, events, fx);
@@ -427,6 +471,53 @@ impl Driver {
         } else {
             Vec::new()
         }
+    }
+
+    /// Re-attempt a steer the module wants and does not have, once the
+    /// gates that refused it permit one.
+    ///
+    /// The driver owns this because the supervisor owns neither a clock
+    /// nor a view of the world, and the alternative — an operator
+    /// re-running `packetframe reconfigure` — is not a mechanism, it is
+    /// a person. The failure it closes: bird's dump is behind, the
+    /// canary lever is turned, the completeness gate refuses, the mirror
+    /// converges a minute later, and nothing steers.
+    ///
+    /// Level-triggered rather than edge-triggered, deliberately. An edge
+    /// needs the driver to have observed the gate closed at the moment
+    /// of the refusal, and it never does: the refusal happens inside an
+    /// `Action::Steer` during `apply`, and the gate may already read open
+    /// by the next tick. So the condition is the state of the world —
+    /// something is wanted, nothing forbids it — and
+    /// [`STEER_RETRY_EVERY`] is what stops a steer that keeps failing
+    /// for its own reasons from being re-attempted every tick.
+    ///
+    /// One thing it deliberately does NOT do: rescue a want whose target
+    /// is empty. `steer` refuses that before it reaches its stale-rule
+    /// removal, so such a retry could only fail — but every supported
+    /// path that empties the target also clears the want, and the case
+    /// where it does not (a `steer off` whose unsteer was refused) needs
+    /// a teardown outcome meaning "reconciled to nothing steered", which
+    /// is filed separately rather than smuggled in here.
+    fn poll_steer_retry(&mut self, now: Instant, obs: &mut dyn Observe) -> Vec<Event> {
+        if !self.sup.steer_retry_pending() {
+            self.last_steer_retry = None;
+            return Vec::new();
+        }
+        if self
+            .last_steer_retry
+            .is_some_and(|t| now.duration_since(t) < STEER_RETRY_EVERY)
+        {
+            return Vec::new();
+        }
+        if !obs.steer_permitted() {
+            // Still refused. Nothing is recorded, so the moment the gate
+            // opens the next tick acts — the interval paces attempts,
+            // not the waiting.
+            return Vec::new();
+        }
+        self.last_steer_retry = Some(now);
+        vec![Event::SteerUnblocked]
     }
 
     /// Apply events through the supervisor, execute what they ask for,
@@ -522,6 +613,12 @@ mod tests {
         pings: usize,
         drains: usize,
         api_readies: usize,
+        /// What the gates say about a steer. Default `false` — the
+        /// interesting case is a gate that refuses, and a double that
+        /// permits by omission would let a retry test pass without the
+        /// gate ever being consulted.
+        steer_permitted: bool,
+        steer_gate_reads: usize,
     }
 
     impl Observe for World {
@@ -539,6 +636,10 @@ mod tests {
             } else {
                 Ok(())
             }
+        }
+        fn steer_permitted(&mut self) -> bool {
+            self.steer_gate_reads += 1;
+            self.steer_permitted
         }
         fn drain_batch(&mut self, _now: Instant) -> Result<Drain, String> {
             self.drains += 1;
@@ -562,6 +663,9 @@ mod tests {
     struct Fx {
         calls: Vec<&'static str>,
         kill_disposition: Option<Disposition>,
+        /// The steer path refusing on its own terms — the completeness
+        /// gate, or a NIC that will not take the insert.
+        steer_fails: bool,
     }
 
     impl Effects for Fx {
@@ -580,6 +684,9 @@ mod tests {
         }
         fn steer(&mut self) -> Result<(), String> {
             self.calls.push("steer");
+            if self.steer_fails {
+                return Err("refusing to steer: the mirror is still loading".into());
+            }
             Ok(())
         }
         fn restore_steer(&mut self) -> Result<(), String> {
@@ -1290,6 +1397,182 @@ mod tests {
             "the canary is the operator's lever: {:?}",
             fx.calls
         );
+    }
+
+    // ---- The refused steer, retried ----
+
+    /// Drive to `Ready`, turn the canary lever, and have the steer
+    /// refused — the state an operator lands in when bird's dump is
+    /// behind their lever move.
+    fn refused_canary(t0: Instant, d: &mut Driver, w: &mut World, fx: &mut Fx) {
+        d.inject(t0, Event::StartRequested, fx);
+        settle(d, t0, w, fx);
+        d.inject(at(t0, 20), Event::VerifyPassed, fx);
+        assert_eq!(d.state(), State::Ready);
+        fx.steer_fails = true;
+        d.inject(at(t0, 21), Event::SteerRequested, fx);
+        assert!(fx.calls.contains(&"steer"), "{:?}", fx.calls);
+        assert_eq!(d.state(), State::Ready, "refused, so still unsteered");
+        assert!(
+            d.supervisor().steer_retry_pending(),
+            "the want must outlive the refusal"
+        );
+    }
+
+    /// The gap this whole mechanism exists for: the refusal clears and
+    /// the module steers, with no operator in the loop.
+    ///
+    /// Before it, `steer_wanted` was read by exactly two things — the
+    /// health text and `(Verifying, VerifyPassed)` — and verify does not
+    /// recur in steady state. So the module knew it wanted to steer,
+    /// said so in `steering DEGRADED`, and waited for a human.
+    #[test]
+    fn a_refused_steer_is_re_attempted_once_the_gate_opens() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            ..Default::default()
+        };
+        refused_canary(t0, &mut d, &mut w, &mut fx);
+
+        // While the gate refuses, nothing is attempted — but it IS asked.
+        fx.calls.clear();
+        for ms in (100..30_000).step_by(500) {
+            d.tick(at(t0, ms), &mut w, &mut fx);
+        }
+        assert!(
+            !fx.calls.contains(&"steer"),
+            "a closed gate must not be walked past: {:?}",
+            fx.calls
+        );
+        assert!(
+            w.steer_gate_reads > 0,
+            "and it must actually be consulted, or the test proves nothing"
+        );
+
+        // The mirror catches up. No reconfigure, no restart.
+        fx.steer_fails = false;
+        w.steer_permitted = true;
+        let t = d.tick(at(t0, 30_100), &mut w, &mut fx);
+        assert!(
+            t.events.contains(&Event::SteerUnblocked),
+            "the open gate must produce the retry: {:?}",
+            t.events
+        );
+        assert!(fx.calls.contains(&"steer"), "{:?}", fx.calls);
+        assert_eq!(d.state(), State::Steered);
+        assert!(!d.supervisor().steer_retry_pending(), "nothing outstanding");
+    }
+
+    /// A steer that keeps failing under an open gate must not be
+    /// re-attempted every tick.
+    ///
+    /// The completeness verdict is a level, not an edge, and the steer
+    /// can fail for reasons no gate knows about — a NIC refusing the
+    /// insert. In steady state a tick happens every ping interval, so
+    /// without the interval this would be two ethtool round trips a
+    /// second, forever, on a fault that is not going to clear.
+    #[test]
+    fn a_steer_that_keeps_failing_is_paced_not_hot_looped() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            ..Default::default()
+        };
+        refused_canary(t0, &mut d, &mut w, &mut fx);
+
+        // The gate opens, but the NIC keeps refusing.
+        w.steer_permitted = true;
+        fx.calls.clear();
+        let window = Duration::from_secs(90);
+        for ms in (100..window.as_millis() as u64).step_by(100) {
+            d.tick(at(t0, ms), &mut w, &mut fx);
+        }
+        let attempts = fx.calls.iter().filter(|c| **c == "steer").count();
+        let ceiling = (window.as_secs() / STEER_RETRY_EVERY.as_secs()) as usize + 1;
+        assert!(
+            attempts >= 2,
+            "a repeatedly failing steer must still keep trying: {attempts}"
+        );
+        assert!(
+            attempts <= ceiling,
+            "{attempts} attempts in {window:?} — the interval is not pacing anything"
+        );
+        assert!(d.supervisor().steer_retry_pending(), "still outstanding");
+    }
+
+    /// A port that never asked to steer is not steered by a gate that
+    /// happens to be open. The first steer is the operator's canary, and
+    /// this mechanism must not become a way around it.
+    #[test]
+    fn an_open_gate_does_not_steer_a_first_attach() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            steer_permitted: true,
+            ..Default::default()
+        };
+        d.inject(t0, Event::StartRequested, &mut fx);
+        settle(&mut d, t0, &mut w, &mut fx);
+        d.inject(at(t0, 20), Event::VerifyPassed, &mut fx);
+        assert_eq!(d.state(), State::Ready);
+
+        fx.calls.clear();
+        for ms in (100..120_000).step_by(1_000) {
+            d.tick(at(t0, ms), &mut w, &mut fx);
+        }
+        assert!(
+            !fx.calls.contains(&"steer"),
+            "the canary is the operator's lever: {:?}",
+            fx.calls
+        );
+        assert_eq!(
+            w.steer_gate_reads, 0,
+            "with nothing wanted there is nothing to ask the gate about"
+        );
+    }
+
+    /// And a port that IS steering is left alone: the retry is for a
+    /// steer that is missing, not a periodic re-assert of one that is
+    /// not. Drift under live steering is the audit's business, and its
+    /// remedy is deliberately the operator's.
+    #[test]
+    fn a_steered_port_is_not_re_steered_on_the_interval() {
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            batches: 1,
+            steer_permitted: true,
+            ..Default::default()
+        };
+        d.inject(t0, Event::StartRequested, &mut fx);
+        settle(&mut d, t0, &mut w, &mut fx);
+        d.inject(at(t0, 20), Event::VerifyPassed, &mut fx);
+        d.inject(at(t0, 21), Event::SteerRequested, &mut fx);
+        assert_eq!(d.state(), State::Steered);
+
+        fx.calls.clear();
+        w.steer_gate_reads = 0;
+        for ms in (100..120_000).step_by(1_000) {
+            d.tick(at(t0, ms), &mut w, &mut fx);
+        }
+        assert!(
+            !fx.calls.contains(&"steer"),
+            "steady state must not carry an ethtool round trip: {:?}",
+            fx.calls
+        );
+        assert_eq!(w.steer_gate_reads, 0);
     }
 
     /// An event the supervisor ignores must not produce actions.

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -506,8 +506,14 @@ impl Driver {
     /// [`STEER_RETRY_EVERY`] is what stops a steer that keeps failing
     /// for its own reasons from being re-attempted every tick.
     ///
-    /// `drained_idle` is this tick's proof that the engine has nothing
-    /// left to send, and it is a PRECONDITION, not a nicety. The
+    /// `drained_idle` is this tick's proof that the ENGINE has nothing
+    /// left to send, and it is a PRECONDITION, not a nicety. It is only
+    /// half the currency question — the source can still be holding
+    /// changes the engine has not pulled, which `steer_permitted`'s
+    /// backlog check covers — and neither half sees work that was
+    /// drained out of the source and then dropped rather than handed
+    /// back. See `Core::source_current` for why that last part is an
+    /// invariant other code has to keep, not something checkable here. The
     /// ledger's counts are the other gate's evidence and they can be
     /// clean over deltas VPP never received: `RouteFeed::drain_changes`
     /// removes the batch from the mirror, and `Engine::apply_changes`

--- a/crates/modules/vpp-offload/src/liveness.rs
+++ b/crates/modules/vpp-offload/src/liveness.rs
@@ -151,6 +151,23 @@ impl WedgeDetector {
     pub fn is_wedged(&self, now: Instant, budget: Duration) -> bool {
         self.silent_for(now) > budget
     }
+
+    /// Did the most recent probe get an answer?
+    ///
+    /// A **different question** from [`Self::is_wedged`], and the gap
+    /// between them is the point. The budget exists so ordinary jitter
+    /// does not cost a restart, so two unanswered pings are deliberately
+    /// tolerated — which is right for deciding whether to TEAR DOWN a
+    /// dataplane carrying traffic, and wrong for deciding to start
+    /// diverting traffic INTO one. Steering into that tolerated window
+    /// puts packets on a VF whose VPP has already stopped answering,
+    /// and nothing takes them off again until the budget expires.
+    ///
+    /// So: no clock, no constant, no tolerance. The API answered the
+    /// last thing we asked it, or it did not.
+    pub fn answered_last_probe(&self) -> bool {
+        self.last_ok >= self.last_attempt
+    }
 }
 
 #[cfg(test)]

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1339,6 +1339,18 @@ impl Core {
     /// between what bird advertises and what VPP holds" (review
     /// finding, PR #160).
     ///
+    /// **This is only a complete proof while an undelivered batch goes
+    /// BACK to the source.** The backlog can only report work the source
+    /// still holds, so anything that takes a batch out of the feed and
+    /// then drops it is invisible here — and to the ledger, and to
+    /// completeness. `Engine::apply_changes` did exactly that until
+    /// #161: `drain_changes` is destructive, and a failed
+    /// `send_neighbour` returned before the loop that queues the batch's
+    /// routes, so those deltas existed nowhere and no count moved. The
+    /// requeue is what makes this predicate cover them. Anything added
+    /// later that drains the source and can fail must hand the batch
+    /// back for the same reason, or this silently stops covering it.
+    ///
     /// Carries the empty-target exception like the other two, and the
     /// history is the argument for keeping it that way: this predicate
     /// was added AFTER the exception was pushed down into each gate, on

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1256,6 +1256,43 @@ impl Core {
         self.steering.retarget(ports, plan);
         self.last_steer_audit = None;
     }
+
+    /// The completeness verdict steering is judged against, or `None`
+    /// when the deployment configured no authority.
+    ///
+    /// One accessor because it has two readers that must not disagree:
+    /// [`Effects::steer`], which refuses on it, and
+    /// [`Observe::steer_permitted`], which decides whether re-attempting
+    /// a refused steer is worth anything. A retry keyed to a different
+    /// question than the refusal is either a loop that never stops
+    /// asking or one that never asks again. The polarity is
+    /// [`packetframe_common::fib::Completeness::permits_steering`]'s, on
+    /// the type, so only the verdict travels.
+    fn steer_verdict(&self) -> Option<packetframe_common::fib::Completeness> {
+        self.completeness.as_ref().map(|h| h.verdict())
+    }
+
+    /// Whether the FIB itself is fit to take traffic, on the same terms
+    /// the operator's first steer is held to.
+    ///
+    /// The second gate, and the one that is easy to forget: `steer` does
+    /// not apply it — `apply_steering` and `Verdict::may_steer` do — so
+    /// a retry that consulted completeness alone would walk straight
+    /// past `VerifyIncomplete`. That arm reaches `Ready` with the want
+    /// intact and emits no steer precisely because routes are withheld
+    /// or unresolvable; re-attempting there would divert traffic into
+    /// the FIB with known holes that the arm exists to protect.
+    ///
+    /// Discriminated on the NIC LEDGER rather than the supervisor's
+    /// belief, as `start_resync` does, and for the same reason: rules in
+    /// the NIC are what puts packets on VPP. Where some are already
+    /// installed this is a reconcile, not a first steer, and gating it
+    /// on `installing` — nonzero whenever routes are in flight, routine
+    /// under a live feed — would hold off the repair of a partly
+    /// installed target indefinitely.
+    fn fib_fit_to_steer(&self) -> bool {
+        !self.steering.installed().is_empty() || !self.engine.counts().blocks_first_steer()
+    }
 }
 
 impl Observe for ObserveView {
@@ -1288,6 +1325,14 @@ impl Observe for ObserveView {
             .engine
             .ping()
             .map_err(|e| e.to_string())
+    }
+
+    fn steer_permitted(&mut self) -> bool {
+        let c = self.core.borrow();
+        // Both gates, through the same accessors the steer path and the
+        // verify verdict use. Neither is re-derived here: this asks the
+        // question, it does not answer it a second time.
+        c.steer_verdict().is_none_or(|v| v.permits_steering()) && c.fib_fit_to_steer()
     }
 
     fn drain_batch(&mut self, now: std::time::Instant) -> Result<crate::driver::Drain, String> {
@@ -1788,21 +1833,22 @@ impl Effects for EffectsView {
         // the check sits at the single point both go through.
         //
         // Refusing is cheap and self-correcting: it becomes
-        // `SteerFailed`, which leaves `steer_wanted` set, so the next
-        // verify retries — and by then the dump has usually finished. No
-        // rules are installed, so `rules_remain` is unaffected.
-        if let Some(handle) = &c.completeness {
-            let verdict = handle.verdict();
+        // `SteerFailed`, which leaves `steer_wanted` set, and the driver
+        // re-attempts the steer once this verdict permits one — see
+        // `Event::SteerUnblocked`. No rules are installed, so
+        // `rules_remain` is unaffected.
+        if let Some(verdict) = c.steer_verdict() {
             if !verdict.permits_steering() {
                 return Err(format!(
                     "refusing to steer: {}. Traffic would be diverted into a table that \
                      cannot forward it, and a steered miss is dropped rather than falling \
-                     back to the kernel path. NOTHING RETRIES THIS: the want is \
-                     remembered, but only a convergence or `packetframe reconfigure` \
-                     emits another steer, so re-run it once the mirror has caught up. \
+                     back to the kernel path. The want is remembered and re-attempted on \
+                     its own, at most every {}s, once the verdict permits — \
+                     `packetframe reconfigure` asks immediately rather than waiting. \
                      `require-table-complete off` opts out where there is no bird to \
                      compare against",
-                    verdict.describe()
+                    verdict.describe(),
+                    crate::driver::STEER_RETRY_EVERY.as_secs()
                 ));
             }
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1272,8 +1272,7 @@ impl Core {
         self.completeness.as_ref().map(|h| h.verdict())
     }
 
-    /// Whether the FIB itself is fit to take traffic, on the same terms
-    /// the operator's first steer is held to.
+    /// Whether the FIB itself is fit to take traffic.
     ///
     /// The second gate, and the one that is easy to forget: `steer` does
     /// not apply it — `apply_steering` and `Verdict::may_steer` do — so
@@ -1283,15 +1282,26 @@ impl Core {
     /// or unresolvable; re-attempting there would divert traffic into
     /// the FIB with known holes that the arm exists to protect.
     ///
-    /// Discriminated on the NIC LEDGER rather than the supervisor's
-    /// belief, as `start_resync` does, and for the same reason: rules in
-    /// the NIC are what puts packets on VPP. Where some are already
-    /// installed this is a reconcile, not a first steer, and gating it
-    /// on `installing` — nonzero whenever routes are in flight, routine
-    /// under a live feed — would hold off the repair of a partly
-    /// installed target indefinitely.
+    /// Applied UNCONDITIONALLY, unlike `apply_steering`, which exempts
+    /// an already-steering port. That exemption exists because
+    /// `blocks_first_steer` counts `installing`, nonzero whenever routes
+    /// are in flight and so routine under a live feed that gating an
+    /// operator's reconcile on it would fail at random. The retry does
+    /// not need it: it runs only on a tick whose drain reported
+    /// `Drain::Idle`, which is that exemption's whole subject matter
+    /// already excluded.
+    ///
+    /// An earlier version exempted a non-empty NIC ledger on the same
+    /// reasoning, and that was wrong in a case the ledger cannot
+    /// distinguish: a FIRST steer whose rollback could not delete leaves
+    /// debris, so "some rules are installed" stops meaning "this port
+    /// was steering happily". If the table then developed holes, the
+    /// retry would install the REST of the allowlist into it and widen
+    /// the blackhole the debris had started (review finding, PR #160).
+    /// Nothing is lost by dropping it: a partly-installed target over a
+    /// whole FIB still repairs, because that FIB does not block.
     fn fib_fit_to_steer(&self) -> bool {
-        !self.steering.installed().is_empty() || !self.engine.counts().blocks_first_steer()
+        !self.engine.counts().blocks_first_steer()
     }
 }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1319,6 +1319,36 @@ impl Core {
             .map(|h| h.verdict())
     }
 
+    /// Whether the source has handed over everything it holds.
+    ///
+    /// Not a gate the steer path applies — it is the thing neither gate
+    /// can see. `Drain::Idle` is the ENGINE's pending map going empty,
+    /// which is weaker than it looks: `drain_batch` pulls at most
+    /// `DELTA_BATCH` and sends at most `DRAIN_BATCH`, and the two are
+    /// the same number, so one tick can pull 4096, send all 4096, and
+    /// report idle with the feed still holding the rest of a burst. A
+    /// reload is hundreds of thousands.
+    ///
+    /// The ledger has not classified those changes, so nothing is
+    /// `installing`; completeness compares bird against the MIRROR,
+    /// which the tee already updated, so a burst of route UPDATES keeps
+    /// the count identical and the verdict converged. Everything reads
+    /// healthy while VPP is tens of thousands of changes behind, and
+    /// steering there blackholes every prefix in the gap —
+    /// `RouteSource::backlog`'s own doc calls it "an unexplained gap
+    /// between what bird advertises and what VPP holds" (review
+    /// finding, PR #160).
+    ///
+    /// Carries the empty-target exception like the other two, and the
+    /// history is the argument for keeping it that way: this predicate
+    /// was added AFTER the exception was pushed down into each gate, on
+    /// the reasoning that a later one could otherwise land on the wrong
+    /// side of a shared early return. It did exactly that on the first
+    /// attempt — a backlog held back a reconcile that only removes.
+    fn source_current(&self) -> bool {
+        !self.steer_diverts_traffic() || self.source.backlog() == 0
+    }
+
     /// Whether the FIB itself is fit to take traffic.
     ///
     /// The second gate, and the one that is easy to forget: `steer` does
@@ -1398,7 +1428,9 @@ impl Observe for ObserveView {
         // a `steer off`'s reconcile-to-empty from `Ready`, and asking a
         // stricter question here than the one `steer` answers is how a
         // retry ends up either refusing forever or asking forever.
-        c.steer_verdict().is_none_or(|v| v.permits_steering()) && c.fib_fit_to_steer()
+        c.source_current()
+            && c.steer_verdict().is_none_or(|v| v.permits_steering())
+            && c.fib_fit_to_steer()
     }
 
     fn drain_batch(&mut self, now: std::time::Instant) -> Result<crate::driver::Drain, String> {
@@ -2819,6 +2851,84 @@ mod tests {
         assert!(
             obs.steer_permitted(),
             "the retry asked a stricter question than the steer it drives"
+        );
+    }
+
+    /// A source still holding changes disqualifies the moment, however
+    /// clean everything else looks.
+    ///
+    /// The engine's pending map going empty is not the same statement:
+    /// `drain_batch` pulls at most `DELTA_BATCH` and sends at most
+    /// `DRAIN_BATCH`, and they are the same number, so one tick can pull
+    /// 4096, send all 4096, and report `Drain::Idle` with the feed still
+    /// holding the rest of a reload. Neither gate sees it — the ledger
+    /// has not classified those changes, and completeness compares bird
+    /// against the mirror the tee already updated, so a burst of route
+    /// UPDATES keeps the count identical and the verdict converged.
+    /// Everything reads healthy while VPP is tens of thousands of
+    /// changes behind (review finding, PR #160).
+    #[test]
+    fn a_source_backlog_defers_the_retry() {
+        struct Backlogged(std::cell::Cell<u64>);
+        impl RouteSource for Backlogged {
+            fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+            fn for_each_neighbour(&self, _: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
+            fn route_count(&self) -> u64 {
+                0
+            }
+            fn change_seq(&self) -> u64 {
+                0
+            }
+            fn backlog(&self) -> u64 {
+                self.0.get()
+            }
+        }
+
+        // Everything else is as permissive as it gets: no completeness
+        // handle, an empty ledger, a target that asks for a port.
+        let rt = Runtime::new(
+            engine(),
+            Box::new(Backlogged(std::cell::Cell::new(4_096))),
+            Box::new(LedgerSteering {
+                configured: 1,
+                ..Default::default()
+            }),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        {
+            let (mut obs, _) = rt.views();
+            assert!(
+                !obs.steer_permitted(),
+                "changes the engine has not pulled are invisible to both gates, and \
+                 steering over them blackholes every prefix in the backlog"
+            );
+        }
+        // Drained: the same moment is fine.
+        rt.core.borrow_mut().source = Box::new(Backlogged(std::cell::Cell::new(0)));
+        {
+            let (mut obs, _) = rt.views();
+            assert!(obs.steer_permitted());
+        }
+
+        // ...but a backlog must NOT hold back a reconcile to an empty
+        // target, for the same reason neither gate does: that steer only
+        // removes rules, and changes still queued for a table it is
+        // taking traffic OFF are no argument for leaving it steered.
+        // This predicate was added after the exception was pushed down
+        // into each gate, and got this wrong on the first attempt.
+        rt.core.borrow_mut().source = Box::new(Backlogged(std::cell::Cell::new(4_096)));
+        rt.core.borrow_mut().steering = Box::new(LedgerSteering {
+            configured: 0,
+            ..Default::default()
+        });
+        let (mut obs, _) = rt.views();
+        assert!(
+            obs.steer_permitted(),
+            "a backlog is a reason not to divert traffic INTO VPP, not a reason to \
+             leave a rollback unfinished"
         );
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -920,12 +920,33 @@ fn apply_steering(
         if !steered {
             let counts = runtime.status().counts;
             if counts.blocks_first_steer() {
+                // The ask is RECORDED before the refusal is returned.
+                //
+                // This gate sits before the injection while the
+                // completeness gate sits inside the effect, and that
+                // difference is an accident of where each check landed —
+                // not something an operator can see or should care
+                // about. Without this line the same lever move retried
+                // itself or did not depending on which one caught it:
+                // the completeness refusal becomes `SteerFailed` and
+                // keeps the want, this one returned with the machine
+                // never having heard of the request (review finding).
+                //
+                // Safe against the canary rule because of the early
+                // return above: reaching here means the operator moved
+                // the lever, or a want already existed. Config intent
+                // alone never gets this far.
+                driver.inject(Instant::now(), Event::SteerDeferred, fx);
                 return Err(format!(
                     "refusing the first steer: the FIB is incomplete ({} unresolvable, {} \
                      withheld, {} still installing). Diverting traffic into it would \
                      blackhole exactly the prefixes that are missing. `packetframe status` \
-                     reports all three; they must be zero",
-                    counts.unresolvable, counts.withheld, counts.installing
+                     reports all three; they must be zero. The request is remembered: the \
+                     module steers on its own once they are, at most {}s later",
+                    counts.unresolvable,
+                    counts.withheld,
+                    counts.installing,
+                    crate::driver::STEER_RETRY_EVERY.as_secs()
                 ));
             }
         }

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -823,8 +823,10 @@ impl StatusSnapshot {
             "a convergence re-applies steering only if it verifies clean — one that ends \
              with routes withheld or unresolvable parks in the staging state and emits no \
              steer at all, and a steer that IS emitted can still be refused by the \
-             completeness gate. Nothing retries after either, so if this line outlives \
-             the convergence, `packetframe reconfigure` is the retry"
+             completeness gate. Both settle in the staging state with the want \
+             remembered, and from there the module re-attempts the steer by itself once \
+             both gates permit. `packetframe reconfigure` asks immediately rather than \
+             waiting"
                 .to_string()
         };
         // Stray rules do NOT share that remedy, and sharing it was a
@@ -906,9 +908,27 @@ impl StatusSnapshot {
             (true, _) => (HealthState::Healthy, None),
             // Intended but absent: a failed steer, or steering torn down
             // by trouble and not yet restored.
+            //
+            // The self-repair is named only from `Ready`, which is where
+            // it is actually armed: a refused steer settles there and
+            // the module re-attempts it (`Event::SteerUnblocked`).
+            // Everywhere else the repair is the convergence, on its own
+            // schedule — and predicting a paced retry that is not
+            // running is exactly how the lines in this file have gone
+            // wrong before.
             (false, true) => (
                 HealthState::Degraded,
-                Some("steering intended but not in place — traffic is on the eBPF tier".into()),
+                Some(if matches!(self.state, State::Ready) {
+                    format!(
+                        "steering intended but not in place — traffic is on the eBPF tier. \
+                         The module re-attempts it on its own, at most every {}s, once \
+                         nothing is refusing it; `packetframe reconfigure` asks immediately \
+                         and reports the reason if it is refused again",
+                        crate::driver::STEER_RETRY_EVERY.as_secs()
+                    )
+                } else {
+                    "steering intended but not in place — traffic is on the eBPF tier".to_string()
+                }),
             ),
             // The deliberate staging state: all members up, FIB synced
             // and verified, nothing diverted. Every canary's waypoint
@@ -921,8 +941,18 @@ impl StatusSnapshot {
             // for me" must not print the same line.
             (false, false) if self.steer_configured => (
                 HealthState::Healthy,
+                // The continuations are load-bearing: without the
+                // trailing `\` the source indentation is part of the
+                // string, and this arm shipped two twenty-space runs in
+                // an operator's line for exactly that reason. It went
+                // unnoticed because the guard test rendered only the
+                // arms an already-steering port reaches; it covers
+                // these now.
                 Some(
-                    "configured `steer on`, awaiting an operator lever move; traffic is on                      the eBPF tier. A first attach never steers by itself — set the port                      `steer off`, `packetframe reconfigure`, then back to `steer on` and                      reconfigure again (canary ladder, docs/runbooks/vpp-offload.md)"
+                    "configured `steer on`, awaiting an operator lever move; traffic is on \
+                     the eBPF tier. A first attach never steers by itself — set the port \
+                     `steer off`, `packetframe reconfigure`, then back to `steer on` and \
+                     reconfigure again (canary ladder, docs/runbooks/vpp-offload.md)"
                         .into(),
                 ),
             ),
@@ -1330,6 +1360,17 @@ mod tests {
         sup
     }
 
+    /// Every `(steered, steer_intended)` a snapshot can carry.
+    ///
+    /// The steering health match has four arms and a `steered` snapshot
+    /// reaches exactly one of them, so a matrix built from
+    /// `steered_supervisor()` alone renders a quarter of the lines it
+    /// looks like it renders — which is how a twenty-space run shipped
+    /// in the awaiting-a-lever line under two class guards.
+    fn steering_postures() -> [(bool, bool); 4] {
+        [(true, true), (false, true), (false, false), (true, false)]
+    }
+
     fn snap_of(
         sup: &Supervisor,
         led: &RouteLedger,
@@ -1543,6 +1584,14 @@ mod tests {
             "ethtool -N <iface> delete <loc>",
             "steer",
             "require-table-complete off",
+            // Config directives rather than commands, but they go
+            // through the same check for the same reason: an operator
+            // types what the line prints, and a mangled one sends them
+            // to edit something that does not exist. Rendered by the
+            // awaiting-a-lever arm, which nothing exercised until the
+            // matrix covered the unsteered postures.
+            "steer on",
+            "steer off",
         ];
         let mut seen: Vec<String> = Vec::new();
         for state in [
@@ -1556,48 +1605,56 @@ mod tests {
             State::AdoptedResyncing,
         ] {
             for steer_configured in [true, false] {
-                for (missing, stray, unreadable) in [
-                    (1usize, 0usize, None),
-                    (0, 1, None),
-                    (1, 1, Some("EIO: readback failed".to_string())),
-                    (0, 0, Some("EIO: readback failed".to_string())),
-                    (0, 0, None),
-                ] {
-                    let led = ledger_with(10, 0, 0);
-                    let mut snap = snap_of(
-                        &steered_supervisor(),
-                        &led,
-                        ApiHealth::Answering {
-                            silent_for: Duration::from_millis(200),
-                        },
-                        verified(3),
-                        ports_up(),
-                    );
-                    snap.state = state;
-                    snap.steer_configured = steer_configured;
-                    snap.steer_missing = missing;
-                    snap.steer_stray = stray;
-                    snap.steer_audit_unreadable = unreadable.clone();
+                // Both sides of the steering match, not just the arms an
+                // already-steering port reaches. A `steered` snapshot
+                // returns None from three of the four, so the matrix was
+                // silently rendering one of them — and the awaiting-a-
+                // lever line sat mangled underneath.
+                for steering in steering_postures() {
+                    for (missing, stray, unreadable) in [
+                        (1usize, 0usize, None),
+                        (0, 1, None),
+                        (1, 1, Some("EIO: readback failed".to_string())),
+                        (0, 0, Some("EIO: readback failed".to_string())),
+                        (0, 0, None),
+                    ] {
+                        let led = ledger_with(10, 0, 0);
+                        let mut snap = snap_of(
+                            &steered_supervisor(),
+                            &led,
+                            ApiHealth::Answering {
+                                silent_for: Duration::from_millis(200),
+                            },
+                            verified(3),
+                            ports_up(),
+                        );
+                        snap.state = state;
+                        snap.steer_configured = steer_configured;
+                        (snap.steered, snap.steer_intended) = steering;
+                        snap.steer_missing = missing;
+                        snap.steer_stray = stray;
+                        snap.steer_audit_unreadable = unreadable.clone();
 
-                    for sub in snap.report().subsystems {
-                        let Some(msg) = sub.message else { continue };
-                        let mut rest = msg.as_str();
-                        while let Some(open) = rest.find('`') {
-                            rest = &rest[open + 1..];
-                            let Some(close) = rest.find('`') else { break };
-                            let span = &rest[..close];
-                            rest = &rest[close + 1..];
-                            if !seen.iter().any(|s| s == span) {
-                                seen.push(span.to_string());
+                        for sub in snap.report().subsystems {
+                            let Some(msg) = sub.message else { continue };
+                            let mut rest = msg.as_str();
+                            while let Some(open) = rest.find('`') {
+                                rest = &rest[open + 1..];
+                                let Some(close) = rest.find('`') else { break };
+                                let span = &rest[..close];
+                                rest = &rest[close + 1..];
+                                if !seen.iter().any(|s| s == span) {
+                                    seen.push(span.to_string());
+                                }
+                                assert!(
+                                    ALLOWED.contains(&span),
+                                    "{} in {state:?} prints `{span}`, which is not a \
+                                     command this module means to emit. Either it is \
+                                     mangled — the way `ethtool -n reconfigure` was — or \
+                                     it is new and belongs in ALLOWED. Full line: {msg}",
+                                    sub.name
+                                );
                             }
-                            assert!(
-                                ALLOWED.contains(&span),
-                                "{} in {state:?} prints `{span}`, which is not a command \
-                                 this module means to emit. Either it is mangled — the \
-                                 way `ethtool -n reconfigure` was — or it is new and \
-                                 belongs in ALLOWED. Full line: {msg}",
-                                sub.name
-                            );
                         }
                     }
                 }
@@ -1626,35 +1683,48 @@ mod tests {
             State::Steered,
             State::AdoptedResyncing,
         ] {
-            for (missing, stray, unreadable) in [
-                (1usize, 0usize, None),
-                (0, 1, None),
-                (1, 1, Some("EIO: readback failed".to_string())),
-                (0, 0, Some("EIO: readback failed".to_string())),
-            ] {
-                let led = ledger_with(10, 0, 0);
-                let mut snap = snap_of(
-                    &steered_supervisor(),
-                    &led,
-                    ApiHealth::Answering {
-                        silent_for: Duration::from_millis(200),
-                    },
-                    verified(3),
-                    ports_up(),
-                );
-                snap.state = state;
-                snap.steer_missing = missing;
-                snap.steer_stray = stray;
-                snap.steer_audit_unreadable = unreadable.clone();
+            // Both values of `steer_configured` and every steering
+            // posture, because the arms a steered snapshot never reaches
+            // are exactly where the second instance of this defect was
+            // sitting — the awaiting-a-lever line, unrendered by this
+            // guard and by the backtick one.
+            for steer_configured in [true, false] {
+                for steering in steering_postures() {
+                    for (missing, stray, unreadable) in [
+                        (1usize, 0usize, None),
+                        (0, 1, None),
+                        (1, 1, Some("EIO: readback failed".to_string())),
+                        (0, 0, Some("EIO: readback failed".to_string())),
+                        (0, 0, None),
+                    ] {
+                        let led = ledger_with(10, 0, 0);
+                        let mut snap = snap_of(
+                            &steered_supervisor(),
+                            &led,
+                            ApiHealth::Answering {
+                                silent_for: Duration::from_millis(200),
+                            },
+                            verified(3),
+                            ports_up(),
+                        );
+                        snap.state = state;
+                        snap.steer_configured = steer_configured;
+                        (snap.steered, snap.steer_intended) = steering;
+                        snap.steer_missing = missing;
+                        snap.steer_stray = stray;
+                        snap.steer_audit_unreadable = unreadable.clone();
 
-                for sub in snap.report().subsystems {
-                    let Some(msg) = sub.message else { continue };
-                    assert!(
-                        !msg.contains("   "),
-                        "{} in {state:?} renders a whitespace run — a line an operator \
-                         reads at 3am, mangled by a source-formatting artefact: {msg:?}",
-                        sub.name
-                    );
+                        for sub in snap.report().subsystems {
+                            let Some(msg) = sub.message else { continue };
+                            assert!(
+                                !msg.contains("   "),
+                                "{} in {state:?} renders a whitespace run — a line an \
+                                 operator reads at 3am, mangled by a source-formatting \
+                                 artefact: {msg:?}",
+                                sub.name
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -2093,6 +2163,64 @@ mod tests {
             .find(|x| x.name == SUBSYS_STEERING)
             .unwrap();
         assert_eq!(steer.state, HealthState::Degraded);
+    }
+
+    /// The intended-but-absent line names the module's own retry only
+    /// where that retry is armed.
+    ///
+    /// From `Ready` a refused steer is re-attempted on the driver's
+    /// interval, so telling the operator to run `reconfigure` is telling
+    /// them to do by hand what is already happening. From anywhere else
+    /// nothing is armed and the repair rides the next convergence —
+    /// promising a paced retry there would be the same overclaim this
+    /// file has now made four times.
+    #[test]
+    fn the_retry_is_named_only_where_it_is_armed() {
+        let mut sup = ready_supervisor();
+        sup.on(Event::SteerFailed {
+            rules_remain: false,
+        });
+        assert!(sup.steer_retry_pending());
+
+        let line = |state: State| {
+            let mut snap = snap_of(
+                &sup,
+                &ledger_with(10, 0, 0),
+                ApiHealth::Answering {
+                    silent_for: Duration::ZERO,
+                },
+                verified(1),
+                ports_up(),
+            );
+            snap.state = state;
+            snap.report()
+                .subsystems
+                .into_iter()
+                .find(|x| x.name == SUBSYS_STEERING)
+                .and_then(|x| x.message)
+                .unwrap_or_default()
+        };
+
+        let ready = line(State::Ready);
+        assert!(
+            ready.contains("re-attempts it on its own"),
+            "from Ready the module is already retrying, and the line must say so: {ready}"
+        );
+        assert!(
+            ready.contains(&format!("{}s", crate::driver::STEER_RETRY_EVERY.as_secs())),
+            "and name the interval from the constant that governs it: {ready}"
+        );
+        for state in [State::Backoff, State::Syncing, State::AdoptedResyncing] {
+            let msg = line(state);
+            assert!(
+                msg.contains("intended but not in place"),
+                "{state:?}: still the same complaint: {msg}"
+            );
+            assert!(
+                !msg.contains("re-attempts it on its own"),
+                "{state:?}: nothing is armed here — the repair is the convergence: {msg}"
+            );
+        }
     }
 
     /// The two ways to be unsteered must not print the same line.

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -322,6 +322,29 @@ pub enum Event {
     /// [`crate::runtime::Steering::retarget`] first; `Action::Steer`
     /// reconciles the NIC to whatever the target now is.
     SteerRequested,
+    /// The gates that refused a wanted steer now permit one.
+    ///
+    /// The caller owns both the observation and its pacing, the same
+    /// division as [`Self::FallbackSettled`]: the supervisor holds no
+    /// clock and cannot read a completeness verdict or a route ledger,
+    /// so it cannot notice this itself. See
+    /// [`crate::driver::STEER_RETRY_EVERY`] for the pacing, which is
+    /// what keeps a permanently-refusing gate from becoming a hot loop.
+    ///
+    /// Exists because a refused steer was otherwise never retried at
+    /// all. The refusal leaves `steer_wanted` set and settles in
+    /// `Ready`, and the only two things that emit [`Action::Steer`] are
+    /// the verify at the end of a convergence — which does not recur in
+    /// steady state — and an explicit `packetframe reconfigure`. So an
+    /// operator turning the canary lever while bird's dump was behind
+    /// got a refusal, the mirror caught up a minute later, and the
+    /// module sat in `Ready` knowing it wanted to steer and saying so in
+    /// its health line until a human asked again (found reviewing #157).
+    ///
+    /// Deliberately NOT a want in itself: it acts only where one is
+    /// already recorded, so it can never steer a first attach on its
+    /// own. [`Supervisor::steer_intended`] holds that distinction.
+    SteerUnblocked,
     /// The operator turned the canary lever OFF — the rollback landing
     /// zone. Membership stays, the FIB stays synced, traffic goes back
     /// to the fallback tier.
@@ -465,6 +488,23 @@ impl Supervisor {
     /// designed staging state, the other is a rollout that broke.
     pub fn steer_intended(&self) -> bool {
         self.steered || self.steer_wanted
+    }
+
+    /// Whether a wanted steer is outstanding and could be retried from
+    /// here — the caller's half of [`Event::SteerUnblocked`].
+    ///
+    /// The caller decides *when* to look at the gates; this says whether
+    /// looking is worth anything. It lives here, next to the arm that
+    /// acts on the event, for the same reason
+    /// [`State::accepts_steering_changes`] does: a predicate the caller
+    /// re-derives is a copy, and copies drift apart — twice already in
+    /// this file.
+    ///
+    /// **Not** [`Self::steer_intended`], which is the health surface's
+    /// question and answers yes for a port that is steering perfectly
+    /// well. This one is only true where something is missing.
+    pub fn steer_retry_pending(&self) -> bool {
+        matches!(self.state, State::Ready) && self.steer_wanted
     }
 
     pub fn failures(&self) -> u32 {
@@ -709,6 +749,27 @@ impl Supervisor {
                 self.steer_wanted = true;
                 vec![Action::Steer]
             }
+            // The same lever, re-pulled by the module rather than by a
+            // human, once whatever refused it has cleared.
+            //
+            // `Ready` only. That is where a refused steer settles, and
+            // from `State::Steered` there is nothing to retry — the rules
+            // are in and acknowledged — so re-asserting them on a timer
+            // would put an ethtool round trip on the steady-state path
+            // for no fault. Drift *while* steered is the audit's
+            // business, and its remedy is deliberately the operator's.
+            //
+            // The want is READ, never set: a port that has never asked to
+            // steer stays in the staging state however complete its table
+            // becomes, because the first steer is the operator's canary.
+            // That is the whole reason this is not simply "steer whenever
+            // the config says to".
+            //
+            // `steered` is deliberately not consulted. A reconcile whose
+            // rollback could not delete lands here too — `Ready` with
+            // `steered == true` and the want set — and that is a steer
+            // that did not fully happen, so it wants the same retry.
+            (Ready, SteerUnblocked) if self.steer_wanted => vec![Action::Steer],
             // Believed down only on `Unsteered`, exactly as everywhere
             // else. The state returns to `Ready` because that is what
             // membership-without-steering is — the designed staging
@@ -1602,6 +1663,130 @@ mod tests {
             s.steer_intended(),
             "a rollout that broke must be distinguishable from the designed staging state"
         );
+    }
+
+    /// ...and the retry is what turns that remembered want back into a
+    /// steer, without an operator asking a second time.
+    ///
+    /// The gap this arm closes: `steer_wanted` was read by exactly two
+    /// things — the health text and `(Verifying, VerifyPassed)` — and a
+    /// verify does not recur in steady state. So a canary step refused
+    /// by the completeness gate sat in `Ready`, correctly reporting
+    /// `steering intended but not in place`, until a human ran
+    /// `reconfigure`.
+    #[test]
+    fn a_refused_steer_is_retried_when_its_blocker_clears() {
+        let mut s = ready_unsteered();
+        s.on(Event::SteerRequested);
+        s.on(Event::SteerFailed {
+            rules_remain: false,
+        });
+        assert!(s.steer_retry_pending(), "wanted, and not in place");
+
+        assert_eq!(
+            s.on(Event::SteerUnblocked),
+            vec![Action::Steer],
+            "the module must ask again itself once the gate permits"
+        );
+        // Still only an attempt: `Steered` is the acknowledgement here
+        // exactly as on every other path.
+        assert_eq!(s.state(), State::Ready);
+        assert!(!s.is_steered());
+
+        s.on(Event::Steered);
+        assert_eq!(s.state(), State::Steered);
+        assert!(
+            !s.steer_retry_pending(),
+            "nothing is outstanding once the rules are acknowledged"
+        );
+        assert!(
+            s.on(Event::SteerUnblocked).is_empty(),
+            "and a live steered port must not be re-asserted on a timer"
+        );
+    }
+
+    /// A reconcile whose rollback could not delete lands in `Ready` with
+    /// rules still in the NIC — a steer that half happened. It wants the
+    /// same retry, which is why the arm reads the want rather than
+    /// `steered`.
+    #[test]
+    fn a_partly_installed_steer_is_retried_too() {
+        let mut s = running_and_steered();
+        s.on(Event::SteerRequested);
+        s.on(Event::SteerFailed { rules_remain: true });
+        assert_eq!(s.state(), State::Ready);
+        assert!(s.is_steered(), "rules are still diverting traffic");
+        assert_eq!(s.on(Event::SteerUnblocked), vec![Action::Steer]);
+    }
+
+    /// The canary constraint, from the other side: an open gate is not a
+    /// request. A port that has never asked to steer must stay in the
+    /// staging state however complete its table becomes — otherwise this
+    /// mechanism is just "steer whenever the config says to", which is
+    /// the decision the module is not allowed to make.
+    #[test]
+    fn an_unblocked_steer_does_not_steer_a_first_attach() {
+        let mut s = ready_unsteered();
+        assert!(!s.steer_intended());
+        assert!(!s.steer_retry_pending());
+        assert!(s.on(Event::SteerUnblocked).is_empty());
+        assert!(!s.steer_intended(), "and it must leave no want behind");
+    }
+
+    /// Nor may it undo a deliberate `steer off` — including the one
+    /// whose removal the NIC refused, where rules are still installed
+    /// and the want is deliberately clear. Reconciling THAT needs a
+    /// teardown outcome meaning "reconciled to nothing steered", which
+    /// is a different change.
+    #[test]
+    fn an_unblocked_steer_does_not_reverse_a_rollback() {
+        let mut s = running_and_steered();
+        s.on(Event::UnsteerRequested);
+        s.on(Event::Unsteered);
+        assert!(s.on(Event::SteerUnblocked).is_empty());
+
+        let mut refused = running_and_steered();
+        refused.on(Event::UnsteerRequested);
+        refused.on(Event::UnsteerFailed);
+        assert!(refused.is_steered(), "the rules outlived the request");
+        assert!(
+            refused.on(Event::SteerUnblocked).is_empty(),
+            "an operator pulling traffic OFF must not have it put back"
+        );
+    }
+
+    /// Outside `Ready` it is stale, like every other steering request:
+    /// there is either no verified FIB to divert into or a teardown in
+    /// progress. The want survives regardless, and the convergence that
+    /// ends those states emits the steer itself.
+    #[test]
+    fn an_unblocked_steer_is_ignored_outside_the_staging_state() {
+        for (label, mut s) in [
+            ("converging", {
+                let mut s = Supervisor::new();
+                s.on(Event::StartRequested);
+                s.on(Event::ApiUp);
+                s
+            }),
+            ("adopted resync", {
+                let mut s = Supervisor::new();
+                s.on(Event::Adopted { steered: true });
+                s
+            }),
+            ("backoff", {
+                let mut s = running_and_steered();
+                s.on(Event::ProcessExited { status: None });
+                s
+            }),
+            ("stopped", Supervisor::new()),
+        ] {
+            let before = s.state();
+            assert!(
+                s.on(Event::SteerUnblocked).is_empty(),
+                "{label}: a steer from {before:?} is not what anybody asked for"
+            );
+            assert_eq!(s.state(), before, "{label}: and it must not move the state");
+        }
     }
 
     /// Turning it off is the rollback landing zone: membership stays,

--- a/crates/modules/vpp-offload/src/supervisor.rs
+++ b/crates/modules/vpp-offload/src/supervisor.rs
@@ -322,6 +322,28 @@ pub enum Event {
     /// [`crate::runtime::Steering::retarget`] first; `Action::Steer`
     /// reconciles the NIC to whatever the target now is.
     SteerRequested,
+    /// The operator asked to steer and the caller declined **before
+    /// attempting it** — the FIB gate in
+    /// [`crate::service`]`::apply_steering`, which refuses a first steer
+    /// while routes are withheld, unresolvable or still installing.
+    ///
+    /// Records the want and does nothing else. Deliberately NOT
+    /// [`Self::SteerFailed`], which asserts an attempt that this path
+    /// never made: `rules_remain` is documented as read from the
+    /// steering ledger after a rollback, and an operator reading
+    /// `SteerFailed` in a log goes looking for a NIC that refused an
+    /// insert. This module has spent several rounds separating "asked
+    /// for and broken" from "never attempted"; a second event is
+    /// cheaper than blurring that again.
+    ///
+    /// Without it the same operator action retried or not depending on
+    /// which gate caught it. A steer refused by the completeness gate
+    /// goes through `Action::Steer`, so the refusal becomes
+    /// `SteerFailed` and the want survives to be retried; one refused by
+    /// the FIB gate returned before the request ever entered the
+    /// machine, so nothing was recorded and the offload stayed down
+    /// until a human asked a second time (review finding, PR #160).
+    SteerDeferred,
     /// The gates that refused a wanted steer now permit one.
     ///
     /// The caller owns both the observation and its pacing, the same
@@ -748,6 +770,15 @@ impl Supervisor {
             (Ready | State::Steered, SteerRequested) => {
                 self.steer_wanted = true;
                 vec![Action::Steer]
+            }
+            // The ask, recorded without being acted on. Same states as
+            // `SteerRequested`, because it IS that request — declined by
+            // a gate that sits before the injection rather than inside
+            // the effect. No action: the caller has already decided not
+            // to steer, and the want is the whole point.
+            (Ready | State::Steered, SteerDeferred) => {
+                self.steer_wanted = true;
+                vec![]
             }
             // The same lever, re-pulled by the module rather than by a
             // human, once whatever refused it has cleared.
@@ -1702,6 +1733,47 @@ mod tests {
         assert!(
             s.on(Event::SteerUnblocked).is_empty(),
             "and a live steered port must not be re-asserted on a timer"
+        );
+    }
+
+    /// A refusal raised BEFORE the attempt records the want just the
+    /// same, so the retry covers it.
+    ///
+    /// Which gate catches an operator's lever move is an implementation
+    /// seam: the completeness gate refuses inside the effect and leaves
+    /// a `SteerFailed` behind, the FIB gate refuses in the service
+    /// before injecting anything. Only the second needed an event to
+    /// say the ask happened, and without it the same action retried or
+    /// did not depending on which one fired.
+    #[test]
+    fn a_steer_declined_before_it_was_attempted_is_still_wanted() {
+        let mut s = ready_unsteered();
+        assert!(
+            s.on(Event::SteerDeferred).is_empty(),
+            "the caller has already decided not to steer; this only records"
+        );
+        assert!(!s.is_steered(), "and nothing was diverted");
+        assert!(
+            s.steer_retry_pending(),
+            "but the ask stands, so the retry owns it from here"
+        );
+        assert_eq!(s.on(Event::SteerUnblocked), vec![Action::Steer]);
+    }
+
+    /// It is a record of a REQUEST, so it is refused where a request
+    /// would be: config intent cannot reach it, and neither can a state
+    /// with no verified FIB to steer into.
+    #[test]
+    fn a_deferred_steer_is_ignored_outside_the_converged_states() {
+        let mut s = Supervisor::new();
+        s.on(Event::StartRequested);
+        s.on(Event::ApiUp);
+        assert_eq!(s.state(), State::Syncing);
+        assert!(s.on(Event::SteerDeferred).is_empty());
+        assert!(
+            !s.steer_intended(),
+            "a request refused outside the converged states leaves no want, exactly \
+             as SteerRequested does"
         );
     }
 

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -2337,3 +2337,246 @@ fn a_flap_demotes_attestation_only_until_a_newer_report_arrives() {
     );
     assert!(events.contains(&Event::VerifyPassed), "{events:?}");
 }
+
+/// The canary step refused by the completeness gate must steer itself
+/// once the mirror catches up — no `packetframe reconfigure`, no
+/// restart, no operator.
+///
+/// The whole loop, because the gap was in the seam between its layers
+/// rather than in any one of them. `RuntimeEffects::steer` refuses on
+/// the verdict, that becomes `SteerFailed`, and the supervisor settles
+/// in `Ready` with `steer_wanted` set — read, before this, by only the
+/// health text and the next `VerifyPassed`, which does not recur in
+/// steady state. So every layer behaved correctly and the offload
+/// stayed down until a human asked again (found reviewing #157).
+#[test]
+fn a_steer_refused_by_completeness_retries_when_the_mirror_catches_up() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+
+    let fake = Fake::start("steer-retry");
+    let log: steered::Log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let rt = runtime_custom(
+        &fake,
+        Box::new(Mirror {
+            routes: (0..5).map(|i| fake_vpp::v4(0, i)).collect(),
+        }),
+        // Nothing in the NIC yet: this is the staging state a canary
+        // ladder starts from.
+        Box::new(steered::RecordingSteering {
+            rules: Vec::new(),
+            log: log.clone(),
+        }),
+        1_000_000,
+    );
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    // bird's dump is still arriving: five of a thousand.
+    handle.publish(CompletenessReport {
+        authority_routes: 1_000,
+        mirror_routes: 5,
+        at: std::time::Instant::now(),
+    });
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (mut now, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+
+    // The operator turns the lever. The gate declines it.
+    {
+        let (_, mut fx) = rt.views();
+        let t = d.inject(now, Event::SteerRequested, &mut fx);
+        let refusal = t
+            .outcome
+            .failures
+            .iter()
+            .map(|(_, why)| why.clone())
+            .collect::<Vec<_>>()
+            .join("; ");
+        assert!(
+            refusal.contains("refusing to steer"),
+            "the gate must be what declined it: {refusal:?}"
+        );
+    }
+    assert_eq!(d.state(), State::Ready, "verified, not diverting");
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "the refusal is before the NIC: {:?}",
+        log.lock().unwrap()
+    );
+    assert!(d.supervisor().steer_intended(), "but the want is recorded");
+
+    // Minutes pass with the mirror still short. Nothing steers, and
+    // nothing hammers the NIC either.
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..2_000 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert!(
+        log.lock().unwrap().is_empty(),
+        "an incomplete mirror must stay unsteered: {:?}",
+        log.lock().unwrap()
+    );
+    assert_eq!(d.state(), State::Ready);
+
+    // bird finishes its dump. Nothing else happens — no reconfigure,
+    // no injected event, no restart.
+    handle.publish(CompletenessReport {
+        authority_routes: 5,
+        mirror_routes: 5,
+        at: std::time::Instant::now(),
+    });
+    // Bounded ticking rather than `run_until`, so a regression reads as
+    // "it never steered" instead of "the loop did not settle".
+    let mut events = Vec::new();
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..64 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            events.extend(t.events.clone());
+            for e in rt.take_pending() {
+                events.extend(d.inject(now, e, &mut fx).events);
+            }
+            rt.set_steered(d.supervisor().is_steered());
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+
+    assert_eq!(
+        log.lock().unwrap().as_slice(),
+        &["steer"],
+        "the module knew it wanted to steer and the gate now permits it — nothing \
+         should be waiting on an operator"
+    );
+    assert!(
+        events.contains(&Event::SteerUnblocked),
+        "and it must be the gate clearing that drove it: {events:?}"
+    );
+    assert_eq!(d.state(), State::Steered);
+    assert!(d.supervisor().is_steered());
+}
+
+/// ...and it must not walk past the OTHER gate on the way.
+///
+/// `VerifyIncomplete` reaches `Ready` with the want intact and emits no
+/// steer at all, deliberately: routes are withheld or unresolvable, and
+/// diverting traffic into a FIB with known holes blackholes exactly the
+/// prefixes that did not fit. The retry lives in `Ready` and reads the
+/// want, so a version that consulted only the completeness verdict
+/// would undo that arm on the next tick — the gate is on the route
+/// ledger, not on bird.
+#[test]
+fn the_retry_does_not_steer_into_a_table_with_known_holes() {
+    /// Refuses every steer and counts the asking. The count is the
+    /// assertion: the gate must stop the retry BEFORE the NIC.
+    #[derive(Default)]
+    struct CountingRefusal(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+    impl packetframe_vpp_offload::runtime::Steering for CountingRefusal {
+        fn missing_from_nic(
+            &self,
+        ) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
+            Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
+        }
+        fn configured_ports(&self) -> usize {
+            1
+        }
+        fn steer(&mut self) -> Result<(), String> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err("the NIC would not take it".into())
+        }
+        fn unsteer(&mut self) -> Result<(), String> {
+            Ok(())
+        }
+        fn installed(&self) -> Vec<(String, u32)> {
+            Vec::new()
+        }
+        fn retarget(
+            &mut self,
+            _ports: Vec<(String, u32)>,
+            _plan: packetframe_vpp_offload::steer::RuleSet,
+        ) {
+        }
+    }
+
+    let fake = Fake::start("steer-retry-holes");
+    let asked = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // Five routes into a two-route heap: three are withheld, which is
+    // what makes the verify incomplete rather than failed.
+    let rt = runtime_custom(
+        &fake,
+        Box::new(Mirror {
+            routes: (0..5).map(|i| fake_vpp::v4(0, i)).collect(),
+        }),
+        Box::new(CountingRefusal(std::sync::Arc::clone(&asked))),
+        2,
+    );
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (mut now, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    assert!(
+        events.contains(&Event::VerifyIncomplete),
+        "the table must not fit, or this test is about nothing: {events:?}"
+    );
+    assert!(rt.status().counts.withheld > 0);
+
+    // The operator turns the lever anyway and the NIC refuses, leaving
+    // a want outstanding over an incomplete table.
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(now, Event::SteerRequested, &mut fx);
+    }
+    assert_eq!(asked.load(std::sync::atomic::Ordering::SeqCst), 1);
+    assert!(
+        d.supervisor().steer_retry_pending(),
+        "the want is outstanding — only the FIB gate may be holding it"
+    );
+
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..2_000 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+    }
+    assert_eq!(
+        asked.load(std::sync::atomic::Ordering::SeqCst),
+        1,
+        "the retry must not re-ask while routes are withheld — that is the arm \
+         VerifyIncomplete exists to hold"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -2485,12 +2485,24 @@ fn a_steer_refused_by_completeness_retries_when_the_mirror_catches_up() {
 /// want, so a version that consulted only the completeness verdict
 /// would undo that arm on the next tick — the gate is on the route
 /// ledger, not on bird.
+/// Run for BOTH rollback outcomes, because the discriminator between
+/// them was where this gate first went wrong. A steer rolls back
+/// all-or-nothing, but the rollback itself can fail to delete — so a
+/// FIRST steer can leave debris, and "some rules are in the NIC" then
+/// stops meaning "this port was steering happily". Reading a non-empty
+/// ledger as a reconcile therefore exempted exactly the case that most
+/// needs the gate: the retry would install the REST of the allowlist
+/// into a holey table and widen the blackhole the debris started
+/// (review finding, PR #160).
 #[test]
 fn the_retry_does_not_steer_into_a_table_with_known_holes() {
     /// Refuses every steer and counts the asking. The count is the
     /// assertion: the gate must stop the retry BEFORE the NIC.
-    #[derive(Default)]
-    struct CountingRefusal(std::sync::Arc<std::sync::atomic::AtomicUsize>);
+    /// `debris` is what the rollback could not delete.
+    struct CountingRefusal {
+        asked: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+        debris: Vec<(String, u32)>,
+    }
     impl packetframe_vpp_offload::runtime::Steering for CountingRefusal {
         fn missing_from_nic(
             &self,
@@ -2501,14 +2513,22 @@ fn the_retry_does_not_steer_into_a_table_with_known_holes() {
             1
         }
         fn steer(&mut self) -> Result<(), String> {
-            self.0.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.asked.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Err("the NIC would not take it".into())
         }
         fn unsteer(&mut self) -> Result<(), String> {
             Ok(())
         }
         fn installed(&self) -> Vec<(String, u32)> {
-            Vec::new()
+            // Empty until a steer has been attempted: debris is what a
+            // rollback COULD NOT DELETE, so it cannot predate the
+            // attempt. Reporting it from the start would make the
+            // attach look like a steered adoption and defer the resync
+            // instead.
+            if self.asked.load(std::sync::atomic::Ordering::SeqCst) == 0 {
+                return Vec::new();
+            }
+            self.debris.clone()
         }
         fn retarget(
             &mut self,
@@ -2518,65 +2538,81 @@ fn the_retry_does_not_steer_into_a_table_with_known_holes() {
         }
     }
 
-    let fake = Fake::start("steer-retry-holes");
-    let asked = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
-    // Five routes into a two-route heap: three are withheld, which is
-    // what makes the verify incomplete rather than failed.
-    let rt = runtime_custom(
-        &fake,
-        Box::new(Mirror {
-            routes: (0..5).map(|i| fake_vpp::v4(0, i)).collect(),
-        }),
-        Box::new(CountingRefusal(std::sync::Arc::clone(&asked))),
-        2,
-    );
-    let mut d = Driver::new();
-    let t0 = Instant::now();
-    {
-        let (mut obs, _) = rt.views();
-        use packetframe_vpp_offload::driver::Observe as _;
-        assert!(obs.api_ready());
-    }
-    {
-        let (_, mut fx) = rt.views();
-        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
-    }
-    let (mut now, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
-    assert!(
-        events.contains(&Event::VerifyIncomplete),
-        "the table must not fit, or this test is about nothing: {events:?}"
-    );
-    assert!(rt.status().counts.withheld > 0);
-
-    // The operator turns the lever anyway and the NIC refuses, leaving
-    // a want outstanding over an incomplete table.
-    {
-        let (_, mut fx) = rt.views();
-        d.inject(now, Event::SteerRequested, &mut fx);
-    }
-    assert_eq!(asked.load(std::sync::atomic::Ordering::SeqCst), 1);
-    assert!(
-        d.supervisor().steer_retry_pending(),
-        "the want is outstanding — only the FIB gate may be holding it"
-    );
-
-    {
-        let (mut obs, mut fx) = rt.views();
-        for _ in 0..2_000 {
-            let t = d.tick(now, &mut obs, &mut fx);
-            for e in rt.take_pending() {
-                d.inject(now, e, &mut fx);
-            }
-            now += t
-                .sleep
-                .unwrap_or(Duration::from_millis(100))
-                .max(Duration::from_millis(1));
+    for (name, debris) in [
+        ("steer-retry-holes-clean", Vec::new()),
+        ("steer-retry-holes-debris", vec![("eth4".to_string(), 1u32)]),
+    ] {
+        let left_behind = !debris.is_empty();
+        let fake = Fake::start(name);
+        let asked = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        // Five routes into a two-route heap: three are withheld, which
+        // is what makes the verify incomplete rather than failed.
+        let rt = runtime_custom(
+            &fake,
+            Box::new(Mirror {
+                routes: (0..5).map(|i| fake_vpp::v4(0, i)).collect(),
+            }),
+            Box::new(CountingRefusal {
+                asked: std::sync::Arc::clone(&asked),
+                debris,
+            }),
+            2,
+        );
+        let mut d = Driver::new();
+        let t0 = Instant::now();
+        {
+            let (mut obs, _) = rt.views();
+            use packetframe_vpp_offload::driver::Observe as _;
+            assert!(obs.api_ready());
         }
+        {
+            let (_, mut fx) = rt.views();
+            d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+        }
+        let (mut now, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+        assert!(
+            events.contains(&Event::VerifyIncomplete),
+            "{name}: the table must not fit, or this test is about nothing: {events:?}"
+        );
+        assert!(rt.status().counts.withheld > 0, "{name}");
+
+        // The operator turns the lever anyway and the NIC refuses,
+        // leaving a want outstanding over an incomplete table.
+        {
+            let (_, mut fx) = rt.views();
+            d.inject(now, Event::SteerRequested, &mut fx);
+        }
+        assert_eq!(asked.load(std::sync::atomic::Ordering::SeqCst), 1, "{name}");
+        assert_eq!(
+            d.supervisor().is_steered(),
+            left_behind,
+            "{name}: the ledger is what says whether anything is diverted"
+        );
+        assert!(
+            d.supervisor().steer_retry_pending(),
+            "{name}: the want is outstanding — only the FIB gate may be holding it"
+        );
+
+        {
+            let (mut obs, mut fx) = rt.views();
+            for _ in 0..2_000 {
+                let t = d.tick(now, &mut obs, &mut fx);
+                for e in rt.take_pending() {
+                    d.inject(now, e, &mut fx);
+                }
+                rt.set_steered(d.supervisor().is_steered());
+                now += t
+                    .sleep
+                    .unwrap_or(Duration::from_millis(100))
+                    .max(Duration::from_millis(1));
+            }
+        }
+        assert_eq!(
+            asked.load(std::sync::atomic::Ordering::SeqCst),
+            1,
+            "{name}: the retry must not re-ask while routes are withheld — that is the \
+             arm VerifyIncomplete exists to hold, and rules left by a failed rollback \
+             are not a licence to add more"
+        );
     }
-    assert_eq!(
-        asked.load(std::sync::atomic::Ordering::SeqCst),
-        1,
-        "the retry must not re-ask while routes are withheld — that is the arm \
-         VerifyIncomplete exists to hold"
-    );
 }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1734,3 +1734,129 @@ fn an_allowlist_change_under_live_steering_is_always_reconciled() {
 
     svc.stop();
 }
+
+/// A first steer the FIB gate refuses must leave the ask on the record,
+/// so the module's own retry owns it from there.
+///
+/// Which gate catches an operator's lever move is an implementation
+/// seam. The completeness gate refuses inside `Effects::steer`, so the
+/// refusal becomes `SteerFailed` and the want survives; the FIB gate
+/// refuses in `apply_steering` before anything is injected, so the
+/// machine never heard of the request — same operator action, same
+/// visible outcome, and one of them retried while the other waited for
+/// a human (review finding, PR #160).
+///
+/// Asserted through the published health surface rather than by peeking
+/// at the supervisor, because that is where the difference shows: the
+/// designed staging state and a rollout that stalled must not print the
+/// same line.
+#[test]
+fn a_first_steer_refused_by_the_fib_gate_is_still_remembered() {
+    let fake = Fake::start("svc-fib-gate-want");
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            // Six routes into a two-route heap: four are withheld, so
+            // `blocks_first_steer()` holds and the verify is incomplete.
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![PortAttach {
+                    port: "eth4".into(),
+                    pci_addr: "0002:07:00.1".into(),
+                    port_id: 0,
+                    num_rx_queues: 1,
+                    pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+                }],
+                vec!["eth4".into()],
+                2,
+                FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(SpySteering(spy)),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if svc.status().expect("published").state == State::Ready {
+            break;
+        }
+        assert!(Instant::now() < deadline, "did not reach Ready");
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Before the lever, this is the designed staging state.
+    let steering_line = |s: &packetframe_vpp_offload::service::Published| {
+        s.report
+            .subsystems
+            .iter()
+            .find(|x| x.name == "steering")
+            .and_then(|x| x.message.clone())
+            .unwrap_or_default()
+    };
+    let before = svc.status().expect("published");
+    assert!(
+        !steering_line(&before).contains("intended but not in place"),
+        "nothing has been asked for yet: {}",
+        steering_line(&before)
+    );
+
+    // The operator turns the lever into an incomplete table.
+    let err = svc
+        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .expect_err("an incomplete FIB is not one to divert traffic into");
+    assert!(err.contains("refusing the first steer"), "{err}");
+    assert!(
+        err.contains("remembered"),
+        "and the answer must say the ask survives, or an operator re-runs it \
+         needlessly: {err}"
+    );
+
+    // The record is what matters: `steer_intended` is the predicate the
+    // retry reads, and the health line is where an operator sees it.
+    let after = svc.status().expect("published");
+    assert!(
+        steering_line(&after).contains("intended but not in place"),
+        "a refused lever move must not read as the staging state — that is the \
+         distinction the retry keys on: {}",
+        steering_line(&after)
+    );
+    assert!(
+        after
+            .metrics
+            .contains("packetframe_vpp_steer_intended{module=\"vpp-offload\"} 1"),
+        "{}",
+        after.metrics
+    );
+    assert!(
+        log.lock().unwrap().iter().all(|c| c != "steer"),
+        "and nothing may have been installed: {:?}",
+        log.lock().unwrap()
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1189,14 +1189,20 @@ impl packetframe_vpp_offload::runtime::Steering for SpySteering {
     }
 }
 
-/// Fails the first steer, then succeeds — the shape a refusal leaves
-/// behind (the completeness gate declining `Action::Steer`).
-struct FailFirstSteer {
+/// Refuses every steer until `allow` is set — the shape a completeness
+/// refusal leaves behind, held open under the test's control.
+///
+/// Held open rather than clearing after one call, because the module
+/// now re-attempts a refused steer by itself
+/// (`Event::SteerUnblocked`), and a double that succeeded on the second
+/// call would be steered by that retry before this test could ask —
+/// which is the module working, but not what this test is about.
+struct GatedSteer {
     log: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
-    failed: bool,
+    allow: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
-impl packetframe_vpp_offload::runtime::Steering for FailFirstSteer {
+impl packetframe_vpp_offload::runtime::Steering for GatedSteer {
     fn missing_from_nic(&self) -> Result<packetframe_vpp_offload::runtime::SteeringAudit, String> {
         Ok(packetframe_vpp_offload::runtime::SteeringAudit::clean())
     }
@@ -1204,8 +1210,7 @@ impl packetframe_vpp_offload::runtime::Steering for FailFirstSteer {
         1
     }
     fn steer(&mut self) -> Result<(), String> {
-        if !self.failed {
-            self.failed = true;
+        if !self.allow.load(std::sync::atomic::Ordering::SeqCst) {
             self.log.lock().unwrap().push("steer-refused".into());
             return Err("refusing to steer: the route mirror holds 3 of 10 routes".into());
         }
@@ -1240,12 +1245,20 @@ impl packetframe_vpp_offload::runtime::Steering for FailFirstSteer {
 ///
 /// `steer_intended()` is the predicate that separates "never steered,
 /// waiting for the operator's canary" from "asked for and broken".
+///
+/// The module also re-attempts a refused steer on its own now, which is
+/// a different mechanism on a different clock — so the guard here is
+/// the ANSWER rather than the eventual outcome: with the refusal held
+/// open, a `reconfigure` that injected must come back with the steer's
+/// own reason, and one that took the early return cannot.
 #[test]
 fn a_reconfigure_retries_a_steer_that_was_refused() {
     let fake = Fake::start("svc-retry-refused");
     let sock = fake.path.clone();
     let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
     let spy = std::sync::Arc::clone(&log);
+    let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let gate = std::sync::Arc::clone(&allow);
 
     let svc = SupervisionService::start(
         "vpp-offload",
@@ -1270,9 +1283,9 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
             let runtime = Runtime::new(
                 engine,
                 Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
-                Box::new(FailFirstSteer {
+                Box::new(GatedSteer {
                     log: std::sync::Arc::clone(&spy),
-                    failed: false,
+                    allow: std::sync::Arc::clone(&gate),
                 }),
                 Box::new(NullStore),
                 Box::new(NoResources),
@@ -1311,23 +1324,39 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
         "a refused steer leaves traffic on the fallback tier"
     );
 
-    // The blocker clears, and they re-run the SAME config — no lever
-    // movement, because there is nothing to move.
+    // They re-run the SAME config — no lever movement, because there is
+    // nothing to move. With the refusal still held open, the answer is
+    // the proof: a `reconfigure` that injected comes back carrying the
+    // steer's own reason, and one that took the staging early return
+    // answers Ok having done nothing at all.
+    let again = svc
+        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+        .expect_err(
+            "an unchanged-config reconfigure over a refused steer must re-attempt it; \
+             reporting Ok while doing nothing is worse than refusing, because the \
+             operator has no way to tell",
+        );
+    assert!(
+        again.contains("refusing to steer"),
+        "the answer must be the steer's own, not a staging no-op: {again}"
+    );
+
+    // And with the blocker gone it lands, without waiting out the
+    // module's own retry interval.
+    allow.store(true, std::sync::atomic::Ordering::SeqCst);
     svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
         .expect("the retry is accepted");
-
     assert_eq!(
         svc.status().expect("published").state,
         State::Steered,
-        "the retry must actually steer — reporting Ok while doing nothing is worse \
-         than refusing, because the operator has no way to tell"
+        "the retry must actually steer"
     );
     let seen = log.lock().unwrap().clone();
-    assert_eq!(
-        seen,
-        vec!["steer-refused".to_string(), "steer".to_string()],
-        "exactly one refusal and one successful retry: {seen:?}"
+    assert!(
+        seen.iter().filter(|s| *s == "steer-refused").count() >= 2,
+        "both reconfigures must have reached the steer: {seen:?}"
     );
+    assert_eq!(seen.last().map(String::as_str), Some("steer"), "{seen:?}");
 }
 
 fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -259,9 +259,18 @@ packetframe status | grep -A6 'module health'
 ```
 
 `packetframe reconfigure` reports the outcome synchronously. If it says
-the change was refused or withdrawn, **it did not happen** — that is
-deliberate, so "the rollout step succeeded" and "the rollout step was
-queued" cannot look the same.
+the change was refused or withdrawn, **it is not in effect** — that is
+deliberate, so "the rollout step succeeded" and "the rollout step is
+pending" cannot look the same.
+
+Not in effect is not the same as forgotten. A steer refused by either
+gate — the completeness verdict, or a FIB still holding withheld,
+unresolvable or in-flight routes — leaves the *ask* recorded, and the
+module re-attempts it on its own once the refusal clears, at most every
+30 s. The refusal message says so when that is what will happen. What
+it never does is report success for something that has not taken
+effect, which is the property this rung depends on: read the answer,
+then confirm with `ethtool -n` before moving to the next rung.
 
 Then watch actual traffic, not counters: PMTUD in particular. A DF
 packet larger than the MTU through a steered path must come back as a
@@ -784,6 +793,9 @@ device appeared in the table or a member port is missing. Check the
 
 This also **blocks the first steer** on an unsteered port, by design:
 if the table cannot be installed, traffic must not be diverted into it.
+A lever move refused on those grounds is remembered, and the steer goes
+in on its own once the count reaches zero — so fix the mapping and
+watch, rather than re-running `reconfigure` on a timer.
 
 ### `packetframe_vpp_routes{state="withheld"} > 0`
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -134,7 +134,11 @@ members up, FIB synced and verified, nothing diverted: that is every
 canary's waypoint and every rollback's landing zone. Distinguish it from
 `steering DEGRADED — steering intended but not in place — traffic is on
 the eBPF tier`, which means a steer was attempted and failed, or was torn
-down by trouble and not yet restored.
+down by trouble and not yet restored. From `Ready` that line also names
+the module's own retry — a refused steer is re-attempted at most every
+30 s once nothing is refusing it — so it is worth reading twice before
+reaching for `reconfigure`: if it is still there a minute later, the
+refusal is still standing and the reason is what to chase.
 
 And the overall verdict is deliberately **not** the maximum of the
 subsystems. Health tracks whether packets are forwarded correctly, not
@@ -400,9 +404,11 @@ steering  DEGRADED — 1 steering rule(s) ... a convergence re-applies
                      with routes withheld or unresolvable parks in the
                      staging state and emits no steer at all, and a steer
                      that IS emitted can still be refused by the
-                     completeness gate. Nothing retries after either, so
-                     if this line outlives the convergence, `packetframe
-                     reconfigure` is the retry
+                     completeness gate. Both settle in the staging state
+                     with the want remembered, and from there the module
+                     re-attempts the steer by itself once both gates
+                     permit. `packetframe reconfigure` asks immediately
+                     rather than waiting
 ```
 
 **Read that second sentence.** There are two ways the automatic path
@@ -410,13 +416,23 @@ declines. A verify that ends `VerifyIncomplete` — routes withheld or
 unresolvable — parks in the staging state and emits no steer at all,
 deliberately: diverting traffic into a FIB with known holes is what
 that arm exists to prevent. And a steer that *is* emitted still meets
-the completeness gate, which a stale or negative verdict refuses. After that the supervisor
-settles in `Ready` with the want remembered and **nothing emits another
-steer** — verify does not recur in steady state. So this is not a
-promise that the drift clears itself; it is a statement about where the
-next attempt comes from. If the line is still there once the module
-reaches `Ready`, restore completeness (watch `fib-synced`) and run
-`packetframe reconfigure`.
+the completeness gate, which a stale or negative verdict refuses.
+
+Either way the supervisor settles in `Ready` with the want remembered,
+and **that is where the retry lives**: from `Ready`, and only where a
+want was actually recorded, the module re-attempts the steer at most
+every 30 s for as long as either gate refuses. So the drift does clear
+itself once the blocker does — what the line will not promise is that
+the blocker clears. If it is still there minutes later, read the
+refusal: restore completeness (watch `fib-synced`), or find the
+withheld and unresolvable counts in `packetframe status`. Running
+`packetframe reconfigure` asks immediately instead of waiting out the
+interval, and reports the reason if it is refused again.
+
+The retry is **not** a way around the canary. It acts only where a want
+was already recorded — a steer that was asked for and failed, an adopted
+VPP that came with rules, a death while steered — never on `steer on`
+alone, so a first attach still waits for a human.
 
 Nothing is dropping meanwhile — the affected prefix is on the eBPF
 tier, which is where it belongs.
@@ -655,12 +671,16 @@ module vpp-offload
 ```
 
 With it, `steer` refuses while the mirror disagrees with bird's count,
-reports why, and retries itself once the mirror converges. Without it
-there is no gate at all — the refusal path is compiled out — and the
-canary ladder is the only thing between an early lever-move and traffic
-diverted into a 10%-loaded FIB. `off` is the documented opt-out for
-boxes with no bird to compare against (the shadow), not a default to
-leave alone.
+reports why, and re-attempts itself — at most every 30 s — once the
+mirror converges, so an early lever-move costs a wait rather than a lost
+offload. Without it there is no gate at all — the refusal path is
+compiled out — and the canary ladder is the only thing between an early
+lever-move and traffic diverted into a 10%-loaded FIB. (The retry
+itself does not depend on the gate — a steer the NIC refused is
+re-attempted either way — but with no verdict to wait on, an early
+lever-move steers into whatever is loaded at that instant.) `off` is
+the documented opt-out for boxes with no bird to compare against (the
+shadow), not a default to leave alone.
 
 ### `packetframe status` disagrees with what you just did
 
@@ -720,20 +740,31 @@ mirror is short of the table and steering into it would blackhole
 whatever has not arrived — and a steered miss is dropped, where an
 unsteered one falls through to the kernel path.
 
-**It does not retry on its own** — a belief three operator-facing texts
-carried until 2026-08-11. The refusal leaves the *want* set, but the
-only two things that emit a steer are the verify at the end of a
-convergence and an explicit `packetframe reconfigure`; verify does not
-recur in steady state. So during a first convergence the dump usually
-finishes in time and the steer lands, and outside that you have to
-re-run it. Watch the two counts converge:
+**It retries on its own** — from `Ready`, at most every 30 s, for as
+long as the want stands. The refusal leaves the want set and the module
+re-asks the gate on its own tick, so the ordinary outcome is that the
+dump finishes and the steer lands a few tens of seconds later with
+nobody doing anything.
+
+Read that as a bounded wait, not a guarantee. Until 2026-08-11 it was
+not true at all: the only two things that emitted a steer were the
+verify at the end of a convergence — which does not recur in steady
+state — and an explicit `packetframe reconfigure`, so a lever move that
+raced bird's dump left the offload down until a human asked again.
+Three operator-facing texts said otherwise, and the retry that made
+them true landed afterwards. On a daemon older than that date, the
+manual path below is the only one.
+
+Watch the two counts converge:
 
 ```bash
 birdc show route count
 packetframe status | grep -A6 'module health'
 ```
 
-Once they agree, `packetframe reconfigure` re-applies the steer.
+Once they agree the steer lands by itself within the interval;
+`packetframe reconfigure` asks immediately if you would rather not wait
+(and it reports the reason if the gate refuses again).
 
 If it persists, the mirror is genuinely not keeping up and that is a
 fast-path problem, not a steering one — check the integrity checker's


### PR DESCRIPTION
Closes the behaviour gap #157 documented and filed: a steer refused by
the completeness gate was never retried.

## The failure

`RuntimeEffects::steer` refuses when `completeness.verdict()` does not
permit steering. That becomes `Event::SteerFailed`, and the supervisor
sets `steer_wanted = true`, settles in `Ready`, and emits nothing.
`steer_wanted` was then read by exactly two things — `steer_intended()`
for the health text, and the `(Verifying, VerifyPassed)` arm — and only
two things emitted `Action::Steer` at all: that verify, and an explicit
`packetframe reconfigure`. Verify does not recur in steady state
(`fib-synced` shows `last ok 19526s ago` on a long-lived daemon).

So: bird's dump is behind, the operator turns the canary lever, the
steer is refused, the mirror catches up a minute later — and nothing
steers. The module knows it wants to, reports `steering DEGRADED —
steering intended but not in place`, and sits there until a human runs
`reconfigure` or VPP restarts.

## The change

**`Event::SteerUnblocked`**, the caller's observation that the gates now
permit a steer — the same division of labour as `FallbackSettled`, since
the supervisor holds no clock and cannot read a verdict. One arm acts on
it:

```rust
(Ready, SteerUnblocked) if self.steer_wanted => vec![Action::Steer],
```

The constraints are in what it does not read:

- **`Ready` only.** From `Steered` the rules are in and acknowledged;
  re-asserting them on a timer would put an ethtool round trip on the
  steady-state path for no fault. Drift under live steering stays the
  audit's business, with the operator's remedy.
- **The want is read, never set.** A port that never asked to steer
  stays in the staging state however complete its table becomes. Every
  assignment to `steer_wanted` was re-checked against
  `steer_intended()`'s doc comment before relying on this: adoption
  -while-steered, an explicit request, a death or wedge while steered, a
  failed steer, and inherited rules that the config still asks for.
  None fires on a bare first attach.
- **`steered` is not consulted**, so a reconcile whose rollback could
  not delete — `Ready` with rules still in the NIC — is retried too.

**Two gates, not one**, and this is the part worth a reviewer's
attention. `steer` refuses on the completeness verdict;
`SinkCounts::blocks_first_steer()` is applied by `apply_steering` and
`Verdict::may_steer`, *not* by `steer`. A retry keyed to completeness
alone would therefore walk straight past `VerifyIncomplete`, which
reaches `Ready` with the want intact and emits no steer precisely
because routes are withheld or unresolvable — and the next tick would
divert traffic into the FIB with known holes that arm exists to protect.
`Observe::steer_permitted` reads both, the verdict through the same
`Core::steer_verdict()` accessor the refusal uses, and discriminates
first-steer from reconcile on the NIC ledger the way `start_resync`
does.

**Pacing.** Level-triggered, not edge-triggered: the refusal happens
inside `Action::Steer` during `apply`, so the driver never observes the
gate closed and there is no edge to catch. `STEER_RETRY_EVERY` (30 s,
matching `STEER_AUDIT_EVERY`, which paces the other periodic ethtool
traffic on this path) is a floor between *attempts*, not a wait before
the first one — entering the wanted-but-absent state arms nothing, and
the timestamp clears as soon as nothing is outstanding. A steer that
keeps failing for reasons no gate knows about is paced rather than
retried every ping interval.

## Deliberately not in scope

- **A want whose target is empty.** `steer` refuses that before its
  stale-rule removal, so such a retry could only fail. Every supported
  path that empties the target also clears the want, and the one that
  does not — a `steer off` whose unsteer was refused — needs a teardown
  outcome meaning "reconciled to nothing steered". Still filed
  separately; noted in `poll_steer_retry`'s doc so the next reader
  knows it was considered.
- **Drift while steered** (`steer_missing > 0` in `Steered`).

## Tests

Both integration tests were verified against the defect rather than
merely written to pass:

- `a_steer_refused_by_completeness_retries_when_the_mirror_catches_up`
  (`vpp_runtime`) — the whole loop: converge, lever turned, gate
  refuses, minutes of ticking with nothing steered, verdict flips to
  Converged, steer lands. **Fails** with `poll_steer_retry` removed.
- `the_retry_does_not_steer_into_a_table_with_known_holes` — five routes
  into a two-route heap, want outstanding over an incomplete table, and
  the NIC must never be asked again. **Fails** with the FIB gate dropped
  from `steer_permitted`.
- Driver: gate-opens, the pacing ceiling over a 90 s window, no steer on
  a first attach with an open gate, no re-assert while steered.
- Supervisor: the retry, the partly-installed reconcile, the first-attach
  refusal, both rollback shapes (acknowledged and refused unsteer), and
  every non-`Ready` state ignoring the event.

`a_reconfigure_retries_a_steer_that_was_refused` needed restructuring:
its double succeeded on the second call, which the module's own retry
now consumes before the test can ask. The refusal is held open under the
test's control instead, and the guard is the *answer* — a `reconfigure`
that injected comes back carrying the steer's own reason, one that took
the staging early return cannot — which is the property that test was
added for and is now immune to the retry's clock.

## Operator-facing texts

All three #157 corrected are corrected again, plus one it missed:
`require-table-complete`'s own runbook section still said `steer`
"retries itself once the mirror converges", which was false when written
and is true now. Both the refusal error and the health line interpolate
`STEER_RETRY_EVERY` rather than hardcoding 30.

The `intended but not in place` line names the retry **only from
`Ready`**, where it is armed — elsewhere the repair is still the
convergence, and promising a paced retry that is not running would be
the same overclaim this file has now made four times.

## One thing found in passing

The `configured steer on, awaiting an operator lever move` health line
was shipping two twenty-space runs: the rustfmt-eats-the-continuation
defect `dfdc9b8` shipped and `cbba3ce` added a class guard for. Both
guards missed it because they build their matrix from
`steered_supervisor()`, which reaches one of the steering match's four
arms — so three of the four lines were never rendered by the tests that
exist to render every line. Fixed the literal, and both guards now walk
all four `(steered, steer_intended)` postures and both values of
`steer_configured`; verified by re-mangling. That pulled `steer on` and
`steer off` into `ALLOWED` — config directives rather than commands, but
an operator types what the line prints.

## Verification

`make test` (35 binaries) and `make lint` green on the host. The
qemu-verifier matrix and the four cross-builds are CI's; nothing here is
Linux-only, but the vpp-offload integration tests do run in that job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
