### PR TITLE
fix(vpp-offload): repair main's build — #159's tests predate #158's members

### DIFF
--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1891,7 +1891,7 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = steering(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
         assert_eq!(
             s.steer().expect("installs"),
             SteerOutcome::Steered,
@@ -1931,7 +1931,7 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = steering(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
         s.steer().expect("installs");
         let stuck: Vec<u32> = s.installed().iter().map(|(_, loc)| *loc).collect();
         sys::wedge_delete(&stuck);
@@ -3361,7 +3361,7 @@ mod tests {
         }
 
         sys::reset();
-        let mut fx = SteeringOnly(NtupleSteering::new(
+        let mut fx = SteeringOnly(steering(
             vec![("eth4".into(), 0)],
             plan_for(&[[198, 18, 0, 0]]),
         ));


### PR DESCRIPTION
`main` is red. `cargo clippy --workspace --all-targets` fails on every Linux target at `crates/modules/vpp-offload/src/ntuple.rs`:

```
error[E0061]: this function takes 3 arguments but 2 arguments were supplied
    --> crates/modules/vpp-offload/src/ntuple.rs:1894:21
    --> crates/modules/vpp-offload/src/ntuple.rs:932:12
```

…three times, at 1894, 1934 and 3364.

## How it landed

- #158 gave `NtupleSteering::new` a third parameter, `members`, and added the `steering(ports, plan)` test helper that fills it (`NtupleSteering::new(ports.clone(), ports, plan)`).
- #159 added three new `NtupleSteering::new(...)` call sites in tests, passing two arguments. It was CI-green against a base that predated #158.

Merging #159 without re-running against the new base landed the mismatch. `git blame` confirms the split: the signature is 5a94d9a (#158), all three call sites are 3991d53 (#159).

Nothing caught it locally because `ntuple.rs` is Linux-only — a macOS `cargo clippy` never compiles the file, exactly the trap CLAUDE.md's "Platform constraints" section describes. The jobs that do compile it are the four cross-builds' `clippy --all-targets` and the Linux `fmt + clippy + test`, so all five fail and **every open PR inherits it** regardless of content.

## The fix

The three call sites go through `steering()`, which is what the helper exists for — `members` and `ports` identical, as in every other test in the file. No production code and no test semantics change.

## Verification

Run with the *pinned* toolchain (worth noting: a Homebrew `rustc` earlier on `PATH` silently shadows rustup's 1.95.0 shim, and Homebrew's has no Linux std, so a local cross-target check appears to fail for an unrelated reason):

- `cargo clippy --workspace --all-targets --all-features --target x86_64-unknown-linux-gnu -- -D warnings` → exit 0 (fails on `origin/main`)
- `cargo fmt --all --check` → clean
- `cargo test --workspace` → all green

Worth a look at why #159 merged without a CI run against its post-#158 base; a required up-to-date-before-merge branch check would have caught this class outright.

Blocks #161, which is otherwise unrelated and inherits all five failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)