### PR TITLE
fix(vpp-offload): a refused neighbour must not cost the batch its routes

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -155,6 +155,35 @@ pub trait RouteSource {
         SourceChanges::default()
     }
 
+    /// Take back the part of a [`Self::drain_changes`] batch that could
+    /// not be applied, so it is retried intact.
+    ///
+    /// Handed **everything still owed**, routes included — that is the
+    /// whole point. `drain_changes` is destructive on the live feed, so
+    /// a batch whose neighbours failed partway used to lose its route
+    /// half outright: out of the source's queue, never into the engine's,
+    /// and nothing retried it. VPP then forwarded a stale FIB — a
+    /// withdrawn prefix still forwarded, a changed nexthop still on the
+    /// old adjacency — with `installed`/`installing`/`withheld`/
+    /// `unresolvable` all unaffected, and readback verification blind to
+    /// it, since verify samples prefixes the LEDGER believes installed
+    /// and the ledger never learned these existed.
+    ///
+    /// Implementations must treat this as **fill-if-absent**. An entry
+    /// already queued for the same prefix or nexthop was written after
+    /// this batch was drained, so it is the newer intent and has to win;
+    /// re-inserting the batch's older value would resurrect a state the
+    /// source has already replaced.
+    ///
+    /// **No default body**, and not because a no-op would be wrong for
+    /// the static sources — they hand nothing over, so this is never
+    /// called with work to lose. It is the delegating wrapper:
+    /// `route_count` had a default, the production loader's
+    /// `Arc<RouteFeed>` inherited it while forwarding every other
+    /// method, and a `requeue` that silently does not delegate is
+    /// exactly the bug above, back again.
+    fn requeue(&self, changes: SourceChanges);
+
     /// How many changes are queued but not yet handed over.
     ///
     /// Reported so a source that is filling faster than the engine drains
@@ -262,7 +291,12 @@ pub struct ResyncPlan {
 #[derive(Debug, Clone)]
 pub struct Verdict {
     pub outcome: VerifyOutcome,
-    /// False when the ledger holds routes it could not install.
+    /// False when the ledger holds routes it could not install, or when
+    /// route intent is outstanding somewhere the ledger cannot see it —
+    /// the runtime narrows it for the second case, which the counts
+    /// cannot express (a delta batch handed back to the source after a
+    /// failed neighbour send is not `installing`, not `withheld` and not
+    /// `unresolvable`; it is simply not there yet).
     pub may_steer: bool,
 }
 
@@ -1038,63 +1072,39 @@ impl ConvergenceEngine {
     /// unresolvable, so a new nexthop arriving in the same batch as the
     /// routes that use it would black-hole them for a full resync cycle
     /// if applied the other way round.
+    ///
+    /// A neighbour that fails hands the **whole remainder** back to the
+    /// source — the neighbour that failed, the ones not tried, and every
+    /// route in the batch — and only then returns the error.
+    /// `drain_changes` is destructive, so returning early with the route
+    /// loop unreached dropped that batch's deltas: out of the feed's
+    /// pending map, never into ours, retried by nothing. An already-
+    /// steered VPP went on forwarding a withdrawn prefix and resolving a
+    /// changed nexthop to its old adjacency, with every count clean and
+    /// verify unable to see it (verify samples what the ledger believes
+    /// installed, and the ledger never learned these existed).
+    ///
+    /// Handing the routes BACK rather than queueing them here is what
+    /// keeps the ordering intact. Queued now, they would install through
+    /// an adjacency VPP has just refused — #115's worst finding arriving
+    /// through the delta door, which is the trap the note in
+    /// [`Self::apply_neighbour`] describes.
     pub fn apply_changes(&mut self, src: &dyn RouteSource, max: usize) -> Result<u64, EngineError> {
-        let changes = src.drain_changes(max);
+        let mut changes = src.drain_changes(max);
         if changes.is_empty() {
             return Ok(0);
         }
         let n = changes.len() as u64;
-        for (nh, state) in changes.neighbours {
-            match state {
-                Some((dev, mac)) => {
-                    self.nexthops.set_device(nh, dev);
-                    // And PROGRAM it, which is the whole point.
-                    //
-                    // `set_device` alone makes `resolve` return `Some`, so
-                    // routes through this nexthop classify as resolvable
-                    // and install — while VPP, which runs without
-                    // linux-cp and can never ARP for the adjacency, has
-                    // nothing to send them to. Verification would not
-                    // catch it either: it checks a route exists on an
-                    // interface we own, deliberately not that its
-                    // adjacency resolves. That is #115's worst finding
-                    // exactly, arriving through the delta door instead of
-                    // the resync one.
-                    if let Some(idx) = self
-                        .nexthops
-                        .resolve(&nh)
-                        .and_then(|t| self.port_index.get(&t))
-                    {
-                        // Identical to what VPP acknowledged: nothing to
-                        // send. The delta path re-learning a neighbour at
-                        // daemon start is routine — the resolver re-reads
-                        // the kernel table — and re-adding it walks every
-                        // dependent route (the second door of the 5.5 s
-                        // adoption blackhole; the first was
-                        // `program_neighbours`).
-                        if self.neighbours_installed.get(&(idx, nh)) != Some(&mac) {
-                            self.send_neighbour(nh, idx, mac, true)?;
-                        }
-                    }
-                }
-                // Forgotten rather than left at its last known device —
-                // see `NexthopMap::forget_device`. The routes through it
-                // become unresolvable, which is the honest answer and the
-                // one health reports.
-                //
-                // The adjacency is withdrawn from VPP first, while the
-                // mapping that names its interface is still there to
-                // withdraw it *with*.
-                None => {
-                    if let Some(idx) = self
-                        .nexthops
-                        .resolve(&nh)
-                        .and_then(|t| self.port_index.get(&t))
-                    {
-                        self.send_neighbour(nh, idx, [0; 6], false)?;
-                    }
-                    self.nexthops.forget_device(&nh);
-                }
+        // Popped from the back, which reorders nothing that has an order:
+        // the feed holds neighbour deltas in a `HashMap`, so the batch
+        // arrives in an arbitrary order already, and each entry names a
+        // distinct nexthop. What matters is that whatever has not been
+        // applied is still in the vec when a failure hands it back.
+        while let Some((nh, state)) = changes.neighbours.pop() {
+            if let Err(e) = self.apply_neighbour(nh, state.clone()) {
+                changes.neighbours.push((nh, state));
+                src.requeue(changes);
+                return Err(e);
             }
         }
         for (prefix, nhs) in changes.routes {
@@ -1104,6 +1114,80 @@ impl ConvergenceEngine {
             }
         }
         Ok(n)
+    }
+
+    /// Apply one neighbour delta: program the adjacency in VPP, then
+    /// record the mapping that makes routes through it resolvable.
+    fn apply_neighbour(
+        &mut self,
+        nh: IpAddr,
+        state: Option<(String, [u8; 6])>,
+    ) -> Result<(), EngineError> {
+        match state {
+            Some((dev, mac)) => {
+                // Resolved through the device the delta names, WITHOUT
+                // recording it yet — the send comes first and the mapping
+                // second.
+                //
+                // `set_device` alone makes `resolve` return `Some`, so
+                // routes through this nexthop classify as resolvable and
+                // install — while VPP, which runs without linux-cp and
+                // can never ARP for the adjacency, has nothing to send
+                // them to. Verification would not catch it either: it
+                // checks a route exists on an interface we own,
+                // deliberately not that its adjacency resolves. That is
+                // #115's worst finding exactly, arriving through the
+                // delta door instead of the resync one.
+                //
+                // Recording it before the send left that door open even
+                // when the send FAILED: the mapping survived the error,
+                // so the next drain resolved every pending route through
+                // an adjacency VPP had refused and installed them clean.
+                if let Some(idx) = self
+                    .nexthops
+                    .target_for_device(&dev)
+                    .and_then(|t| self.port_index.get(&t))
+                {
+                    // Identical to what VPP acknowledged: nothing to
+                    // send. The delta path re-learning a neighbour at
+                    // daemon start is routine — the resolver re-reads
+                    // the kernel table — and re-adding it walks every
+                    // dependent route (the second door of the 5.5 s
+                    // adoption blackhole; the first was
+                    // `program_neighbours`).
+                    if self.neighbours_installed.get(&(idx, nh)) != Some(&mac) {
+                        self.send_neighbour(nh, idx, mac, true)?;
+                    }
+                }
+                // Recorded even for a device VPP does not own, where the
+                // send above never happened: `resolve` answers `None` for
+                // an excluded device either way, so the entry cannot make
+                // such a route installable, and leaving it out would make
+                // a later loss for the same nexthop look like a mapping
+                // that was never learned.
+                self.nexthops.set_device(nh, dev);
+                Ok(())
+            }
+            // Forgotten rather than left at its last known device —
+            // see `NexthopMap::forget_device`. The routes through it
+            // become unresolvable, which is the honest answer and the
+            // one health reports.
+            //
+            // The adjacency is withdrawn from VPP first, while the
+            // mapping that names its interface is still there to
+            // withdraw it *with*.
+            None => {
+                if let Some(idx) = self
+                    .nexthops
+                    .resolve(&nh)
+                    .and_then(|t| self.port_index.get(&t))
+                {
+                    self.send_neighbour(nh, idx, [0; 6], false)?;
+                }
+                self.nexthops.forget_device(&nh);
+                Ok(())
+            }
+        }
     }
 
     pub fn begin_resync(&mut self, src: &dyn RouteSource) -> ResyncPlan {
@@ -1351,6 +1435,9 @@ mod tests {
     }
 
     impl RouteSource for Mirror {
+        fn requeue(&self, _: SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -48,7 +48,8 @@ use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
 use crate::vpp_api::generated::{
     IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails, IpNeighborDump,
-    IpRoute, IpRouteDetails, IpRouteDump, IpTable, ADDRESS_IP4, FIB_API_PATH_TYPE_NORMAL,
+    IpRoute, IpRouteDetails, IpRouteDump, IpTable, ADDRESS_IP4, ADDRESS_IP6,
+    FIB_API_PATH_TYPE_NORMAL,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -894,31 +895,43 @@ impl ConvergenceEngine {
     /// [`Self::reconcile_unacked_neighbours`] — because a second
     /// hand-written copy of the flag filter is how the two would come to
     /// disagree about what "an entry we would have created" means.
+    ///
+    /// Asked **once per family the policy carries**, from the same
+    /// `dump_families` the FIB readback uses. A v4-only dump answers "not
+    /// present" for every v6 neighbour, and both consumers read absence as
+    /// permission to send: the resync walk re-adds a v6 adjacency VPP
+    /// already holds, and `settle_unacked` drops a v6 claim it cannot
+    /// verify — each paying the dependent-FIB walk this ledger exists to
+    /// avoid (review finding). Under `V4Only` this is exactly the single
+    /// dump it was before.
     fn dump_static_neighbours(&mut self) -> Result<HashSet<(u32, IpAddr, [u8; 6])>, EngineError> {
-        let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
-        let details: Vec<IpNeighborDetails> = match t.dump(IpNeighborDump {
-            context: 0,
-            sw_if_index: u32::MAX,
-            af: ADDRESS_IP4,
-        }) {
-            Ok(d) => d,
-            Err(e) => {
-                self.disconnect();
-                return Err(EngineError::Transport(e));
-            }
-        };
         let mut out = HashSet::new();
-        for d in details {
-            // EXACT flags, not a bit test: `send_neighbour` programs
-            // precisely IP_NEIGHBOR_STATIC, so an entry carrying any
-            // extra flag (STATIC|NO_FIB_ENTRY, say) is not the entry
-            // we would create, and skipping it would silently
-            // preserve the difference forever (review finding).
-            if d.neighbor.flags != IP_NEIGHBOR_STATIC {
-                continue;
-            }
-            if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {
-                out.insert((d.neighbor.sw_if_index, ip, d.neighbor.mac_address));
+        for &is_ip6 in self.drainer.families().dump_families() {
+            let af = if is_ip6 { ADDRESS_IP6 } else { ADDRESS_IP4 };
+            let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
+            let details: Vec<IpNeighborDetails> = match t.dump(IpNeighborDump {
+                context: 0,
+                sw_if_index: u32::MAX,
+                af,
+            }) {
+                Ok(d) => d,
+                Err(e) => {
+                    self.disconnect();
+                    return Err(EngineError::Transport(e));
+                }
+            };
+            for d in details {
+                // EXACT flags, not a bit test: `send_neighbour` programs
+                // precisely IP_NEIGHBOR_STATIC, so an entry carrying any
+                // extra flag (STATIC|NO_FIB_ENTRY, say) is not the entry
+                // we would create, and skipping it would silently
+                // preserve the difference forever (review finding).
+                if d.neighbor.flags != IP_NEIGHBOR_STATIC {
+                    continue;
+                }
+                if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {
+                    out.insert((d.neighbor.sw_if_index, ip, d.neighbor.mac_address));
+                }
             }
         }
         Ok(out)

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -404,6 +404,32 @@ pub struct ConvergenceEngine {
     /// from VPP's own dump (in `program_neighbours`); cleared with the
     /// process, because it describes a table that died with it.
     neighbours_installed: std::collections::HashMap<(u32, IpAddr), [u8; 6]>,
+    /// Neighbours whose last message reached the socket but whose reply
+    /// never came back, so `neighbours_installed` cannot be trusted for
+    /// them until VPP is asked again.
+    ///
+    /// A transport error after the write is genuinely ambiguous — VPP may
+    /// have applied the change — and the ledger records only
+    /// acknowledgements, so both directions are left describing the wrong
+    /// table. They fail in opposite ways and the second is the dangerous
+    /// one:
+    ///
+    /// - An unacknowledged **add** VPP did apply gets sent again on the
+    ///   retry, and re-adding an existing static neighbour walks every
+    ///   dependent FIB entry: ~1M routes hang off one adjacency here, for
+    ///   a measured 5.51 s blackhole (shadow, 2026-08-08).
+    /// - An unacknowledged **remove** VPP did apply leaves the ledger
+    ///   claiming an adjacency VPP no longer has, and the delta path's
+    ///   skip then absorbs the next add of that exact MAC — silently,
+    ///   permanently, with every route through it black-holed. Strictly
+    ///   worse than a redundant walk.
+    ///
+    /// Both are settled by asking VPP, so these keys are reconciled
+    /// against a fresh `ip_neighbor_dump` before either send path
+    /// consults the ledger again. Keyed, not a flag, so the dump corrects
+    /// exactly what is in doubt — a wholesale rebuild would drop what the
+    /// v4-only dump cannot see.
+    neighbours_unacked: std::collections::HashSet<(u32, IpAddr)>,
     drainer: Drainer,
 
     /// Whether MCAM rules are diverting traffic right now.
@@ -459,6 +485,7 @@ impl ConvergenceEngine {
             ledger: RouteLedger::new(Capacity::new(high_water_routes)),
             nexthops: NexthopMap::new(members),
             neighbours_installed: std::collections::HashMap::new(),
+            neighbours_unacked: std::collections::HashSet::new(),
             drainer: Drainer::new(DEFAULT_WINDOW).with_families(families),
             steered: false,
             last_api_error: None,
@@ -810,40 +837,19 @@ impl ConvergenceEngine {
         // that walk is the price of correctness — and a dynamic entry
         // must be replaced with a static one, because VPP can never
         // refresh it here (MCAM cannot steer ARP).
-        let mut existing: HashSet<(u32, IpAddr, [u8; 6])> = HashSet::new();
-        {
-            let t = self.transport.as_mut().expect("checked just above");
-            let details: Vec<IpNeighborDetails> = match t.dump(IpNeighborDump {
-                context: 0,
-                sw_if_index: u32::MAX,
-                af: ADDRESS_IP4,
-            }) {
-                Ok(d) => d,
-                Err(e) => {
-                    self.disconnect();
-                    return Err(EngineError::Transport(e));
-                }
-            };
-            for d in details {
-                // EXACT flags, not a bit test: `send_neighbour` programs
-                // precisely IP_NEIGHBOR_STATIC, so an entry carrying any
-                // extra flag (STATIC|NO_FIB_ENTRY, say) is not the entry
-                // we would create, and skipping it would silently
-                // preserve the difference forever (review finding).
-                if d.neighbor.flags != IP_NEIGHBOR_STATIC {
-                    continue;
-                }
-                if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {
-                    existing.insert((d.neighbor.sw_if_index, ip, d.neighbor.mac_address));
-                }
-            }
-        }
+        let existing = self.dump_static_neighbours()?;
         // Seed the acknowledged ledger from VPP's own answer, so the
         // DELTA path's skip covers adopted entries too — not only ones
         // this process sent.
         for &(idx, ip, mac) in &existing {
             self.neighbours_installed.insert((idx, ip), mac);
         }
+        // Insert-only above, so a key VPP no longer holds keeps its stale
+        // entry — harmless for the general case (the walk below re-sends
+        // anything whose MAC differs) but not for one left in doubt,
+        // where a stale "installed" is what makes the skip permanent.
+        // Those are corrected against the same dump.
+        self.settle_unacked(&existing);
 
         // Collect first: the visitor borrows `src` while the sends need
         // `&mut self`.
@@ -881,6 +887,95 @@ impl ConvergenceEngine {
         Ok(programmed)
     }
 
+    /// Every static neighbour VPP currently holds, as
+    /// `(sw_if_index, address, MAC)`.
+    ///
+    /// One dump, two consumers — the resync walk's skip and
+    /// [`Self::reconcile_unacked_neighbours`] — because a second
+    /// hand-written copy of the flag filter is how the two would come to
+    /// disagree about what "an entry we would have created" means.
+    fn dump_static_neighbours(&mut self) -> Result<HashSet<(u32, IpAddr, [u8; 6])>, EngineError> {
+        let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
+        let details: Vec<IpNeighborDetails> = match t.dump(IpNeighborDump {
+            context: 0,
+            sw_if_index: u32::MAX,
+            af: ADDRESS_IP4,
+        }) {
+            Ok(d) => d,
+            Err(e) => {
+                self.disconnect();
+                return Err(EngineError::Transport(e));
+            }
+        };
+        let mut out = HashSet::new();
+        for d in details {
+            // EXACT flags, not a bit test: `send_neighbour` programs
+            // precisely IP_NEIGHBOR_STATIC, so an entry carrying any
+            // extra flag (STATIC|NO_FIB_ENTRY, say) is not the entry
+            // we would create, and skipping it would silently
+            // preserve the difference forever (review finding).
+            if d.neighbor.flags != IP_NEIGHBOR_STATIC {
+                continue;
+            }
+            if let Some(ip) = crate::fib_sync::from_address(&d.neighbor.ip_address) {
+                out.insert((d.neighbor.sw_if_index, ip, d.neighbor.mac_address));
+            }
+        }
+        Ok(out)
+    }
+
+    /// Ask VPP what became of the neighbours whose replies never arrived,
+    /// and make the ledger say that.
+    ///
+    /// Called before either send path consults `neighbours_installed`, so
+    /// the skip decides against what VPP holds rather than against what we
+    /// last managed to hear. See [`Self::neighbours_unacked`] for why both
+    /// directions need it and why the remove case is the dangerous one.
+    ///
+    /// A no-op with nothing in doubt, which is every ordinary tick — the
+    /// dump only happens after a transport error mid-neighbour.
+    fn reconcile_unacked_neighbours(&mut self) -> Result<(), EngineError> {
+        if self.neighbours_unacked.is_empty() {
+            return Ok(());
+        }
+        let existing = self.dump_static_neighbours()?;
+        self.settle_unacked(&existing);
+        Ok(())
+    }
+
+    /// Apply a dump's answer to the in-doubt keys, then consider them
+    /// settled. Split from the dump so the resync walk, which has already
+    /// paid for one, does not issue a second.
+    fn settle_unacked(&mut self, existing: &HashSet<(u32, IpAddr, [u8; 6])>) {
+        if self.neighbours_unacked.is_empty() {
+            return;
+        }
+        for (idx, ip) in std::mem::take(&mut self.neighbours_unacked) {
+            match existing
+                .iter()
+                .find(|(i, a, _)| *i == idx && *a == ip)
+                .map(|(_, _, mac)| *mac)
+            {
+                // VPP has it: record the MAC it actually holds, which is
+                // what stops the retry re-adding it and walking ~1M
+                // dependent routes. Not necessarily the MAC we sent —
+                // if the add never landed, this is the older entry, and
+                // recording it truthfully is what makes the delta path
+                // re-send.
+                Some(mac) => {
+                    self.neighbours_installed.insert((idx, ip), mac);
+                }
+                // VPP does not: drop the claim. An unacknowledged remove
+                // that did land would otherwise leave the ledger
+                // asserting an adjacency that is gone, and the skip would
+                // swallow every later add of that MAC.
+                None => {
+                    self.neighbours_installed.remove(&(idx, ip));
+                }
+            }
+        }
+    }
+
     /// One `ip_neighbor_add_del`, the single place this message is built.
     ///
     /// Extracted because there are now two callers — the resync walk and
@@ -908,6 +1003,12 @@ impl ConvergenceEngine {
         }) {
             Ok(r) => r,
             Err(e) => {
+                // The message was written; the answer never came. VPP may
+                // have applied it, so the ledger is not entitled to an
+                // opinion about this neighbour until VPP is asked again.
+                // See `neighbours_unacked` — both directions fail here,
+                // and silently.
+                self.neighbours_unacked.insert((sw_if_index, ip));
                 self.disconnect();
                 return Err(EngineError::Transport(e));
             }
@@ -1090,6 +1191,14 @@ impl ConvergenceEngine {
     /// through the delta door, which is the trap the note in
     /// [`Self::apply_neighbour`] describes.
     pub fn apply_changes(&mut self, src: &dyn RouteSource, max: usize) -> Result<u64, EngineError> {
+        // Before the drain, so a failure here costs nothing: nothing has
+        // been taken from the source yet. The skip below consults
+        // `neighbours_installed`, and after a transport error mid-neighbour
+        // that ledger describes a table VPP may not have — so VPP is asked
+        // first. Ordinary ticks have nothing in doubt and this is free.
+        if self.transport.is_some() {
+            self.reconcile_unacked_neighbours()?;
+        }
         let mut changes = src.drain_changes(max);
         if changes.is_empty() {
             return Ok(0);
@@ -1366,6 +1475,11 @@ impl ConvergenceEngine {
         self.loop_index = None;
         // The neighbour ledger describes the dead instance's table.
         self.neighbours_installed.clear();
+        // And so does the doubt about it: whatever the dead VPP did or did
+        // not apply is moot, and carrying the keys over would make the
+        // replacement's first delta pay for a dump that can only confirm
+        // an empty table.
+        self.neighbours_unacked.clear();
         self.pending = PendingMap::new();
         self.ledger = RouteLedger::new(self.ledger_capacity());
         self.phase = None;

--- a/crates/modules/vpp-offload/src/feed.rs
+++ b/crates/modules/vpp-offload/src/feed.rs
@@ -256,6 +256,52 @@ impl RouteSource for RouteFeed {
         SourceChanges { routes, neighbours }
     }
 
+    /// Put an undelivered batch back into the pending maps.
+    ///
+    /// **Fill-if-absent** in both, which is what makes this safe against
+    /// the churn that ran while the batch was out: an entry already
+    /// queued for the same prefix or nexthop was written by the other
+    /// tier AFTER this batch was drained, so it is the newer intent and
+    /// last-write-wins says it must survive. Re-inserting the batch's
+    /// older value would resurrect a withdrawal the source has since
+    /// replaced with a live route.
+    ///
+    /// `seq` is deliberately NOT bumped. It counts mutations of the
+    /// SOURCE, and the adopted-resync gate reads it as "the feed is still
+    /// loading, do not diff against it yet". Our own undelivered work
+    /// coming back is not source activity, and counting it would hold the
+    /// deferral open for as long as VPP kept refusing — an adopted VPP
+    /// left forwarding an unreconciled table by the very mechanism that
+    /// exists to protect it.
+    fn requeue(&self, changes: SourceChanges) {
+        let mut g = self.lock();
+        for (nh, state) in changes.neighbours {
+            if g.neigh_pending.contains_key(&nh) {
+                continue;
+            }
+            // Re-derived from the mirror rather than by converting the
+            // device NAME in the batch back to an ifindex. The mirror is
+            // authoritative and current, so a neighbour that moved links
+            // while the batch was out comes back pointing where it is
+            // now; one the mirror no longer holds comes back as a loss,
+            // which is the honest delta and a no-op in the engine for a
+            // nexthop it never managed to program.
+            let raw = match state {
+                Some(_) => g.neighbours.get(&nh).copied(),
+                None => None,
+            };
+            g.neigh_pending.insert(nh, raw);
+        }
+        for (prefix, nhs) in changes.routes {
+            let key = PrefixKey::from(prefix);
+            if g.pending.contains_key(&key) {
+                continue;
+            }
+            let id = nhs.map(|v| g.intern(&v));
+            g.pending.insert(key, id);
+        }
+    }
+
     fn backlog(&self) -> u64 {
         let g = self.lock();
         (g.pending.len() + g.neigh_pending.len()) as u64
@@ -333,6 +379,9 @@ impl RouteSource for RouteFeed {
 impl RouteSource for std::sync::Arc<RouteFeed> {
     fn drain_changes(&self, max: usize) -> SourceChanges {
         (**self).drain_changes(max)
+    }
+    fn requeue(&self, changes: SourceChanges) {
+        (**self).requeue(changes)
     }
     fn backlog(&self) -> u64 {
         (**self).backlog()
@@ -440,6 +489,124 @@ mod tests {
         let f = RouteFeed::new();
         f.route_withdrawn(v4(203, 0));
         assert_eq!(f.drain_changes(64).routes, vec![(v4(203, 0), None)]);
+    }
+
+    /// An undelivered batch comes back whole, so the engine can retry it.
+    ///
+    /// The engine hands back everything it could not apply — including the
+    /// ROUTE half of a batch whose neighbour programming failed, which is
+    /// the half that used to be dropped. `drain_changes` had already
+    /// removed those prefixes from `pending`, so they were gone from both
+    /// tiers at once: VPP kept forwarding a withdrawn prefix, the counts
+    /// stayed clean, and only a full resync could recover.
+    #[test]
+    fn an_undelivered_batch_comes_back_whole() {
+        let f = RouteFeed::new();
+        let lo = some_real_ifindex();
+        f.route_resolved(v4(198, 51), &[nh(1)]);
+        f.route_withdrawn(v4(203, 0));
+        f.neighbour_resolved(nh(1), [2, 0, 0, 0, 0, 1], lo);
+
+        let batch = f.drain_changes(64);
+        assert_eq!(batch.len(), 3);
+        assert_eq!(f.stats().pending, 0, "the drain emptied both maps");
+        assert_eq!(f.stats().pending_neighbours, 0);
+
+        f.requeue(batch);
+        assert_eq!(f.stats().pending, 2, "both routes are queued again");
+        assert_eq!(f.stats().pending_neighbours, 1);
+
+        let again = f.drain_changes(64);
+        assert_eq!(
+            again.routes,
+            vec![(v4(198, 51), Some(vec![nh(1)])), (v4(203, 0), None)],
+            "the upsert and the withdrawal both survive, unchanged"
+        );
+        assert_eq!(again.neighbours.len(), 1);
+        assert_eq!(again.neighbours[0].0, nh(1));
+        assert_eq!(
+            again.neighbours[0].1.as_ref().map(|(_, mac)| *mac),
+            Some([2, 0, 0, 0, 0, 1]),
+            "with the MAC the engine still owes VPP"
+        );
+    }
+
+    /// A requeue must not overwrite what arrived while the batch was out.
+    ///
+    /// The batch is older than anything queued since it was drained, so
+    /// fill-if-absent is the only correct rule: re-inserting its value
+    /// would resurrect a withdrawal the source has already replaced with
+    /// a live route, and the engine would delete a prefix bird is
+    /// advertising.
+    #[test]
+    fn a_requeue_never_displaces_newer_intent() {
+        let f = RouteFeed::new();
+        let lo = some_real_ifindex();
+        f.route_withdrawn(v4(198, 51));
+        f.neighbour_lost(nh(1));
+        let stale = f.drain_changes(64);
+
+        // The other tier moves on while the batch is undelivered.
+        f.route_resolved(v4(198, 51), &[nh(2)]);
+        f.neighbour_resolved(nh(1), [2, 0, 0, 0, 0, 9], lo);
+
+        f.requeue(stale);
+        let out = f.drain_changes(64);
+        assert_eq!(
+            out.routes,
+            vec![(v4(198, 51), Some(vec![nh(2)]))],
+            "the stale withdrawal must not displace the live route"
+        );
+        assert_eq!(
+            out.neighbours[0].1.as_ref().map(|(_, mac)| *mac),
+            Some([2, 0, 0, 0, 0, 9]),
+            "nor the stale loss displace the re-learned neighbour"
+        );
+    }
+
+    /// A requeue is not source activity, so it must not bump `seq`.
+    ///
+    /// The adopted-resync gate reads `seq` as "the feed is still loading,
+    /// do not diff against it yet". Counting our own undelivered work as
+    /// churn would hold that deferral open for as long as VPP kept
+    /// refusing — leaving an adopted VPP forwarding an unreconciled table
+    /// by way of the mechanism that exists to protect it.
+    #[test]
+    fn a_requeue_does_not_read_as_source_churn() {
+        let f = RouteFeed::new();
+        f.route_resolved(v4(198, 51), &[nh(1)]);
+        let batch = f.drain_changes(64);
+        let before = f.change_seq();
+        f.requeue(batch);
+        assert_eq!(f.change_seq(), before);
+    }
+
+    /// A neighbour comes back pointing where the mirror says it is NOW.
+    ///
+    /// The batch carries a resolved device *name*; the requeue re-derives
+    /// the `(MAC, ifindex)` pair from the mirror instead of converting
+    /// that name back. A neighbour the mirror has since dropped therefore
+    /// comes back as a loss rather than as an add for an adjacency that no
+    /// longer exists.
+    #[test]
+    fn a_requeued_neighbour_the_mirror_dropped_comes_back_as_a_loss() {
+        let f = RouteFeed::new();
+        let lo = some_real_ifindex();
+        f.neighbour_resolved(nh(1), [2, 0, 0, 0, 0, 1], lo);
+        let batch = f.drain_changes(64);
+        assert!(batch.neighbours[0].1.is_some(), "drained as an add");
+
+        // Gone from the mirror, and its own loss delta already drained.
+        f.neighbour_lost(nh(1));
+        let _ = f.drain_changes(64);
+
+        f.requeue(batch);
+        let out = f.drain_changes(64);
+        assert_eq!(
+            out.neighbours,
+            vec![(nh(1), None)],
+            "an add for a neighbour that is gone must come back as a loss"
+        );
     }
 
     /// `drain` is bounded and resumes in key order.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1003,6 +1003,9 @@ mod tests {
 
     struct NoRoutes;
     impl engine::RouteSource for NoRoutes {
+        fn requeue(&self, _: engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn for_each_route(
             &self,
             _: &mut dyn FnMut(packetframe_common::fib::IpPrefix, &[std::net::IpAddr]),

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1891,7 +1891,7 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = steering(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
         assert_eq!(
             s.steer().expect("installs"),
             SteerOutcome::Steered,
@@ -1931,7 +1931,7 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = steering(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
         s.steer().expect("installs");
         let stuck: Vec<u32> = s.installed().iter().map(|(_, loc)| *loc).collect();
         sys::wedge_delete(&stuck);
@@ -3361,7 +3361,7 @@ mod tests {
         }
 
         sys::reset();
-        let mut fx = SteeringOnly(NtupleSteering::new(
+        let mut fx = SteeringOnly(steering(
             vec![("eth4".into(), 0)],
             plan_for(&[[198, 18, 0, 0]]),
         ));

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -2007,7 +2007,34 @@ impl Effects for EffectsView {
     fn start_verify(&mut self) -> Result<(), String> {
         let mut c = self.core.borrow_mut();
         match c.engine.run_verify() {
-            Ok(verdict) => {
+            Ok(mut verdict) => {
+                // A failed delivery attempt narrows the verdict, because
+                // the ledger's counts cannot describe one. `apply_changes`
+                // hands an unapplied delta batch back to the source, so
+                // its routes are neither installed nor installing nor
+                // withheld nor unresolvable — they are simply not here,
+                // and `blocks_first_steer` reads a table with a hole in it
+                // as complete. Steering into that diverts traffic into a
+                // FIB that is behind bird by however much the failed batch
+                // held.
+                //
+                // Wider than strictly needed — a transport failure mid-
+                // drain also sets this, and that batch is safe in the
+                // pending map — and deliberately so: every cause is "the
+                // last attempt to push route intent into VPP did not
+                // land", and the conservative direction for a FIRST steer
+                // is to wait one tick for the retry. It clears on the
+                // next clean drain.
+                if let Some(why) = &c.last_drain_error {
+                    if verdict.may_steer {
+                        tracing::warn!(
+                            error = %why,
+                            "verify passed but the last route-update attempt did not; \
+                             withholding the first steer until one lands"
+                        );
+                    }
+                    verdict.may_steer = false;
+                }
                 // The verdict is an observation of what VPP answered.
                 // It reaches the supervisor through the loop's inject,
                 // not from inside this Effects call — the same seam
@@ -2108,6 +2135,9 @@ mod tests {
 
     struct EmptySource;
     impl RouteSource for EmptySource {
+        fn requeue(&self, _: crate::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
         fn for_each_neighbour(&self, _: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
         fn route_count(&self) -> u64 {

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -918,7 +918,8 @@ fn apply_steering(
         // refusing leaves the PREVIOUS rules installed, so a prefix the
         // operator just removed from the allowlist keeps being diverted.
         if !steered {
-            let counts = runtime.status().counts;
+            let rs = runtime.status();
+            let counts = rs.counts;
             if counts.blocks_first_steer() {
                 return Err(format!(
                     "refusing the first steer: the FIB is incomplete ({} unresolvable, {} \
@@ -926,6 +927,22 @@ fn apply_steering(
                      blackhole exactly the prefixes that are missing. `packetframe status` \
                      reports all three; they must be zero",
                     counts.unresolvable, counts.withheld, counts.installing
+                ));
+            }
+            // The counts alone are not the whole gate, because a delta
+            // batch that could not be delivered is in none of them. When
+            // a neighbour send fails, `apply_changes` hands the batch
+            // back to the route source to be retried intact — so its
+            // routes are not installed, not installing, not withheld and
+            // not unresolvable, and this gate read a table with a known
+            // hole as complete. It clears as soon as one update lands, so
+            // the remedy is to look again, not to reconfigure something.
+            if let Some(why) = &rs.drain_error {
+                return Err(format!(
+                    "refusing the first steer: the last route update could not be applied to \
+                     VPP ({why}), so its prefixes are missing from the FIB without appearing \
+                     in any of the counts. It is retried every tick — `packetframe status` \
+                     stops reporting the route-feed subsystem once one lands"
                 ));
             }
         }

--- a/crates/modules/vpp-offload/src/sink.rs
+++ b/crates/modules/vpp-offload/src/sink.rs
@@ -299,7 +299,18 @@ impl NexthopMap {
 
     /// Resolve one nexthop, or `None` if its device is excluded.
     pub fn resolve(&self, nexthop: &IpAddr) -> Option<NexthopTarget> {
-        let dev = self.device_of.get(nexthop)?;
+        self.target_for_device(self.device_of.get(nexthop)?)
+    }
+
+    /// The same mapping policy, applied to a device name this map has not
+    /// been told about yet.
+    ///
+    /// Exists so the delta path can ask "where would this nexthop land?"
+    /// before committing the nexthop→device pair. Programming the
+    /// adjacency has to happen first, and recording the mapping in order
+    /// to look the interface up would make every route through the
+    /// nexthop installable before VPP had acknowledged anything.
+    pub fn target_for_device(&self, dev: &str) -> Option<NexthopTarget> {
         if let Some((port, vlan)) = self.vlans.get(dev) {
             // A VLAN whose underlying port was never made a member is
             // still excluded: the subif has nothing to sit on.
@@ -315,7 +326,9 @@ impl NexthopMap {
         self.members
             .iter()
             .any(|m| m == dev)
-            .then(|| NexthopTarget::Vf { port: dev.clone() })
+            .then(|| NexthopTarget::Vf {
+                port: dev.to_string(),
+            })
     }
 
     /// Resolve a whole nexthop set. Returns only the resolvable targets;

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -120,6 +120,13 @@ pub struct Behaviour {
     /// Reject this many *deletes* with a non-zero retval before
     /// accepting them.
     pub reject_deletes: usize,
+    /// Reject this many neighbour **adds** with a non-zero retval before
+    /// accepting them, WITHOUT closing the connection.
+    ///
+    /// The shape a hangup cannot model: the stream is fine, so the engine
+    /// keeps its transport, and the failure is one message refused in the
+    /// middle of a delta batch whose route half has not been applied yet.
+    pub reject_neighbour_adds: usize,
     /// Advertise garbage CRCs in the handshake's message table — the
     /// version-skew shape the transport must refuse loudly.
     pub garbage_crcs: bool,
@@ -351,10 +358,16 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                     mac: n.neighbor.mac_address,
                     flags: n.neighbor.flags,
                 });
+                let retval = if n.is_add && behaviour.reject_neighbour_adds > 0 {
+                    behaviour.reject_neighbour_adds -= 1;
+                    -1
+                } else {
+                    0
+                };
                 out = reply_head("ip_neighbor_add_del_reply");
                 IpNeighborAddDelReply {
                     context: ctx,
-                    retval: 0,
+                    retval,
                     stats_index: 0,
                 }
                 .encode(&mut out);

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -103,6 +103,11 @@ pub enum Event {
         sw_if_index: u32,
         mac: [u8; 6],
         flags: u8,
+        /// Add or remove. A removal carries a zero MAC, so without this
+        /// the two are only distinguishable by a convention the assertion
+        /// has to know — and "the adjacency was programmed again" is
+        /// exactly the claim one test needs to make precisely.
+        is_add: bool,
     },
 }
 
@@ -127,6 +132,18 @@ pub struct Behaviour {
     /// keeps its transport, and the failure is one message refused in the
     /// middle of a delta batch whose route half has not been applied yet.
     pub reject_neighbour_adds: usize,
+    /// Apply the next neighbour op and then drop the connection **without
+    /// replying**, once.
+    ///
+    /// The ambiguous case, and the only one that matters for the
+    /// unacknowledged-neighbour ledger: the write landed, VPP acted on it,
+    /// and the client cannot know. A `reject_*` reply is unambiguous (VPP
+    /// told us) and a hangup *before* the op is unambiguous the other way;
+    /// this is neither, which is why the client has to ask afterwards.
+    ///
+    /// One-shot, so the reconnect can complete the job — the same reason
+    /// `hangup_after` is.
+    pub swallow_neighbour_reply: bool,
     /// Advertise garbage CRCs in the handshake's message table — the
     /// version-skew shape the transport must refuse loudly.
     pub garbage_crcs: bool,
@@ -195,13 +212,20 @@ impl Fake {
 
         thread::spawn(move || {
             let mut b = behaviour;
+            // VPP's neighbour table, OUTSIDE the accept loop, because it
+            // has to survive a reconnect — a socket the client lost is not
+            // a table VPP forgot. That persistence is the whole subject of
+            // the unacknowledged-neighbour tests: the entry is still there
+            // when we come back and ask.
+            let mut neighbours: Vec<([u8; 4], u32, [u8; 6], u8)> = b.existing_neighbours.to_vec();
             // Accept repeatedly: a disconnect-and-reconnect is part of
             // what these tests exercise.
             while let Ok((mut sock, _)) = listener.accept() {
-                serve(&mut sock, &tx, b);
+                serve(&mut sock, &tx, b, &mut neighbours);
                 // One-shot hangup: the point of that test is that a fresh
                 // connection can finish the job.
                 b.hangup_after = None;
+                b.swallow_neighbour_reply = false;
             }
         });
 
@@ -221,7 +245,12 @@ impl Fake {
     }
 }
 
-fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) -> Option<()> {
+fn serve(
+    sock: &mut UnixStream,
+    tx: &Sender<Event>,
+    mut behaviour: Behaviour,
+    neighbours: &mut Vec<([u8; 4], u32, [u8; 6], u8)>,
+) -> Option<()> {
     // What `sw_interface_set_mac_address` last set, per interface. The
     // dump reports it, so `attach::set_mac`'s readback has a real answer
     // to compare against rather than a constant that always matches.
@@ -328,7 +357,7 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
             // A DUMP, streamed like the others: details frames, no
             // terminator, ended by the trailing control_ping's reply.
             "ip_neighbor_dump" => {
-                for &(ip, sw_if_index, mac, flags) in behaviour.existing_neighbours {
+                for &(ip, sw_if_index, mac, flags) in neighbours.iter() {
                     let mut d = reply_head("ip_neighbor_details");
                     let mut un = [0u8; 16];
                     un[..4].copy_from_slice(&ip);
@@ -357,6 +386,7 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                     sw_if_index: n.neighbor.sw_if_index,
                     mac: n.neighbor.mac_address,
                     flags: n.neighbor.flags,
+                    is_add: n.is_add,
                 });
                 let retval = if n.is_add && behaviour.reject_neighbour_adds > 0 {
                     behaviour.reject_neighbour_adds -= 1;
@@ -364,6 +394,27 @@ fn serve(sock: &mut UnixStream, tx: &Sender<Event>, mut behaviour: Behaviour) ->
                 } else {
                     0
                 };
+                // A real VPP applies the op before it answers, so the
+                // table moves even when the answer never arrives.
+                if retval == 0 {
+                    let mut key = [0u8; 4];
+                    key.copy_from_slice(&n.neighbor.ip_address.un.0[..4]);
+                    neighbours
+                        .retain(|(ip, idx, _, _)| !(*ip == key && *idx == n.neighbor.sw_if_index));
+                    if n.is_add {
+                        neighbours.push((
+                            key,
+                            n.neighbor.sw_if_index,
+                            n.neighbor.mac_address,
+                            n.neighbor.flags,
+                        ));
+                    }
+                }
+                // Applied, then silence: the client cannot tell whether we
+                // acted. This is the case `neighbours_unacked` exists for.
+                if behaviour.swallow_neighbour_reply {
+                    return None;
+                }
                 out = reply_head("ip_neighbor_add_del_reply");
                 IpNeighborAddDelReply {
                     context: ctx,

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -32,7 +32,7 @@ use wire::{name_for, read_frame, reply_head, request_context, write_frame};
 use packetframe_vpp_offload::vpp_api::generated::{
     Address, AddressUnion, ControlPingReply, CreateLoopbackReply, DevAttachReply,
     DevCreatePortIfReply, FibPath, FibPathNh, IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply,
-    IpNeighborDetails, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails,
+    IpNeighborDetails, IpNeighborDump, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails,
     IpRouteLookupReply, MessageTableEntry, Prefix, SockclntCreateReply,
     SwInterfaceAddDelAddressReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
     SwInterfaceSetMacAddressReply, SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
@@ -357,6 +357,17 @@ fn serve(
             // A DUMP, streamed like the others: details frames, no
             // terminator, ended by the trailing control_ping's reply.
             "ip_neighbor_dump" => {
+                // Honour the requested family. Every entry this fake holds
+                // is v4, so a v6 dump answers empty — which is what a real
+                // v4-only table does, and what makes "one dump per carried
+                // family" observable rather than a coincidence.
+                let mut d = Decoder::new(&req);
+                let want = IpNeighborDump::decode(&mut d)
+                    .expect("decodes as a neighbour dump")
+                    .af;
+                if want != ADDRESS_IP4 {
+                    continue;
+                }
                 for &(ip, sw_if_index, mac, flags) in neighbours.iter() {
                     let mut d = reply_head("ip_neighbor_details");
                     let mut un = [0u8; 16];

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -50,6 +50,9 @@ const ALLOW: [IpPrefix; 1] = [IpPrefix::V4 {
 /// route source; convergence itself is `vpp_service.rs`'s job.
 struct Mirror;
 impl RouteSource for Mirror {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn route_count(&self) -> u64 {
         let mut n = 0u64;
         self.for_each_route(&mut |_, _| n += 1);

--- a/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
+++ b/crates/modules/vpp-offload/tests/vpp_convergence_bench.rs
@@ -93,6 +93,9 @@ struct FileSource {
 }
 
 impl RouteSource for FileSource {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
         for (p, nhs) in &self.routes {
             visit(*p, nhs);

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -1049,6 +1049,84 @@ fn an_unacknowledged_neighbour_add_is_not_blindly_re_added() {
         "an adjacency VPP already holds must not be re-added — that walk is \
          ~1M dependent routes and 5.5 s of blackhole: {after:?}"
     );
+    assert_eq!(
+        after
+            .iter()
+            .filter(|ev| matches!(ev, Event::Msg(m) if m == "ip_neighbor_dump"))
+            .count(),
+        1,
+        "and `V4Only` asks exactly once — the per-family loop must not cost \
+         a spare round trip on the policy this NIC actually runs: {after:?}"
+    );
+}
+
+/// The reconciling dump covers **every family the policy carries**.
+///
+/// A v4-only dump answers "not present" for a v6 neighbour, and both
+/// consumers of that answer read absence as permission to send: the resync
+/// walk re-adds a v6 adjacency VPP already holds, and `settle_unacked`
+/// drops a v6 claim it could not verify. Either pays the dependent-FIB
+/// walk this ledger exists to avoid, so under `FamilyPolicy::Both` the
+/// question has to be asked twice (review finding).
+///
+/// The count is the assertion because that is the whole of the fix. What
+/// happens to a v6 entry once found is `settle_unacked`, which the two
+/// directional tests above already pin — the fake holds only v4
+/// neighbours, so a v6 dump here answers empty exactly as a real v4-only
+/// table would.
+#[test]
+fn the_reconciling_dump_covers_every_carried_family() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+
+    let fake = silent_fake("neigh-unacked-v6");
+    // Same wiring as `engine_for`, with the one difference under test.
+    let mut e = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: "eth4".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        }],
+        vec!["eth4".into()],
+        1_000_000,
+        FamilyPolicy::Both,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
+    );
+    assert!(e.api_ready(), "handshake");
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    let base = QueuedSource::default();
+    e.begin_resync(&base);
+    e.program_neighbours(&base).expect("programming");
+    drain_to_empty(&mut e);
+    let _ = fake.drain_events();
+
+    // Leave a neighbour in doubt, then let the retry reconcile.
+    const MAC_CHANGED: [u8; 6] = [0x02, 0, 0, 0, 0, 0x78];
+    let src = QueuedSource::with(SourceChanges {
+        neighbours: vec![(nh(), Some(("eth4".into(), MAC_CHANGED)))],
+        routes: Vec::new(),
+    });
+    e.apply_changes(&src, 64)
+        .expect_err("the reply never comes");
+    let _ = fake.drain_events();
+    assert!(e.api_ready(), "reconnects");
+    e.apply_changes(&src, 64).expect("the retry applies");
+
+    let dumps = fake
+        .drain_events()
+        .into_iter()
+        .filter(|ev| matches!(ev, Event::Msg(m) if m == "ip_neighbor_dump"))
+        .count();
+    assert_eq!(
+        dumps, 2,
+        "both families must be asked about; a v4-only dump reads every v6 \
+         adjacency as absent and re-adds it"
+    );
 }
 
 /// An unacknowledged neighbour REMOVAL must not leave the ledger claiming

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -430,6 +430,7 @@ fn static_neighbours_are_programmed_before_the_routes_that_need_them() {
                 sw_if_index,
                 mac,
                 flags,
+                ..
             } => Some((*sw_if_index, *mac, *flags)),
             _ => None,
         })
@@ -959,6 +960,139 @@ fn a_refused_adjacency_never_becomes_resolvable() {
     assert!(
         e.counts().blocks_first_steer(),
         "which is loud: the hole blocks a first steer rather than hiding"
+    );
+}
+
+/// A converged engine against a VPP that applies the next neighbour op and
+/// then goes silent, leaving its outcome unknowable to the client.
+fn silent_after_neighbour(tag: &str, fake: &Fake) -> ConvergenceEngine {
+    let mut e = engine_for(fake);
+    assert!(e.api_ready(), "handshake for {tag}");
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    let base = QueuedSource::default();
+    e.begin_resync(&base);
+    // VPP already holds the neighbour, so nothing is sent here and the
+    // swallow stays armed for the delta under test.
+    assert_eq!(e.program_neighbours(&base).expect("programming"), 0);
+    drain_to_empty(&mut e);
+    let _ = fake.drain_events();
+    e
+}
+
+fn silent_fake(tag: &str) -> Fake {
+    Fake::start_behaving(
+        tag,
+        Behaviour {
+            swallow_neighbour_reply: true,
+            existing_neighbours: RESYNC_NEIGHBOUR,
+            ..Default::default()
+        },
+    )
+}
+
+/// An unacknowledged neighbour ADD is not blindly re-sent.
+///
+/// A transport error after the write is genuinely ambiguous: VPP may have
+/// applied the change. `neighbours_installed` records only
+/// acknowledgements, so it comes out of this describing a table VPP may not
+/// have — and re-adding an existing static neighbour is not a no-op. VPP
+/// replaces the entry and walks every dependent FIB entry: ~1M routes hang
+/// off one adjacency here, for a measured 5.51 s of null-node (shadow,
+/// 2026-08-08). Requeueing the batch made that retry certain rather than
+/// incidental, so the ledger has to be reconciled against VPP first.
+///
+/// The fake applies the op and then goes silent, which is the only faithful
+/// model of the ambiguity: a refused retval is VPP telling us, and a hangup
+/// *before* the op is unambiguous the other way.
+///
+/// See [`an_unacknowledged_neighbour_removal_does_not_strand_the_ledger`]
+/// for the opposite direction, which fails worse.
+#[test]
+fn an_unacknowledged_neighbour_add_is_not_blindly_re_added() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+
+    let fake = silent_fake("neigh-unacked-add");
+    let mut e = silent_after_neighbour("neigh-unacked-add", &fake);
+
+    // A MAC change on the adjacency every route resolves through — the
+    // expensive one to re-add. VPP applies it and never answers.
+    const MAC_CHANGED: [u8; 6] = [0x02, 0, 0, 0, 0, 0x77];
+    let src = QueuedSource::with(SourceChanges {
+        neighbours: vec![(nh(), Some(("eth4".into(), MAC_CHANGED)))],
+        routes: Vec::new(),
+    });
+    e.apply_changes(&src, 64)
+        .expect_err("the reply never comes");
+    assert_eq!(src.queued(), 1, "the batch is owed, as ever");
+    let sent = fake.drain_events();
+    assert!(
+        sent.iter()
+            .any(|ev| matches!(ev, Event::Neighbour { mac, .. } if *mac == MAC_CHANGED)),
+        "the add did reach VPP: {sent:?}"
+    );
+
+    // Reconnect and retry. The reconciling dump must find VPP already
+    // holding the new MAC and absorb the re-add.
+    assert!(e.api_ready(), "reconnects");
+    e.apply_changes(&src, 64).expect("the retry applies");
+    let after = fake.drain_events();
+    assert!(
+        after
+            .iter()
+            .any(|ev| matches!(ev, Event::Msg(m) if m == "ip_neighbor_dump")),
+        "the only way to know what VPP holds is to have asked: {after:?}"
+    );
+    assert!(
+        !after
+            .iter()
+            .any(|ev| matches!(ev, Event::Neighbour { mac, .. } if *mac == MAC_CHANGED)),
+        "an adjacency VPP already holds must not be re-added — that walk is \
+         ~1M dependent routes and 5.5 s of blackhole: {after:?}"
+    );
+}
+
+/// An unacknowledged neighbour REMOVAL must not leave the ledger claiming
+/// an adjacency VPP no longer has.
+///
+/// The dangerous direction, and the one a "don't retransmit adds" fix would
+/// miss entirely. `send_neighbour` clears `neighbours_installed` only on an
+/// acknowledgement, so a removal VPP applied but never confirmed leaves the
+/// ledger asserting the adjacency is installed. The delta path's skip —
+/// `neighbours_installed.get(..) != Some(&mac)` — then swallows the next
+/// add of that exact MAC, permanently, and every route through it
+/// black-holes with the counts clean. Worse than a redundant walk, and in
+/// the same silent-hole family as the delta loss this PR fixes.
+#[test]
+fn an_unacknowledged_neighbour_removal_does_not_strand_the_ledger() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+
+    let fake = silent_fake("neigh-unacked-remove");
+    let mut e = silent_after_neighbour("neigh-unacked-remove", &fake);
+
+    // VPP applies the removal and goes silent.
+    let lost = QueuedSource::with(SourceChanges {
+        neighbours: vec![(nh(), None)],
+        routes: Vec::new(),
+    });
+    e.apply_changes(&lost, 64)
+        .expect_err("the removal's reply never comes");
+    let _ = fake.drain_events();
+
+    // The nexthop comes back, with the very MAC the ledger still remembers.
+    assert!(e.api_ready(), "reconnects");
+    let back = QueuedSource::with(SourceChanges {
+        neighbours: vec![(nh(), Some(("eth4".into(), MAC)))],
+        routes: Vec::new(),
+    });
+    e.apply_changes(&back, 64).expect("the re-add applies");
+    let readded = fake.drain_events();
+    assert!(
+        readded.iter().any(|ev| matches!(
+            ev,
+            Event::Neighbour { mac, is_add: true, .. } if *mac == MAC
+        )),
+        "VPP applied the removal, so the adjacency must be programmed again — \
+         a ledger that still claims it makes this a silent blackhole: {readded:?}"
     );
 }
 

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -34,6 +34,9 @@ struct Mirror {
 }
 
 impl RouteSource for Mirror {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn route_count(&self) -> u64 {
         let mut n = 0u64;
         self.for_each_route(&mut |_, _| n += 1);
@@ -267,6 +270,9 @@ struct OrphanedMirror {
 }
 
 impl RouteSource for OrphanedMirror {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn route_count(&self) -> u64 {
         let mut n = 0u64;
         self.for_each_route(&mut |_, _| n += 1);
@@ -463,6 +469,9 @@ fn static_neighbours_are_programmed_before_the_routes_that_need_them() {
 fn neighbours_on_foreign_devices_are_skipped() {
     struct MixedMirror;
     impl RouteSource for MixedMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
@@ -661,6 +670,9 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
 
     struct ThreeNeighbours;
     impl RouteSource for ThreeNeighbours {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
         fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
             visit(nh(), "eth4", MAC); // identical in VPP: keep
@@ -726,6 +738,230 @@ fn adoption_programs_only_missing_or_stale_neighbours() {
     );
 }
 
+/// The nexthop the delta path is about to program, and the MAC it
+/// carries. Shared by the two refused-neighbour tests below.
+const DELTA_NH: IpAddr = IpAddr::V4(Ipv4Addr::new(192, 0, 2, 22));
+const DELTA_MAC: [u8; 6] = [0x02, 0, 0, 0, 0, 0xfe];
+
+/// A source whose delta batches the test queues by hand, and which
+/// **models the feed on a requeue**: an undelivered batch goes back on the
+/// queue, so the next drain re-serves it intact.
+#[derive(Default)]
+struct QueuedSource {
+    queue: std::sync::Mutex<Vec<packetframe_vpp_offload::engine::SourceChanges>>,
+}
+
+impl QueuedSource {
+    fn with(changes: packetframe_vpp_offload::engine::SourceChanges) -> Self {
+        Self {
+            queue: std::sync::Mutex::new(vec![changes]),
+        }
+    }
+
+    fn queued(&self) -> usize {
+        self.queue.lock().unwrap().len()
+    }
+}
+
+impl RouteSource for QueuedSource {
+    fn requeue(&self, changes: packetframe_vpp_offload::engine::SourceChanges) {
+        self.queue.lock().unwrap().insert(0, changes);
+    }
+    fn drain_changes(&self, _max: usize) -> packetframe_vpp_offload::engine::SourceChanges {
+        self.queue.lock().unwrap().pop().unwrap_or_default()
+    }
+    fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+        for i in 0..4u8 {
+            visit(v4(0, i), &[nh()]);
+        }
+    }
+    fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+        visit(nh(), "eth4", MAC);
+    }
+    fn route_count(&self) -> u64 {
+        4
+    }
+    fn change_seq(&self) -> u64 {
+        4
+    }
+}
+
+/// A converged engine against a VPP that will refuse the next `n`
+/// neighbour adds. Its own resync neighbour is already in VPP, so the
+/// refusal lands on the DELTA's nexthop instead of being spent on setup.
+fn refusing_engine(tag: &str, fake: &Fake) -> ConvergenceEngine {
+    let mut e = engine_for(fake);
+    assert!(e.api_ready(), "handshake for {tag}");
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    let src = QueuedSource::default();
+    e.begin_resync(&src);
+    e.program_neighbours(&src).expect("programming");
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 4, "the base table converges");
+    let _ = fake.drain_events();
+    e
+}
+
+/// VPP already holds the resync's own neighbour, correct and static.
+const RESYNC_NEIGHBOUR: &[([u8; 4], u32, [u8; 6], u8)] =
+    &[([192, 0, 2, 1], ASSIGNED_INDEX, MAC, 1)];
+
+/// A refused neighbour hands the WHOLE delta batch back, routes included,
+/// and the retry lands them.
+///
+/// `drain_changes` is destructive: the feed removes what it returns. So
+/// returning early on the neighbour send left the batch's route half
+/// applied nowhere — out of the feed's pending map, never into the
+/// engine's, retried by nothing. An already-steered VPP went on
+/// forwarding a withdrawn prefix and resolving a changed nexthop to its
+/// old adjacency, with `installed`/`installing`/`withheld`/
+/// `unresolvable` all unaffected, so health read fine and verify could
+/// not see it: verify samples prefixes the LEDGER believes installed, and
+/// the ledger never learned these existed. Only a full resync recovered.
+///
+/// Handing the routes BACK rather than queueing them is the load-bearing
+/// half. Queued here they would install through the adjacency VPP just
+/// refused, which is #115's worst finding — see the sibling test.
+#[test]
+fn a_refused_neighbour_hands_the_whole_delta_batch_back() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+
+    // Withdrawn while steered: the delta that used to vanish.
+    let withdrawn = v4(0, 3);
+    // Learned through the nexthop VPP is refusing.
+    let learned = v4(0, 200);
+
+    let fake = Fake::start_behaving(
+        "delta-refused",
+        Behaviour {
+            reject_neighbour_adds: 1,
+            existing_neighbours: RESYNC_NEIGHBOUR,
+            ..Default::default()
+        },
+    );
+    let mut e = refusing_engine("delta-refused", &fake);
+
+    let src = QueuedSource::with(SourceChanges {
+        neighbours: vec![(DELTA_NH, Some(("eth4".into(), DELTA_MAC)))],
+        routes: vec![(withdrawn, None), (learned, Some(vec![DELTA_NH]))],
+    });
+
+    let err = e
+        .apply_changes(&src, 64)
+        .expect_err("VPP refused the neighbour add");
+    assert!(
+        format!("{err:?}").contains("NeighbourRefused"),
+        "the refusal must surface as itself: {err:?}"
+    );
+    assert!(
+        e.pending().is_empty(),
+        "the routes must NOT be queued behind a refused adjacency"
+    );
+    assert_eq!(
+        src.queued(),
+        1,
+        "the batch must be back at the source, not dropped on the floor"
+    );
+
+    // The fake's refusal was count-based and is spent. The retry lands
+    // the adjacency and, with it, the deltas that used to be lost.
+    e.apply_changes(&src, 64)
+        .expect("the retried batch applies");
+    drain_to_empty(&mut e);
+    assert_eq!(src.queued(), 0, "nothing owed once it lands");
+
+    let events = fake.drain_events();
+    assert!(
+        events
+            .iter()
+            .any(|ev| matches!(ev, Event::Neighbour { mac, .. } if *mac == DELTA_MAC)),
+        "the adjacency is programmed on the retry: {events:?}"
+    );
+    let routes: Vec<&WireRoute> = events
+        .iter()
+        .filter_map(|ev| match ev {
+            Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        routes.iter().any(|r| !r.is_add && r.addr == [10, 0, 3, 0]),
+        "the withdrawal the batch carried must finally reach VPP: {routes:?}"
+    );
+    assert!(
+        routes.iter().any(|r| r.is_add && r.addr == [10, 0, 200, 0]),
+        "and so must the route learned through the new nexthop: {routes:?}"
+    );
+    assert_eq!(
+        e.counts().unresolvable,
+        0,
+        "and the table is complete again"
+    );
+}
+
+/// A nexthop VPP refused must not become resolvable.
+///
+/// This is why the fix cannot simply queue the batch's routes and return
+/// the error. `set_device` alone makes `resolve` answer `Some`, so every
+/// route through the nexthop classifies installable and installs — while
+/// VPP, which runs without linux-cp and can never ARP for the adjacency,
+/// has nothing to send them to. Readback verification checks that a route
+/// exists on an interface we own, deliberately not that its adjacency
+/// resolves, so it passes. That is #115's worst finding: "a route through
+/// an unprogrammed adjacency installs cleanly, verifies cleanly, and drops
+/// every packet".
+///
+/// Recording the mapping before the send left that door open even on
+/// failure — the entry survived the error, so the next drain resolved
+/// through an adjacency VPP had refused. `unresolvable` is the honest
+/// answer, and it is loud: it blocks the first steer and fails verify.
+#[test]
+fn a_refused_adjacency_never_becomes_resolvable() {
+    use packetframe_vpp_offload::engine::SourceChanges;
+
+    let fake = Fake::start_behaving(
+        "delta-unresolvable",
+        Behaviour {
+            reject_neighbour_adds: 1,
+            existing_neighbours: RESYNC_NEIGHBOUR,
+            ..Default::default()
+        },
+    );
+    let mut e = refusing_engine("delta-unresolvable", &fake);
+
+    let refused = QueuedSource::with(SourceChanges {
+        neighbours: vec![(DELTA_NH, Some(("eth4".into(), DELTA_MAC)))],
+        routes: Vec::new(),
+    });
+    e.apply_changes(&refused, 64).expect_err("refused");
+    let _ = fake.drain_events();
+
+    // A later batch — routes only, so nothing re-attempts the adjacency.
+    let after = QueuedSource::with(SourceChanges {
+        neighbours: Vec::new(),
+        routes: vec![(v4(0, 201), Some(vec![DELTA_NH]))],
+    });
+    e.apply_changes(&after, 64).expect("routes alone apply");
+    drain_to_empty(&mut e);
+
+    assert_eq!(
+        e.counts().unresolvable,
+        1,
+        "a route through an unacknowledged adjacency must read unresolvable"
+    );
+    assert!(
+        !fake
+            .drain_events()
+            .iter()
+            .any(|ev| matches!(ev, Event::Route(WireRoute { is_add: true, .. }))),
+        "and nothing may reach VPP's FIB for it"
+    );
+    assert!(
+        e.counts().blocks_first_steer(),
+        "which is loud: the hole blocks a first steer rather than hiding"
+    );
+}
+
 /// The delta path consults the same acknowledged-neighbour ledger as
 /// the resync path — pinned against the second door of the 5.5 s
 /// adoption blackhole (shadow, 2026-08-08).
@@ -749,6 +985,11 @@ fn the_delta_path_does_not_re_add_an_acknowledged_neighbour() {
         changes: Mutex<Vec<SourceChanges>>,
     }
     impl RouteSource for ScriptedSource {
+        fn requeue(&self, changes: SourceChanges) {
+            // Back on the stack, so the next drain re-serves it — which
+            // is what `RouteFeed` does, refilling its pending maps.
+            self.changes.lock().unwrap().push(changes);
+        }
         fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
         fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
             visit(nh(), "eth4", MAC);

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -19,7 +19,7 @@ mod fake_vpp;
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
 
-use fake_vpp::{Fake, ASSIGNED_INDEX, MAC};
+use fake_vpp::{Behaviour, Fake, ASSIGNED_INDEX, MAC};
 use packetframe_common::fib::IpPrefix;
 use packetframe_vpp_offload::attach::PortAttach;
 use packetframe_vpp_offload::driver::Driver;
@@ -33,6 +33,9 @@ struct Mirror {
 }
 
 impl RouteSource for Mirror {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn route_count(&self) -> u64 {
         let mut n = 0u64;
         self.for_each_route(&mut |_, _| n += 1);
@@ -592,6 +595,164 @@ fn local_interface() -> (u32, String) {
     panic!("no usable interface at index 1..16");
 }
 
+/// A refused neighbour must not cost the batch its route deltas — proved
+/// through the production seam, real `RouteFeed` included.
+///
+/// `RouteFeed::drain_changes` is destructive: it drains `neigh_pending`
+/// and removes each route key from `pending`. So a neighbour send that
+/// failed mid-batch returned before the route loop and those deltas were
+/// gone from both tiers at once — out of the feed's pending map, never
+/// into the engine's, retried by nothing. On a STEERED offload that is a
+/// stale FIB with no signal: the withdrawn prefix keeps being forwarded
+/// and the changed nexthop keeps resolving to its old adjacency, while
+/// `installed`/`installing`/`withheld`/`unresolvable` all stay clean and
+/// verify cannot see it (it samples prefixes the LEDGER believes
+/// installed, and the ledger never learned these existed). Only a full
+/// resync recovered.
+///
+/// Asserted on the wire and on the health surface: the deltas land on the
+/// retry, and while they are owed the backlog says so rather than
+/// reporting a converged table.
+#[test]
+fn a_refused_neighbour_does_not_cost_the_batch_its_routes() {
+    use packetframe_common::fib::ResolvedRouteSink as _;
+    use packetframe_vpp_offload::driver::Observe as _;
+    use packetframe_vpp_offload::feed::RouteFeed;
+    use std::sync::Arc;
+
+    // VPP already holds the base nexthop, so the one refusal below lands
+    // on the delta's adjacency rather than being spent during the resync.
+    const EXISTING: &[([u8; 4], u32, [u8; 6], u8)] = &[([192, 0, 2, 1], ASSIGNED_INDEX, MAC, 1)];
+
+    let (ifindex, dev) = local_interface();
+    let fake = Fake::start_behaving(
+        "refused-neigh-loop",
+        Behaviour {
+            reject_neighbour_adds: 1,
+            existing_neighbours: EXISTING,
+            ..Default::default()
+        },
+    );
+    let feed = Arc::new(RouteFeed::new());
+    feed.neighbour_resolved(fake_vpp::nh(), MAC, ifindex);
+    feed.route_resolved(fake_vpp::v4(0, 1), &[fake_vpp::nh()]);
+
+    let engine = ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: dev.clone(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+        }],
+        vec![dev],
+        1_000_000,
+        FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
+    );
+    let rt = Runtime::new(
+        engine,
+        Box::new(feed.clone()),
+        Box::new(SteeringUnavailable),
+        Box::new(NullStore),
+        Box::new(NoResources),
+        "/usr/bin/vpp",
+        "/tmp/startup.conf",
+    );
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        assert!(obs.api_ready(), "the fake must answer the handshake");
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (mut now, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    assert_eq!(rt.status().counts.installed, 1, "the base table converged");
+    let _ = fake.drain_events();
+
+    // One batch: a nexthop VPP will refuse, the withdrawal of the live
+    // prefix, and a route through the new nexthop.
+    let late_nh = std::net::IpAddr::V4(std::net::Ipv4Addr::new(192, 0, 2, 23));
+    let late_mac = [0x02, 0x00, 0x5e, 0x00, 0x00, 0x17];
+    feed.neighbour_resolved(late_nh, late_mac, ifindex);
+    feed.route_withdrawn(fake_vpp::v4(0, 1));
+    feed.route_resolved(fake_vpp::v4(0, 202), &[late_nh]);
+
+    let mut refusal_seen = false;
+    let mut owed_while_refused = 0;
+    let mut saw_withdraw = false;
+    let mut saw_late_add = false;
+    for _ in 0..64 {
+        let t = {
+            let (mut obs, mut fx) = rt.views();
+            d.tick(now, &mut obs, &mut fx)
+        };
+        for e in rt.take_pending() {
+            let (_, mut fx) = rt.views();
+            d.inject(now, e, &mut fx);
+        }
+        let status = rt.status();
+        if let Some(why) = &status.drain_error {
+            assert!(
+                why.contains("refused the static neighbour for 192.0.2.23"),
+                "the refusal must be reported as itself: {why}"
+            );
+            refusal_seen = true;
+            owed_while_refused = owed_while_refused.max(status.source_backlog);
+        }
+        for e in fake.drain_events() {
+            if let fake_vpp::Event::Route(r) = e {
+                if r.addr == [10, 0, 1, 0] && !r.is_add {
+                    saw_withdraw = true;
+                }
+                if r.addr == [10, 0, 202, 0] && r.is_add {
+                    saw_late_add = true;
+                }
+            }
+        }
+        if saw_withdraw && saw_late_add {
+            break;
+        }
+        now += t
+            .sleep
+            .unwrap_or(Duration::from_millis(100))
+            .max(Duration::from_millis(1));
+    }
+
+    assert!(refusal_seen, "the test never reached the refusal it models");
+    assert!(
+        owed_while_refused >= 2,
+        "the undelivered routes must be visible as owed while the send is \
+         failing, not silently absent: backlog peaked at {owed_while_refused}"
+    );
+    assert!(
+        saw_withdraw,
+        "the withdrawal the refused batch carried never reached VPP — a \
+         steered offload would still be forwarding that prefix"
+    );
+    assert!(
+        saw_late_add,
+        "nor did the route learned through the new nexthop"
+    );
+    assert_eq!(
+        rt.status().source_backlog,
+        0,
+        "and nothing is left owed once the retry lands"
+    );
+    assert!(
+        rt.status().drain_error.is_none(),
+        "a recovered delta apply must stop being reported"
+    );
+}
+
 /// A nexthop first seen **after** convergence gets its static neighbour
 /// programmed, not just its device mapping.
 ///
@@ -720,6 +881,9 @@ fn an_adopted_resync_waits_for_the_source_instead_of_withdrawing_the_table() {
     /// route feed mid-reload, as a fixture.
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
@@ -893,6 +1057,9 @@ fn a_source_still_growing_past_the_floor_keeps_deferring() {
 
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
@@ -1058,6 +1225,9 @@ fn quiescence_is_a_rate_not_a_per_check_delta() {
 
     struct SharedMirror(Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);
@@ -1274,6 +1444,9 @@ fn balanced_churn_is_not_quiescence() {
         seq: Arc<Mutex<u64>>,
     }
     impl RouteSource for ChurningMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
             for p in &self.routes {
                 visit(*p, &[fake_vpp::nh()]);
@@ -1393,6 +1566,9 @@ mod steered {
 
     pub struct SharedMirror(pub Arc<Mutex<Vec<IpPrefix>>>);
     impl RouteSource for SharedMirror {
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
         fn route_count(&self) -> u64 {
             let mut n = 0u64;
             self.for_each_route(&mut |_, _| n += 1);

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -27,6 +27,9 @@ use packetframe_vpp_offload::supervisor::{Event, State};
 
 struct Mirror(Vec<IpPrefix>);
 impl RouteSource for Mirror {
+    fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+        unreachable!("this source hands nothing over, so nothing can come back")
+    }
     fn route_count(&self) -> u64 {
         let mut n = 0u64;
         self.for_each_route(&mut |_, _| n += 1);

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -839,18 +839,30 @@ restart.
 
 ### `route-feed DEGRADED` / `packetframe_vpp_drain_failing 1`
 
-The last attempt to push route updates into VPP did not land. The batch
-is **not lost**: whatever could not be applied goes back to the route
-feed, so it is counted in `packetframe_vpp_source_backlog` and retried
-every tick until it lands. The offload is forwarding a table that is
-behind bird, not a wrong one.
+The last attempt to push route updates into VPP did not land. The work is
+**not lost** and is retried every tick — the offload is forwarding a table
+that is behind bird, not a wrong one.
+
+**Which queue holds it depends on where it failed, and the two are
+different metrics.** The row itself prints both counts; do not read one of
+them as the whole answer:
+
+- Work that never reached VPP's FIB because the *drain* broke mid-batch is
+  requeued in the engine's pending map → `packetframe_vpp_pending_ops`.
+  `source_backlog` can sit at zero throughout.
+- Work handed back to the route feed because a *neighbour* send failed
+  before its batch's routes were applied → `packetframe_vpp_source_backlog`.
 
 Read the reason on the row. Two shapes matter:
 
 - **A transport error** (`socket closed`, `context mismatch`). The engine
   drops its connection and reconnects on the next tick; one of these in
   isolation is noise. Sustained, it is VPP not answering, and the wedge
-  detector owns that.
+  detector owns that. This is the `pending_ops` shape above — unless the
+  socket broke on a neighbour message, in which case the batch went back
+  to the feed *and* the affected adjacency is reconciled against a fresh
+  `ip_neighbor_dump` before anything is re-sent, because a write whose
+  reply never arrived may or may not have been applied.
 - **`VPP refused the static neighbour for <nexthop> (retval …)`** — VPP
   rejected an adjacency. This one blocks the whole delta stream: routes
   through an unprogrammed adjacency install cleanly, verify cleanly and

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -837,6 +837,34 @@ on the old segments. That refusal is not pedantry: applying it anyway is
 the mid-resync OOM abort gate 0b found. Raise `expected-routes`, then
 restart.
 
+### `route-feed DEGRADED` / `packetframe_vpp_drain_failing 1`
+
+The last attempt to push route updates into VPP did not land. The batch
+is **not lost**: whatever could not be applied goes back to the route
+feed, so it is counted in `packetframe_vpp_source_backlog` and retried
+every tick until it lands. The offload is forwarding a table that is
+behind bird, not a wrong one.
+
+Read the reason on the row. Two shapes matter:
+
+- **A transport error** (`socket closed`, `context mismatch`). The engine
+  drops its connection and reconnects on the next tick; one of these in
+  isolation is noise. Sustained, it is VPP not answering, and the wedge
+  detector owns that.
+- **`VPP refused the static neighbour for <nexthop> (retval …)`** — VPP
+  rejected an adjacency. This one blocks the whole delta stream: routes
+  through an unprogrammed adjacency install cleanly, verify cleanly and
+  drop every packet, so nothing in the batch is applied until the
+  adjacency is. Check that the nexthop's egress device is a configured
+  `port` (or a declared VLAN over one) and that `ip neigh` still shows
+  the nexthop with a real MAC.
+
+While this is set on an **unsteered** port, the first steer is refused —
+the missing prefixes are in none of the `unresolvable`/`withheld`/
+`installing` counts, so those reading zero is not enough on its own. It
+clears as soon as one update lands; look again rather than reconfiguring
+anything.
+
 ### The offload restarts repeatedly
 
 `packetframe status` carries the reason on the failing subsystem, and it
@@ -1092,4 +1120,6 @@ refused rather than adopted.
   `require-table-complete off` hands the judgement back to you, and rung
   0's soak is what discharges it: the `unresolvable`, `withheld` and
   `installing` counts must all read zero before you turn the first
-  lever.
+  lever — **and no `route-feed` row may be present**. Those three counts
+  cannot describe an update that never reached VPP at all, which is why
+  that row is a separate condition on the same gate.


### PR DESCRIPTION
Fixes the delta loss found while reviewing #160. That PR guarded its own consumer — its paced steer retry now requires the tick's drain to have reported `Drain::Idle` — but the underlying loss was untouched, and it is the wider bug: it desynchronises an already-steered VPP with no retry involved.

## The bug

`RouteFeed::drain_changes` is **destructive**: it `drain()`s `neigh_pending` and `remove()`s each route key from `pending`. `Engine::apply_changes` returned early via `self.send_neighbour(...)?`, so the `for (prefix, nhs) in changes.routes` loop — the only thing that puts route deltas into `self.pending` — was never reached. Those deltas were gone from both tiers at once: out of the feed's pending map, never into the engine's, retried by nothing. The mirror still held the routes, so only a full resync recovered.

While STEERED that is the worst shape this module has. VPP forwards a stale FIB with no signal — a withdrawn prefix keeps being forwarded, a changed nexthop keeps going to the old adjacency — and `installed`/`installing`/`withheld`/`unresolvable` are all unaffected, so health reports fine. Verify cannot catch it either: it samples prefixes the *ledger* believes installed, and the ledger never learned these existed. `SinkCounts::blocks_first_steer()` was blind to it too, so both `packetframe reconfigure` and the automatic steer could divert traffic into the stale FIB.

## The fix

**The whole remainder goes back to the source** — the neighbour that failed, the ones not tried, and every route in the batch — and only then does the error return. `RouteFeed::requeue` refills its pending maps **fill-if-absent**, so a delta the other tier wrote while the batch was out stays the newer intent (last-write-wins). `seq` is deliberately not bumped: it is the adopted-resync gate's quiescence signal, and counting our own undelivered work as source churn would hold that deferral open for as long as VPP kept refusing.

The naive fix — queueing `changes.routes` before returning the error — is wrong, and this keeps neighbours-before-routes intact instead. Alongside it, **`set_device` now waits for VPP's acknowledgement**: recorded before the send it survived the error, leaving the *next* drain free to resolve every pending route through a refused adjacency and install it clean. That is #115's worst finding ("a route through an unprogrammed adjacency installs cleanly, verifies cleanly, and drops every packet") arriving through the delta door. `NexthopMap::target_for_device` applies the mapping policy to a device name without committing the pair.

Two steer gates follow, because the counts cannot describe an update that never reached VPP at all:

- the verify verdict narrows to `VerifyIncomplete` while a delivery attempt is outstanding (`Ready`, want preserved — the designed safe staging arm, not a failure);
- the operator's first-steer refusal in `reconfigure` names the reason.

Both are **first-steer only**. Gating a reconcile would refuse an allowlist change and leave the previous rules diverting a prefix the operator just removed.

`RouteSource::requeue` has **no default body**. `route_count` had one, the production loader's `Arc<RouteFeed>` inherited it while forwarding every other method, and a `requeue` that silently does not delegate is this bug again.

## Tests

Each was confirmed to fail with the corresponding half of the fix reverted.

- `feed.rs`: the batch comes back whole; a requeue never displaces newer intent (both directions); it does not read as source churn; an add for a neighbour the mirror dropped comes back as a loss.
- `vpp_engine.rs`: `a_refused_neighbour_hands_the_whole_delta_batch_back` — nothing queued behind the refusal, the batch is back at the source, and the retry lands both the withdrawal and the new route on the wire. `a_refused_adjacency_never_becomes_resolvable` — a later route through the refused nexthop reads `unresolvable`, never reaches VPP's FIB, and blocks a first steer.
- `vpp_runtime.rs`: `a_refused_neighbour_does_not_cost_the_batch_its_routes` — the full loop through the real `RouteFeed`, asserting the wire *and* that the backlog reports the routes as owed while the send is failing.
- The fake gained `reject_neighbour_adds`, which models what a hangup cannot: the stream stays up and one message is refused mid-batch.

`docs/runbooks/vpp-offload.md` gains a `route-feed DEGRADED` triage section, and the rung-0 gotcha now says that row must be absent before the first lever — the three counts reading zero is not sufficient on its own.

## Deliberately not addressed

Both loud, both pre-existing:

- One refused neighbour still blocks the whole delta stream. That is the all-or-nothing ordering contract; per-nexthop isolation is a larger design change. Behaviour is unchanged here — it blocked before too, just while losing the batch.
- A route recorded `Unresolvable` is not retried when its adjacency later lands (the drainer's `Begun::Done` drops it from the pending map). It blocks first steer, fails verify, and reports degraded until a resync.

`make test` and `make lint` are green locally; the BPF-ELF stub warning is the expected macOS dev-box behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)