### PR TITLE
fix(vpp-offload): repair main — `NtupleSteering::new` gained an argument

### DIFF
--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1891,7 +1891,14 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = NtupleSteering::new(
+            // Member AND steered at construction: these drive a
+            // `steer off` retarget, so the port has to be acquired for
+            // `vf_for` to answer once the target no longer names it.
+            vec![("eth0".into(), 0)],
+            vec![("eth0".into(), 0)],
+            plan_for(&[[198, 18, 0, 0]]),
+        );
         assert_eq!(
             s.steer().expect("installs"),
             SteerOutcome::Steered,
@@ -1931,7 +1938,14 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        let mut s = NtupleSteering::new(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        let mut s = NtupleSteering::new(
+            // Member AND steered at construction: these drive a
+            // `steer off` retarget, so the port has to be acquired for
+            // `vf_for` to answer once the target no longer names it.
+            vec![("eth0".into(), 0)],
+            vec![("eth0".into(), 0)],
+            plan_for(&[[198, 18, 0, 0]]),
+        );
         s.steer().expect("installs");
         let stuck: Vec<u32> = s.installed().iter().map(|(_, loc)| *loc).collect();
         sys::wedge_delete(&stuck);
@@ -3362,6 +3376,7 @@ mod tests {
 
         sys::reset();
         let mut fx = SteeringOnly(NtupleSteering::new(
+            vec![("eth4".into(), 0)],
             vec![("eth4".into(), 0)],
             plan_for(&[[198, 18, 0, 0]]),
         ));


### PR DESCRIPTION
**`main` has not compiled its tests since 3991d53.** The shipped library is fine; `cargo test` and `clippy --all-targets` are not, so CI is red on `main`.

## What happened

#158 changed `NtupleSteering::new(ports, plan)` to `new(members, ports, plan)`. #159 added three tests calling the old two-argument form. Neither branch contained the other, so:

- both were green on their own,
- git merged them **without a conflict** — the two PRs never touch the same lines,
- the break exists only in the combination, and only at compile time.

## The fix

Three call sites in `ntuple.rs`'s test module. `members` is set equal to `ports` at each, because all three drive a port that is acquired *and* steered at construction — and two of them then retarget to an empty target, which is precisely the case where `vf_for` has to keep answering after the port leaves the steering list. Setting `members` empty there would have compiled and quietly exercised #158's residual delete-by-location path instead of its verification path.

No behaviour change. 735 tests green, clippy clean on the workspace.

## #160 needs a rebase, not a merge

[#160](https://github.com/unredacted/packetframe/pull/160) is still open and green **against a `main` that no longer exists**. It carries this same arity break plus two test doubles whose `steer` still returns `Result<(), String>` where #159 made it `Result<SteerOutcome, String>`. Merging it on its current check will red `main` a second time.

I verified the three-way combination locally before any of this merged: with those fixups it is 747 tests green and clippy clean, so nothing here is a design conflict — it is purely the seam that no single branch could see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)