### PR TITLE
fix(cli): a daemon we cannot identify is not a daemon that is gone

### DIFF
--- a/crates/cli/src/atomic.rs
+++ b/crates/cli/src/atomic.rs
@@ -7,10 +7,13 @@
 //! neither takes a lock, so a partially written file is not a rare race
 //! but the ordinary outcome of overlapping a read with a write.
 //!
-//! The temp path is opened `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` (see
-//! [`crate::loader::create_excl_no_follow`]) so a pre-existing symlink
-//! at the temp path cannot redirect the privileged write — the May 2026
-//! audit Slice 4 finding.
+//! On Linux the write happens relative to a directory descriptor
+//! obtained by a component-wise no-follow walk (see
+//! `crate::loader::create_and_open_dir_no_follow`), and the temp file
+//! is opened `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` against it — so
+//! neither a symlink at the temp path (the May 2026 audit Slice 4
+//! finding) nor one at any intermediate component (review finding on
+//! the state writers) can redirect the privileged write.
 
 use std::io::Write as _;
 use std::path::Path;
@@ -30,33 +33,37 @@ pub fn write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
     // The same filename with `.tmp` appended, so the temp file stays on
     // the same filesystem as the target. `with_extension("tmp")` would
     // drop the `.prom` and stop a second writer distinguishing ours.
-    let tmp = path.with_file_name(format!(
-        "{}.tmp",
-        path.file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or("packetframe.out"),
-    ));
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?;
+    let tmp_name = format!("{name}.tmp");
+    // On Linux everything happens relative to ONE directory descriptor
+    // obtained by a component-wise no-follow walk — the same discipline
+    // as the state-record writers, for the same reason: `O_NOFOLLOW` on
+    // the temp file guards only the final component, so an intermediate
+    // symlink in a configured path carried this root writer wherever it
+    // pointed (review finding on the state writers; this is the same
+    // primitive with different callers). A symlink anywhere in the path
+    // fails `ELOOP` and the write is refused.
+    #[cfg(target_os = "linux")]
     {
-        #[cfg(target_os = "linux")]
-        let mut f = crate::loader::create_excl_no_follow(&tmp).or_else(|e| {
-            // Symmetry with the loader helper's retry path. On a crashed
-            // predecessor the `.tmp` leftover is a regular file: unlink
-            // and retry once. A symlink (attacker pre-creation) trips
-            // O_NOFOLLOW on the retry too.
-            if e.kind() == std::io::ErrorKind::AlreadyExists {
-                let meta = std::fs::symlink_metadata(&tmp)?;
-                if meta.file_type().is_file() {
-                    std::fs::remove_file(&tmp)?;
-                    return crate::loader::create_excl_no_follow(&tmp);
-                }
-            }
-            Err(e)
-        })?;
-        #[cfg(not(target_os = "linux"))]
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let dir = crate::loader::create_and_open_dir_no_follow(parent)?;
+        {
+            let mut f = crate::loader::openat_excl_with_retry(&dir, &tmp_name)?;
+            f.write_all(contents)?;
+            f.sync_all()?;
+        }
+        crate::loader::renameat_within(&dir, &tmp_name, name)?;
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        let tmp = path.with_file_name(&tmp_name);
         let mut f = std::fs::File::create(&tmp)?;
         f.write_all(contents)?;
         f.sync_all()?;
+        std::fs::rename(&tmp, path)?;
     }
-    std::fs::rename(&tmp, path)?;
     Ok(())
 }

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -352,20 +352,38 @@ fn decide_from_record(
         };
     }
     let Some(recorded) = recorded else {
-        // Legacy record. The exe match still CONFIRMS — a process
-        // running this very binary, at the pid a root-owned file names,
-        // is ours. Its FAILURE proves nothing, and reading that as
-        // absence is the whole defect.
-        return if exe_matches {
-            DaemonPresence::Running { pid }
+        // Legacy record: a root-owned file names a pid and nothing
+        // else. THE RULE, now applied here too: only a matching
+        // identity confirms a live pid, and weaker evidence never
+        // upgrades a verdict.
+        //
+        // This arm used to confirm on the executable match, arguing
+        // that our binary at a root-recorded pid is ours. But the exe
+        // predicate deliberately accepts versioned siblings across
+        // bundles — right for FINDING a daemon, not for identifying
+        // one — so a legacy record surviving a crash, its pid reused
+        // by a `packetframe* run` from another bundle and another
+        // state directory, read as `Running` and took root's SIGHUP
+        // (review finding; the identity-mismatch arm fell to the same
+        // reasoning one round earlier).
+        //
+        // The cost lands once, on the first upgrade from a pre-sidecar
+        // build: `reconfigure` refuses and `status` cannot confirm
+        // until the daemon restarts on a build that records identity.
+        // `status` usually recovers sooner than that — the health
+        // snapshot carries the publisher's own identity, which is the
+        // matching-identity evidence this record lacks.
+        let what = if exe_matches {
+            "a packetframe daemon is running at that pid, but a pid alone cannot show it \
+             is the one that wrote the record"
         } else {
-            DaemonPresence::Unknown {
-                why: format!(
-                    "pid {pid} is running but the record predates identity tracking, and this \
-                     command is a different binary than that process — restart the daemon on \
-                     this build to make it checkable"
-                ),
-            }
+            "this command is a different binary than that process"
+        };
+        return DaemonPresence::Unknown {
+            why: format!(
+                "pid {pid} is running but the record predates identity tracking — {what}; \
+                 restart the daemon on this build to make it checkable"
+            ),
         };
     };
     let Some((ticks, boot)) = live_identity else {
@@ -646,12 +664,20 @@ mod tests {
             "so nothing destructive may proceed on it"
         );
 
-        // Same record, same binary: the exe match still confirms.
-        assert_eq!(
-            decide(Record::Found(42, None), true, None, true, || {
-                Scan::NoneFound
-            }),
-            DaemonPresence::Running { pid: 42 }
+        // Same record, exe match passing: STILL Unknown. The predicate
+        // accepts versioned siblings across bundles — right for finding
+        // a daemon, not for identifying one — so a legacy record whose
+        // pid was reused by a `packetframe* run` from another bundle
+        // read as Running and took root's SIGHUP (review finding).
+        // Only a matching identity confirms; this record cannot carry
+        // one, so a live pid under it is never better than Unknown.
+        let legacy_exe = decide(Record::Found(42, None), true, None, true, || {
+            Scan::NoneFound
+        });
+        assert!(
+            matches!(legacy_exe, DaemonPresence::Unknown { .. }),
+            "an exe match must not upgrade an identity-less record to signal-capable: \
+             {legacy_exe:?}"
         );
 
         // Identity recorded and matching: Running whatever the exe says.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -209,8 +209,8 @@ pub enum Record {
     /// finding).
     Unauthenticated(i32),
     /// Two authenticated records that disagree: a valid pid file names
-    /// one pid, and the sidecar names a DIFFERENT pid whose identity
-    /// matches a live process.
+    /// one pid, and the sidecar names a DIFFERENT pid that could not be
+    /// ruled out as a live process — shown live, or unanswerable.
     ///
     /// Nothing in the data says which record is stale. A restart whose
     /// pid-file rewrite failed (it is non-fatal) leaves the OLD pid
@@ -370,9 +370,9 @@ fn decide_from_record(
             return DaemonPresence::Unknown {
                 why: format!(
                     "two authenticated records disagree: the pid file names {recorded} but \
-                     the identity sidecar names {sidecar}, which matches a live process — \
-                     likely a failed pid-file rewrite during a restart. Restart the daemon \
-                     to re-record both, or remove the stale pid file"
+                     the identity sidecar names {sidecar}, which could not be ruled out as \
+                     a live daemon — likely a failed pid-file rewrite during a restart. \
+                     Restart the daemon to re-record both, or remove the stale pid file"
                 ),
             }
         }
@@ -523,17 +523,44 @@ pub fn self_boot_id() -> Option<String> {
 }
 
 /// Whether a recorded identity describes a process that is alive right
-/// now: the pid exists in a non-zombie state, its start ticks match,
-/// and the boot id is this boot's.
+/// now. THREE answers, because the callers act on the negative:
+/// `Some(true)` — alive, non-zombie, ticks and boot id match;
+/// `Some(false)` — positively shown absent, exited, or a different
+/// process (the pid was reused); `None` — could not be established.
 ///
-/// This is the one question that can arbitrate between two
-/// authenticated records that disagree — `/proc` is the only party
-/// with an opinion about which of them still describes something.
+/// This is the arbiter between two authenticated records that disagree
+/// — `/proc` is the only party with an opinion about which still
+/// describes something — and the first version was a bool, collapsing
+/// "could not read its state" into "not live". A transient `/proc`
+/// read failure then discarded the live replacement's sidecar as
+/// stale, and the dead pid in the old record resolved to `Gone`
+/// (review finding: the same cannot-tell-vs-no collapse as `Scan` and
+/// `Sidecar`, in the third structure this module grew).
 #[cfg(target_os = "linux")]
-fn identity_is_live(id: &DaemonIdentity) -> bool {
-    proc_state(id.pid).is_ok_and(state_is_alive)
-        && start_ticks(id.pid).ok() == Some(id.start_ticks)
-        && boot_id().ok().as_deref() == Some(id.boot_id.as_str())
+fn identity_liveness(id: &DaemonIdentity) -> Option<bool> {
+    let state = match proc_state(id.pid) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Some(false),
+        Err(_) => return None,
+    };
+    if !state_is_alive(state) {
+        return Some(false);
+    }
+    let ticks = match start_ticks(id.pid) {
+        Ok(t) => t,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Some(false),
+        Err(_) => return None,
+    };
+    if ticks != id.start_ticks {
+        return Some(false);
+    }
+    match boot_id() {
+        Ok(b) if b == id.boot_id => Some(true),
+        // A different boot id means every recorded tick count is from a
+        // previous boot: the recorded process is positively gone.
+        Ok(_) => Some(false),
+        Err(_) => None,
+    }
 }
 
 /// Read a state file and say whether it was root-owned, through ONE
@@ -741,15 +768,23 @@ pub fn presence_of(
                     // pid dead" resolve to `Gone` under the live
                     // replacement (review finding, P1). Which record
                     // is stale is decided by /proc, the only party
-                    // with an opinion: an identity matching a live
-                    // process is a daemon, whoever else is named.
-                    Sidecar::Identity(id) if identity_is_live(&id) => Record::ConflictingRecords {
-                        recorded: pid,
-                        sidecar: id.pid,
-                    },
-                    // The sidecar names nothing living, so IT is the
-                    // stale one; the pid file stands alone, as an
-                    // identity-less record.
+                    // with an opinion — and ONLY a positive answer
+                    // discards: `Some(false)` means shown dead,
+                    // exited, or a different process. `None` means the
+                    // question went unanswered, and an unanswered
+                    // question keeps the conflict, because "could not
+                    // read its state" is not "not live" (review
+                    // finding: the arbiter itself had the module's
+                    // recurring collapse).
+                    Sidecar::Identity(id) if identity_liveness(&id) != Some(false) => {
+                        Record::ConflictingRecords {
+                            recorded: pid,
+                            sidecar: id.pid,
+                        }
+                    }
+                    // The sidecar names something positively gone, so
+                    // IT is the stale one; the pid file stands alone,
+                    // as an identity-less record.
                     Sidecar::Identity(_) => Record::Found(pid, None),
                     _ => Record::Found(pid, None),
                 }

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -567,8 +567,10 @@ fn read_with_provenance(path: &Path) -> std::io::Result<(String, bool)> {
     Ok((raw, root_owned))
 }
 
-/// Whether the state DIRECTORY itself can vouch for what it contains:
-/// root-owned, a real directory, not group- or world-writable.
+/// Whether the state DIRECTORY can vouch for what it contains: the
+/// directory itself root-owned, a real directory, not group- or
+/// world-writable — and NOT MOVABLE, which is a property of its
+/// ancestors, not of it.
 ///
 /// Per-file ownership is not enough, and the gap is `rename`: moving a
 /// file needs write on the two directories and nothing from the file,
@@ -579,12 +581,36 @@ fn read_with_provenance(path: &Path) -> std::io::Result<(String, bool)> {
 /// write is a directory whose contents they choose, whoever owns the
 /// files; so in such a directory, no record confirms a live pid.
 ///
-/// Opened `O_DIRECTORY | O_NOFOLLOW` and judged on the descriptor,
-/// which also refuses a state dir that is itself a symlink. Errors
-/// return `false` — treat as unauthenticated, never as trusted.
+/// And checking the directory alone is not enough either, for the same
+/// operation one level up: under a writable parent, two whole
+/// root-owned state directories can have their NAMES exchanged without
+/// a byte of either being modified, so the configured path leads to the
+/// other instance's records and every per-file and per-directory check
+/// passes (review finding — the first replay fix, replayed against
+/// itself). So the ancestors are checked too, every one to the root:
+/// each must be root-owned and either not writable by others or
+/// sticky — in a sticky directory (`/tmp`) only the owner of an entry
+/// may rename it, and the entry in question is root-owned.
+///
+/// Symlinks are refused ANYWHERE in the path, not just at the final
+/// component: a symlinked ancestor is repointable by whoever can write
+/// its containing directory, which is the swap again without a rename
+/// of the target. `canonicalize` resolves every link, so equality with
+/// the configured path proves there were none. The cost, documented in
+/// the runbook: a state dir configured through a symlinked path (e.g.
+/// `/var/run` on systems where it links to `/run`) must be configured
+/// by its real path.
+///
+/// Judged on descriptors and canonical paths; errors return `false` —
+/// unauthenticated, never trusted.
 #[cfg(target_os = "linux")]
 fn dir_is_authentic(dir: &Path) -> bool {
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    // No symlinks anywhere in the path.
+    match std::fs::canonicalize(dir) {
+        Ok(canon) if canon == dir => {}
+        _ => return false,
+    }
     let Ok(f) = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
@@ -595,7 +621,24 @@ fn dir_is_authentic(dir: &Path) -> bool {
     let Ok(meta) = f.metadata() else {
         return false;
     };
-    meta.is_dir() && meta.uid() == 0 && meta.mode() & 0o022 == 0
+    if !(meta.is_dir() && meta.uid() == 0 && meta.mode() & 0o022 == 0) {
+        return false;
+    }
+    // The chain: nobody below root may be able to rename this
+    // directory or any ancestor of it. The path is symlink-free (just
+    // proven), so plain metadata on each ancestor examines the
+    // directory it names.
+    for ancestor in dir.ancestors().skip(1) {
+        let Ok(meta) = std::fs::metadata(ancestor) else {
+            return false;
+        };
+        let mode = meta.mode();
+        let unmovable_children = mode & 0o022 == 0 || mode & 0o1000 != 0;
+        if !(meta.is_dir() && meta.uid() == 0 && unmovable_children) {
+            return false;
+        }
+    }
+    true
 }
 
 /// What the sidecar yields when it must stand as the record of last
@@ -1166,6 +1209,31 @@ mod tests {
             matches!(p, DaemonPresence::Unknown { .. }),
             "records in a directory others can write may have been renamed in whole from \
              another instance's state dir; they must not become signal-capable: {p:?}"
+        );
+
+        // And the swap one level up: a state dir that is ITSELF
+        // impeccable — root-owned, 0755, authentic records — sitting
+        // under a writable parent can be renamed away whole and another
+        // instance's swapped into its name, so the ancestor chain is
+        // part of what authenticates it (review finding).
+        let sub = dir.join("state");
+        std::fs::create_dir_all(&sub).expect("scratch");
+        let sub_pid = sub.join("packetframe.pid");
+        let sub_ident = sub.join("packetframe.identity");
+        std::fs::write(&sub_pid, format!("{}\n", real.pid)).expect("write");
+        std::fs::write(&sub_ident, real.encode()).expect("write");
+        if unsafe { libc::geteuid() } == 0 {
+            std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o755)).expect("chmod");
+            std::fs::set_permissions(&sub_pid, std::fs::Permissions::from_mode(0o644))
+                .expect("chmod");
+            std::fs::set_permissions(&sub_ident, std::fs::Permissions::from_mode(0o644))
+                .expect("chmod");
+        }
+        let p = presence_of(&sub_pid, &sub_ident, |_| true, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Unknown { .. }),
+            "a movable state dir is not bound to its configured path, however authentic \
+             its contents: {p:?}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -343,12 +343,27 @@ fn decide_from_record(
     // reboot the pids can coincide.
     //
     // Concluding `Gone` there was the fail-open half: it licenses
-    // `detach` while a rolled-back daemon is live. Falling back to the
-    // executable match answers both correctly — a live daemon at that
-    // pid is found, and a reused pid held by anything else lands in
-    // `Unknown`, where the destructive path refuses.
+    // `detach` while a rolled-back daemon is live. `Unknown` is the
+    // whole answer — the mismatch says which daemon this is NOT, and
+    // nothing says which one it is.
     //
-    // The previous attempt dated the two files by mtime, which a
+    // It briefly fell back to the executable match and returned
+    // `Running`. That rehabilitated a record the identity had just
+    // CONTRADICTED, on weaker evidence than the contradiction: a
+    // `packetframe run` from another bundle and another state directory
+    // satisfies the exe check, so a reused pid made `reconfigure`
+    // SIGHUP an unrelated production daemon into a config reload while
+    // the intended one timed out (review finding). Reachable because
+    // that predicate now accepts versioned siblings, which is exactly
+    // right for FINDING a daemon and not enough for identifying one.
+    //
+    // The rollback case it was meant to serve — an old build rewriting
+    // the pid file under a sidecar it cannot know to remove — needs the
+    // pids to coincide across a reboot before it lands here at all, and
+    // its cost is a refusal that names the pid. Signalling a stranger
+    // is not.
+    //
+    // An earlier attempt dated the two files by mtime, which a
     // coarse-resolution filesystem defeats and which forced an ordering
     // on the writer. Removed: cleverness standing in for the
     // observation that a mismatched record is simply not evidence.
@@ -371,15 +386,21 @@ fn decide_from_record(
         // found by this record and by nothing else, which is why the
         // record path may not add an executable requirement on top.
         DaemonPresence::Running { pid }
-    } else if exe_matches {
-        // Not the recorded process, but a daemon nonetheless — which is
-        // what a rollback leaves behind.
-        DaemonPresence::Running { pid }
     } else {
+        // `exe_matches` deliberately does not appear here. It changes
+        // this from "some process holds that pid" to "some packetframe
+        // daemon holds that pid", which is worth SAYING — an operator
+        // triaging the refusal wants to know — and is not identity.
+        let what = if exe_matches {
+            "is running a packetframe daemon, but not the one the record describes"
+        } else {
+            "does not match the recorded identity and is not a packetframe daemon"
+        };
         DaemonPresence::Unknown {
             why: format!(
-                "pid {pid} does not match the recorded identity — reused, or the record is \
-                 stale — and it is not running a packetframe daemon"
+                "pid {pid} {what} — the pid was reused, or the record is stale. Check what \
+                 pid {pid} is before acting on it; restarting the daemon re-records the \
+                 identity"
             ),
         }
     }
@@ -593,9 +614,11 @@ mod tests {
                 !is_gone(&mismatch(false)) && !is_gone(&mismatch(true)),
                 "a mismatched record never proves absence, whatever the executable says"
             );
-            // And it falls back rather than refusing outright: a daemon
-            // at that pid is still a daemon.
-            assert_eq!(mismatch(true), DaemonPresence::Running { pid: 42 });
+            // Nor is it confirmation. The executable check finds *a*
+            // daemon, which is not *the* daemon, and reading it as one
+            // aimed `reconfigure`'s SIGHUP at an unrelated instance
+            // (review finding).
+            assert!(matches!(mismatch(true), DaemonPresence::Unknown { .. }));
             assert!(matches!(mismatch(false), DaemonPresence::Unknown { .. }));
         }
 
@@ -770,17 +793,24 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A rollback to a build without the sidecar still works.
+    /// A contradicted record settles nothing in EITHER direction.
     ///
-    /// That build rewrites only the pid file and cannot know to remove
-    /// `packetframe.identity`; after a reboot the pids can coincide, so
-    /// the stale record gets matched to the live daemon and rejects it.
-    /// The first attempt dated the files by mtime, which a coarse
-    /// filesystem defeats. The answer is simpler: a record that does
-    /// not describe the live process is not evidence about it, so the
-    /// executable match decides — and a rolled-back daemon is found.
+    /// Not `Gone`: a rollback to a build without the sidecar rewrites
+    /// only the pid file and cannot know to remove
+    /// `packetframe.identity`, so after a reboot the pids can coincide
+    /// and the stale record rejects a live daemon — concluding absence
+    /// there licenses `detach` to unlink pins beneath it. (The first
+    /// attempt dated the files by mtime, which a coarse filesystem
+    /// defeats.)
+    ///
+    /// And not `Running` on an executable match either, which is what
+    /// it briefly did: a `packetframe run` from another bundle and
+    /// another state directory passes that check, so a reused pid put
+    /// `reconfigure`'s SIGHUP into an unrelated daemon (review
+    /// finding). The identity said this is not the recorded process;
+    /// a weaker check does not get to overrule it.
     #[test]
-    fn a_stale_record_does_not_condemn_the_daemon_that_replaced_it() {
+    fn a_contradicted_record_identifies_nothing_in_either_direction() {
         let stale = |exe| {
             decide(
                 Record::Found(42, Some(id(42, 900))),
@@ -790,15 +820,22 @@ mod tests {
                 || Scan::NoneFound,
             )
         };
-        assert_eq!(
-            stale(true),
-            DaemonPresence::Running { pid: 42 },
-            "the live daemon is found by its executable, not condemned by a record it \
-             never wrote"
-        );
+        for exe in [true, false] {
+            assert!(
+                matches!(stale(exe), DaemonPresence::Unknown { .. }),
+                "exe_matches={exe}: a mismatched identity is unknown, never absent and \
+                 never confirmed: {:?}",
+                stale(exe)
+            );
+        }
+        // The distinction still reaches the operator, because it is
+        // what they triage with — it just does not license an action.
+        let DaemonPresence::Unknown { why } = stale(true) else {
+            unreachable!()
+        };
         assert!(
-            !is_gone(&stale(false)),
-            "and where nothing confirms it, the answer is unknown rather than absent"
+            why.contains("packetframe daemon"),
+            "the refusal has to say a daemon holds that pid: {why}"
         );
     }
 

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -137,6 +137,33 @@ pub fn start_ticks(pid: i32) -> std::io::Result<u64> {
         .map_err(|e| bad_data(&format!("start_ticks parse: {e}")))
 }
 
+/// Whether the process is alive in the sense that matters here: it can
+/// still hold FDs, answer a signal, and publish health.
+///
+/// Directory existence is not that. A daemon that has exited but has
+/// not been reaped keeps `/proc/<pid>` and its original start ticks, so
+/// it read as `Running` — `status` presented its final snapshot as
+/// current, `reconfigure` waited out its timeout for an acknowledgement
+/// that could never come, and `detach` refused for as long as the
+/// zombie persisted, even though its FDs are already closed and the
+/// links released (review finding).
+///
+/// The state is the first token after the comm field, which is why the
+/// last `)` is the anchor here too.
+#[cfg(target_os = "linux")]
+pub fn proc_state(pid: i32) -> std::io::Result<char> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))?;
+    stat.rfind(')')
+        .and_then(|i| stat[i + 1..].split_whitespace().next())
+        .and_then(|s| s.chars().next())
+        .ok_or_else(|| bad_data("no state field in /proc/<pid>/stat"))
+}
+
+/// `Z` (zombie) and `X` (dead) are exits that have not been reaped.
+pub fn state_is_alive(state: char) -> bool {
+    !matches!(state, 'Z' | 'X' | 'x')
+}
+
 #[cfg(target_os = "linux")]
 pub fn boot_id() -> std::io::Result<String> {
     Ok(std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?
@@ -305,7 +332,16 @@ pub fn presence_of(
         // Only the no-record path consults the scan, and only to find.
         _ => return decide(record, false, None, false, scan()),
     };
-    let alive = Path::new(&format!("/proc/{pid}")).exists();
+    // Not directory existence: a zombie keeps its entry and its start
+    // ticks, and is not a daemon anything can talk to.
+    let alive = match proc_state(pid) {
+        Ok(state) => state_is_alive(state),
+        // No entry at all is the ordinary dead case. Any other read
+        // error leaves `alive` true, so the identity check below
+        // decides rather than this line guessing.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => Path::new(&format!("/proc/{pid}")).exists(),
+    };
     let live_identity = match (start_ticks(pid), boot_id()) {
         (Ok(t), Ok(b)) => Some((t, b)),
         _ => None,
@@ -452,6 +488,17 @@ mod tests {
             false,
             None
         )));
+    }
+
+    /// A zombie is not a daemon.
+    #[test]
+    fn unreaped_exits_are_not_alive() {
+        for dead in ['Z', 'X', 'x'] {
+            assert!(!state_is_alive(dead), "state {dead} has already exited");
+        }
+        for live in ['R', 'S', 'D', 'T', 't', 'I'] {
+            assert!(state_is_alive(live), "state {live} is a process to respect");
+        }
     }
 
     /// A legacy record parses as "pid, no identity" rather than as an

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -88,26 +88,40 @@ impl DaemonIdentity {
     /// Parse a record. `Ok(None)` for a legacy file holding only a pid,
     /// which is a different thing from a malformed one.
     pub fn decode(s: &str) -> std::io::Result<(i32, Option<Self>)> {
-        let mut parts = s.split_whitespace();
-        let pid: i32 = parts
-            .next()
-            .ok_or_else(|| bad_data("empty pid file"))?
-            .parse()
-            .map_err(|e| bad_data(&format!("pid parse: {e}")))?;
-        let (Some(ticks), Some(boot)) = (parts.next(), parts.next()) else {
-            return Ok((pid, None));
+        let parts: Vec<&str> = s.split_whitespace().collect();
+        let pid = |raw: &str| -> std::io::Result<i32> {
+            raw.parse()
+                .map_err(|e| bad_data(&format!("pid parse: {e}")))
         };
-        let start_ticks = ticks
-            .parse()
-            .map_err(|e| bad_data(&format!("start_ticks parse: {e}")))?;
-        Ok((
-            pid,
-            Some(Self {
-                pid,
-                start_ticks,
-                boot_id: boot.to_string(),
-            }),
-        ))
+        match parts.as_slice() {
+            [] => Err(bad_data("empty record")),
+            // EXACTLY one field is the legacy shape. A partially
+            // written identity — pid and ticks, no boot id, which a
+            // truncated write produces — used to land here too, and the
+            // legacy path then accepted a reused pid on an exe match
+            // alone: `reconfigure` would signal it and `status` would
+            // present the old report as current (review finding).
+            [one] => Ok((pid(one)?, None)),
+            [p, ticks, boot] => {
+                let p = pid(p)?;
+                Ok((
+                    p,
+                    Some(Self {
+                        pid: p,
+                        start_ticks: ticks
+                            .parse()
+                            .map_err(|e| bad_data(&format!("start_ticks parse: {e}")))?,
+                        boot_id: boot.to_string(),
+                    }),
+                ))
+            }
+            // Anything else is a record this build does not understand:
+            // report it rather than guessing which half to trust.
+            other => Err(bad_data(&format!(
+                "expected 1 or 3 fields, found {}",
+                other.len()
+            ))),
+        }
     }
 }
 
@@ -576,6 +590,22 @@ mod tests {
         }
         for live in ['R', 'S', 'D', 'T', 't', 'I'] {
             assert!(state_is_alive(live), "state {live} is a process to respect");
+        }
+    }
+
+    /// A partial identity is not a legacy record.
+    ///
+    /// Both arrive as "a pid and no usable identity", and treating them
+    /// alike put a truncated write on the legacy path, where an exe
+    /// match alone accepts a reused pid (review finding).
+    #[test]
+    fn a_half_written_identity_is_refused_not_downgraded() {
+        for partial in ["12345 998877", "12345 998877 boot extra", "12345 x y"] {
+            assert!(
+                DaemonIdentity::decode(partial).is_err(),
+                "`{partial}` is not a record this build understands, and guessing which \
+                 half to trust is how a reused pid gets accepted"
+            );
         }
     }
 

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -197,6 +197,31 @@ pub enum Record {
     Found(i32, Option<DaemonIdentity>),
 }
 
+/// What a search of the process table established.
+///
+/// Three-valued for the same reason [`DaemonPresence`] is: a search
+/// that could not run and a search that ran and found nothing are
+/// different facts, and collapsing them into one `None` made the
+/// second the default reading of the first (review finding).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Scan {
+    /// A process running a packetframe daemon, at this pid.
+    Found(i32),
+    /// The table was walked end to end, every process in it was
+    /// examined, and none was a daemon.
+    ///
+    /// The strongest negative available, and still not a proof of
+    /// absence: a daemon deployed under a name sharing no prefix with
+    /// ours is invisible here by construction — see
+    /// `proc_exe_looks_like_a_daemon`'s residual limit. The pid record
+    /// is what covers that case, and this variant is only ever
+    /// consulted when there is no record to consult.
+    NoneFound,
+    /// The table could not be walked, or a process in it could not be
+    /// examined. Evidence in neither direction.
+    Inconclusive(String),
+}
+
 /// THE POLICY, as a pure function.
 ///
 /// Deliberately separate from the `/proc` reads: this is a safety
@@ -212,7 +237,7 @@ pub fn decide(
     proc_alive: bool,
     live_identity: Option<(u64, String)>,
     exe_matches: bool,
-    scan: impl FnOnce() -> Option<i32>,
+    scan: impl FnOnce() -> Scan,
 ) -> DaemonPresence {
     // ANY route to `Gone` has to survive the scan, not just the
     // missing-record one. A replacement daemon attaches BEFORE it
@@ -231,18 +256,28 @@ pub fn decide(
     // the table test could not see because it called this directly
     // (review finding). Now there is no `None` to hard-code, and it is
     // only invoked where it can change the answer.
-    let scanned = match &verdict {
-        DaemonPresence::Gone { .. } => scan(),
-        _ => None,
+    let DaemonPresence::Gone { why } = verdict else {
+        return verdict;
     };
-    match (&verdict, scanned) {
-        (DaemonPresence::Gone { why }, Some(found)) => DaemonPresence::Unknown {
+    match scan() {
+        Scan::Found(found) => DaemonPresence::Unknown {
             why: format!(
                 "{why}, but pid {found} is running this binary — it may be a daemon whose \
                  record is stale or was never written"
             ),
         },
-        _ => verdict,
+        // "Survives the scan" has to mean the scan RAN. It returned a
+        // bare `Option`, so a `/proc` that could not be read — or a
+        // process in it that could not be examined — was indistinguishable
+        // from a table with no daemon in it, and licensed `detach`. That
+        // is the same "cannot establish X, therefore not X" this whole
+        // module exists to undo, reproduced inside its own fix (review
+        // finding, P1). It matters most for `Record::Absent`, where the
+        // scan is the ONLY evidence there is.
+        Scan::Inconclusive(reason) => DaemonPresence::Unknown {
+            why: format!("{why}, and the process table could not be searched for one ({reason})"),
+        },
+        Scan::NoneFound => DaemonPresence::Gone { why },
     }
 }
 
@@ -258,10 +293,13 @@ fn decide_from_record(
         // after every module attaches — deliberately, so systemd's
         // `PIDFile=` never points at a half-attached daemon — and a
         // failed write is non-fatal, so a live daemon can legitimately
-        // have none. `scanned` is the independent check: it can FIND a
-        // daemon (a process running this binary), and its silence
-        // proves nothing, which is the polarity the deleted /proc scan
-        // had backwards (review finding).
+        // have none. The scan is the independent check, and on this
+        // branch it is the ONLY evidence in play — so `decide` demotes
+        // this to `Unknown` unless the scan actually completed. A scan
+        // that could not look is not a scan that looked and saw
+        // nothing, which is the polarity the deleted /proc scan had
+        // backwards and that its replacement re-introduced one level
+        // down (review findings).
         Record::Absent => {
             return DaemonPresence::Gone {
                 why: "no pid file".into(),
@@ -432,7 +470,7 @@ pub fn presence_of(
     pid_path: &Path,
     identity_path: &Path,
     exe_matches: impl Fn(i32) -> bool,
-    scan: impl Fn() -> Option<i32>,
+    scan: impl Fn() -> Scan,
 ) -> DaemonPresence {
     let record = match std::fs::read_to_string(pid_path) {
         Ok(s) => match DaemonIdentity::decode(&s) {
@@ -501,7 +539,9 @@ mod tests {
     fn absence_is_never_concluded_from_a_failed_identity_check() {
         // The upgrade window, and the whole bug: a live daemon, a
         // legacy record, and a CLI at a different path. Was `Gone`.
-        let unknown = decide(Record::Found(42, None), true, None, false, || None);
+        let unknown = decide(Record::Found(42, None), true, None, false, || {
+            Scan::NoneFound
+        });
         assert!(
             matches!(unknown, DaemonPresence::Unknown { .. }),
             "a live pid we cannot identify is not absence: {unknown:?}"
@@ -513,7 +553,9 @@ mod tests {
 
         // Same record, same binary: the exe match still confirms.
         assert_eq!(
-            decide(Record::Found(42, None), true, None, true, || None),
+            decide(Record::Found(42, None), true, None, true, || {
+                Scan::NoneFound
+            }),
             DaemonPresence::Running { pid: 42 }
         );
 
@@ -526,7 +568,7 @@ mod tests {
                 true,
                 Some((900, "boot-a".into())),
                 false,
-                || None,
+                || Scan::NoneFound,
             ),
             DaemonPresence::Running { pid: 42 }
         );
@@ -544,7 +586,7 @@ mod tests {
                     true,
                     Some((live.0, live.1.to_string())),
                     exe,
-                    || None,
+                    || Scan::NoneFound,
                 )
             };
             assert!(
@@ -563,7 +605,7 @@ mod tests {
             true,
             None,
             true,
-            || None
+            || Scan::NoneFound
         )));
 
         // No process: absent, regardless of what was recorded.
@@ -572,10 +614,10 @@ mod tests {
             false,
             None,
             true,
-            || None
+            || Scan::NoneFound
         )));
         assert!(is_gone(&decide(Record::Absent, false, None, false, || {
-            None
+            Scan::NoneFound
         })));
 
         // EVERY route to Gone must survive the scan, not just the
@@ -592,13 +634,32 @@ mod tests {
                 None,
             ),
         ] {
-            let alone = decide(record.clone(), alive, live.clone(), false, || None);
+            let alone = decide(record.clone(), alive, live.clone(), false, || {
+                Scan::NoneFound
+            });
             assert!(is_gone(&alone), "{label}: the record alone says gone");
-            let with_scan = decide(record, alive, live, false, || Some(77));
+            let with_scan = decide(record.clone(), alive, live.clone(), false, || {
+                Scan::Found(77)
+            });
             assert!(
                 matches!(with_scan, DaemonPresence::Unknown { .. }),
                 "{label}: but a process running this binary makes it unprovable: \
                  {with_scan:?}"
+            );
+            // And a scan that could not LOOK is not a scan that looked
+            // and saw nothing. `Option` conflated the two, so an
+            // unreadable `/proc` — or one process in it that could not
+            // be examined — read as positive absence and licensed
+            // `detach` (review finding). This is the same defect the
+            // whole module exists to undo, one level inside its own
+            // fix, which is why the assertion is here rather than in a
+            // test of its own.
+            let blind = decide(record, alive, live, false, || {
+                Scan::Inconclusive("proc unreadable".into())
+            });
+            assert!(
+                matches!(blind, DaemonPresence::Unknown { .. }),
+                "{label}: a scan that could not run cannot confirm absence: {blind:?}"
             );
         }
 
@@ -609,7 +670,7 @@ mod tests {
             false,
             None,
             false,
-            || None
+            || Scan::NoneFound
         )));
     }
 
@@ -639,10 +700,10 @@ mod tests {
         std::fs::write(&ident, "2147483646 1 boot-a").expect("write");
 
         assert!(
-            is_gone(&presence_of(&path, &ident, |_| false, || None)),
+            is_gone(&presence_of(&path, &ident, |_| false, || Scan::NoneFound)),
             "with nothing running, a dead record is absence"
         );
-        let with_daemon = presence_of(&path, &ident, |_| false, || Some(77));
+        let with_daemon = presence_of(&path, &ident, |_| false, || Scan::Found(77));
         assert!(
             matches!(with_daemon, DaemonPresence::Unknown { .. }),
             "but a live daemon the scan can see must reach this path too — this is \
@@ -700,7 +761,7 @@ mod tests {
         // though `decode` understands the shape.
         std::fs::write(&pidfile, real.encode()).expect("write");
         let _ = std::fs::remove_file(&ident);
-        let planted = presence_of(&pidfile, &ident, |_| false, || None);
+        let planted = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
         assert!(
             !matches!(planted, DaemonPresence::Running { .. }),
             "an identity in the unauthenticated pid file is not an identity: {planted:?}"
@@ -726,7 +787,7 @@ mod tests {
                 true,
                 Some((7777, "boot-after-reboot".to_string())),
                 exe,
-                || None,
+                || Scan::NoneFound,
             )
         };
         assert_eq!(

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -297,6 +297,23 @@ fn decide_from_record(
             why: format!("pid {pid} is running but its identity could not be read"),
         };
     };
+    // A record that does NOT describe the live process settles nothing:
+    // two situations produce it and the data cannot separate them. The
+    // pid was reused after our daemon died, or the record is stale — a
+    // rollback to a build that does not maintain the sidecar rewrites
+    // only the pid file and cannot know to remove it, and after a
+    // reboot the pids can coincide.
+    //
+    // Concluding `Gone` there was the fail-open half: it licenses
+    // `detach` while a rolled-back daemon is live. Falling back to the
+    // executable match answers both correctly — a live daemon at that
+    // pid is found, and a reused pid held by anything else lands in
+    // `Unknown`, where the destructive path refuses.
+    //
+    // The previous attempt dated the two files by mtime, which a
+    // coarse-resolution filesystem defeats and which forced an ordering
+    // on the writer. Removed: cleverness standing in for the
+    // observation that a mismatched record is simply not evidence.
     if ticks == recorded.start_ticks && boot == recorded.boot_id {
         // Identity matched, and the record was shown to be root-owned
         // before it was read — see `record_is_authentic`, which is what
@@ -310,12 +327,15 @@ fn decide_from_record(
         // against an attacker who cannot get past the file check
         // anyway.
         DaemonPresence::Running { pid }
+    } else if exe_matches {
+        // Not the recorded process, but a daemon nonetheless — which is
+        // what a rollback leaves behind.
+        DaemonPresence::Running { pid }
     } else {
-        // Alive, but not the process that wrote the record: the pid was
-        // reused. The one case where a live pid still proves absence.
-        DaemonPresence::Gone {
+        DaemonPresence::Unknown {
             why: format!(
-                "pid {pid} is running but was reused; the daemon that wrote the record is gone"
+                "pid {pid} does not match the recorded identity — reused, or the record is \
+                 stale — and it is not running a packetframe daemon"
             ),
         }
     }
@@ -374,7 +394,7 @@ pub fn self_boot_id() -> Option<String> {
 /// create in its place is theirs and fails, which drops the identity
 /// and falls back to the executable match — as if none were recorded.
 #[cfg(target_os = "linux")]
-fn read_authentic_identity(path: &Path, pid: i32, pid_path: &Path) -> Option<DaemonIdentity> {
+fn read_authentic_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
     use std::io::Read;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
@@ -385,20 +405,6 @@ fn read_authentic_identity(path: &Path, pid: i32, pid_path: &Path) -> Option<Dae
         .ok()?;
     let meta = f.metadata().ok()?;
     if !meta.is_file() || meta.uid() != 0 || meta.mode() & 0o022 != 0 {
-        return None;
-    }
-    // OLDER than the pid record means it describes a previous daemon.
-    // The pid alone cannot tell them apart: roll back to a pre-sidecar
-    // build, which rewrites only the pid file and cannot know to remove
-    // this one, and after a reboot the pids can coincide — then the
-    // stale ticks reject the live daemon as reused and `reconfigure`
-    // stays unavailable for its whole life (review finding). The daemon
-    // writes the pid file first and this second, so a current pair is
-    // never inverted.
-    let record_time = std::fs::metadata(pid_path)
-        .and_then(|m| m.modified())
-        .ok()?;
-    if meta.modified().ok()? < record_time {
         return None;
     }
     let mut raw = String::new();
@@ -432,7 +438,7 @@ pub fn presence_of(
             // It also stays a bare pid on the write side, because CLIs
             // from other bundles parse it whole.
             Ok((pid, _unauthenticated)) => {
-                Record::Found(pid, read_authentic_identity(identity_path, pid, pid_path))
+                Record::Found(pid, read_authentic_identity(identity_path, pid))
             }
             Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
         },
@@ -519,27 +525,31 @@ mod tests {
             DaemonPresence::Running { pid: 42 }
         );
 
-        // Identity mismatch: the pid was reused, so our daemon IS gone.
-        // The only case where a live pid proves absence.
-        let reused = decide(
-            Record::Found(42, Some(id(42, 900))),
-            true,
-            Some((901, "boot-a".into())),
-            true,
-            || None,
-        );
-        assert!(is_gone(&reused), "{reused:?}");
-
-        // Same pid and ticks across a reboot is a real collision, and
-        // the boot id is what separates them.
-        let rebooted = decide(
-            Record::Found(42, Some(id(42, 900))),
-            true,
-            Some((900, "boot-b".into())),
-            true,
-            || None,
-        );
-        assert!(is_gone(&rebooted), "{rebooted:?}");
+        // A record that does not describe the live process is NOT
+        // absence. Two situations produce it — the pid was reused, or
+        // the record is stale after a rollback to a build that does not
+        // maintain it — and nothing in the data separates them, so
+        // concluding `Gone` licensed `detach` while a rolled-back
+        // daemon was live (review finding).
+        for live in [(901, "boot-a"), (900, "boot-b")] {
+            let mismatch = |exe| {
+                decide(
+                    Record::Found(42, Some(id(42, 900))),
+                    true,
+                    Some((live.0, live.1.to_string())),
+                    exe,
+                    || None,
+                )
+            };
+            assert!(
+                !is_gone(&mismatch(false)) && !is_gone(&mismatch(true)),
+                "a mismatched record never proves absence, whatever the executable says"
+            );
+            // And it falls back rather than refusing outright: a daemon
+            // at that pid is still a daemon.
+            assert_eq!(mismatch(true), DaemonPresence::Running { pid: 42 });
+            assert!(matches!(mismatch(false), DaemonPresence::Unknown { .. }));
+        }
 
         // Identity recorded but unreadable now: cannot tell.
         assert!(!is_gone(&decide(
@@ -574,12 +584,6 @@ mod tests {
                 Record::Found(42, Some(id(42, 900))),
                 false,
                 None,
-            ),
-            (
-                "recorded pid reused",
-                Record::Found(42, Some(id(42, 900))),
-                true,
-                Some((901, "boot-a".to_string())),
             ),
         ] {
             let alone = decide(record.clone(), alive, live.clone(), false, || None);
@@ -682,7 +686,7 @@ mod tests {
         std::fs::write(&ident, real.encode()).expect("write");
         std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o666)).expect("chmod");
         assert!(
-            read_authentic_identity(&ident, me, &pidfile).is_none(),
+            read_authentic_identity(&ident, me).is_none(),
             "a record any user can write must not decide which pid is our daemon"
         );
 
@@ -699,37 +703,36 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// A sidecar older than the pid record belongs to a past daemon.
+    /// A rollback to a build without the sidecar still works.
     ///
-    /// Roll back to a build that predates the sidecar: it rewrites only
-    /// the pid file and cannot know to remove this one, and after a
-    /// reboot the pids can coincide. Matched by pid alone, the stale
-    /// ticks then reject the live daemon as reused, and `reconfigure`
-    /// stays unavailable for its whole life (review finding).
-    #[cfg(target_os = "linux")]
+    /// That build rewrites only the pid file and cannot know to remove
+    /// `packetframe.identity`; after a reboot the pids can coincide, so
+    /// the stale record gets matched to the live daemon and rejects it.
+    /// The first attempt dated the files by mtime, which a coarse
+    /// filesystem defeats. The answer is simpler: a record that does
+    /// not describe the live process is not evidence about it, so the
+    /// executable match decides — and a rolled-back daemon is found.
     #[test]
-    fn a_sidecar_older_than_the_pid_record_is_ignored() {
-        let dir = std::env::temp_dir().join(format!("pf-rollback-{}", std::process::id()));
-        let _ = std::fs::remove_dir_all(&dir);
-        std::fs::create_dir_all(&dir).expect("scratch");
-        let ident = dir.join("packetframe.identity");
-        let pidfile = dir.join("packetframe.pid");
-        let me = std::process::id() as i32;
-
-        // The newer daemon's sidecar, written first…
-        let real = DaemonIdentity::current().expect("own identity");
-        std::fs::write(&ident, real.encode()).expect("write");
-        std::thread::sleep(std::time::Duration::from_millis(1100));
-        // …then a rollback daemon writes only the pid file, later.
-        std::fs::write(&pidfile, format!("{me}\n")).expect("write");
-
-        assert!(
-            read_authentic_identity(&ident, me, &pidfile).is_none(),
-            "a sidecar predating the pid record describes a daemon that is gone, and \
-             matching it by pid rejects the live one as reused"
+    fn a_stale_record_does_not_condemn_the_daemon_that_replaced_it() {
+        let stale = |exe| {
+            decide(
+                Record::Found(42, Some(id(42, 900))),
+                true,
+                Some((7777, "boot-after-reboot".to_string())),
+                exe,
+                || None,
+            )
+        };
+        assert_eq!(
+            stale(true),
+            DaemonPresence::Running { pid: 42 },
+            "the live daemon is found by its executable, not condemned by a record it \
+             never wrote"
         );
-
-        let _ = std::fs::remove_dir_all(&dir);
+        assert!(
+            !is_gone(&stale(false)),
+            "and where nothing confirms it, the answer is unknown rather than absent"
+        );
     }
 
     /// A partial identity is not a legacy record.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -195,8 +195,11 @@ pub enum Record {
     Unreadable(String),
     /// A pid, and an identity if the daemon that wrote it recorded one.
     Found(i32, Option<DaemonIdentity>),
-    /// A pid from a record that is not root-owned, so its provenance is
-    /// whoever could write the state directory.
+    /// A pid from a record whose provenance is whoever could write the
+    /// state directory: the file is not root-owned, or the directory
+    /// itself is writable by others — in which case even a root-owned
+    /// file proves nothing, because `rename` moves files between
+    /// directories without touching their contents or ownership.
     ///
     /// Kept apart from `Found` rather than folded into it: an
     /// unauthenticated record may still show that a pid is DEAD — that
@@ -337,9 +340,10 @@ fn decide_from_record(
         Record::Unauthenticated(pid) if proc_alive => {
             return DaemonPresence::Unknown {
                 why: format!(
-                    "pid {pid} is running, but the record naming it is not root-owned — \
-                     anything with write access to the state directory could have put it \
-                     there, so it cannot be acted on"
+                    "pid {pid} is running, but the record naming it cannot be trusted — the \
+                     file is not root-owned, or the state directory is writable by others, \
+                     and anything with write access could have put the record there (or \
+                     moved it there whole), so it cannot be acted on"
                 ),
             }
         }
@@ -563,6 +567,91 @@ fn read_with_provenance(path: &Path) -> std::io::Result<(String, bool)> {
     Ok((raw, root_owned))
 }
 
+/// Whether the state DIRECTORY itself can vouch for what it contains:
+/// root-owned, a real directory, not group- or world-writable.
+///
+/// Per-file ownership is not enough, and the gap is `rename`: moving a
+/// file needs write on the two directories and nothing from the file,
+/// so an unprivileged user with write on two state dirs could relocate
+/// a root-owned pid file and sidecar — never creating or modifying a
+/// root-owned byte — and have root's `reconfigure` for one instance
+/// SIGHUP the other (review finding). A directory the attacker can
+/// write is a directory whose contents they choose, whoever owns the
+/// files; so in such a directory, no record confirms a live pid.
+///
+/// Opened `O_DIRECTORY | O_NOFOLLOW` and judged on the descriptor,
+/// which also refuses a state dir that is itself a symlink. Errors
+/// return `false` — treat as unauthenticated, never as trusted.
+#[cfg(target_os = "linux")]
+fn dir_is_authentic(dir: &Path) -> bool {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+    let Ok(f) = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+        .open(dir)
+    else {
+        return false;
+    };
+    let Ok(meta) = f.metadata() else {
+        return false;
+    };
+    meta.is_dir() && meta.uid() == 0 && meta.mode() & 0o022 == 0
+}
+
+/// What the sidecar yields when it must stand as the record of last
+/// resort — when the pid file is missing or unusable.
+///
+/// Three-valued, because "no sidecar" and "a sidecar that cannot
+/// vouch" license opposite things: a missing file falls through to the
+/// scan and may end in `Gone`, while a present-but-unreadable one is
+/// exactly a live daemon's record mid-trouble and must stay `Unknown`.
+/// The first version collapsed both into `None`, so a transient read
+/// failure on the sidecar of a daemon whose pid write had also failed
+/// read as `Absent`, survived a name-limited scan, and licensed
+/// `detach` (review finding, P1 — the same collapse the `Scan` enum
+/// had just been introduced to fix, one file over).
+#[cfg(target_os = "linux")]
+enum Sidecar {
+    /// No file at all.
+    Missing,
+    /// Authentic, whole, and carrying a full identity.
+    Identity(DaemonIdentity),
+    /// Present, but it cannot vouch: unreadable, malformed, not
+    /// root-owned, identity-less, or sitting in a directory anyone can
+    /// rewrite.
+    Unusable(String),
+}
+
+#[cfg(target_os = "linux")]
+fn sidecar_record(path: &Path, dir_authentic: bool) -> Sidecar {
+    match read_with_provenance(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Sidecar::Missing,
+        Err(e) => Sidecar::Unusable(format!("cannot read {}: {e}", path.display())),
+        Ok((raw, root_owned)) => {
+            if !dir_authentic {
+                return Sidecar::Unusable(format!(
+                    "{} sits in a state directory that is not root-owned and unwritable by \
+                     others, so its contents could have been placed there by anyone",
+                    path.display()
+                ));
+            }
+            if !root_owned {
+                return Sidecar::Unusable(format!("{} is not root-owned", path.display()));
+            }
+            match DaemonIdentity::decode(&raw) {
+                Ok((_, Some(id))) => Sidecar::Identity(id),
+                // The daemon never writes a pid-only sidecar; whatever
+                // produced this, it identifies nothing.
+                Ok((pid, None)) => Sidecar::Unusable(format!(
+                    "{} holds only a pid ({pid}), not an identity",
+                    path.display()
+                )),
+                Err(e) => Sidecar::Unusable(format!("malformed {}: {e}", path.display())),
+            }
+        }
+    }
+}
+
 /// Establish presence from the record at `pid_path`. Thin I/O over
 /// [`decide`], which holds the policy.
 #[cfg(target_os = "linux")]
@@ -572,6 +661,26 @@ pub fn presence_of(
     exe_matches: impl Fn(i32) -> bool,
     scan: impl Fn() -> Scan,
 ) -> DaemonPresence {
+    // The directory gate applies to BOTH files: file ownership cannot
+    // say which directory a record was written FOR, and `rename` moves
+    // root-owned files between attacker-writable directories without
+    // touching a byte of them (review finding — the replay).
+    let dir_ok = pid_path.parent().is_some_and(dir_is_authentic);
+    // The sidecar consulted whenever the pid file cannot answer alone —
+    // missing, unreadable, or undecodable. It carries its own pid, it
+    // is authenticated, and it identifies the daemon WITHOUT reference
+    // to what its binary is called, which is the case the name-limited
+    // `/proc` scan cannot see (review finding). The identity it names
+    // still has to match the live process in `decide`, so a stale one
+    // ends in `Unknown`, not a confirmation.
+    let fall_back_to_sidecar = |on_no_sidecar: Record| match sidecar_record(identity_path, dir_ok) {
+        Sidecar::Identity(id) => Record::Found(id.pid, Some(id)),
+        Sidecar::Missing => on_no_sidecar,
+        // A sidecar that exists but cannot vouch is not a missing one:
+        // it is what a live daemon's record looks like mid-trouble, and
+        // reading it as absence licensed `detach` (review finding, P1).
+        Sidecar::Unusable(why) => Record::Unreadable(why),
+    };
     let record = match read_with_provenance(pid_path) {
         Ok((s, root_owned)) => match DaemonIdentity::decode(&s) {
             // The pid file yields a PID AND NOTHING ELSE. It is not
@@ -581,26 +690,28 @@ pub fn presence_of(
             // an inline identity was preferred here (review finding).
             // It also stays a bare pid on the write side, because CLIs
             // from other bundles parse it whole.
-            Ok((pid, _unauthenticated)) if root_owned => {
+            Ok((pid, _unauthenticated)) if root_owned && dir_ok => {
                 Record::Found(pid, read_authentic_identity(identity_path, Some(pid)))
             }
             Ok((pid, _)) => Record::Unauthenticated(pid),
-            Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
+            // A pid file that exists but does not parse says nothing —
+            // but the sidecar might: a torn pid write next to a whole,
+            // authentic identity is still an identifiable daemon, and
+            // refusing `reconfigure` for its whole lifetime over the
+            // torn file helped no one (review finding).
+            Err(e) => fall_back_to_sidecar(Record::Unreadable(format!(
+                "unreadable {}: {e}",
+                pid_path.display()
+            ))),
         },
         // NO pid file, which is not the same as no daemon: the write is
         // non-fatal and happens after attach, and the daemon carries on
-        // to write its sidecar. So the sidecar is the record here — it
-        // carries its own pid, it is authenticated, and it identifies
-        // the daemon WITHOUT reference to what its binary is called,
-        // which is the case the name-limited `/proc` scan cannot see
-        // (review finding).
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-            match read_authentic_identity(identity_path, None) {
-                Some(id) => Record::Found(id.pid, Some(id)),
-                None => Record::Absent,
-            }
-        }
-        Err(e) => Record::Unreadable(format!("cannot read {}: {e}", pid_path.display())),
+        // to write its sidecar. So the sidecar is the record here.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => fall_back_to_sidecar(Record::Absent),
+        Err(e) => fall_back_to_sidecar(Record::Unreadable(format!(
+            "cannot read {}: {e}",
+            pid_path.display()
+        ))),
     };
     let pid = match &record {
         Record::Found(pid, _) | Record::Unauthenticated(pid) => *pid,
@@ -947,20 +1058,114 @@ mod tests {
         if unsafe { libc::geteuid() } != 0 {
             return;
         }
+        use std::os::unix::fs::PermissionsExt;
         let dir = std::env::temp_dir().join(format!("pf-sidecar-only-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch");
+        // The reader trusts nothing in a directory others can write, so
+        // pin the mode rather than inherit the umask.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755)).expect("chmod");
         let pidfile = dir.join("packetframe.pid");
         let ident = dir.join("packetframe.identity");
         // No pid file at all — only the identity, naming this process.
         let real = DaemonIdentity::current().expect("own identity");
         std::fs::write(&ident, real.encode()).expect("write");
+        std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o644)).expect("chmod");
 
         let p = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
         assert!(
             matches!(p, DaemonPresence::Running { .. }),
             "the sidecar names a live process and is root-owned; nothing about the \
              executable's NAME may be needed to find it: {p:?}"
+        );
+
+        // And a TORN PID FILE beside that sidecar is the same daemon:
+        // the pid file exists but does not parse, and refusing
+        // `reconfigure` for the daemon's whole lifetime over the torn
+        // file helps no one when the sidecar identifies it (review
+        // finding).
+        std::fs::write(&pidfile, "12a4!\n").expect("write");
+        std::fs::set_permissions(&pidfile, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let p = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Running { .. }),
+            "a torn pid file next to a whole, authentic sidecar is still an identifiable \
+             daemon: {p:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A sidecar that exists but cannot vouch is not a missing one.
+    ///
+    /// With no pid file, the sidecar is the record of last resort, and
+    /// the first version collapsed "present but unreadable or
+    /// malformed" into "no sidecar" — `Record::Absent` — so a daemon
+    /// whose pid write failed and whose sidecar hit transient trouble
+    /// read as absent, survived a completed name-limited scan, and
+    /// licensed `detach` (review finding, P1). Malformed lands the same
+    /// whether or not the suite runs as root: as root the file is
+    /// authentic and fails decode; as non-root it fails provenance.
+    /// Either way it must surface as `Unknown`, never `Gone`.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_unusable_sidecar_is_not_a_missing_one() {
+        let dir = std::env::temp_dir().join(format!("pf-sidecar-torn-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let pidfile = dir.join("packetframe.pid");
+        let ident = dir.join("packetframe.identity");
+        std::fs::write(&ident, "not an identity at all\n").expect("write");
+
+        let p = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Unknown { .. }),
+            "a present-but-unusable sidecar, as the record of last resort, is `cannot \
+             tell` — reading it as absence is what licenses detach under a live daemon: \
+             {p:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A writable state directory vouches for nothing inside it.
+    ///
+    /// Per-file root ownership cannot say which directory a record was
+    /// written FOR: `rename` moves a root-owned file between
+    /// attacker-writable directories without reading or modifying it,
+    /// so records replayed whole from another instance's state dir
+    /// would pass every per-file check and aim root's SIGHUP at that
+    /// other instance (review finding). The directory gate makes the
+    /// replay unexpressible — a directory the attacker can write into
+    /// is a directory whose records confirm nothing.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_writable_state_directory_vouches_for_nothing() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!("pf-replay-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        // Records that would be fully authentic in a root-owned dir:
+        // this process's real identity, its real pid.
+        let real = DaemonIdentity::current().expect("own identity");
+        let pidfile = dir.join("packetframe.pid");
+        let ident = dir.join("packetframe.identity");
+        std::fs::write(&pidfile, format!("{}\n", real.pid)).expect("write");
+        std::fs::write(&ident, real.encode()).expect("write");
+        if unsafe { libc::geteuid() } == 0 {
+            std::fs::set_permissions(&pidfile, std::fs::Permissions::from_mode(0o644))
+                .expect("chmod");
+            std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o644))
+                .expect("chmod");
+        }
+        // The directory itself is world-writable — the replay surface.
+        std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o777)).expect("chmod");
+
+        let p = presence_of(&pidfile, &ident, |_| true, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Unknown { .. }),
+            "records in a directory others can write may have been renamed in whole from \
+             another instance's state dir; they must not become signal-capable: {p:?}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -374,7 +374,7 @@ pub fn self_boot_id() -> Option<String> {
 /// create in its place is theirs and fails, which drops the identity
 /// and falls back to the executable match — as if none were recorded.
 #[cfg(target_os = "linux")]
-fn read_authentic_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
+fn read_authentic_identity(path: &Path, pid: i32, pid_path: &Path) -> Option<DaemonIdentity> {
     use std::io::Read;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
@@ -385,6 +385,20 @@ fn read_authentic_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
         .ok()?;
     let meta = f.metadata().ok()?;
     if !meta.is_file() || meta.uid() != 0 || meta.mode() & 0o022 != 0 {
+        return None;
+    }
+    // OLDER than the pid record means it describes a previous daemon.
+    // The pid alone cannot tell them apart: roll back to a pre-sidecar
+    // build, which rewrites only the pid file and cannot know to remove
+    // this one, and after a reboot the pids can coincide — then the
+    // stale ticks reject the live daemon as reused and `reconfigure`
+    // stays unavailable for its whole life (review finding). The daemon
+    // writes the pid file first and this second, so a current pair is
+    // never inverted.
+    let record_time = std::fs::metadata(pid_path)
+        .and_then(|m| m.modified())
+        .ok()?;
+    if meta.modified().ok()? < record_time {
         return None;
     }
     let mut raw = String::new();
@@ -418,7 +432,7 @@ pub fn presence_of(
             // It also stays a bare pid on the write side, because CLIs
             // from other bundles parse it whole.
             Ok((pid, _unauthenticated)) => {
-                Record::Found(pid, read_authentic_identity(identity_path, pid))
+                Record::Found(pid, read_authentic_identity(identity_path, pid, pid_path))
             }
             Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
         },
@@ -668,7 +682,7 @@ mod tests {
         std::fs::write(&ident, real.encode()).expect("write");
         std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o666)).expect("chmod");
         assert!(
-            read_authentic_identity(&ident, me).is_none(),
+            read_authentic_identity(&ident, me, &pidfile).is_none(),
             "a record any user can write must not decide which pid is our daemon"
         );
 
@@ -680,6 +694,39 @@ mod tests {
         assert!(
             !matches!(planted, DaemonPresence::Running { .. }),
             "an identity in the unauthenticated pid file is not an identity: {planted:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A sidecar older than the pid record belongs to a past daemon.
+    ///
+    /// Roll back to a build that predates the sidecar: it rewrites only
+    /// the pid file and cannot know to remove this one, and after a
+    /// reboot the pids can coincide. Matched by pid alone, the stale
+    /// ticks then reject the live daemon as reused, and `reconfigure`
+    /// stays unavailable for its whole life (review finding).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_sidecar_older_than_the_pid_record_is_ignored() {
+        let dir = std::env::temp_dir().join(format!("pf-rollback-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let ident = dir.join("packetframe.identity");
+        let pidfile = dir.join("packetframe.pid");
+        let me = std::process::id() as i32;
+
+        // The newer daemon's sidecar, written first…
+        let real = DaemonIdentity::current().expect("own identity");
+        std::fs::write(&ident, real.encode()).expect("write");
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        // …then a rollback daemon writes only the pid file, later.
+        std::fs::write(&pidfile, format!("{me}\n")).expect("write");
+
+        assert!(
+            read_authentic_identity(&ident, me, &pidfile).is_none(),
+            "a sidecar predating the pid record describes a daemon that is gone, and \
+             matching it by pid rejects the live one as reused"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -171,11 +171,28 @@ pub fn decide(
     proc_alive: bool,
     live_identity: Option<(u64, String)>,
     exe_matches: bool,
+    scanned: Option<i32>,
 ) -> DaemonPresence {
     let (pid, recorded) = match record {
+        // No record is NOT evidence of no daemon. The file is written
+        // after every module attaches — deliberately, so systemd's
+        // `PIDFile=` never points at a half-attached daemon — and a
+        // failed write is non-fatal, so a live daemon can legitimately
+        // have none. `scanned` is the independent check: it can FIND a
+        // daemon (a process running this binary), and its silence
+        // proves nothing, which is the polarity the deleted /proc scan
+        // had backwards (review finding).
         Record::Absent => {
-            return DaemonPresence::Gone {
-                why: "no pid file; nothing recorded a daemon".into(),
+            return match scanned {
+                Some(pid) => DaemonPresence::Unknown {
+                    why: format!(
+                        "no pid file, but pid {pid} is running this binary — it may be a \
+                         daemon that could not write its record"
+                    ),
+                },
+                None => DaemonPresence::Gone {
+                    why: "no pid file, and no process is running this binary".into(),
+                },
             }
         }
         Record::Unreadable(why) => return DaemonPresence::Unknown { why },
@@ -224,7 +241,11 @@ pub fn decide(
 /// Establish presence from the record at `pid_path`. Thin I/O over
 /// [`decide`], which holds the policy.
 #[cfg(target_os = "linux")]
-pub fn presence_of(pid_path: &Path, exe_matches: impl Fn(i32) -> bool) -> DaemonPresence {
+pub fn presence_of(
+    pid_path: &Path,
+    exe_matches: impl Fn(i32) -> bool,
+    scan: impl Fn() -> Option<i32>,
+) -> DaemonPresence {
     let record = match std::fs::read_to_string(pid_path) {
         Ok(s) => match DaemonIdentity::decode(&s) {
             Ok((pid, id)) => Record::Found(pid, id),
@@ -235,14 +256,15 @@ pub fn presence_of(pid_path: &Path, exe_matches: impl Fn(i32) -> bool) -> Daemon
     };
     let pid = match &record {
         Record::Found(pid, _) => *pid,
-        _ => return decide(record, false, None, false),
+        // Only the no-record path consults the scan, and only to find.
+        _ => return decide(record, false, None, false, scan()),
     };
     let alive = Path::new(&format!("/proc/{pid}")).exists();
     let live_identity = match (start_ticks(pid), boot_id()) {
         (Ok(t), Ok(b)) => Some((t, b)),
         _ => None,
     };
-    decide(record, alive, live_identity, exe_matches(pid))
+    decide(record, alive, live_identity, exe_matches(pid), None)
 }
 
 #[cfg(test)]
@@ -274,7 +296,7 @@ mod tests {
     fn absence_is_never_concluded_from_a_failed_identity_check() {
         // The upgrade window, and the whole bug: a live daemon, a
         // legacy record, and a CLI at a different path. Was `Gone`.
-        let unknown = decide(Record::Found(42, None), true, None, false);
+        let unknown = decide(Record::Found(42, None), true, None, false, None);
         assert!(
             matches!(unknown, DaemonPresence::Unknown { .. }),
             "a live pid we cannot identify is not absence: {unknown:?}"
@@ -286,7 +308,7 @@ mod tests {
 
         // Same record, same binary: the exe match still confirms.
         assert_eq!(
-            decide(Record::Found(42, None), true, None, true),
+            decide(Record::Found(42, None), true, None, true, None),
             DaemonPresence::Running { pid: 42 }
         );
 
@@ -299,6 +321,7 @@ mod tests {
                 true,
                 Some((900, "boot-a".into())),
                 false,
+                None,
             ),
             DaemonPresence::Running { pid: 42 }
         );
@@ -310,6 +333,7 @@ mod tests {
             true,
             Some((901, "boot-a".into())),
             true,
+            None,
         );
         assert!(is_gone(&reused), "{reused:?}");
 
@@ -320,6 +344,7 @@ mod tests {
             true,
             Some((900, "boot-b".into())),
             true,
+            None,
         );
         assert!(is_gone(&rebooted), "{rebooted:?}");
 
@@ -328,7 +353,8 @@ mod tests {
             Record::Found(42, Some(id(42, 900))),
             true,
             None,
-            true
+            true,
+            None
         )));
 
         // No process: absent, regardless of what was recorded.
@@ -336,9 +362,20 @@ mod tests {
             Record::Found(42, Some(id(42, 900))),
             false,
             None,
-            true
+            true,
+            None
         )));
-        assert!(is_gone(&decide(Record::Absent, false, None, false)));
+        assert!(is_gone(&decide(Record::Absent, false, None, false, None)));
+
+        // No record, but a process IS running this binary: the daemon
+        // may simply have failed to write one — the file is written
+        // after attach and a failed write is non-fatal. Must not read
+        // as absence (review finding, P1).
+        let orphan = decide(Record::Absent, false, None, false, Some(77));
+        assert!(
+            matches!(orphan, DaemonPresence::Unknown { .. }),
+            "a running copy of this binary with no record is not absence: {orphan:?}"
+        );
 
         // Unreadable record: cannot tell. A corrupt file is exactly
         // when the destructive path must not fire.
@@ -346,7 +383,8 @@ mod tests {
             Record::Unreadable("torn".into()),
             false,
             None,
-            false
+            false,
+            None
         )));
     }
 

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -195,6 +195,16 @@ pub enum Record {
     Unreadable(String),
     /// A pid, and an identity if the daemon that wrote it recorded one.
     Found(i32, Option<DaemonIdentity>),
+    /// A pid from a record that is not root-owned, so its provenance is
+    /// whoever could write the state directory.
+    ///
+    /// Kept apart from `Found` rather than folded into it: an
+    /// unauthenticated record may still show that a pid is DEAD — that
+    /// is a fact about `/proc`, not about the file — and `detach` after
+    /// a crash depends on it. What it may not do is confirm a LIVE pid,
+    /// which is what let a planted record aim root's SIGHUP (review
+    /// finding).
+    Unauthenticated(i32),
 }
 
 /// What a search of the process table established.
@@ -293,19 +303,47 @@ fn decide_from_record(
         // after every module attaches — deliberately, so systemd's
         // `PIDFile=` never points at a half-attached daemon — and a
         // failed write is non-fatal, so a live daemon can legitimately
-        // have none. The scan is the independent check, and on this
-        // branch it is the ONLY evidence in play — so `decide` demotes
-        // this to `Unknown` unless the scan actually completed. A scan
-        // that could not look is not a scan that looked and saw
-        // nothing, which is the polarity the deleted /proc scan had
-        // backwards and that its replacement re-introduced one level
-        // down (review findings).
+        // have none. Reaching here means the sidecar did not cover it
+        // either (`presence_of` reads that first), so the scan is the
+        // only evidence in play — and `decide` demotes this to
+        // `Unknown` unless the scan actually completed. A scan that
+        // could not look is not a scan that looked and saw nothing,
+        // which is the polarity the deleted /proc scan had backwards
+        // and that its replacement re-introduced one level down
+        // (review findings).
+        //
+        // THE RESIDUAL, stated because it is a deliberate trade and not
+        // an oversight: a completed scan is still name-limited, so a
+        // daemon that wrote NEITHER file and runs under a binary name
+        // sharing no prefix with ours reads as absent. Refusing on
+        // every recordless `Absent` instead would disable `detach`
+        // after every clean stop — the daemon removes both files on the
+        // way out, and `detach` is the advertised recovery path — which
+        // trades a narrow hole for a certain one. Closing it properly
+        // needs evidence that does not go through pids at all: whether
+        // any process holds the pinned links. See the runbook.
         Record::Absent => {
             return DaemonPresence::Gone {
                 why: "no pid file".into(),
             }
         }
         Record::Unreadable(why) => return DaemonPresence::Unknown { why },
+        // A record anyone could have written names a pid; it does not
+        // vouch for it. Liveness still applies below — a dead pid is
+        // dead whoever claimed it, and `detach` after a crash needs
+        // that — but a LIVE one cannot be confirmed from here, which is
+        // what let a planted record pick the process root SIGHUPs
+        // (review finding).
+        Record::Unauthenticated(pid) if proc_alive => {
+            return DaemonPresence::Unknown {
+                why: format!(
+                    "pid {pid} is running, but the record naming it is not root-owned — \
+                     anything with write access to the state directory could have put it \
+                     there, so it cannot be acted on"
+                ),
+            }
+        }
+        Record::Unauthenticated(pid) => (pid, None),
         Record::Found(pid, id) => (pid, id),
     };
     if !proc_alive {
@@ -454,34 +492,57 @@ pub fn self_boot_id() -> Option<String> {
 /// THERE used to supply an identity that never passed this function at
 /// all.
 ///
-/// Root-owned, a regular file, and not group- or world-writable. An
-/// attacker with directory write can still unlink it; anything they
-/// create in its place is theirs and fails, which drops the identity
-/// and falls back to the executable match — as if none were recorded.
+/// Unlinking it is still available to an attacker with directory write;
+/// anything they create in its place is theirs and fails the check,
+/// which drops the identity — as if none had been recorded. What that
+/// falls back to is no longer an executable match alone: the pid file
+/// must itself be root-owned before the identity-less path will confirm
+/// anything (review finding).
 #[cfg(target_os = "linux")]
-fn read_authentic_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
+fn read_authentic_identity(path: &Path, pid: Option<i32>) -> Option<DaemonIdentity> {
+    let (raw, root_owned) = read_with_provenance(path).ok()?;
+    if !root_owned {
+        return None;
+    }
+    let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
+    // A sidecar naming a different pid is left from a previous daemon.
+    // Comparing a live process against a dead one's ticks would call
+    // the live one reused, so this reads as "no identity recorded".
+    //
+    // `None` is the case where there is no pid file to disagree with,
+    // so the sidecar's own pid is the record — see `presence_of`.
+    if pid.is_some_and(|pid| recorded_pid != pid) {
+        return None;
+    }
+    id
+}
+
+/// Read a state file and say whether it was root-owned, through ONE
+/// descriptor.
+///
+/// Provenance rather than a bare read because the two files are trusted
+/// differently and both are trusted for something: the sidecar only if
+/// authentic, the pid file's pid for liveness either way. Returning the
+/// bit alongside the bytes is what stops a caller reading the file and
+/// then forgetting to ask.
+///
+/// Root-owned, a regular file, and not group- or world-writable. An
+/// attacker with directory write can still unlink either file; anything
+/// they create in its place is theirs and fails this.
+#[cfg(target_os = "linux")]
+fn read_with_provenance(path: &Path) -> std::io::Result<(String, bool)> {
     use std::io::Read;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
     let mut f = std::fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_NOFOLLOW)
-        .open(path)
-        .ok()?;
-    let meta = f.metadata().ok()?;
-    if !meta.is_file() || meta.uid() != 0 || meta.mode() & 0o022 != 0 {
-        return None;
-    }
+        .open(path)?;
+    let meta = f.metadata()?;
+    let root_owned = meta.is_file() && meta.uid() == 0 && meta.mode() & 0o022 == 0;
     let mut raw = String::new();
-    f.read_to_string(&mut raw).ok()?;
-    let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
-    // A sidecar naming a different pid is left from a previous daemon.
-    // Comparing a live process against a dead one's ticks would call
-    // the live one reused, so this reads as "no identity recorded".
-    if recorded_pid != pid {
-        return None;
-    }
-    id
+    f.read_to_string(&mut raw)?;
+    Ok((raw, root_owned))
 }
 
 /// Establish presence from the record at `pid_path`. Thin I/O over
@@ -493,8 +554,8 @@ pub fn presence_of(
     exe_matches: impl Fn(i32) -> bool,
     scan: impl Fn() -> Scan,
 ) -> DaemonPresence {
-    let record = match std::fs::read_to_string(pid_path) {
-        Ok(s) => match DaemonIdentity::decode(&s) {
+    let record = match read_with_provenance(pid_path) {
+        Ok((s, root_owned)) => match DaemonIdentity::decode(&s) {
             // The pid file yields a PID AND NOTHING ELSE. It is not
             // authenticated, so an identity read from it would let an
             // attacker with directory write plant a combined record and
@@ -502,16 +563,29 @@ pub fn presence_of(
             // an inline identity was preferred here (review finding).
             // It also stays a bare pid on the write side, because CLIs
             // from other bundles parse it whole.
-            Ok((pid, _unauthenticated)) => {
-                Record::Found(pid, read_authentic_identity(identity_path, pid))
+            Ok((pid, _unauthenticated)) if root_owned => {
+                Record::Found(pid, read_authentic_identity(identity_path, Some(pid)))
             }
+            Ok((pid, _)) => Record::Unauthenticated(pid),
             Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
         },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Record::Absent,
+        // NO pid file, which is not the same as no daemon: the write is
+        // non-fatal and happens after attach, and the daemon carries on
+        // to write its sidecar. So the sidecar is the record here — it
+        // carries its own pid, it is authenticated, and it identifies
+        // the daemon WITHOUT reference to what its binary is called,
+        // which is the case the name-limited `/proc` scan cannot see
+        // (review finding).
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            match read_authentic_identity(identity_path, None) {
+                Some(id) => Record::Found(id.pid, Some(id)),
+                None => Record::Absent,
+            }
+        }
         Err(e) => Record::Unreadable(format!("cannot read {}: {e}", pid_path.display())),
     };
     let pid = match &record {
-        Record::Found(pid, _) => *pid,
+        Record::Found(pid, _) | Record::Unauthenticated(pid) => *pid,
         _ => return decide(record, false, None, false, scan),
     };
     // Not directory existence: a zombie keeps its entry and its start
@@ -776,7 +850,7 @@ mod tests {
         std::fs::write(&ident, real.encode()).expect("write");
         std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o666)).expect("chmod");
         assert!(
-            read_authentic_identity(&ident, me).is_none(),
+            read_authentic_identity(&ident, Some(me)).is_none(),
             "a record any user can write must not decide which pid is our daemon"
         );
 
@@ -788,6 +862,79 @@ mod tests {
         assert!(
             !matches!(planted, DaemonPresence::Running { .. }),
             "an identity in the unauthenticated pid file is not an identity: {planted:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A record anyone could have written names a pid; it vouches for
+    /// nothing.
+    ///
+    /// With directory write and no sidecar to authenticate, an
+    /// unprivileged user could plant a pid file naming any
+    /// `packetframe* run` process — one from another bundle, with its
+    /// own state directory — and the identity-less path read the
+    /// widened executable match as proof it was ours. A root
+    /// `reconfigure` then SIGHUPs a stranger into a config reload
+    /// (review finding).
+    ///
+    /// Liveness is the exception, and deliberately so: a dead pid is
+    /// dead whoever named it. That keeps `detach` working after a crash
+    /// on a state dir the daemon no longer owns.
+    #[test]
+    fn an_unauthenticated_record_cannot_confirm_a_live_pid() {
+        for exe in [true, false] {
+            let live = decide(Record::Unauthenticated(42), true, None, exe, || {
+                Scan::NoneFound
+            });
+            assert!(
+                matches!(live, DaemonPresence::Unknown { .. }),
+                "exe_matches={exe}: a planted record must not be able to name the process \
+                 root acts on: {live:?}"
+            );
+            let dead = decide(Record::Unauthenticated(42), false, None, exe, || {
+                Scan::NoneFound
+            });
+            assert!(
+                is_gone(&dead),
+                "exe_matches={exe}: but a dead pid is dead whoever named it, or `detach` \
+                 stops working after a crash: {dead:?}"
+            );
+        }
+    }
+
+    /// A daemon whose pid-file write failed is found by its sidecar.
+    ///
+    /// The write is non-fatal and the daemon carries on to record its
+    /// identity, so this is the ordinary shape of "no pid file, live
+    /// daemon" — and the `/proc` scan that used to be the only
+    /// backstop for it is name-limited by construction, so a daemon
+    /// deployed under an unrelated binary name was invisible and
+    /// `detach` unlinked pins beneath it (review finding). The sidecar
+    /// identifies it without reference to what it is called.
+    ///
+    /// Root-only, because the point is a root-owned record and this
+    /// cannot forge one. It runs in the qemu CI job, which is root.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_daemon_whose_pid_write_failed_is_found_by_its_sidecar() {
+        if unsafe { libc::geteuid() } != 0 {
+            return;
+        }
+        let dir = std::env::temp_dir().join(format!("pf-sidecar-only-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let pidfile = dir.join("packetframe.pid");
+        let ident = dir.join("packetframe.identity");
+        // No pid file at all — only the identity, naming this process.
+        let real = DaemonIdentity::current().expect("own identity");
+        std::fs::write(&ident, real.encode()).expect("write");
+
+        let p = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Running { .. }),
+            "the sidecar names a live process and is root-owned; nothing about the \
+             executable's NAME may be needed to find it: {p:?}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -298,6 +298,17 @@ fn decide_from_record(
         };
     };
     if ticks == recorded.start_ticks && boot == recorded.boot_id {
+        // Identity matched, and the record was shown to be root-owned
+        // before it was read — see `record_is_authentic`, which is what
+        // stops an unprivileged writer naming a victim pid here.
+        //
+        // Deliberately NOT also requiring an executable match. The
+        // ownership check already closes that attack (an unprivileged
+        // user cannot create a root-owned file), and demanding the exe
+        // as well would refuse a daemon deployed under a different
+        // binary NAME — a legitimate packaging choice — for no gain
+        // against an attacker who cannot get past the file check
+        // anyway.
         DaemonPresence::Running { pid }
     } else {
         // Alive, but not the process that wrote the record: the pid was
@@ -338,6 +349,31 @@ pub fn self_boot_id() -> Option<String> {
     }
 }
 
+/// Whether a record can be believed about WHICH process it names.
+///
+/// The identity path returns `Running` without consulting the
+/// executable, so the record decides who `reconfigure` signals as root.
+/// If `state-dir` is writable by an unprivileged user — a custom one
+/// under `/tmp`, say — that user can unlink both records and write
+/// their own naming a victim pid, with the victim's start ticks and
+/// boot id, both world-readable. The exe check this replaced would have
+/// refused; without this, root SIGHUPs whatever they chose (review
+/// finding, P1).
+///
+/// Root-owned and not writable by group or other. An attacker with
+/// directory write can still delete the file, but anything they create
+/// in its place is theirs and fails here — which drops the identity and
+/// falls back to the executable match, exactly as if none had been
+/// recorded.
+#[cfg(target_os = "linux")]
+fn record_is_authentic(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match std::fs::metadata(path) {
+        Ok(m) => m.uid() == 0 && m.mode() & 0o022 == 0,
+        Err(_) => false,
+    }
+}
+
 /// The sidecar identity, if it describes the pid the pid file names.
 ///
 /// A sidecar naming a DIFFERENT pid is left over from a previous
@@ -347,6 +383,11 @@ pub fn self_boot_id() -> Option<String> {
 /// than concluding.
 #[cfg(target_os = "linux")]
 fn read_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
+    // Unauthenticated records name a pid; they do not get to decide
+    // that a pid is ours.
+    if !record_is_authentic(path) {
+        return None;
+    }
     let raw = std::fs::read_to_string(path).ok()?;
     let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
     if recorded_pid != pid {
@@ -591,6 +632,49 @@ mod tests {
         for live in ['R', 'S', 'D', 'T', 't', 'I'] {
             assert!(state_is_alive(live), "state {live} is a process to respect");
         }
+    }
+
+    /// An identity record only counts if root wrote it.
+    ///
+    /// The identity path returns `Running` without consulting the
+    /// executable, so the record decides who `reconfigure` signals as
+    /// root. With a `state-dir` an unprivileged user can write, that
+    /// user could name a victim pid and supply its start ticks and boot
+    /// id — both world-readable — and the exe check this replaced would
+    /// no longer be there to refuse (review finding, P1).
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn an_unprivileged_identity_record_is_not_believed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = std::env::temp_dir().join(format!("pf-authentic-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let path = dir.join("packetframe.identity");
+        std::fs::write(&path, "1 2 boot").expect("write");
+
+        // Written by this test, so not root-owned unless the suite runs
+        // as root — in which case the mode is what has to disqualify it.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).expect("chmod");
+        assert!(
+            !record_is_authentic(&path),
+            "a record any user can write must not decide which pid is our daemon"
+        );
+
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
+        let owned_by_root = std::fs::metadata(&path)
+            .map(|m| {
+                use std::os::unix::fs::MetadataExt;
+                m.uid() == 0
+            })
+            .unwrap_or(false);
+        assert_eq!(
+            record_is_authentic(&path),
+            owned_by_root,
+            "0600 is necessary but not sufficient — ownership is the other half"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A partial identity is not a legacy record.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -198,7 +198,7 @@ pub fn decide(
     proc_alive: bool,
     live_identity: Option<(u64, String)>,
     exe_matches: bool,
-    scanned: Option<i32>,
+    scan: impl FnOnce() -> Option<i32>,
 ) -> DaemonPresence {
     // ANY route to `Gone` has to survive the scan, not just the
     // missing-record one. A replacement daemon attaches BEFORE it
@@ -208,6 +208,19 @@ pub fn decide(
     // unlink pins under it. The first fix covered the case that was
     // named; this covers the rule (review finding, P1).
     let verdict = decide_from_record(record, proc_alive, live_identity, exe_matches);
+    // The scan is a CLOSURE, and it is run here rather than passed in
+    // as a value. As a value the caller had to remember to supply it on
+    // every path, and did not: `presence_of` hard-coded `None` for
+    // every `Record::Found`, so the rule this function had just been
+    // restructured to enforce never reached the case it was written
+    // for. The policy was right and the wiring silently was not, which
+    // the table test could not see because it called this directly
+    // (review finding). Now there is no `None` to hard-code, and it is
+    // only invoked where it can change the answer.
+    let scanned = match &verdict {
+        DaemonPresence::Gone { .. } => scan(),
+        _ => None,
+    };
     match (&verdict, scanned) {
         (DaemonPresence::Gone { why }, Some(found)) => DaemonPresence::Unknown {
             why: format!(
@@ -329,8 +342,7 @@ pub fn presence_of(
     };
     let pid = match &record {
         Record::Found(pid, _) => *pid,
-        // Only the no-record path consults the scan, and only to find.
-        _ => return decide(record, false, None, false, scan()),
+        _ => return decide(record, false, None, false, scan),
     };
     // Not directory existence: a zombie keeps its entry and its start
     // ticks, and is not a daemon anything can talk to.
@@ -346,7 +358,7 @@ pub fn presence_of(
         (Ok(t), Ok(b)) => Some((t, b)),
         _ => None,
     };
-    decide(record, alive, live_identity, exe_matches(pid), None)
+    decide(record, alive, live_identity, exe_matches(pid), scan)
 }
 
 #[cfg(test)]
@@ -378,7 +390,7 @@ mod tests {
     fn absence_is_never_concluded_from_a_failed_identity_check() {
         // The upgrade window, and the whole bug: a live daemon, a
         // legacy record, and a CLI at a different path. Was `Gone`.
-        let unknown = decide(Record::Found(42, None), true, None, false, None);
+        let unknown = decide(Record::Found(42, None), true, None, false, || None);
         assert!(
             matches!(unknown, DaemonPresence::Unknown { .. }),
             "a live pid we cannot identify is not absence: {unknown:?}"
@@ -390,7 +402,7 @@ mod tests {
 
         // Same record, same binary: the exe match still confirms.
         assert_eq!(
-            decide(Record::Found(42, None), true, None, true, None),
+            decide(Record::Found(42, None), true, None, true, || None),
             DaemonPresence::Running { pid: 42 }
         );
 
@@ -403,7 +415,7 @@ mod tests {
                 true,
                 Some((900, "boot-a".into())),
                 false,
-                None,
+                || None,
             ),
             DaemonPresence::Running { pid: 42 }
         );
@@ -415,7 +427,7 @@ mod tests {
             true,
             Some((901, "boot-a".into())),
             true,
-            None,
+            || None,
         );
         assert!(is_gone(&reused), "{reused:?}");
 
@@ -426,7 +438,7 @@ mod tests {
             true,
             Some((900, "boot-b".into())),
             true,
-            None,
+            || None,
         );
         assert!(is_gone(&rebooted), "{rebooted:?}");
 
@@ -436,7 +448,7 @@ mod tests {
             true,
             None,
             true,
-            None
+            || None
         )));
 
         // No process: absent, regardless of what was recorded.
@@ -445,9 +457,11 @@ mod tests {
             false,
             None,
             true,
-            None
+            || None
         )));
-        assert!(is_gone(&decide(Record::Absent, false, None, false, None)));
+        assert!(is_gone(&decide(Record::Absent, false, None, false, || {
+            None
+        })));
 
         // EVERY route to Gone must survive the scan, not just the
         // missing-record one — a replacement attaches before it
@@ -469,9 +483,9 @@ mod tests {
                 Some((901, "boot-a".to_string())),
             ),
         ] {
-            let alone = decide(record.clone(), alive, live.clone(), false, None);
+            let alone = decide(record.clone(), alive, live.clone(), false, || None);
             assert!(is_gone(&alone), "{label}: the record alone says gone");
-            let with_scan = decide(record, alive, live, false, Some(77));
+            let with_scan = decide(record, alive, live, false, || Some(77));
             assert!(
                 matches!(with_scan, DaemonPresence::Unknown { .. }),
                 "{label}: but a process running this binary makes it unprovable: \
@@ -486,8 +500,43 @@ mod tests {
             false,
             None,
             false,
-            None
+            || None
         )));
+    }
+
+    /// The WIRING, not the policy: `presence_of` must hand the scan to
+    /// every path, including a record that names a dead pid.
+    ///
+    /// The policy test above passes `decide` its arguments directly, so
+    /// it could not see that `presence_of` hard-coded `None` for every
+    /// `Record::Found` — the rule was enforced in the function and
+    /// never delivered to the case it was written for, which is a live
+    /// replacement whose predecessor's record is still on disk (review
+    /// finding). Testing a policy in isolation says nothing about
+    /// whether anything asks it the right question.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn the_scan_reaches_the_stale_record_path() {
+        let dir = std::env::temp_dir().join(format!("pf-wiring-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch");
+        let path = dir.join("packetframe.pid");
+        // A record naming a pid that cannot exist: dead, so the record
+        // alone says Gone.
+        std::fs::write(&path, "2147483646 1 boot-a").expect("write");
+
+        assert!(
+            is_gone(&presence_of(&path, |_| false, || None)),
+            "with nothing running, a dead record is absence"
+        );
+        let with_daemon = presence_of(&path, |_| false, || Some(77));
+        assert!(
+            matches!(with_daemon, DaemonPresence::Unknown { .. }),
+            "but a live daemon the scan can see must reach this path too — this is \
+             where `detach` would otherwise unlink pins beneath it: {with_daemon:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A zombie is not a daemon.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -349,47 +349,50 @@ pub fn self_boot_id() -> Option<String> {
     }
 }
 
-/// Whether a record can be believed about WHICH process it names.
+/// The sidecar identity, read and authenticated through ONE descriptor.
 ///
-/// The identity path returns `Running` without consulting the
-/// executable, so the record decides who `reconfigure` signals as root.
-/// If `state-dir` is writable by an unprivileged user — a custom one
-/// under `/tmp`, say — that user can unlink both records and write
-/// their own naming a victim pid, with the victim's start ticks and
-/// boot id, both world-readable. The exe check this replaced would have
-/// refused; without this, root SIGHUPs whatever they chose (review
-/// finding, P1).
+/// Two ways this was bypassable, both P1, both found after the first
+/// attempt at it:
 ///
-/// Root-owned and not writable by group or other. An attacker with
-/// directory write can still delete the file, but anything they create
-/// in its place is theirs and fails here — which drops the identity and
-/// falls back to the executable match, exactly as if none had been
-/// recorded.
+/// The check ran `metadata()` on a pathname and then `read_to_string()`
+/// on the same pathname. An attacker with directory write can point the
+/// name at a root-owned file for the first call and swap in their own
+/// before the second — a check-then-use race they can retry until it
+/// lands. So the file is opened once, `O_NOFOLLOW`, and both the
+/// ownership check and the read happen on that descriptor: whatever
+/// passes the check is what is read, and a symlink at the final
+/// component fails the open outright.
+///
+/// And identity is taken from HERE ONLY. `decode` accepts a combined
+/// `<pid> <ticks> <boot>` record because the sidecar uses that shape,
+/// but the pid file is not authenticated, so a combined record planted
+/// THERE used to supply an identity that never passed this function at
+/// all.
+///
+/// Root-owned, a regular file, and not group- or world-writable. An
+/// attacker with directory write can still unlink it; anything they
+/// create in its place is theirs and fails, which drops the identity
+/// and falls back to the executable match — as if none were recorded.
 #[cfg(target_os = "linux")]
-fn record_is_authentic(path: &Path) -> bool {
-    use std::os::unix::fs::MetadataExt;
-    match std::fs::metadata(path) {
-        Ok(m) => m.uid() == 0 && m.mode() & 0o022 == 0,
-        Err(_) => false,
-    }
-}
+fn read_authentic_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
+    use std::io::Read;
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 
-/// The sidecar identity, if it describes the pid the pid file names.
-///
-/// A sidecar naming a DIFFERENT pid is left over from a previous
-/// daemon. Treating it as this one's would compare a live process
-/// against a dead one's ticks and call the live process reused — so a
-/// mismatch reads as "no identity recorded", which falls back rather
-/// than concluding.
-#[cfg(target_os = "linux")]
-fn read_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
-    // Unauthenticated records name a pid; they do not get to decide
-    // that a pid is ours.
-    if !record_is_authentic(path) {
+    let mut f = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .ok()?;
+    let meta = f.metadata().ok()?;
+    if !meta.is_file() || meta.uid() != 0 || meta.mode() & 0o022 != 0 {
         return None;
     }
-    let raw = std::fs::read_to_string(path).ok()?;
+    let mut raw = String::new();
+    f.read_to_string(&mut raw).ok()?;
     let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
+    // A sidecar naming a different pid is left from a previous daemon.
+    // Comparing a live process against a dead one's ticks would call
+    // the live one reused, so this reads as "no identity recorded".
     if recorded_pid != pid {
         return None;
     }
@@ -407,13 +410,15 @@ pub fn presence_of(
 ) -> DaemonPresence {
     let record = match std::fs::read_to_string(pid_path) {
         Ok(s) => match DaemonIdentity::decode(&s) {
-            // The pid file stays a BARE PID — CLIs from other bundles
-            // parse it whole, and widening it broke their `reconfigure`
-            // (review finding) — so identity comes from the sidecar.
-            // `decode` still accepts a combined record, because a
-            // reader must not care which shape it meets.
-            Ok((pid, inline)) => {
-                Record::Found(pid, inline.or_else(|| read_identity(identity_path, pid)))
+            // The pid file yields a PID AND NOTHING ELSE. It is not
+            // authenticated, so an identity read from it would let an
+            // attacker with directory write plant a combined record and
+            // pick the pid root signals — which is what happened when
+            // an inline identity was preferred here (review finding).
+            // It also stays a bare pid on the write side, because CLIs
+            // from other bundles parse it whole.
+            Ok((pid, _unauthenticated)) => {
+                Record::Found(pid, read_authentic_identity(identity_path, pid))
             }
             Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
         },
@@ -634,44 +639,47 @@ mod tests {
         }
     }
 
-    /// An identity record only counts if root wrote it.
+    /// An identity record only counts if root wrote it, and only the
+    /// SIDECAR can carry one.
     ///
     /// The identity path returns `Running` without consulting the
-    /// executable, so the record decides who `reconfigure` signals as
-    /// root. With a `state-dir` an unprivileged user can write, that
-    /// user could name a victim pid and supply its start ticks and boot
-    /// id — both world-readable — and the exe check this replaced would
-    /// no longer be there to refuse (review finding, P1).
+    /// executable — that is what survives an upgrade — so the record
+    /// decides which pid `reconfigure` signals as root. Three ways that
+    /// was reachable by an unprivileged writer, each found after the
+    /// last was fixed: no ownership check at all; a check on the
+    /// pathname rather than the file that was read; and a combined
+    /// record planted in the unauthenticated pid file, which bypassed
+    /// the check entirely.
     #[cfg(target_os = "linux")]
     #[test]
-    fn an_unprivileged_identity_record_is_not_believed() {
+    fn only_a_root_owned_sidecar_can_name_our_daemon() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = std::env::temp_dir().join(format!("pf-authentic-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch");
-        let path = dir.join("packetframe.identity");
-        std::fs::write(&path, "1 2 boot").expect("write");
+        let me = std::process::id() as i32;
+        let ident = dir.join("packetframe.identity");
+        let pidfile = dir.join("packetframe.pid");
 
-        // Written by this test, so not root-owned unless the suite runs
-        // as root — in which case the mode is what has to disqualify it.
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o666)).expect("chmod");
+        // A sidecar this test wrote — so not root-owned unless the
+        // suite runs as root, in which case the mode disqualifies it.
+        let real = DaemonIdentity::current().expect("own identity");
+        std::fs::write(&ident, real.encode()).expect("write");
+        std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o666)).expect("chmod");
         assert!(
-            !record_is_authentic(&path),
+            read_authentic_identity(&ident, me).is_none(),
             "a record any user can write must not decide which pid is our daemon"
         );
 
-        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).expect("chmod");
-        let owned_by_root = std::fs::metadata(&path)
-            .map(|m| {
-                use std::os::unix::fs::MetadataExt;
-                m.uid() == 0
-            })
-            .unwrap_or(false);
-        assert_eq!(
-            record_is_authentic(&path),
-            owned_by_root,
-            "0600 is necessary but not sufficient — ownership is the other half"
+        // The combined record in the PID FILE must supply nothing, even
+        // though `decode` understands the shape.
+        std::fs::write(&pidfile, real.encode()).expect("write");
+        let _ = std::fs::remove_file(&ident);
+        let planted = presence_of(&pidfile, &ident, |_| false, || None);
+        assert!(
+            !matches!(planted, DaemonPresence::Running { .. }),
+            "an identity in the unauthenticated pid file is not an identity: {planted:?}"
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -320,12 +320,18 @@ fn decide_from_record(
         // stops an unprivileged writer naming a victim pid here.
         //
         // Deliberately NOT also requiring an executable match. The
-        // ownership check already closes that attack (an unprivileged
-        // user cannot create a root-owned file), and demanding the exe
+        // ownership check already closes that attack — an unprivileged
+        // user cannot create a root-owned file — and demanding the exe
         // as well would refuse a daemon deployed under a different
-        // binary NAME — a legitimate packaging choice — for no gain
-        // against an attacker who cannot get past the file check
-        // anyway.
+        // binary NAME for no gain against an attacker who cannot get
+        // past the file check anyway.
+        //
+        // That claim about renamed binaries was inconsistent with the
+        // scan, which required an exactly equal filename and so missed
+        // the daemon it exists to find (review finding). The scan now
+        // accepts a versioned sibling; a name sharing no prefix is
+        // found by this record and by nothing else, which is why the
+        // record path may not add an executable requirement on top.
         DaemonPresence::Running { pid }
     } else if exe_matches {
         // Not the recorded process, but a daemon nonetheless — which is

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -173,6 +173,32 @@ pub fn decide(
     exe_matches: bool,
     scanned: Option<i32>,
 ) -> DaemonPresence {
+    // ANY route to `Gone` has to survive the scan, not just the
+    // missing-record one. A replacement daemon attaches BEFORE it
+    // rewrites the record, and its write is non-fatal — so a stale
+    // record naming a dead or recycled pid is exactly the shape a live
+    // replacement leaves, and returning `Gone` there let `detach`
+    // unlink pins under it. The first fix covered the case that was
+    // named; this covers the rule (review finding, P1).
+    let verdict = decide_from_record(record, proc_alive, live_identity, exe_matches);
+    match (&verdict, scanned) {
+        (DaemonPresence::Gone { why }, Some(found)) => DaemonPresence::Unknown {
+            why: format!(
+                "{why}, but pid {found} is running this binary — it may be a daemon whose \
+                 record is stale or was never written"
+            ),
+        },
+        _ => verdict,
+    }
+}
+
+/// What the record alone establishes, before the scan gets a say.
+fn decide_from_record(
+    record: Record,
+    proc_alive: bool,
+    live_identity: Option<(u64, String)>,
+    exe_matches: bool,
+) -> DaemonPresence {
     let (pid, recorded) = match record {
         // No record is NOT evidence of no daemon. The file is written
         // after every module attaches — deliberately, so systemd's
@@ -183,16 +209,8 @@ pub fn decide(
         // proves nothing, which is the polarity the deleted /proc scan
         // had backwards (review finding).
         Record::Absent => {
-            return match scanned {
-                Some(pid) => DaemonPresence::Unknown {
-                    why: format!(
-                        "no pid file, but pid {pid} is running this binary — it may be a \
-                         daemon that could not write its record"
-                    ),
-                },
-                None => DaemonPresence::Gone {
-                    why: "no pid file, and no process is running this binary".into(),
-                },
+            return DaemonPresence::Gone {
+                why: "no pid file".into(),
             }
         }
         Record::Unreadable(why) => return DaemonPresence::Unknown { why },
@@ -235,6 +253,34 @@ pub fn decide(
                 "pid {pid} is running but was reused; the daemon that wrote the record is gone"
             ),
         }
+    }
+}
+
+/// This process's own start ticks, or `None` where they cannot be read.
+///
+/// `Option` rather than a fallible read the caller must handle: a
+/// snapshot that cannot record its identity is still worth publishing,
+/// and the reader treats the absence as "cannot confirm".
+pub fn self_start_ticks() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        start_ticks(std::process::id() as i32).ok()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
+    }
+}
+
+/// This boot's id, or `None` where it cannot be read.
+pub fn self_boot_id() -> Option<String> {
+    #[cfg(target_os = "linux")]
+    {
+        boot_id().ok()
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        None
     }
 }
 
@@ -367,15 +413,35 @@ mod tests {
         )));
         assert!(is_gone(&decide(Record::Absent, false, None, false, None)));
 
-        // No record, but a process IS running this binary: the daemon
-        // may simply have failed to write one — the file is written
-        // after attach and a failed write is non-fatal. Must not read
-        // as absence (review finding, P1).
-        let orphan = decide(Record::Absent, false, None, false, Some(77));
-        assert!(
-            matches!(orphan, DaemonPresence::Unknown { .. }),
-            "a running copy of this binary with no record is not absence: {orphan:?}"
-        );
+        // EVERY route to Gone must survive the scan, not just the
+        // missing-record one — a replacement attaches before it
+        // rewrites the record, and its write is non-fatal, so each of
+        // these is a shape a live daemon leaves behind. The first fix
+        // covered only the case that had been named (review finding).
+        for (label, record, alive, live) in [
+            ("no record", Record::Absent, false, None),
+            (
+                "recorded pid dead",
+                Record::Found(42, Some(id(42, 900))),
+                false,
+                None,
+            ),
+            (
+                "recorded pid reused",
+                Record::Found(42, Some(id(42, 900))),
+                true,
+                Some((901, "boot-a".to_string())),
+            ),
+        ] {
+            let alone = decide(record.clone(), alive, live.clone(), false, None);
+            assert!(is_gone(&alone), "{label}: the record alone says gone");
+            let with_scan = decide(record, alive, live, false, Some(77));
+            assert!(
+                matches!(with_scan, DaemonPresence::Unknown { .. }),
+                "{label}: but a process running this binary makes it unprovable: \
+                 {with_scan:?}"
+            );
+        }
 
         // Unreadable record: cannot tell. A corrupt file is exactly
         // when the destructive path must not fire.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -324,17 +324,42 @@ pub fn self_boot_id() -> Option<String> {
     }
 }
 
+/// The sidecar identity, if it describes the pid the pid file names.
+///
+/// A sidecar naming a DIFFERENT pid is left over from a previous
+/// daemon. Treating it as this one's would compare a live process
+/// against a dead one's ticks and call the live process reused — so a
+/// mismatch reads as "no identity recorded", which falls back rather
+/// than concluding.
+#[cfg(target_os = "linux")]
+fn read_identity(path: &Path, pid: i32) -> Option<DaemonIdentity> {
+    let raw = std::fs::read_to_string(path).ok()?;
+    let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
+    if recorded_pid != pid {
+        return None;
+    }
+    id
+}
+
 /// Establish presence from the record at `pid_path`. Thin I/O over
 /// [`decide`], which holds the policy.
 #[cfg(target_os = "linux")]
 pub fn presence_of(
     pid_path: &Path,
+    identity_path: &Path,
     exe_matches: impl Fn(i32) -> bool,
     scan: impl Fn() -> Option<i32>,
 ) -> DaemonPresence {
     let record = match std::fs::read_to_string(pid_path) {
         Ok(s) => match DaemonIdentity::decode(&s) {
-            Ok((pid, id)) => Record::Found(pid, id),
+            // The pid file stays a BARE PID — CLIs from other bundles
+            // parse it whole, and widening it broke their `reconfigure`
+            // (review finding) — so identity comes from the sidecar.
+            // `decode` still accepts a combined record, because a
+            // reader must not care which shape it meets.
+            Ok((pid, inline)) => {
+                Record::Found(pid, inline.or_else(|| read_identity(identity_path, pid)))
+            }
             Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
         },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Record::Absent,
@@ -523,13 +548,17 @@ mod tests {
         let path = dir.join("packetframe.pid");
         // A record naming a pid that cannot exist: dead, so the record
         // alone says Gone.
-        std::fs::write(&path, "2147483646 1 boot-a").expect("write");
+        // Bare pid in the pid file, identity in the sidecar — the
+        // shapes the daemon actually writes.
+        std::fs::write(&path, "2147483646\n").expect("write");
+        let ident = dir.join("packetframe.identity");
+        std::fs::write(&ident, "2147483646 1 boot-a").expect("write");
 
         assert!(
-            is_gone(&presence_of(&path, |_| false, || None)),
+            is_gone(&presence_of(&path, &ident, |_| false, || None)),
             "with nothing running, a dead record is absence"
         );
-        let with_daemon = presence_of(&path, |_| false, || Some(77));
+        let with_daemon = presence_of(&path, &ident, |_| false, || Some(77));
         assert!(
             matches!(with_daemon, DaemonPresence::Unknown { .. }),
             "but a live daemon the scan can see must reach this path too — this is \

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -208,6 +208,19 @@ pub enum Record {
     /// which is what let a planted record aim root's SIGHUP (review
     /// finding).
     Unauthenticated(i32),
+    /// Two authenticated records that disagree: a valid pid file names
+    /// one pid, and the sidecar names a DIFFERENT pid whose identity
+    /// matches a live process.
+    ///
+    /// Nothing in the data says which record is stale. A restart whose
+    /// pid-file rewrite failed (it is non-fatal) leaves the OLD pid
+    /// file beside the NEW daemon's sidecar — so discarding the
+    /// sidecar for disagreeing with the pid file turned "old pid dead"
+    /// plus a name-limited scan into `Gone`, and `detach` unlinked
+    /// pins beneath the live replacement (review finding, P1). A
+    /// disagreement between two authenticated records with a live
+    /// daemon in one of them can never resolve to absence.
+    ConflictingRecords { recorded: i32, sidecar: i32 },
 }
 
 /// What a search of the process table established.
@@ -348,6 +361,21 @@ fn decide_from_record(
             }
         }
         Record::Unauthenticated(pid) => (pid, None),
+        // A live daemon exists whichever record is stale, so no
+        // verdict below — least of all `Gone` — may be reached from
+        // the pid file alone. Signalling needs certainty about WHICH
+        // process, and two disagreeing authenticated records are the
+        // definition of not having it.
+        Record::ConflictingRecords { recorded, sidecar } => {
+            return DaemonPresence::Unknown {
+                why: format!(
+                    "two authenticated records disagree: the pid file names {recorded} but \
+                     the identity sidecar names {sidecar}, which matches a live process — \
+                     likely a failed pid-file rewrite during a restart. Restart the daemon \
+                     to re-record both, or remove the stale pid file"
+                ),
+            }
+        }
         Record::Found(pid, id) => (pid, id),
     };
     if !proc_alive {
@@ -494,49 +522,18 @@ pub fn self_boot_id() -> Option<String> {
     }
 }
 
-/// The sidecar identity, read and authenticated through ONE descriptor.
+/// Whether a recorded identity describes a process that is alive right
+/// now: the pid exists in a non-zombie state, its start ticks match,
+/// and the boot id is this boot's.
 ///
-/// Two ways this was bypassable, both P1, both found after the first
-/// attempt at it:
-///
-/// The check ran `metadata()` on a pathname and then `read_to_string()`
-/// on the same pathname. An attacker with directory write can point the
-/// name at a root-owned file for the first call and swap in their own
-/// before the second — a check-then-use race they can retry until it
-/// lands. So the file is opened once, `O_NOFOLLOW`, and both the
-/// ownership check and the read happen on that descriptor: whatever
-/// passes the check is what is read, and a symlink at the final
-/// component fails the open outright.
-///
-/// And identity is taken from HERE ONLY. `decode` accepts a combined
-/// `<pid> <ticks> <boot>` record because the sidecar uses that shape,
-/// but the pid file is not authenticated, so a combined record planted
-/// THERE used to supply an identity that never passed this function at
-/// all.
-///
-/// Unlinking it is still available to an attacker with directory write;
-/// anything they create in its place is theirs and fails the check,
-/// which drops the identity — as if none had been recorded. What that
-/// falls back to is no longer an executable match alone: the pid file
-/// must itself be root-owned before the identity-less path will confirm
-/// anything (review finding).
+/// This is the one question that can arbitrate between two
+/// authenticated records that disagree — `/proc` is the only party
+/// with an opinion about which of them still describes something.
 #[cfg(target_os = "linux")]
-fn read_authentic_identity(path: &Path, pid: Option<i32>) -> Option<DaemonIdentity> {
-    let (raw, root_owned) = read_with_provenance(path).ok()?;
-    if !root_owned {
-        return None;
-    }
-    let (recorded_pid, id) = DaemonIdentity::decode(&raw).ok()?;
-    // A sidecar naming a different pid is left from a previous daemon.
-    // Comparing a live process against a dead one's ticks would call
-    // the live one reused, so this reads as "no identity recorded".
-    //
-    // `None` is the case where there is no pid file to disagree with,
-    // so the sidecar's own pid is the record — see `presence_of`.
-    if pid.is_some_and(|pid| recorded_pid != pid) {
-        return None;
-    }
-    id
+fn identity_is_live(id: &DaemonIdentity) -> bool {
+    proc_state(id.pid).is_ok_and(state_is_alive)
+        && start_ticks(id.pid).ok() == Some(id.start_ticks)
+        && boot_id().ok().as_deref() == Some(id.boot_id.as_str())
 }
 
 /// Read a state file and say whether it was root-owned, through ONE
@@ -734,7 +731,28 @@ pub fn presence_of(
             // It also stays a bare pid on the write side, because CLIs
             // from other bundles parse it whole.
             Ok((pid, _unauthenticated)) if root_owned && dir_ok => {
-                Record::Found(pid, read_authentic_identity(identity_path, Some(pid)))
+                match sidecar_record(identity_path, dir_ok) {
+                    Sidecar::Identity(id) if id.pid == pid => Record::Found(pid, Some(id)),
+                    // A sidecar naming a DIFFERENT pid used to be
+                    // discarded as a previous daemon's leftover. It is
+                    // just as much the shape a restart leaves when its
+                    // pid-file rewrite fails: NEW sidecar, OLD pid
+                    // file — and discarding the newer record let "old
+                    // pid dead" resolve to `Gone` under the live
+                    // replacement (review finding, P1). Which record
+                    // is stale is decided by /proc, the only party
+                    // with an opinion: an identity matching a live
+                    // process is a daemon, whoever else is named.
+                    Sidecar::Identity(id) if identity_is_live(&id) => Record::ConflictingRecords {
+                        recorded: pid,
+                        sidecar: id.pid,
+                    },
+                    // The sidecar names nothing living, so IT is the
+                    // stale one; the pid file stands alone, as an
+                    // identity-less record.
+                    Sidecar::Identity(_) => Record::Found(pid, None),
+                    _ => Record::Found(pid, None),
+                }
             }
             Ok((pid, _)) => Record::Unauthenticated(pid),
             // A pid file that exists but does not parse says nothing —
@@ -1020,7 +1038,6 @@ mod tests {
         let dir = std::env::temp_dir().join(format!("pf-authentic-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch");
-        let me = std::process::id() as i32;
         let ident = dir.join("packetframe.identity");
         let pidfile = dir.join("packetframe.pid");
 
@@ -1030,7 +1047,7 @@ mod tests {
         std::fs::write(&ident, real.encode()).expect("write");
         std::fs::set_permissions(&ident, std::fs::Permissions::from_mode(0o666)).expect("chmod");
         assert!(
-            read_authentic_identity(&ident, Some(me)).is_none(),
+            matches!(sidecar_record(&ident, true), Sidecar::Unusable(_)),
             "a record any user can write must not decide which pid is our daemon"
         );
 
@@ -1136,7 +1153,47 @@ mod tests {
              daemon: {p:?}"
         );
 
+        // A VALID stale pid file — naming a dead pid — beside that live
+        // sidecar is the restart-with-failed-rewrite shape, and it used
+        // to discard the sidecar for disagreeing with the pid file:
+        // "old pid dead" plus a name-limited scan became `Gone`, and
+        // `detach` unlinked pins beneath the live replacement (review
+        // finding, P1). Two authenticated records that disagree, with a
+        // live daemon in one, resolve to nothing.
+        std::fs::write(&pidfile, "2147483646\n").expect("write");
+        std::fs::set_permissions(&pidfile, std::fs::Permissions::from_mode(0o644)).expect("chmod");
+        let p = presence_of(&pidfile, &ident, |_| false, || Scan::NoneFound);
+        assert!(
+            matches!(p, DaemonPresence::Unknown { .. }),
+            "a stale-but-valid pid file must not override a live sidecar into Gone: {p:?}"
+        );
+
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// Two authenticated records that disagree resolve to nothing —
+    /// never to absence, never to a signal-capable confirmation.
+    #[test]
+    fn conflicting_records_never_resolve_either_way() {
+        for alive in [false, true] {
+            for exe in [false, true] {
+                let p = decide(
+                    Record::ConflictingRecords {
+                        recorded: 42,
+                        sidecar: 43,
+                    },
+                    alive,
+                    None,
+                    exe,
+                    || Scan::NoneFound,
+                );
+                assert!(
+                    matches!(p, DaemonPresence::Unknown { .. }),
+                    "alive={alive} exe={exe}: a record conflict with a live daemon in it \
+                     must stay Unknown: {p:?}"
+                );
+            }
+        }
     }
 
     /// A sidecar that exists but cannot vouch is not a missing one.

--- a/crates/cli/src/daemon_presence.rs
+++ b/crates/cli/src/daemon_presence.rs
@@ -1,0 +1,392 @@
+//! Is the daemon that wrote the state still running?
+//!
+//! Three callers ask this — `status` to say whether its report is
+//! current, `reconfigure` before signalling a pid, and `detach` before
+//! unlinking pins the daemon holds FDs for — and they had one answer
+//! between them: does some process run *my exact executable path*.
+//!
+//! That is an identity test being used as a liveness test, and the two
+//! diverge in exactly the window an upgrade creates. Deploy a new
+//! bundle, run any of the three from it while the old daemon is still
+//! up, and the paths differ:
+//!
+//! - `status` printed `STALE — the daemon is gone` over a daemon that
+//!   was demonstrably alive (observed on the shadow, 2026-08-12);
+//! - `reconfigure` refused with "not a packetframe process (stale
+//!   pidfile?)", which is the canary lever failing mid-rollout;
+//! - `detach` found no daemon and **proceeded**, which is the one that
+//!   costs an outage. Its own comment records the precedent: the detach
+//!   ran, reported clean, and `ip link show` still had `xdpgeneric`
+//!   attached, because the daemon holds the `bpf_link` FDs.
+//!
+//! It was also wrong in the other direction. The comparison is on the
+//! path *string*, with a trailing ` (deleted)` stripped, so a daemon
+//! whose binary had been replaced under it read as "the same binary as
+//! me" while running entirely different code.
+//!
+//! So this answers three-valued, and the callers apply their own safe
+//! default — which is the point, because theirs are opposite. `status`
+//! may say "cannot tell" and be useful. `detach` must have positive
+//! evidence of ABSENCE before it touches anything.
+//!
+//! Identity is the pair the rest of this codebase already uses for
+//! adoption: `(pid, start_ticks)` against a `boot_id`, because a bare
+//! pid is reusable and `start_ticks` counts from boot. The daemon
+//! records its own at startup, in the root-owned state dir, so no
+//! user-settable name is trusted anywhere — the reason the exe check
+//! existed in the first place (`comm` is settable via `prctl`).
+
+#![cfg_attr(not(target_os = "linux"), allow(dead_code))]
+
+#[cfg(target_os = "linux")]
+use std::path::Path;
+
+/// What can be established about the daemon named by the pid file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DaemonPresence {
+    /// A live process, confirmed to be the one that wrote the record.
+    Running { pid: i32 },
+    /// Positively established absent: no record, no such process, or a
+    /// pid whose identity no longer matches what was recorded — which
+    /// means it was reused and our daemon is gone.
+    Gone { why: String },
+    /// Neither could be shown. **Not** a synonym for absent: a caller
+    /// that would act destructively must treat this as present.
+    Unknown { why: String },
+}
+
+/// The identity a daemon records for itself, and that a later CLI
+/// checks against.
+///
+/// Written as one line so the file stays `cat`-able and a legacy
+/// single-pid file still parses — an older daemon's record yields
+/// `None` here rather than a parse error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DaemonIdentity {
+    pub pid: i32,
+    pub start_ticks: u64,
+    pub boot_id: String,
+}
+
+impl DaemonIdentity {
+    /// This process's own identity, for the daemon to record.
+    #[cfg(target_os = "linux")]
+    pub fn current() -> std::io::Result<Self> {
+        let pid = std::process::id() as i32;
+        Ok(Self {
+            pid,
+            start_ticks: start_ticks(pid)?,
+            boot_id: boot_id()?,
+        })
+    }
+
+    /// One line: `<pid> <start_ticks> <boot_id>`.
+    pub fn encode(&self) -> String {
+        format!("{} {} {}", self.pid, self.start_ticks, self.boot_id)
+    }
+
+    /// Parse a record. `Ok(None)` for a legacy file holding only a pid,
+    /// which is a different thing from a malformed one.
+    pub fn decode(s: &str) -> std::io::Result<(i32, Option<Self>)> {
+        let mut parts = s.split_whitespace();
+        let pid: i32 = parts
+            .next()
+            .ok_or_else(|| bad_data("empty pid file"))?
+            .parse()
+            .map_err(|e| bad_data(&format!("pid parse: {e}")))?;
+        let (Some(ticks), Some(boot)) = (parts.next(), parts.next()) else {
+            return Ok((pid, None));
+        };
+        let start_ticks = ticks
+            .parse()
+            .map_err(|e| bad_data(&format!("start_ticks parse: {e}")))?;
+        Ok((
+            pid,
+            Some(Self {
+                pid,
+                start_ticks,
+                boot_id: boot.to_string(),
+            }),
+        ))
+    }
+}
+
+fn bad_data(msg: &str) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, msg.to_string())
+}
+
+/// Field 22 of `/proc/<pid>/stat`, the process start time in clock
+/// ticks since boot.
+///
+/// Parsed from the LAST `)` rather than by splitting from the start:
+/// field 2 is `comm` in parentheses and may itself contain spaces and
+/// brackets, which is the classic way this parse goes wrong.
+#[cfg(target_os = "linux")]
+pub fn start_ticks(pid: i32) -> std::io::Result<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{pid}/stat"))?;
+    let tail = stat
+        .rfind(')')
+        .map(|i| &stat[i + 1..])
+        .ok_or_else(|| bad_data("no comm terminator in /proc/<pid>/stat"))?;
+    // After `)` the fields are state (3) onward, so start_ticks (22) is
+    // the 20th token here.
+    tail.split_whitespace()
+        .nth(19)
+        .ok_or_else(|| bad_data("short /proc/<pid>/stat"))?
+        .parse()
+        .map_err(|e| bad_data(&format!("start_ticks parse: {e}")))
+}
+
+#[cfg(target_os = "linux")]
+pub fn boot_id() -> std::io::Result<String> {
+    Ok(std::fs::read_to_string("/proc/sys/kernel/random/boot_id")?
+        .trim()
+        .to_string())
+}
+
+/// What the reader could observe, so the policy below can be decided
+/// without touching a filesystem.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Record {
+    /// No pid file. Nothing was ever recorded, or a clean exit removed it.
+    Absent,
+    /// Present but unreadable or malformed.
+    Unreadable(String),
+    /// A pid, and an identity if the daemon that wrote it recorded one.
+    Found(i32, Option<DaemonIdentity>),
+}
+
+/// THE POLICY, as a pure function.
+///
+/// Deliberately separate from the `/proc` reads: this is a safety
+/// guard, `detach` acts destructively on its answer, and a table that
+/// can only be exercised on Linux would be unverified on every host a
+/// change is written on.
+///
+/// `live_identity` is `None` when the process exists but its identity
+/// could not be read — which is an answer of "cannot tell", never of
+/// "absent".
+pub fn decide(
+    record: Record,
+    proc_alive: bool,
+    live_identity: Option<(u64, String)>,
+    exe_matches: bool,
+) -> DaemonPresence {
+    let (pid, recorded) = match record {
+        Record::Absent => {
+            return DaemonPresence::Gone {
+                why: "no pid file; nothing recorded a daemon".into(),
+            }
+        }
+        Record::Unreadable(why) => return DaemonPresence::Unknown { why },
+        Record::Found(pid, id) => (pid, id),
+    };
+    if !proc_alive {
+        return DaemonPresence::Gone {
+            why: format!("pid {pid} is not running"),
+        };
+    }
+    let Some(recorded) = recorded else {
+        // Legacy record. The exe match still CONFIRMS — a process
+        // running this very binary, at the pid a root-owned file names,
+        // is ours. Its FAILURE proves nothing, and reading that as
+        // absence is the whole defect.
+        return if exe_matches {
+            DaemonPresence::Running { pid }
+        } else {
+            DaemonPresence::Unknown {
+                why: format!(
+                    "pid {pid} is running but the record predates identity tracking, and this \
+                     command is a different binary than that process — restart the daemon on \
+                     this build to make it checkable"
+                ),
+            }
+        };
+    };
+    let Some((ticks, boot)) = live_identity else {
+        return DaemonPresence::Unknown {
+            why: format!("pid {pid} is running but its identity could not be read"),
+        };
+    };
+    if ticks == recorded.start_ticks && boot == recorded.boot_id {
+        DaemonPresence::Running { pid }
+    } else {
+        // Alive, but not the process that wrote the record: the pid was
+        // reused. The one case where a live pid still proves absence.
+        DaemonPresence::Gone {
+            why: format!(
+                "pid {pid} is running but was reused; the daemon that wrote the record is gone"
+            ),
+        }
+    }
+}
+
+/// Establish presence from the record at `pid_path`. Thin I/O over
+/// [`decide`], which holds the policy.
+#[cfg(target_os = "linux")]
+pub fn presence_of(pid_path: &Path, exe_matches: impl Fn(i32) -> bool) -> DaemonPresence {
+    let record = match std::fs::read_to_string(pid_path) {
+        Ok(s) => match DaemonIdentity::decode(&s) {
+            Ok((pid, id)) => Record::Found(pid, id),
+            Err(e) => Record::Unreadable(format!("unreadable {}: {e}", pid_path.display())),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Record::Absent,
+        Err(e) => Record::Unreadable(format!("cannot read {}: {e}", pid_path.display())),
+    };
+    let pid = match &record {
+        Record::Found(pid, _) => *pid,
+        _ => return decide(record, false, None, false),
+    };
+    let alive = Path::new(&format!("/proc/{pid}")).exists();
+    let live_identity = match (start_ticks(pid), boot_id()) {
+        (Ok(t), Ok(b)) => Some((t, b)),
+        _ => None,
+    };
+    decide(record, alive, live_identity, exe_matches(pid))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Only `Gone` may license a destructive act. `Unknown` must not —
+    /// that is the whole polarity question `detach` turns on.
+    fn is_gone(p: &DaemonPresence) -> bool {
+        matches!(p, DaemonPresence::Gone { .. })
+    }
+
+    fn id(pid: i32, ticks: u64) -> DaemonIdentity {
+        DaemonIdentity {
+            pid,
+            start_ticks: ticks,
+            boot_id: "boot-a".into(),
+        }
+    }
+
+    /// The policy table, on every host.
+    ///
+    /// `detach` acts destructively on this answer and its half of the
+    /// original defect could never be observed without unlinking pins
+    /// under a live daemon — so it is pinned here rather than left
+    /// inferred. The rule that matters: only `Gone` may license a
+    /// destructive act, and it requires positive evidence.
+    #[test]
+    fn absence_is_never_concluded_from_a_failed_identity_check() {
+        // The upgrade window, and the whole bug: a live daemon, a
+        // legacy record, and a CLI at a different path. Was `Gone`.
+        let unknown = decide(Record::Found(42, None), true, None, false);
+        assert!(
+            matches!(unknown, DaemonPresence::Unknown { .. }),
+            "a live pid we cannot identify is not absence: {unknown:?}"
+        );
+        assert!(
+            !is_gone(&unknown),
+            "so nothing destructive may proceed on it"
+        );
+
+        // Same record, same binary: the exe match still confirms.
+        assert_eq!(
+            decide(Record::Found(42, None), true, None, true),
+            DaemonPresence::Running { pid: 42 }
+        );
+
+        // Identity recorded and matching: Running whatever the exe says.
+        // This is the upgrade window working — a different CLI binary
+        // reads its own daemon correctly.
+        assert_eq!(
+            decide(
+                Record::Found(42, Some(id(42, 900))),
+                true,
+                Some((900, "boot-a".into())),
+                false,
+            ),
+            DaemonPresence::Running { pid: 42 }
+        );
+
+        // Identity mismatch: the pid was reused, so our daemon IS gone.
+        // The only case where a live pid proves absence.
+        let reused = decide(
+            Record::Found(42, Some(id(42, 900))),
+            true,
+            Some((901, "boot-a".into())),
+            true,
+        );
+        assert!(is_gone(&reused), "{reused:?}");
+
+        // Same pid and ticks across a reboot is a real collision, and
+        // the boot id is what separates them.
+        let rebooted = decide(
+            Record::Found(42, Some(id(42, 900))),
+            true,
+            Some((900, "boot-b".into())),
+            true,
+        );
+        assert!(is_gone(&rebooted), "{rebooted:?}");
+
+        // Identity recorded but unreadable now: cannot tell.
+        assert!(!is_gone(&decide(
+            Record::Found(42, Some(id(42, 900))),
+            true,
+            None,
+            true
+        )));
+
+        // No process: absent, regardless of what was recorded.
+        assert!(is_gone(&decide(
+            Record::Found(42, Some(id(42, 900))),
+            false,
+            None,
+            true
+        )));
+        assert!(is_gone(&decide(Record::Absent, false, None, false)));
+
+        // Unreadable record: cannot tell. A corrupt file is exactly
+        // when the destructive path must not fire.
+        assert!(!is_gone(&decide(
+            Record::Unreadable("torn".into()),
+            false,
+            None,
+            false
+        )));
+    }
+
+    /// A legacy record parses as "pid, no identity" rather than as an
+    /// error — an older daemon's file must stay readable.
+    #[test]
+    fn a_legacy_record_is_not_a_parse_failure() {
+        let (pid, id) = DaemonIdentity::decode("12345\n").expect("legacy parses");
+        assert_eq!(pid, 12345);
+        assert!(id.is_none());
+
+        let (pid, id) = DaemonIdentity::decode("12345 998877 abc-def").expect("full parses");
+        assert_eq!(pid, 12345);
+        let id = id.expect("identity");
+        assert_eq!(id.start_ticks, 998877);
+        assert_eq!(id.boot_id, "abc-def");
+    }
+
+    /// Field 22 is read past a `comm` that would break a naive split:
+    /// it is parenthesised and may contain spaces and brackets.
+    #[test]
+    fn start_ticks_is_anchored_on_the_last_bracket() {
+        // After the last `)` the first token is field 3 (state), so
+        // field 22 is the 20th here: state plus 18 fillers, then it.
+        let stat = "4242 (evil ) proc 1 2) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 \
+                    987654 23 24";
+        let tail = stat.rfind(')').map(|i| &stat[i + 1..]).expect("terminator");
+        let field22: u64 = tail
+            .split_whitespace()
+            .nth(19)
+            .expect("field")
+            .parse()
+            .expect("number");
+        assert_eq!(field22, 987654, "the last `)` is the only safe anchor");
+    }
+
+    /// And the real reader agrees with that arithmetic on this process.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn start_ticks_reads_this_process() {
+        assert!(start_ticks(std::process::id() as i32).expect("own start_ticks") > 0);
+    }
+}

--- a/crates/cli/src/health.rs
+++ b/crates/cli/src/health.rs
@@ -173,7 +173,15 @@ pub fn publish(state_dir: &Path, modules: Vec<ModuleEntry>) -> Result<(), String
 #[cfg_attr(not(target_os = "linux"), allow(dead_code))]
 pub fn remove(state_dir: &Path) {
     let path = Snapshot::path_in(state_dir);
-    match std::fs::remove_file(&path) {
+    // Through the walked directory descriptor on Linux — a pathname
+    // `remove_file` follows intermediate symlinks, and this runs as
+    // root (review finding on the identity cleanup; same rule for
+    // every removal in a configured directory).
+    #[cfg(target_os = "linux")]
+    let removed = crate::loader::remove_state_record(&path);
+    #[cfg(not(target_os = "linux"))]
+    let removed = std::fs::remove_file(&path);
+    match removed {
         Ok(()) => {}
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
         Err(e) => {

--- a/crates/cli/src/health.rs
+++ b/crates/cli/src/health.rs
@@ -56,6 +56,19 @@ pub struct Snapshot {
     /// The publishing daemon's pid. See the module docs: this is the
     /// liveness question, not a diagnostic.
     pub pid: i32,
+    /// The publisher's start time in clock ticks, and the boot id it
+    /// counts from.
+    ///
+    /// The pid alone cannot say the report is current. A crash whose
+    /// replacement is handed the SAME pid — routine after a reboot,
+    /// possible any time — made the pre-crash report read as live until
+    /// the replacement published its own (review finding). `None` for a
+    /// snapshot written before this was recorded, which reads as
+    /// "cannot confirm" rather than as either answer.
+    #[serde(default)]
+    pub start_ticks: Option<u64>,
+    #[serde(default)]
+    pub boot_id: Option<String>,
     /// Unix seconds at write time, for the age.
     pub written_at: u64,
     pub modules: Vec<ModuleEntry>,
@@ -144,6 +157,8 @@ pub fn poll(state_dir: &Path, modules: &[(String, Box<dyn Module>)], gauges: &Mu
 pub fn publish(state_dir: &Path, modules: Vec<ModuleEntry>) -> Result<(), String> {
     let snapshot = Snapshot {
         pid: std::process::id() as i32,
+        start_ticks: crate::daemon_presence::self_start_ticks(),
+        boot_id: crate::daemon_presence::self_boot_id(),
         written_at: unix_now(),
         modules,
     };
@@ -299,6 +314,8 @@ mod tests {
     fn a_snapshot_from_the_future_reports_no_age() {
         let s = Snapshot {
             pid: 1,
+            start_ticks: None,
+            boot_id: None,
             written_at: unix_now() + 3600,
             modules: Vec::new(),
         };

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -478,7 +478,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 "could not record process identity; removing any stale one so readers fall \
                  back rather than compare against a predecessor"
             );
-            if let Err(e) = std::fs::remove_file(&identity_path) {
+            if let Err(e) = remove_state_record(&identity_path) {
                 if e.kind() != std::io::ErrorKind::NotFound {
                     tracing::error!(
                         path = %identity_path.display(),
@@ -545,12 +545,16 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 
     // Best-effort PID file cleanup. Non-fatal, the file is harmless
     // if left behind (PID will be unrecognized on re-validate).
-    if let Err(e) = std::fs::remove_file(&identity_path) {
+    // Through the walked descriptor, like every other touch of the
+    // state dir by this root process — `remove_file` follows
+    // intermediate symlinks (review finding on the failed-write
+    // cleanup; same rule here).
+    if let Err(e) = remove_state_record(&identity_path) {
         if e.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(path = %identity_path.display(), error = %e, "could not remove identity file");
         }
     }
-    if let Err(e) = std::fs::remove_file(&pid_file_path) {
+    if let Err(e) = remove_state_record(&pid_file_path) {
         if e.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(
                 path = %pid_file_path.display(),
@@ -562,34 +566,12 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     Ok(())
 }
 
-/// Open `path` for writing with `O_NOFOLLOW | O_EXCL | O_CREAT | 0600`
-/// the symlink-safe atomic-write primitive both pidfile / marker
-/// writes (here) and the metrics-textfile writer ([`crate::metrics`])
-/// use for their `.tmp` staging files.
-///
-/// `O_NOFOLLOW` makes the open fail (`ELOOP`) when `path` is a
-/// symlink, so an attacker who can pre-create `<...>.tmp` as a
-/// symlink pointing at e.g. `/etc/passwd` cannot redirect the
-/// privileged daemon's write target. `O_EXCL` makes the open fail
-/// (`EEXIST`) when the path already exists, so a stale `.tmp`
-/// leftover from a crashed run is also surfaced rather than silently
-/// truncated and overwritten, callers handle that one-shot with
-/// `unlink-and-retry`.
-///
-/// The May 2026 audit Slice 4 finding flagged the previous use of
-/// `File::create` (which both follows symlinks and `O_TRUNC`s) on
-/// these temp paths as a privileged-write redirection primitive any
-/// time the parent directory is writable to a non-root user.
-#[cfg(target_os = "linux")]
-pub(crate) fn create_excl_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
-    use std::os::unix::fs::OpenOptionsExt;
-    std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .custom_flags(libc::O_NOFOLLOW)
-        .mode(0o600)
-        .open(path)
-}
+// `create_excl_no_follow` — the pathname O_NOFOLLOW|O_EXCL primitive
+// from the May 2026 audit — is gone. Every privileged write, rename,
+// and unlink in a configured directory now goes through
+// `walk_dir_no_follow` + the `openat`/`renameat`/`unlinkat` helpers
+// below, because O_NOFOLLOW on the final component never guarded the
+// intermediate ones (review finding, P1).
 
 /// Open an ABSOLUTE directory path one component at a time, each step
 /// `openat(O_DIRECTORY | O_NOFOLLOW)` relative to the descriptor of the
@@ -611,7 +593,20 @@ pub(crate) fn create_excl_no_follow(path: &Path) -> std::io::Result<std::fs::Fil
 /// specified through parent traversal, and accepting it would make the
 /// walk's guarantees path-dependent.
 #[cfg(target_os = "linux")]
-fn create_and_open_dir_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+pub(crate) fn create_and_open_dir_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    walk_dir_no_follow(path, true)
+}
+
+/// The non-creating walk, for operations that have no business making
+/// directories — removal in particular: if the walk cannot reach the
+/// directory, there is nothing there this process is entitled to touch.
+#[cfg(target_os = "linux")]
+pub(crate) fn open_dir_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    walk_dir_no_follow(path, false)
+}
+
+#[cfg(target_os = "linux")]
+fn walk_dir_no_follow(path: &Path, create: bool) -> std::io::Result<std::fs::File> {
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
     if !path.is_absolute() {
@@ -637,7 +632,10 @@ fn create_and_open_dir_no_follow(path: &Path) -> std::io::Result<std::fs::File> 
         })?;
         let flags = libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC;
         let mut fd = unsafe { libc::openat(dir.as_raw_fd(), c.as_ptr(), flags) };
-        if fd < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::NotFound {
+        if create
+            && fd < 0
+            && std::io::Error::last_os_error().kind() == std::io::ErrorKind::NotFound
+        {
             // Create it and re-open. A concurrent creator making this
             // mkdirat lose with EEXIST is fine — the reopen decides.
             unsafe { libc::mkdirat(dir.as_raw_fd(), c.as_ptr(), 0o755) };
@@ -682,7 +680,10 @@ fn openat_excl_no_follow(dir: &std::fs::File, name: &str) -> std::io::Result<std
 /// an attacker's symlink is not misclassified as a file. A second
 /// `EEXIST` is a real race between competing writers and errors out.
 #[cfg(target_os = "linux")]
-fn openat_excl_with_retry(dir: &std::fs::File, name: &str) -> std::io::Result<std::fs::File> {
+pub(crate) fn openat_excl_with_retry(
+    dir: &std::fs::File,
+    name: &str,
+) -> std::io::Result<std::fs::File> {
     use std::os::fd::AsRawFd;
     match openat_excl_no_follow(dir, name) {
         Ok(f) => Ok(f),
@@ -714,9 +715,39 @@ fn openat_excl_with_retry(dir: &std::fs::File, name: &str) -> std::io::Result<st
     }
 }
 
+/// Remove a state record through the same component-wise no-follow
+/// walk the writers use — never by resolving the pathname whole.
+///
+/// `std::fs::remove_file` does not follow a symlink at the FINAL
+/// component, but it follows every intermediate one, so the identity
+/// cleanup on a failed write could be pointed at another instance's
+/// state directory and have this root daemon delete THAT instance's
+/// sidecar — disabling its identity-based status and reconfigure
+/// (review finding, P1; the writes had just been converted to
+/// descriptor-relative operations while this cleanup stayed
+/// pathname-based). If the walk cannot reach the directory, nothing is
+/// removed: a path this process refuses to write through is a path it
+/// must refuse to delete through.
+#[cfg(target_os = "linux")]
+pub(crate) fn remove_state_record(path: &Path) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?;
+    let dir = open_dir_no_follow(parent)?;
+    let c = std::ffi::CString::new(name)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in file name"))?;
+    if unsafe { libc::unlinkat(dir.as_raw_fd(), c.as_ptr(), 0) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
 /// `renameat` within one already-walked directory descriptor.
 #[cfg(target_os = "linux")]
-fn renameat_within(dir: &std::fs::File, from: &str, to: &str) -> std::io::Result<()> {
+pub(crate) fn renameat_within(dir: &std::fs::File, from: &str, to: &str) -> std::io::Result<()> {
     use std::os::fd::AsRawFd;
     let (f, t) = (std::ffi::CString::new(from), std::ffi::CString::new(to));
     let (f, t) = (

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -449,15 +449,32 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
         .and_then(|id| write_state_record(&identity_path, &id.encode()))
     {
         Ok(()) => {}
-        // Non-fatal, like the pid file: readers treat a missing
-        // identity as "cannot verify" and fall back, which is safe in
-        // every direction — `detach` refuses rather than proceeds.
-        Err(e) => tracing::warn!(
-            path = %identity_path.display(),
-            error = %e,
-            "could not record process identity; `detach` will refuse rather than risk \
-             unlinking pins under this daemon"
-        ),
+        // Non-fatal, but the OLD sidecar must not survive. A restart
+        // handed its predecessor's pid — routine after a crash — leaves
+        // a record that `read_identity` accepts by pid and whose ticks
+        // then reject the live process, so `reconfigure` and current
+        // health stay unavailable for that daemon's whole lifetime. The
+        // comment here used to claim a failed write "falls back
+        // safely"; it did not (review finding).
+        Err(e) => {
+            tracing::warn!(
+                path = %identity_path.display(),
+                error = %e,
+                "could not record process identity; removing any stale one so readers fall \
+                 back rather than compare against a predecessor"
+            );
+            if let Err(e) = std::fs::remove_file(&identity_path) {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    tracing::error!(
+                        path = %identity_path.display(),
+                        error = %e,
+                        "could not remove the stale identity either; `packetframe \
+                         reconfigure` and current health will be unavailable for this \
+                         daemon — remove the file by hand"
+                    );
+                }
+            }
+        }
     }
     let pid_file_path = config.global.state_dir.join(PIDFILE_NAME);
     if let Err(e) = write_pid_file(&pid_file_path) {
@@ -935,7 +952,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     let pid = match crate::daemon_presence::presence_of(
         &pid_path,
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_matches_current(p as libc::pid_t),
+        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
         scan_for_running_daemon,
     ) {
         crate::daemon_presence::DaemonPresence::Running { pid } => pid as libc::pid_t,
@@ -1221,7 +1238,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_matches_current(p as libc::pid_t),
+        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
         scan_for_running_daemon,
     );
     #[cfg(not(target_os = "linux"))]
@@ -1667,7 +1684,7 @@ fn print_module_health(state_dir: &Path) {
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_matches_current(p as libc::pid_t),
+        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
         scan_for_running_daemon,
     );
     // No /proc to cross-check against, so liveness is unknown rather

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -77,6 +77,15 @@ pub enum ReconfigureError {
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 const PIDFILE_NAME: &str = "packetframe.pid";
 
+/// Sidecar holding the running daemon's `(pid, start_ticks, boot_id)`.
+///
+/// Separate from the pid file rather than folded into it: that file's
+/// format is load-bearing for CLIs we do not ship with, and older ones
+/// parse it whole. A reader that does not know about this file falls
+/// back to what it always did.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+const IDENTITY_NAME: &str = "packetframe.identity";
+
 /// Sub-path under `state-dir` for the reconfigure ack marker. The
 /// daemon writes one line `OK <unix_ns>` after a successful SIGHUP
 /// reconcile or `ERR <unix_ns> <message>` on parse / per-module
@@ -435,6 +444,21 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     // Clean-exit paths below remove it; an uncontrolled crash leaves
     // it stale, which `packetframe reconfigure` detects via the
     // /proc/<pid>/comm cross-check.
+    let identity_path = config.global.state_dir.join(IDENTITY_NAME);
+    match crate::daemon_presence::DaemonIdentity::current()
+        .and_then(|id| std::fs::write(&identity_path, id.encode()))
+    {
+        Ok(()) => {}
+        // Non-fatal, like the pid file: readers treat a missing
+        // identity as "cannot verify" and fall back, which is safe in
+        // every direction — `detach` refuses rather than proceeds.
+        Err(e) => tracing::warn!(
+            path = %identity_path.display(),
+            error = %e,
+            "could not record process identity; `detach` will refuse rather than risk \
+             unlinking pins under this daemon"
+        ),
+    }
     let pid_file_path = config.global.state_dir.join(PIDFILE_NAME);
     if let Err(e) = write_pid_file(&pid_file_path) {
         tracing::warn!(
@@ -498,6 +522,11 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
 
     // Best-effort PID file cleanup. Non-fatal, the file is harmless
     // if left behind (PID will be unrecognized on re-validate).
+    if let Err(e) = std::fs::remove_file(&identity_path) {
+        if e.kind() != std::io::ErrorKind::NotFound {
+            tracing::warn!(path = %identity_path.display(), error = %e, "could not remove identity file");
+        }
+    }
     if let Err(e) = std::fs::remove_file(&pid_file_path) {
         if e.kind() != std::io::ErrorKind::NotFound {
             tracing::warn!(
@@ -576,20 +605,14 @@ fn write_pid_file(path: &Path) -> std::io::Result<()> {
     let tmp = path.with_extension("pid.tmp");
     {
         let mut f = create_excl_no_follow_with_retry(&tmp)?;
-        // Identity, not just a pid. A bare pid is reusable, so every
-        // later reader had to fall back to "does some process run my
-        // exact binary path" — which is false whenever a CLI runs from
-        // a newly deployed bundle while the old daemon is still up,
-        // i.e. during every upgrade. See `daemon_presence`.
-        match crate::daemon_presence::DaemonIdentity::current() {
-            Ok(id) => writeln!(f, "{}", id.encode())?,
-            // The pid alone still works: readers treat a record with no
-            // identity as legacy and fall back rather than guessing.
-            Err(e) => {
-                tracing::warn!(error = %e, "could not read own process identity; recording pid alone");
-                writeln!(f, "{}", std::process::id())?;
-            }
-        }
+        // A BARE PID, exactly as before. The identity goes in a sidecar
+        // instead, because this file has readers we do not ship with:
+        // a CLI from the previous bundle parses the whole trimmed file
+        // as one integer, so widening the format here broke
+        // `reconfigure` for anyone rolling back or running mixed
+        // versions — the same upgrade window this change exists to fix,
+        // in the other direction (review finding).
+        writeln!(f, "{}", std::process::id())?;
         f.sync_all()?;
     }
     std::fs::rename(&tmp, path)
@@ -899,6 +922,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     // recycled process, as root (review finding).
     let pid = match crate::daemon_presence::presence_of(
         &pid_path,
+        &state_dir.join(IDENTITY_NAME),
         |p| proc_exe_matches_current(p as libc::pid_t),
         scan_for_running_daemon,
     ) {
@@ -1177,6 +1201,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     #[cfg(target_os = "linux")]
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
+        &state_dir.join(IDENTITY_NAME),
         |p| proc_exe_matches_current(p as libc::pid_t),
         scan_for_running_daemon,
     );
@@ -1622,6 +1647,7 @@ fn print_module_health(state_dir: &Path) {
     #[cfg(target_os = "linux")]
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
+        &state_dir.join(IDENTITY_NAME),
         |p| proc_exe_matches_current(p as libc::pid_t),
         scan_for_running_daemon,
     );
@@ -1924,7 +1950,12 @@ mod vpp_detach_tests {
         // The exe check fails, as it does whenever the CLI runs from a
         // different path than the daemon.
         // No scan: this is about what the RECORD can establish.
-        let p = presence_of(&dir.join(PIDFILE_NAME), |_| false, || None);
+        let p = presence_of(
+            &dir.join(PIDFILE_NAME),
+            &dir.join(IDENTITY_NAME),
+            |_| false,
+            || None,
+        );
         assert!(
             matches!(p, DaemonPresence::Unknown { .. }),
             "a live pid with no verifiable identity must be Unknown, not Gone — Gone is \
@@ -1934,7 +1965,12 @@ mod vpp_detach_tests {
         // And the same record with the exe check passing still resolves
         // to Running, so the guard has not simply been loosened.
         assert!(matches!(
-            presence_of(&dir.join(PIDFILE_NAME), |_| true, || None),
+            presence_of(
+                &dir.join(PIDFILE_NAME),
+                &dir.join(IDENTITY_NAME),
+                |_| true,
+                || None
+            ),
             DaemonPresence::Running { .. }
         ));
 

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -444,6 +444,21 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     // Clean-exit paths below remove it; an uncontrolled crash leaves
     // it stale, which `packetframe reconfigure` detects via the
     // /proc/<pid>/comm cross-check.
+    let pid_file_path = config.global.state_dir.join(PIDFILE_NAME);
+    if let Err(e) = write_pid_file(&pid_file_path) {
+        tracing::warn!(
+            path = %pid_file_path.display(),
+            error = %e,
+            "could not write PID file; `packetframe reconfigure` and `systemctl reload` will not work"
+        );
+    }
+
+    // AFTER the pid file, and that order is load-bearing: a reader
+    // accepts the sidecar only if it is at least as new as the pid
+    // record. A rollback to a pre-sidecar daemon rewrites only the pid
+    // file and cannot know to remove this one, so without the ordering
+    // its stale identity would be matched to the new daemon by pid and
+    // then reject it as reused (review finding).
     let identity_path = config.global.state_dir.join(IDENTITY_NAME);
     match crate::daemon_presence::DaemonIdentity::current()
         .and_then(|id| write_state_record(&identity_path, &id.encode()))
@@ -476,15 +491,6 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
             }
         }
     }
-    let pid_file_path = config.global.state_dir.join(PIDFILE_NAME);
-    if let Err(e) = write_pid_file(&pid_file_path) {
-        tracing::warn!(
-            path = %pid_file_path.display(),
-            error = %e,
-            "could not write PID file; `packetframe reconfigure` and `systemctl reload` will not work"
-        );
-    }
-
     tracing::info!("fast-path running, SIGHUP to reconfigure, SIGTERM/SIGINT to exit (§8.5)");
 
     let termination = drive_signal_loop(
@@ -1733,7 +1739,8 @@ fn print_module_health(state_dir: &Path) {
         // honest answer, and the one that does not mislead in either
         // direction.
         crate::daemon_presence::DaemonPresence::Running { pid }
-            if *pid == snapshot.pid && snapshot.start_ticks.is_none() =>
+            if *pid == snapshot.pid
+                && (snapshot.start_ticks.is_none() || snapshot.boot_id.is_none()) =>
         {
             println!(
                 "module health (pid {pid}, {age}) — CANNOT CONFIRM this is the report of \

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -882,14 +882,6 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     let pid_path = state_dir.join(PIDFILE_NAME);
     let marker_path = state_dir.join(RECONFIGURE_MARKER_NAME);
 
-    let pid = read_pid_file(&pid_path).map_err(|e| match e.kind() {
-        std::io::ErrorKind::NotFound => ReconfigureError::DaemonNotRunning(format!(
-            "PID file not found at {}, daemon doesn't appear to be running",
-            pid_path.display()
-        )),
-        _ => ReconfigureError::Io(format!("read PID file {}: {e}", pid_path.display())),
-    })?;
-
     // /proc/<pid>/exe cross-check defends against a stale PID file
     // pointing at a recycled PID. We previously consulted
     // /proc/<pid>/comm, but `comm` is user-settable via
@@ -1009,19 +1001,6 @@ fn scan_for_running_daemon() -> Option<i32> {
         }
     }
     None
-}
-
-/// The pid from the record, whichever format it is in.
-///
-/// This parsed the WHOLE trimmed file as a number, so the identity
-/// record (`<pid> <start_ticks> <boot_id>`) failed with `InvalidData`
-/// and `reconfigure` returned before it could signal anything — the
-/// canary lever, broken by the commit that was fixing it (review
-/// finding, P1).
-#[cfg(target_os = "linux")]
-fn read_pid_file(path: &Path) -> std::io::Result<libc::pid_t> {
-    let s = std::fs::read_to_string(path)?;
-    crate::daemon_presence::DaemonIdentity::decode(&s).map(|(pid, _)| pid as libc::pid_t)
 }
 
 /// Read /proc/<pid>/exe as a symlink and compare against the
@@ -1850,7 +1829,8 @@ mod vpp_detach_tests {
 
         // The exe check fails, as it does whenever the CLI runs from a
         // different path than the daemon.
-        let p = presence_of(&dir.join(PIDFILE_NAME), |_| false);
+        // No scan: this is about what the RECORD can establish.
+        let p = presence_of(&dir.join(PIDFILE_NAME), |_| false, || None);
         assert!(
             matches!(p, DaemonPresence::Unknown { .. }),
             "a live pid with no verifiable identity must be Unknown, not Gone — Gone is \
@@ -1860,7 +1840,7 @@ mod vpp_detach_tests {
         // And the same record with the exe check passing still resolves
         // to Running, so the guard has not simply been loosened.
         assert!(matches!(
-            presence_of(&dir.join(PIDFILE_NAME), |_| true),
+            presence_of(&dir.join(PIDFILE_NAME), |_| true, || None),
             DaemonPresence::Running { .. }
         ));
 

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1658,6 +1658,19 @@ fn snapshot_matches_live(snapshot: &crate::health::Snapshot) -> bool {
     let (Some(ticks), Some(boot)) = (snapshot.start_ticks, snapshot.boot_id.as_deref()) else {
         return false;
     };
+    // ALIVE first. An unreaped exit keeps its start ticks, so matching
+    // them proves the publisher is the process that once held that pid
+    // — not that it can still publish. The zombie rule lives in
+    // `presence_of`, and the snapshot fallback added later did not go
+    // through it, so a crashed daemon whose pid record had also become
+    // unreadable read as "confirmed current" (review finding).
+    //
+    // Checked HERE rather than at that call site, so the next caller
+    // inherits it instead of having to remember.
+    match crate::daemon_presence::proc_state(snapshot.pid) {
+        Ok(state) if crate::daemon_presence::state_is_alive(state) => {}
+        _ => return false,
+    }
     matches!(
         (
             crate::daemon_presence::start_ticks(snapshot.pid),

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1063,8 +1063,23 @@ fn proc_exe_looks_like_a_daemon(pid: libc::pid_t) -> bool {
     // is the state an upgraded-in-place daemon is in.
     let target = target.to_string_lossy();
     let target = target.strip_suffix(" (deleted)").unwrap_or(&target);
+    // Equal names, or a versioned sibling: `packetframe-v2` alongside
+    // `packetframe-v1` is a real packaging shape, and the identity path
+    // says elsewhere that a renamed binary is legitimate — so a scan
+    // that demanded exact equality contradicted it, and missed the
+    // daemon it exists to find (review finding).
+    //
+    // The residual limit, stated rather than papered over: a daemon
+    // deployed under a name sharing no prefix with ours is NOT found
+    // here. Nothing short of trusting argv could find it, and argv is
+    // what the May 2026 audit rejected — any local process could then
+    // block `detach` at will. The pid record is what covers that case;
+    // this scan is the backstop for when there is none.
     match (Path::new(target).file_name(), current.as_path().file_name()) {
-        (Some(a), Some(b)) => a == b,
+        (Some(a), Some(b)) => {
+            let (a, b) = (a.to_string_lossy(), b.to_string_lossy());
+            a == b || (a.starts_with("packetframe") && b.starts_with("packetframe"))
+        }
         _ => false,
     }
 }
@@ -1769,6 +1784,24 @@ fn print_module_health(state_dir: &Path) {
         // Neither shown. Saying "gone" here is what printed STALE over
         // a live daemon on the shadow (2026-08-12), because the check
         // asked whether the daemon ran this CLI's own binary.
+        // The record could not answer, but the SNAPSHOT can: it carries
+        // the publisher's own identity, and a match proves that exact
+        // process is running. Reachable whenever the pid record is
+        // missing or stale — a non-fatal write failure, or a
+        // replacement that has attached but not yet rewritten it — and
+        // without this the report reads CANNOT CONFIRM for that
+        // daemon's whole lifetime while the proof sits in the file
+        // being printed (review finding).
+        crate::daemon_presence::DaemonPresence::Unknown { .. }
+            if snapshot_matches_live(&snapshot) =>
+        {
+            println!(
+                "module health (pid {}, {age}) — confirmed by the report's own recorded \
+                 identity; the pid record is missing or stale, which `packetframe detach` \
+                 will refuse on until it is resolved.",
+                snapshot.pid
+            )
+        }
         crate::daemon_presence::DaemonPresence::Unknown { why } => println!(
             "module health (pid {}, {age}) — CANNOT CONFIRM the daemon is still running \
              ({why}). Read the report as possibly historical until it can be checked.",

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -900,10 +900,17 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     // user-writable; readlink-comparing it against our own
     // current_exe is a real identity check rather than a name match.
     // See the May 2026 audit Slice 4 finding.
-    match crate::daemon_presence::presence_of(&pid_path, |p| {
-        proc_exe_matches_current(p as libc::pid_t)
-    }) {
-        crate::daemon_presence::DaemonPresence::Running { .. } => {}
+    // The pid to signal comes FROM the check, not from a second read
+    // of the same file. Reading twice let a concurrent restart swap the
+    // record in between, so the check could validate the replacement
+    // while the signal went to the pid the first read captured — a
+    // recycled process, as root (review finding).
+    let pid = match crate::daemon_presence::presence_of(
+        &pid_path,
+        |p| proc_exe_matches_current(p as libc::pid_t),
+        scan_for_running_daemon,
+    ) {
+        crate::daemon_presence::DaemonPresence::Running { pid } => pid as libc::pid_t,
         crate::daemon_presence::DaemonPresence::Gone { why } => {
             return Err(ReconfigureError::DaemonNotRunning(format!(
                 "no daemon to reconfigure: {why} (stale pidfile at {}?)",
@@ -917,12 +924,11 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
         // exactly the upgrade it was meant to drive.
         crate::daemon_presence::DaemonPresence::Unknown { why } => {
             return Err(ReconfigureError::DaemonNotRunning(format!(
-                "cannot confirm pid {pid} from {} is the packetframe daemon ({why}); refusing \
-                 to signal it",
+                "cannot confirm the daemon named by {} ({why}); refusing to signal it",
                 pid_path.display()
             )));
         }
-    }
+    };
 
     // Snapshot the marker mtime (or NotFound) before signaling so we
     // can detect "changed since SIGHUP."
@@ -971,15 +977,51 @@ pub fn reconfigure(_config_path: &Path) -> Result<(), ReconfigureError> {
     ))
 }
 
+/// Find a process running this executable, if there is one.
+///
+/// **Finds only.** This was `daemon_pid`, and its answer was read as
+/// "no daemon is running" whenever it came back empty — which is false
+/// for any daemon started from a different path, i.e. during every
+/// upgrade, and is how `detach` walked past its own guard. It is kept
+/// because the converse is still sound and still useful: a process
+/// running this exact binary IS a daemon worth refusing to detach
+/// under, even when no pid file names it (a failed record write leaves
+/// exactly that).
+///
+/// `/proc/<pid>/exe` rather than `comm`, which is user-settable via
+/// `prctl` — the May 2026 audit Slice 4 finding.
+#[cfg(target_os = "linux")]
+fn scan_for_running_daemon() -> Option<i32> {
+    let self_pid = std::process::id();
+    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|s| s.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if pid == self_pid {
+            continue;
+        }
+        if proc_exe_matches_current(pid as libc::pid_t) {
+            return Some(pid as i32);
+        }
+    }
+    None
+}
+
+/// The pid from the record, whichever format it is in.
+///
+/// This parsed the WHOLE trimmed file as a number, so the identity
+/// record (`<pid> <start_ticks> <boot_id>`) failed with `InvalidData`
+/// and `reconfigure` returned before it could signal anything — the
+/// canary lever, broken by the commit that was fixing it (review
+/// finding, P1).
 #[cfg(target_os = "linux")]
 fn read_pid_file(path: &Path) -> std::io::Result<libc::pid_t> {
     let s = std::fs::read_to_string(path)?;
-    s.trim().parse::<libc::pid_t>().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("PID parse `{}`: {e}", s.trim()),
-        )
-    })
+    crate::daemon_presence::DaemonIdentity::decode(&s).map(|(pid, _)| pid as libc::pid_t)
 }
 
 /// Read /proc/<pid>/exe as a symlink and compare against the
@@ -1100,9 +1142,11 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // daemon. That is the outage this refusal exists to prevent, and
     // it was reachable exactly when someone was upgrading.
     #[cfg(target_os = "linux")]
-    let presence = crate::daemon_presence::presence_of(&state_dir.join(PIDFILE_NAME), |p| {
-        proc_exe_matches_current(p as libc::pid_t)
-    });
+    let presence = crate::daemon_presence::presence_of(
+        &state_dir.join(PIDFILE_NAME),
+        |p| proc_exe_matches_current(p as libc::pid_t),
+        scan_for_running_daemon,
+    );
     #[cfg(not(target_os = "linux"))]
     let presence = crate::daemon_presence::DaemonPresence::Gone {
         why: "no /proc on this platform; nothing could be attached".into(),
@@ -1516,9 +1560,11 @@ fn print_module_health(state_dir: &Path) {
     // only then learns the daemon is dead has already drawn the
     // conclusion, and it was the wrong one.
     #[cfg(target_os = "linux")]
-    let presence = crate::daemon_presence::presence_of(&state_dir.join(PIDFILE_NAME), |p| {
-        proc_exe_matches_current(p as libc::pid_t)
-    });
+    let presence = crate::daemon_presence::presence_of(
+        &state_dir.join(PIDFILE_NAME),
+        |p| proc_exe_matches_current(p as libc::pid_t),
+        scan_for_running_daemon,
+    );
     // No /proc to cross-check against, so liveness is unknown rather
     // than assumed either way.
     #[cfg(not(target_os = "linux"))]
@@ -1534,9 +1580,19 @@ fn print_module_health(state_dir: &Path) {
     };
 
     match &presence {
-        crate::daemon_presence::DaemonPresence::Running { pid } => {
+        // Running AND the same process that wrote this. A crash whose
+        // replacement records its own pid before publishing health
+        // leaves the old report on disk under a new pid file: validating
+        // the file alone presented history as current, and labelled it
+        // with the replacement's pid (review finding).
+        crate::daemon_presence::DaemonPresence::Running { pid } if *pid == snapshot.pid => {
             println!("module health (pid {pid}, {age}):")
         }
+        crate::daemon_presence::DaemonPresence::Running { pid } => println!(
+            "module health: STALE — this report was written by pid {}, but the daemon \
+             running now is pid {pid}. The report below is history, {age}.",
+            snapshot.pid
+        ),
         crate::daemon_presence::DaemonPresence::Gone { why } => println!(
             "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \
              report below is history, {age}; the dataplane may still be forwarding via its \

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1097,8 +1097,14 @@ fn is_daemon_process(pid: libc::pid_t) -> bool {
     // BYTES: `read_to_string` rejects the whole cmdline if any argument
     // is not UTF-8, and a `--config` path may legally contain arbitrary
     // bytes.
+    // The SUBCOMMAND SLOT, not anywhere in argv. `any` matched a probe
+    // run as `packetframe probe --iface run ...` on an interface named
+    // `run` — which then reads as a daemon, takes SIGHUP from
+    // `reconfigure`, and blocks `detach` (review finding). `struct Cli`
+    // carries nothing but the subcommand, so clap accepts no global
+    // options before it and argv[1] is where `run` must be.
     match std::fs::read(format!("/proc/{pid}/cmdline")) {
-        Ok(cmdline) => cmdline.split(|b| *b == 0).any(|a| a == b"run"),
+        Ok(cmdline) => cmdline.split(|b| *b == 0).nth(1) == Some(b"run".as_slice()),
         Err(_) => false,
     }
 }
@@ -1719,6 +1725,22 @@ fn print_module_health(state_dir: &Path) {
         {
             println!("module health (pid {pid}, {age}):")
         }
+        // A LIVE daemon whose snapshot predates identity recording —
+        // an older build, still publishing. Its report is almost
+        // certainly current, and calling it history was this PR's own
+        // motivating bug in a new shape: a new CLI declaring a running
+        // old daemon dead (review finding). Cannot confirm is the
+        // honest answer, and the one that does not mislead in either
+        // direction.
+        crate::daemon_presence::DaemonPresence::Running { pid }
+            if *pid == snapshot.pid && snapshot.start_ticks.is_none() =>
+        {
+            println!(
+                "module health (pid {pid}, {age}) — CANNOT CONFIRM this is the report of \
+                 the daemon running now: it recorded no identity, which an older build \
+                 does not. Restarting on this build makes it checkable."
+            )
+        }
         // Same pid is not the same process. A replacement handed the
         // pid its predecessor had — routine across a reboot — made the
         // pre-crash report read as live until the replacement published
@@ -1726,14 +1748,10 @@ fn print_module_health(state_dir: &Path) {
         // the snapshot predates identity recording it says so rather
         // than guessing either way.
         crate::daemon_presence::DaemonPresence::Running { pid } => println!(
-            "module health: STALE — this report was written by pid {}{}, and the daemon \
-             running now is pid {pid}. The report below is history, {age}.",
-            snapshot.pid,
-            if snapshot.start_ticks.is_none() {
-                " (which recorded no identity, so it cannot be matched)"
-            } else {
-                ""
-            }
+            "module health: STALE — this report was written by pid {}, and the daemon \
+             running now is pid {pid} (a different process, by its recorded identity). \
+             The report below is history, {age}.",
+            snapshot.pid
         ),
         crate::daemon_presence::DaemonPresence::Gone { why } => println!(
             "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -634,6 +634,23 @@ fn write_state_record(path: &Path, body: &str) -> std::io::Result<()> {
     use std::io::Write;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)?;
+    // The reader trusts records only in a directory nobody else can
+    // write (`dir_is_authentic`): a writable directory lets `rename`
+    // relocate root-owned records whole, so per-file ownership proves
+    // nothing there. `create_dir_all` inherits the umask, and a 002
+    // umask would create a group-writable dir whose every record then
+    // reads as untrusted — `reconfigure` refused for the daemon's whole
+    // lifetime. Clear exactly the group/world-write bits and leave the
+    // rest alone (an operator's deliberate 0700 stays 0700). Best
+    // effort: if it fails, the reader refuses, which is the safe side.
+    if let Ok(meta) = std::fs::metadata(parent) {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode();
+        if mode & 0o022 != 0 {
+            let _ =
+                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(mode & !0o022));
+        }
+    }
     let tmp = path.with_extension("tmp");
     {
         let mut f = create_excl_no_follow_with_retry(&tmp)?;

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1084,19 +1084,6 @@ fn proc_exe_looks_like_a_daemon(pid: libc::pid_t) -> bool {
     }
 }
 
-/// Find a process running this executable, if there is one.
-///
-/// **Finds only.** This was `daemon_pid`, and its answer was read as
-/// "no daemon is running" whenever it came back empty — which is false
-/// for any daemon started from a different path, i.e. during every
-/// upgrade, and is how `detach` walked past its own guard. It is kept
-/// because the converse is still sound and still useful: a process
-/// running this exact binary IS a daemon worth refusing to detach
-/// under, even when no pid file names it (a failed record write leaves
-/// exactly that).
-///
-/// `/proc/<pid>/exe` rather than `comm`, which is user-settable via
-/// `prctl` — the May 2026 audit Slice 4 finding.
 /// Whether `pid` is a packetframe DAEMON: our binary (or another copy
 /// of it), running the `run` subcommand.
 ///
@@ -1112,8 +1099,33 @@ fn proc_exe_looks_like_a_daemon(pid: libc::pid_t) -> bool {
 /// for this to begin with.
 #[cfg(target_os = "linux")]
 fn is_daemon_process(pid: libc::pid_t) -> bool {
+    daemon_process_verdict(pid) == Some(true)
+}
+
+/// The same question, keeping "could not tell" apart from "no".
+///
+/// `None` means a read failed for a reason other than the process
+/// having exited: the answer is unavailable, not negative. The scan
+/// needs that distinction because its negative is what licenses a
+/// destructive `detach`; `is_daemon_process` does not, because there
+/// an unavailable answer already falls through to `Unknown`.
+#[cfg(target_os = "linux")]
+fn daemon_process_verdict(pid: libc::pid_t) -> Option<bool> {
+    // Not knowing our OWN path makes every comparison below vacuous, so
+    // it is unavailability rather than a mismatch — for every pid at
+    // once, which is why the scan cannot conclude anything at all.
+    std::env::current_exe().ok()?;
     if !proc_exe_looks_like_a_daemon(pid) {
-        return false;
+        // Distinguish "the exe link says it is something else" from
+        // "the exe link could not be read at all". A process that has
+        // exited takes its whole `/proc` entry with it and is a plain
+        // no; anything else (EACCES on a hardened kernel, EPERM under
+        // a non-root caller) is unreadable.
+        return match std::fs::read_link(format!("/proc/{pid}/exe")) {
+            Ok(_) => Some(false),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(false),
+            Err(_) => None,
+        };
     }
     // BYTES: `read_to_string` rejects the whole cmdline if any argument
     // is not UTF-8, and a `--config` path may legally contain arbitrary
@@ -1125,15 +1137,52 @@ fn is_daemon_process(pid: libc::pid_t) -> bool {
     // carries nothing but the subcommand, so clap accepts no global
     // options before it and argv[1] is where `run` must be.
     match std::fs::read(format!("/proc/{pid}/cmdline")) {
-        Ok(cmdline) => cmdline.split(|b| *b == 0).nth(1) == Some(b"run".as_slice()),
-        Err(_) => false,
+        Ok(cmdline) => Some(cmdline.split(|b| *b == 0).nth(1) == Some(b"run".as_slice())),
+        // Gone between the two reads: not a daemon, and not a mystery.
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Some(false),
+        // It runs our binary and its argv cannot be read. The only
+        // question left is the only one unanswerable, so this is not a
+        // process the scan may report as harmless.
+        Err(_) => None,
     }
 }
 
+/// Search the process table for a running daemon.
+///
+/// This was `daemon_pid`, and its answer was read as "no daemon is
+/// running" whenever it came back empty — which is false for any daemon
+/// started from a different path, i.e. during every upgrade, and is how
+/// `detach` walked past its own guard. Its positive is still sound and
+/// still useful: a process running this binary IS a daemon worth
+/// refusing to detach under, even when no pid file names it (a failed
+/// record write leaves exactly that).
+///
+/// So it reports THREE answers rather than an `Option`. `NoneFound`
+/// still is not proof of absence — a differently named daemon is
+/// invisible to `proc_exe_looks_like_a_daemon` — but it does assert
+/// that the table was walked and every process in it examined, which
+/// is the part `Option::None` was silently standing in for.
+///
+/// `/proc/<pid>/exe` rather than `comm`, which is user-settable via
+/// `prctl` — the May 2026 audit Slice 4 finding.
 #[cfg(target_os = "linux")]
-fn scan_for_running_daemon() -> Option<i32> {
+fn scan_for_running_daemon() -> crate::daemon_presence::Scan {
+    use crate::daemon_presence::Scan;
     let self_pid = std::process::id();
-    for entry in std::fs::read_dir("/proc").ok()?.flatten() {
+    let dir = match std::fs::read_dir("/proc") {
+        Ok(dir) => dir,
+        Err(e) => return Scan::Inconclusive(format!("/proc could not be listed: {e}")),
+    };
+    // Counted, never skipped. Each is a process the scan cannot vouch
+    // for, and this scan's NEGATIVE is what licenses `detach` to unlink
+    // pins — so an unexaminable process has to reach the caller rather
+    // than quietly leave the total looking complete.
+    let mut unexamined = 0usize;
+    for entry in dir {
+        let Ok(entry) = entry else {
+            unexamined += 1;
+            continue;
+        };
         let Some(pid) = entry
             .file_name()
             .to_str()
@@ -1144,11 +1193,18 @@ fn scan_for_running_daemon() -> Option<i32> {
         if pid == self_pid {
             continue;
         }
-        if is_daemon_process(pid as libc::pid_t) {
-            return Some(pid as i32);
+        match daemon_process_verdict(pid as libc::pid_t) {
+            Some(true) => return Scan::Found(pid as i32),
+            Some(false) => {}
+            None => unexamined += 1,
         }
     }
-    None
+    if unexamined > 0 {
+        return Scan::Inconclusive(format!(
+            "{unexamined} process(es) in /proc could not be examined"
+        ));
+    }
+    Scan::NoneFound
 }
 
 /// Read /proc/<pid>/exe as a symlink and compare against the
@@ -2103,12 +2159,13 @@ mod vpp_detach_tests {
 
         // The exe check fails, as it does whenever the CLI runs from a
         // different path than the daemon.
-        // No scan: this is about what the RECORD can establish.
+        // A scan that ran and found nothing, so what is under test is
+        // what the RECORD alone establishes.
         let p = presence_of(
             &dir.join(PIDFILE_NAME),
             &dir.join(IDENTITY_NAME),
             |_| false,
-            || None,
+            || crate::daemon_presence::Scan::NoneFound,
         );
         assert!(
             matches!(p, DaemonPresence::Unknown { .. }),
@@ -2123,7 +2180,7 @@ mod vpp_detach_tests {
                 &dir.join(PIDFILE_NAME),
                 &dir.join(IDENTITY_NAME),
                 |_| true,
-                || None
+                || crate::daemon_presence::Scan::NoneFound
             ),
             DaemonPresence::Running { .. }
         ));

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -446,7 +446,7 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
     // /proc/<pid>/comm cross-check.
     let identity_path = config.global.state_dir.join(IDENTITY_NAME);
     match crate::daemon_presence::DaemonIdentity::current()
-        .and_then(|id| std::fs::write(&identity_path, id.encode()))
+        .and_then(|id| write_state_record(&identity_path, &id.encode()))
     {
         Ok(()) => {}
         // Non-fatal, like the pid file: readers treat a missing
@@ -598,24 +598,36 @@ fn create_excl_no_follow_with_retry(path: &Path) -> std::io::Result<std::fs::Fil
 /// with `O_NOFOLLOW | O_EXCL | O_CREAT | 0600` so a pre-existing
 /// symlink at `<path>.tmp` cannot redirect the write.
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
-fn write_pid_file(path: &Path) -> std::io::Result<()> {
+/// Write a state-dir record without following a symlink.
+///
+/// O_EXCL|O_NOFOLLOW into a temp name, then rename. `std::fs::write`
+/// would follow: `state-dir` can be a pre-existing directory an
+/// unprivileged user can write, so a `packetframe.identity` symlink
+/// planted before startup would have this root daemon truncate whatever
+/// it pointed at (review finding, P1). The pid file has always been
+/// written this way; the identity sidecar was not, until it was routed
+/// through here.
+fn write_state_record(path: &Path, body: &str) -> std::io::Result<()> {
     use std::io::Write;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
     std::fs::create_dir_all(parent)?;
-    let tmp = path.with_extension("pid.tmp");
+    let tmp = path.with_extension("tmp");
     {
         let mut f = create_excl_no_follow_with_retry(&tmp)?;
-        // A BARE PID, exactly as before. The identity goes in a sidecar
-        // instead, because this file has readers we do not ship with:
-        // a CLI from the previous bundle parses the whole trimmed file
-        // as one integer, so widening the format here broke
-        // `reconfigure` for anyone rolling back or running mixed
-        // versions — the same upgrade window this change exists to fix,
-        // in the other direction (review finding).
-        writeln!(f, "{}", std::process::id())?;
+        writeln!(f, "{body}")?;
         f.sync_all()?;
     }
     std::fs::rename(&tmp, path)
+}
+
+/// A BARE PID, exactly as before. The identity lives in a sidecar
+/// instead, because this file has readers we do not ship with: a CLI
+/// from the previous bundle parses the whole trimmed file as one
+/// integer, so widening the format broke `reconfigure` for anyone
+/// rolling back or running mixed versions.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+fn write_pid_file(path: &Path) -> std::io::Result<()> {
+    write_state_record(path, &std::process::id().to_string())
 }
 
 /// Look through a module section's directives and return its
@@ -1072,8 +1084,15 @@ fn scan_for_running_daemon() -> Option<i32> {
         // finding). Safe to read argv here only because the exe check
         // above already established the binary; a spoofed "run" alone
         // proves nothing.
-        if let Ok(cmdline) = std::fs::read_to_string(format!("/proc/{pid}/cmdline")) {
-            if cmdline.split('\0').any(|a| a == "run") {
+        // BYTES. `read_to_string` rejects the whole cmdline if any
+        // argument is not UTF-8 — a `--config` path may legally contain
+        // arbitrary bytes — and a scan that cannot read the daemon's
+        // argv would then fail to find it, which `presence_of` turns
+        // into `Gone` and `detach` turns into unlinking pins beneath it
+        // (review finding, P1). An unreadable cmdline is not evidence
+        // of anything.
+        if let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) {
+            if cmdline.split(|b| *b == 0).any(|a| a == b"run") {
                 return Some(pid as i32);
             }
         }
@@ -1918,6 +1937,46 @@ mod vpp_detach_tests {
         // The right order is accepted, so the test above is about order
         // and not about the pair being rejected outright.
         assert_eq!(feed_wiring(&["fast-path", "vpp-offload"]), Ok(true));
+    }
+
+    /// State records are never written through a symlink.
+    ///
+    /// `state-dir` can be a pre-existing directory an unprivileged user
+    /// writes to, so a record name planted as a symlink before startup
+    /// would have this root daemon truncate whatever it points at. The
+    /// pid file was always written no-follow; the identity sidecar was
+    /// added with `std::fs::write`, which follows (review finding, P1).
+    /// Both go through one writer now, so the next record cannot get it
+    /// wrong by being written somewhere else.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn a_planted_symlink_does_not_capture_a_state_record() {
+        let dir = std::env::temp_dir().join(format!("pf-symlink-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let victim = dir.join("victim");
+        std::fs::write(&victim, "do not truncate me").unwrap();
+
+        // The attacker's plant, at the name the daemon will write.
+        let planted = dir.join("packetframe.identity");
+        std::os::unix::fs::symlink(&victim, &planted).unwrap();
+
+        // Writing succeeds — the rename replaces the symlink itself —
+        // and the victim is untouched.
+        write_state_record(&planted, "1 2 boot").expect("write");
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "do not truncate me",
+            "the symlink target must not be written through"
+        );
+        assert!(
+            std::fs::read_to_string(&planted)
+                .unwrap()
+                .starts_with("1 2 boot"),
+            "and the record lands at the real path"
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// `detach` refuses when it cannot prove no daemon is running.

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -952,7 +952,7 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     let pid = match crate::daemon_presence::presence_of(
         &pid_path,
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
+        |p| is_daemon_process(p as libc::pid_t),
         scan_for_running_daemon,
     ) {
         crate::daemon_presence::DaemonPresence::Running { pid } => pid as libc::pid_t,
@@ -1076,6 +1076,33 @@ fn proc_exe_looks_like_a_daemon(pid: libc::pid_t) -> bool {
 ///
 /// `/proc/<pid>/exe` rather than `comm`, which is user-settable via
 /// `prctl` — the May 2026 audit Slice 4 finding.
+/// Whether `pid` is a packetframe DAEMON: our binary (or another copy
+/// of it), running the `run` subcommand.
+///
+/// One predicate, because the scan and the record path must ask the
+/// same question. They did not: the scan filtered argv for `run`, while
+/// the legacy record path took a bare executable match — so a stale
+/// pid-only file whose pid had been reused by a long `packetframe
+/// probe` from another bundle read as `Running`, and `reconfigure`
+/// SIGHUPed the probe (review finding).
+///
+/// Reading argv is sound only after the executable check: a spoofed
+/// `run` on its own proves nothing, which is why `comm` was rejected
+/// for this to begin with.
+#[cfg(target_os = "linux")]
+fn is_daemon_process(pid: libc::pid_t) -> bool {
+    if !proc_exe_looks_like_a_daemon(pid) {
+        return false;
+    }
+    // BYTES: `read_to_string` rejects the whole cmdline if any argument
+    // is not UTF-8, and a `--config` path may legally contain arbitrary
+    // bytes.
+    match std::fs::read(format!("/proc/{pid}/cmdline")) {
+        Ok(cmdline) => cmdline.split(|b| *b == 0).any(|a| a == b"run"),
+        Err(_) => false,
+    }
+}
+
 #[cfg(target_os = "linux")]
 fn scan_for_running_daemon() -> Option<i32> {
     let self_pid = std::process::id();
@@ -1090,28 +1117,8 @@ fn scan_for_running_daemon() -> Option<i32> {
         if pid == self_pid {
             continue;
         }
-        if !proc_exe_looks_like_a_daemon(pid as libc::pid_t) {
-            continue;
-        }
-        // And it must be the DAEMON, not another invocation of the same
-        // binary. Dropping this filter when the scanner came back would
-        // have made a concurrent `packetframe probe --duration ...`
-        // look like a daemon and refuse every `detach` for its
-        // lifetime — recovery blocked by an unrelated command (review
-        // finding). Safe to read argv here only because the exe check
-        // above already established the binary; a spoofed "run" alone
-        // proves nothing.
-        // BYTES. `read_to_string` rejects the whole cmdline if any
-        // argument is not UTF-8 — a `--config` path may legally contain
-        // arbitrary bytes — and a scan that cannot read the daemon's
-        // argv would then fail to find it, which `presence_of` turns
-        // into `Gone` and `detach` turns into unlinking pins beneath it
-        // (review finding, P1). An unreadable cmdline is not evidence
-        // of anything.
-        if let Ok(cmdline) = std::fs::read(format!("/proc/{pid}/cmdline")) {
-            if cmdline.split(|b| *b == 0).any(|a| a == b"run") {
-                return Some(pid as i32);
-            }
+        if is_daemon_process(pid as libc::pid_t) {
+            return Some(pid as i32);
         }
     }
     None
@@ -1238,7 +1245,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
+        |p| is_daemon_process(p as libc::pid_t),
         scan_for_running_daemon,
     );
     #[cfg(not(target_os = "linux"))]
@@ -1684,7 +1691,7 @@ fn print_module_health(state_dir: &Path) {
     let presence = crate::daemon_presence::presence_of(
         &state_dir.join(PIDFILE_NAME),
         &state_dir.join(IDENTITY_NAME),
-        |p| proc_exe_looks_like_a_daemon(p as libc::pid_t),
+        |p| is_daemon_process(p as libc::pid_t),
         scan_for_running_daemon,
     );
     // No /proc to cross-check against, so liveness is unknown rather

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -996,8 +996,21 @@ fn scan_for_running_daemon() -> Option<i32> {
         if pid == self_pid {
             continue;
         }
-        if proc_exe_matches_current(pid as libc::pid_t) {
-            return Some(pid as i32);
+        if !proc_exe_matches_current(pid as libc::pid_t) {
+            continue;
+        }
+        // And it must be the DAEMON, not another invocation of the same
+        // binary. Dropping this filter when the scanner came back would
+        // have made a concurrent `packetframe probe --duration ...`
+        // look like a daemon and refuse every `detach` for its
+        // lifetime — recovery blocked by an unrelated command (review
+        // finding). Safe to read argv here only because the exe check
+        // above already established the binary; a spoofed "run" alone
+        // proves nothing.
+        if let Ok(cmdline) = std::fs::read_to_string(format!("/proc/{pid}/cmdline")) {
+            if cmdline.split('\0').any(|a| a == "run") {
+                return Some(pid as i32);
+            }
         }
     }
     None
@@ -1499,6 +1512,33 @@ pub fn status(config_path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+/// Whether the snapshot's own publisher is the process running now.
+///
+/// `false` when the snapshot recorded no identity: that is "cannot
+/// confirm", and for a report that will be read as current it is the
+/// same class of claim this module exists to stop making.
+#[cfg(all(target_os = "linux", feature = "fast-path"))]
+fn snapshot_matches_live(snapshot: &crate::health::Snapshot) -> bool {
+    let (Some(ticks), Some(boot)) = (snapshot.start_ticks, snapshot.boot_id.as_deref()) else {
+        return false;
+    };
+    matches!(
+        (
+            crate::daemon_presence::start_ticks(snapshot.pid),
+            crate::daemon_presence::boot_id()
+        ),
+        (Ok(t), Ok(b)) if t == ticks && b == boot
+    )
+}
+
+/// No `/proc` to compare against, so the publisher cannot be matched —
+/// which reads as "cannot confirm", the same as an unidentified
+/// snapshot on Linux.
+#[cfg(all(not(target_os = "linux"), feature = "fast-path"))]
+fn snapshot_matches_live(_snapshot: &crate::health::Snapshot) -> bool {
+    false
+}
+
 /// Render the daemon's last published module health.
 ///
 /// Everything else `status` prints is read from the kernel or from a pin
@@ -1564,13 +1604,26 @@ fn print_module_health(state_dir: &Path) {
         // leaves the old report on disk under a new pid file: validating
         // the file alone presented history as current, and labelled it
         // with the replacement's pid (review finding).
-        crate::daemon_presence::DaemonPresence::Running { pid } if *pid == snapshot.pid => {
+        crate::daemon_presence::DaemonPresence::Running { pid }
+            if *pid == snapshot.pid && snapshot_matches_live(&snapshot) =>
+        {
             println!("module health (pid {pid}, {age}):")
         }
+        // Same pid is not the same process. A replacement handed the
+        // pid its predecessor had — routine across a reboot — made the
+        // pre-crash report read as live until the replacement published
+        // its own (review finding). The identity settles it, and where
+        // the snapshot predates identity recording it says so rather
+        // than guessing either way.
         crate::daemon_presence::DaemonPresence::Running { pid } => println!(
-            "module health: STALE — this report was written by pid {}, but the daemon \
+            "module health: STALE — this report was written by pid {}{}, and the daemon \
              running now is pid {pid}. The report below is history, {age}.",
-            snapshot.pid
+            snapshot.pid,
+            if snapshot.start_ticks.is_none() {
+                " (which recorded no identity, so it cannot be matched)"
+            } else {
+                ""
+            }
         ),
         crate::daemon_presence::DaemonPresence::Gone { why } => println!(
             "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -643,12 +643,30 @@ fn write_state_record(path: &Path, body: &str) -> std::io::Result<()> {
     // lifetime. Clear exactly the group/world-write bits and leave the
     // rest alone (an operator's deliberate 0700 stays 0700). Best
     // effort: if it fails, the reader refuses, which is the safe side.
-    if let Ok(meta) = std::fs::metadata(parent) {
-        use std::os::unix::fs::PermissionsExt;
-        let mode = meta.permissions().mode();
-        if mode & 0o022 != 0 {
-            let _ =
-                std::fs::set_permissions(parent, std::fs::Permissions::from_mode(mode & !0o022));
+    //
+    // ON THE DESCRIPTOR, never the pathname. The first version ran
+    // `metadata` + `set_permissions` on the path, and both follow
+    // symlinks — so a pre-created `state-dir` symlink pointed this
+    // root chmod at any directory on the system, stripping write bits
+    // from whatever the attacker chose (review finding, P1; the same
+    // pathname-vs-descriptor defect as the record writes, one level
+    // up). `O_DIRECTORY | O_NOFOLLOW` refuses the symlink outright, and
+    // the fchmod applies to the directory that was actually opened. A
+    // symlinked state dir gets no chmod and no trust — the reader's
+    // `dir_is_authentic` refuses it the same way.
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+        if let Ok(dirf) = std::fs::OpenOptions::new()
+            .read(true)
+            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
+            .open(parent)
+        {
+            if let Ok(meta) = dirf.metadata() {
+                let mode = meta.permissions().mode();
+                if meta.is_dir() && mode & 0o022 != 0 {
+                    let _ = dirf.set_permissions(std::fs::Permissions::from_mode(mode & !0o022));
+                }
+            }
         }
     }
     let tmp = path.with_extension("tmp");

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -576,7 +576,20 @@ fn write_pid_file(path: &Path) -> std::io::Result<()> {
     let tmp = path.with_extension("pid.tmp");
     {
         let mut f = create_excl_no_follow_with_retry(&tmp)?;
-        writeln!(f, "{}", std::process::id())?;
+        // Identity, not just a pid. A bare pid is reusable, so every
+        // later reader had to fall back to "does some process run my
+        // exact binary path" — which is false whenever a CLI runs from
+        // a newly deployed bundle while the old daemon is still up,
+        // i.e. during every upgrade. See `daemon_presence`.
+        match crate::daemon_presence::DaemonIdentity::current() {
+            Ok(id) => writeln!(f, "{}", id.encode())?,
+            // The pid alone still works: readers treat a record with no
+            // identity as legacy and fall back rather than guessing.
+            Err(e) => {
+                tracing::warn!(error = %e, "could not read own process identity; recording pid alone");
+                writeln!(f, "{}", std::process::id())?;
+            }
+        }
         f.sync_all()?;
     }
     std::fs::rename(&tmp, path)
@@ -887,11 +900,28 @@ pub fn reconfigure(config_path: &Path) -> Result<(), ReconfigureError> {
     // user-writable; readlink-comparing it against our own
     // current_exe is a real identity check rather than a name match.
     // See the May 2026 audit Slice 4 finding.
-    if !proc_exe_matches_current(pid) {
-        return Err(ReconfigureError::DaemonNotRunning(format!(
-            "PID {pid} from {} is not a packetframe process (stale pidfile?)",
-            pid_path.display()
-        )));
+    match crate::daemon_presence::presence_of(&pid_path, |p| {
+        proc_exe_matches_current(p as libc::pid_t)
+    }) {
+        crate::daemon_presence::DaemonPresence::Running { .. } => {}
+        crate::daemon_presence::DaemonPresence::Gone { why } => {
+            return Err(ReconfigureError::DaemonNotRunning(format!(
+                "no daemon to reconfigure: {why} (stale pidfile at {}?)",
+                pid_path.display()
+            )));
+        }
+        // A pid we cannot identify is one we must not signal. The old
+        // check reported this as "not a packetframe process", which was
+        // also how it read a LIVE daemon whenever this CLI ran from a
+        // different path than it — so the canary lever failed during
+        // exactly the upgrade it was meant to drive.
+        crate::daemon_presence::DaemonPresence::Unknown { why } => {
+            return Err(ReconfigureError::DaemonNotRunning(format!(
+                "cannot confirm pid {pid} from {} is the packetframe daemon ({why}); refusing \
+                 to signal it",
+                pid_path.display()
+            )));
+        }
     }
 
     // Snapshot the marker mtime (or NotFound) before signaling so we
@@ -1025,53 +1055,6 @@ fn parse_reconfigure_marker(body: &str) -> Result<(), ReconfigureError> {
     }
 }
 
-/// Look for a live `packetframe run` daemon via `/proc`. Returns the
-/// pid of the first match, None if none found. Only our own process
-/// name is matched (not arbitrary substrings), so a text editor
-/// holding a `packetframe.conf` file doesn't false-positive.
-#[cfg(target_os = "linux")]
-fn daemon_pid() -> Option<u32> {
-    let self_pid = std::process::id();
-    let entries = std::fs::read_dir("/proc").ok()?;
-    for entry in entries.flatten() {
-        let name = entry.file_name();
-        let pid: u32 = match name.to_str().and_then(|s| s.parse().ok()) {
-            Some(p) => p,
-            None => continue,
-        };
-        if pid == self_pid {
-            continue;
-        }
-        // /proc/<pid>/exe is the kernel-managed identity check (the
-        // May 2026 audit Slice 4 finding). The `comm` field used to
-        // gate this is user-settable via prctl(PR_SET_NAME), so a
-        // local user could rename their own process to "packetframe"
-        // and block the operator's `packetframe detach`. The exe
-        // symlink resolves to the inode the kernel actually exec'd,
-        // and is not user-writable.
-        if !proc_exe_matches_current(pid as libc::pid_t) {
-            continue;
-        }
-        // Confirm it's actually the `run` subcommand, not e.g.
-        // `packetframe detach` from another shell. argv IS still
-        // user-settable, but the exe match above pins identity; a
-        // spoofed argv "run" entry only sources a self-match against
-        // the very same binary.
-        let cmdline_path = format!("/proc/{pid}/cmdline");
-        if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
-            if cmdline.split('\0').any(|a| a == "run") {
-                return Some(pid);
-            }
-        }
-    }
-    None
-}
-
-#[cfg(not(target_os = "linux"))]
-fn daemon_pid() -> Option<u32> {
-    None
-}
-
 pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // Refuse to detach while a `packetframe run` daemon is live. The
     // daemon holds PinnedLink FDs in-process; unlinking the bpffs pin
@@ -1081,16 +1064,6 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // Confirmed outage-adjacent on the reference EFG 2026-04-21, the
     // detach ran, reported clean, but `ip link show` still had
     // `xdpgeneric` attached.
-    if let Some(pid) = daemon_pid() {
-        return Err(format!(
-            "a `packetframe run` daemon is still running (pid {pid}); \
-             stop it first (e.g. `kill {pid}`) before detaching. \
-             Detach unlinks bpffs pins, but the kernel-side bpf_link \
-             holds refs through the daemon's open FDs, both have to \
-             be released for the iface to actually detach."
-        ));
-    }
-
     // `config_has_vpp` decides whether a SCOPED detach may touch VPP.
     //
     // `--all` means "tear down modules beyond those in the supplied config",
@@ -1118,6 +1091,42 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
             false,
         ),
     };
+
+    // Positive evidence of ABSENCE, not merely failure to find a
+    // match. `daemon_pid()` answered by scanning /proc for a process
+    // running this CLI's own executable path, so a detach run from a
+    // freshly deployed bundle — the shape every upgrade has — found
+    // nothing and proceeded straight past this guard, under a live
+    // daemon. That is the outage this refusal exists to prevent, and
+    // it was reachable exactly when someone was upgrading.
+    #[cfg(target_os = "linux")]
+    let presence = crate::daemon_presence::presence_of(&state_dir.join(PIDFILE_NAME), |p| {
+        proc_exe_matches_current(p as libc::pid_t)
+    });
+    #[cfg(not(target_os = "linux"))]
+    let presence = crate::daemon_presence::DaemonPresence::Gone {
+        why: "no /proc on this platform; nothing could be attached".into(),
+    };
+    match presence {
+        crate::daemon_presence::DaemonPresence::Gone { .. } => {}
+        crate::daemon_presence::DaemonPresence::Running { pid } => {
+            return Err(format!(
+                "a `packetframe run` daemon is still running (pid {pid}); \
+                 stop it first (e.g. `kill {pid}`) before detaching. \
+                 Detach unlinks bpffs pins, but the kernel-side bpf_link \
+                 holds refs through the daemon's open FDs, both have to \
+                 be released for the iface to actually detach."
+            ));
+        }
+        crate::daemon_presence::DaemonPresence::Unknown { why } => {
+            return Err(format!(
+                "cannot confirm no `packetframe run` daemon is running ({why}); refusing to \
+                 detach. Unlinking pins under a live daemon leaves the program attached \
+                 through its open FDs while reporting success. Stop the daemon, or remove \
+                 a stale pid file if you have established there is none."
+            ));
+        }
+    }
 
     // `--all` used to be a no-op with a comment saying it would "become
     // meaningful once a second module ships". A second module has now
@@ -1507,11 +1516,15 @@ fn print_module_health(state_dir: &Path) {
     // only then learns the daemon is dead has already drawn the
     // conclusion, and it was the wrong one.
     #[cfg(target_os = "linux")]
-    let live = proc_exe_matches_current(snapshot.pid);
+    let presence = crate::daemon_presence::presence_of(&state_dir.join(PIDFILE_NAME), |p| {
+        proc_exe_matches_current(p as libc::pid_t)
+    });
     // No /proc to cross-check against, so liveness is unknown rather
     // than assumed either way.
     #[cfg(not(target_os = "linux"))]
-    let live = false;
+    let presence = crate::daemon_presence::DaemonPresence::Unknown {
+        why: "no /proc on this platform".into(),
+    };
 
     let age = match crate::health::age_seconds(&snapshot) {
         Some(a) => format!("{a}s old"),
@@ -1520,15 +1533,24 @@ fn print_module_health(state_dir: &Path) {
         None => "written in the future (clock skew)".to_string(),
     };
 
-    if live {
-        println!("module health (pid {}, {age}):", snapshot.pid);
-    } else {
-        println!(
-            "module health: STALE — the daemon that wrote this (pid {}) is gone. The report \
-             below is history, {age}; the dataplane may still be forwarding via its pins \
-             (§8.5).",
+    match &presence {
+        crate::daemon_presence::DaemonPresence::Running { pid } => {
+            println!("module health (pid {pid}, {age}):")
+        }
+        crate::daemon_presence::DaemonPresence::Gone { why } => println!(
+            "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \
+             report below is history, {age}; the dataplane may still be forwarding via its \
+             pins (§8.5).",
             snapshot.pid
-        );
+        ),
+        // Neither shown. Saying "gone" here is what printed STALE over
+        // a live daemon on the shadow (2026-08-12), because the check
+        // asked whether the daemon ran this CLI's own binary.
+        crate::daemon_presence::DaemonPresence::Unknown { why } => println!(
+            "module health (pid {}, {age}) — CANNOT CONFIRM the daemon is still running \
+             ({why}). Read the report as possibly historical until it can be checked.",
+            snapshot.pid
+        ),
     }
 
     for m in &snapshot.modules {
@@ -1741,6 +1763,52 @@ mod vpp_detach_tests {
         // The right order is accepted, so the test above is about order
         // and not about the pair being rejected outright.
         assert_eq!(feed_wiring(&["fast-path", "vpp-offload"]), Ok(true));
+    }
+
+    /// `detach` refuses when it cannot prove no daemon is running.
+    ///
+    /// The policy lives in `daemon_presence::decide` and is tested
+    /// there; this asserts the WIRING, which is the half that was
+    /// wrong. `detach` consulted a /proc scan for a process running its
+    /// own executable path, so a detach launched from a freshly
+    /// deployed bundle — every upgrade — matched nothing and walked
+    /// straight past the guard while the daemon was live. Unlinking
+    /// pins under it leaves the program attached through its open FDs
+    /// and reports success, which is the 2026-04-21 outage.
+    ///
+    /// Uses a legacy record naming THIS process with a deliberately
+    /// non-matching exe check: a live pid whose identity cannot be
+    /// established. The only safe reading is "cannot tell", and the
+    /// only safe action is to stop.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detach_refuses_a_daemon_it_cannot_rule_out() {
+        use crate::daemon_presence::{presence_of, DaemonPresence};
+
+        let dir = std::env::temp_dir().join(format!("pf-detach-unknown-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        // A legacy record — pid only — naming a process that really is
+        // running. This is what an older daemon leaves behind.
+        std::fs::write(dir.join(PIDFILE_NAME), format!("{}\n", std::process::id())).unwrap();
+
+        // The exe check fails, as it does whenever the CLI runs from a
+        // different path than the daemon.
+        let p = presence_of(&dir.join(PIDFILE_NAME), |_| false);
+        assert!(
+            matches!(p, DaemonPresence::Unknown { .. }),
+            "a live pid with no verifiable identity must be Unknown, not Gone — Gone is \
+             what let detach proceed: {p:?}"
+        );
+
+        // And the same record with the exe check passing still resolves
+        // to Running, so the guard has not simply been loosened.
+        assert!(matches!(
+            presence_of(&dir.join(PIDFILE_NAME), |_| true),
+            DaemonPresence::Running { .. }
+        ));
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     /// A recorded pid with no start-time cookie must not be signalled, and

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -2141,49 +2141,50 @@ mod vpp_detach_tests {
     /// pins under it leaves the program attached through its open FDs
     /// and reports success, which is the 2026-04-21 outage.
     ///
-    /// Uses a legacy record naming THIS process with a deliberately
-    /// non-matching exe check: a live pid whose identity cannot be
-    /// established. The only safe reading is "cannot tell", and the
-    /// only safe action is to stop.
+    /// Uses a legacy record naming THIS process: a live pid whose
+    /// identity cannot be established. The only safe reading is "cannot
+    /// tell", and the only safe action is to stop.
+    ///
+    /// The record is made world-writable on purpose, so the assertion
+    /// holds whether or not the suite runs as root — and so it covers
+    /// the second half of the rule as well: a record anyone could have
+    /// written confirms nothing about a LIVE pid, whatever the
+    /// executable says, because otherwise a planted pid file picks the
+    /// process root signals (review finding). The authentic legacy
+    /// record, which this test cannot create without being root, is
+    /// covered in `daemon_presence`'s policy table.
     #[cfg(target_os = "linux")]
     #[test]
     fn detach_refuses_a_daemon_it_cannot_rule_out() {
         use crate::daemon_presence::{presence_of, DaemonPresence};
+        use std::os::unix::fs::PermissionsExt;
 
         let dir = std::env::temp_dir().join(format!("pf-detach-unknown-{}", std::process::id()));
         let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).unwrap();
         // A legacy record — pid only — naming a process that really is
         // running. This is what an older daemon leaves behind.
-        std::fs::write(dir.join(PIDFILE_NAME), format!("{}\n", std::process::id())).unwrap();
+        let pidfile = dir.join(PIDFILE_NAME);
+        std::fs::write(&pidfile, format!("{}\n", std::process::id())).unwrap();
+        std::fs::set_permissions(&pidfile, std::fs::Permissions::from_mode(0o666)).unwrap();
 
-        // The exe check fails, as it does whenever the CLI runs from a
-        // different path than the daemon.
         // A scan that ran and found nothing, so what is under test is
-        // what the RECORD alone establishes.
-        let p = presence_of(
-            &dir.join(PIDFILE_NAME),
-            &dir.join(IDENTITY_NAME),
-            |_| false,
-            || crate::daemon_presence::Scan::NoneFound,
-        );
-        assert!(
-            matches!(p, DaemonPresence::Unknown { .. }),
-            "a live pid with no verifiable identity must be Unknown, not Gone — Gone is \
-             what let detach proceed: {p:?}"
-        );
-
-        // And the same record with the exe check passing still resolves
-        // to Running, so the guard has not simply been loosened.
-        assert!(matches!(
-            presence_of(
-                &dir.join(PIDFILE_NAME),
+        // what the RECORD alone establishes — with the exe check
+        // failing, as it does whenever the CLI runs from a different
+        // path than the daemon, and then passing.
+        for exe in [false, true] {
+            let p = presence_of(
+                &pidfile,
                 &dir.join(IDENTITY_NAME),
-                |_| true,
-                || crate::daemon_presence::Scan::NoneFound
-            ),
-            DaemonPresence::Running { .. }
-        ));
+                |_| exe,
+                || crate::daemon_presence::Scan::NoneFound,
+            );
+            assert!(
+                matches!(p, DaemonPresence::Unknown { .. }),
+                "exe_matches={exe}: a live pid with no verifiable identity must be Unknown, \
+                 not Gone — Gone is what let detach proceed: {p:?}"
+            );
+        }
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -591,29 +591,142 @@ pub(crate) fn create_excl_no_follow(path: &Path) -> std::io::Result<std::fs::Fil
         .open(path)
 }
 
-/// Same shape but with one stale-`.tmp` retry. The retry runs only
-/// when `create_excl_no_follow` returns `AlreadyExists` and the
-/// existing path is a regular file (a leftover from a crashed run);
-/// a `.tmp` that's a symlink hits `ELOOP` on the retried open and
-/// the function gives up. A second `EEXIST` is treated as a real
-/// race between competing writers and errors out.
+/// Open an ABSOLUTE directory path one component at a time, each step
+/// `openat(O_DIRECTORY | O_NOFOLLOW)` relative to the descriptor of the
+/// previous one, creating missing components (0755) on the way.
+///
+/// Why a walk and not one `open`: `O_NOFOLLOW` guards only the FINAL
+/// component. The state-dir writes and the umask chmod used to resolve
+/// the whole path at once, so a symlink at an intermediate component —
+/// `/tmp/plant/state` with `plant` attacker-controlled — carried this
+/// root process wherever the attacker pointed, and the descriptor
+/// "verified" at the end belonged to a directory of their choosing
+/// (review finding, P1; the reader was already refusing such paths via
+/// canonicalize-equality, and the privileged writer must be at least as
+/// suspicious as the reader). Every component is opened without
+/// following; a symlink ANYWHERE fails with `ELOOP` and the write is
+/// refused.
+///
+/// `..` is refused outright — a state dir has no business being
+/// specified through parent traversal, and accepting it would make the
+/// walk's guarantees path-dependent.
 #[cfg(target_os = "linux")]
-fn create_excl_no_follow_with_retry(path: &Path) -> std::io::Result<std::fs::File> {
-    match create_excl_no_follow(path) {
+fn create_and_open_dir_no_follow(path: &Path) -> std::io::Result<std::fs::File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::ffi::OsStrExt;
+    if !path.is_absolute() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("state paths must be absolute: {}", path.display()),
+        ));
+    }
+    let mut dir = std::fs::File::open("/")?;
+    for comp in path.components() {
+        let name = match comp {
+            std::path::Component::RootDir | std::path::Component::CurDir => continue,
+            std::path::Component::Normal(n) => n,
+            other => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("refusing path component {other:?} in {}", path.display()),
+                ))
+            }
+        };
+        let c = std::ffi::CString::new(name.as_bytes()).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in path component")
+        })?;
+        let flags = libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_RDONLY | libc::O_CLOEXEC;
+        let mut fd = unsafe { libc::openat(dir.as_raw_fd(), c.as_ptr(), flags) };
+        if fd < 0 && std::io::Error::last_os_error().kind() == std::io::ErrorKind::NotFound {
+            // Create it and re-open. A concurrent creator making this
+            // mkdirat lose with EEXIST is fine — the reopen decides.
+            unsafe { libc::mkdirat(dir.as_raw_fd(), c.as_ptr(), 0o755) };
+            fd = unsafe { libc::openat(dir.as_raw_fd(), c.as_ptr(), flags) };
+        }
+        if fd < 0 {
+            let e = std::io::Error::last_os_error();
+            return Err(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "open component {name:?} of {}: {e} (a symlink here is refused)",
+                    path.display()
+                ),
+            ));
+        }
+        dir = unsafe { std::fs::File::from_raw_fd(fd) };
+    }
+    Ok(dir)
+}
+
+/// `O_CREAT|O_EXCL|O_NOFOLLOW` a file RELATIVE to an already-walked
+/// directory descriptor, mode 0600 — the dirfd twin of
+/// `create_excl_no_follow`, for writers that must not re-resolve the
+/// directory path between verifying it and using it.
+#[cfg(target_os = "linux")]
+fn openat_excl_no_follow(dir: &std::fs::File, name: &str) -> std::io::Result<std::fs::File> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+    let c = std::ffi::CString::new(name)
+        .map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in file name"))?;
+    let flags = libc::O_CREAT | libc::O_EXCL | libc::O_NOFOLLOW | libc::O_WRONLY | libc::O_CLOEXEC;
+    let fd = unsafe { libc::openat(dir.as_raw_fd(), c.as_ptr(), flags, 0o600 as libc::c_uint) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(unsafe { std::fs::File::from_raw_fd(fd) })
+}
+
+/// Same shape but with one stale-`.tmp` retry, dirfd-relative
+/// throughout. The retry runs only when the create returns
+/// `AlreadyExists` and the existing entry is a regular file (a leftover
+/// from a crashed run), checked with `fstatat(AT_SYMLINK_NOFOLLOW)` so
+/// an attacker's symlink is not misclassified as a file. A second
+/// `EEXIST` is a real race between competing writers and errors out.
+#[cfg(target_os = "linux")]
+fn openat_excl_with_retry(dir: &std::fs::File, name: &str) -> std::io::Result<std::fs::File> {
+    use std::os::fd::AsRawFd;
+    match openat_excl_no_follow(dir, name) {
         Ok(f) => Ok(f),
         Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-            // unlink-and-retry, but only if the leftover is a plain
-            // file. symlink_metadata avoids following the symlink so
-            // we don't misclassify an attacker's symlink as a file.
-            let meta = std::fs::symlink_metadata(path)?;
-            if !meta.file_type().is_file() {
+            let c = std::ffi::CString::new(name).map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in file name")
+            })?;
+            let mut st: libc::stat = unsafe { std::mem::zeroed() };
+            let rc = unsafe {
+                libc::fstatat(
+                    dir.as_raw_fd(),
+                    c.as_ptr(),
+                    &mut st,
+                    libc::AT_SYMLINK_NOFOLLOW,
+                )
+            };
+            if rc != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            if st.st_mode & libc::S_IFMT != libc::S_IFREG {
                 return Err(e);
             }
-            std::fs::remove_file(path)?;
-            create_excl_no_follow(path)
+            if unsafe { libc::unlinkat(dir.as_raw_fd(), c.as_ptr(), 0) } != 0 {
+                return Err(std::io::Error::last_os_error());
+            }
+            openat_excl_no_follow(dir, name)
         }
         Err(e) => Err(e),
     }
+}
+
+/// `renameat` within one already-walked directory descriptor.
+#[cfg(target_os = "linux")]
+fn renameat_within(dir: &std::fs::File, from: &str, to: &str) -> std::io::Result<()> {
+    use std::os::fd::AsRawFd;
+    let (f, t) = (std::ffi::CString::new(from), std::ffi::CString::new(to));
+    let (f, t) = (
+        f.map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in name"))?,
+        t.map_err(|_| std::io::Error::new(std::io::ErrorKind::InvalidInput, "NUL in name"))?,
+    );
+    if unsafe { libc::renameat(dir.as_raw_fd(), f.as_ptr(), dir.as_raw_fd(), t.as_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
 }
 
 /// Atomically write the current PID to `path`. Uses write-then-rename
@@ -633,7 +746,18 @@ fn create_excl_no_follow_with_retry(path: &Path) -> std::io::Result<std::fs::Fil
 fn write_state_record(path: &Path, body: &str) -> std::io::Result<()> {
     use std::io::Write;
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    std::fs::create_dir_all(parent)?;
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?;
+    // EVERYTHING below happens relative to this one descriptor,
+    // obtained by a component-wise no-follow walk: the directory that
+    // was verified is the directory that is chmodded, written into,
+    // and renamed within. Resolving the path again for any of those
+    // steps would reintroduce the symlink redirections this exists to
+    // refuse (review findings, two rounds of them: first the final
+    // component, then the intermediate ones).
+    let dir = create_and_open_dir_no_follow(parent)?;
     // The reader trusts records only in a directory nobody else can
     // write (`dir_is_authentic`): a writable directory lets `rename`
     // relocate root-owned records whole, so per-file ownership proves
@@ -643,39 +767,22 @@ fn write_state_record(path: &Path, body: &str) -> std::io::Result<()> {
     // lifetime. Clear exactly the group/world-write bits and leave the
     // rest alone (an operator's deliberate 0700 stays 0700). Best
     // effort: if it fails, the reader refuses, which is the safe side.
-    //
-    // ON THE DESCRIPTOR, never the pathname. The first version ran
-    // `metadata` + `set_permissions` on the path, and both follow
-    // symlinks — so a pre-created `state-dir` symlink pointed this
-    // root chmod at any directory on the system, stripping write bits
-    // from whatever the attacker chose (review finding, P1; the same
-    // pathname-vs-descriptor defect as the record writes, one level
-    // up). `O_DIRECTORY | O_NOFOLLOW` refuses the symlink outright, and
-    // the fchmod applies to the directory that was actually opened. A
-    // symlinked state dir gets no chmod and no trust — the reader's
-    // `dir_is_authentic` refuses it the same way.
     {
-        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-        if let Ok(dirf) = std::fs::OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW)
-            .open(parent)
-        {
-            if let Ok(meta) = dirf.metadata() {
-                let mode = meta.permissions().mode();
-                if meta.is_dir() && mode & 0o022 != 0 {
-                    let _ = dirf.set_permissions(std::fs::Permissions::from_mode(mode & !0o022));
-                }
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = dir.metadata() {
+            let mode = meta.permissions().mode();
+            if meta.is_dir() && mode & 0o022 != 0 {
+                let _ = dir.set_permissions(std::fs::Permissions::from_mode(mode & !0o022));
             }
         }
     }
-    let tmp = path.with_extension("tmp");
+    let tmp = format!("{name}.tmp");
     {
-        let mut f = create_excl_no_follow_with_retry(&tmp)?;
+        let mut f = openat_excl_with_retry(&dir, &tmp)?;
         writeln!(f, "{body}")?;
         f.sync_all()?;
     }
-    std::fs::rename(&tmp, path)
+    renameat_within(&dir, &tmp, name)
 }
 
 /// A BARE PID, exactly as before. The identity lives in a sidecar
@@ -946,17 +1053,23 @@ fn write_reconfigure_marker(path: &Path, status: &str) {
         .map(|d| d.as_nanos())
         .unwrap_or(0);
     let parent = path.parent().unwrap_or_else(|| Path::new("."));
-    if let Err(e) = std::fs::create_dir_all(parent) {
-        tracing::warn!(error = %e, "could not create reconfigure marker dir");
-        return;
-    }
-    let tmp = path.with_extension("timestamp.tmp");
     let body = format!("{} {}\n", crate::scrub::scrub_control_chars(status), now_ns);
+    // Same dirfd discipline as `write_state_record`: this runs as root
+    // in the daemon's SIGHUP handler, and a marker path resolved whole
+    // would follow an intermediate symlink to wherever it points.
     let r = (|| -> std::io::Result<()> {
-        let mut f = create_excl_no_follow_with_retry(&tmp)?;
-        f.write_all(body.as_bytes())?;
-        f.sync_all()?;
-        std::fs::rename(&tmp, path)
+        let name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "no file name"))?;
+        let dir = create_and_open_dir_no_follow(parent)?;
+        let tmp = format!("{name}.tmp");
+        {
+            let mut f = openat_excl_with_retry(&dir, &tmp)?;
+            f.write_all(body.as_bytes())?;
+            f.sync_all()?;
+        }
+        renameat_within(&dir, &tmp, name)
     })();
     if let Err(e) = r {
         tracing::warn!(error = %e, "could not write reconfigure marker");

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1844,23 +1844,39 @@ fn print_module_health(state_dir: &Path) {
              The report below is history, {age}.",
             snapshot.pid
         ),
-        crate::daemon_presence::DaemonPresence::Gone { why } => println!(
-            "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \
-             report below is history, {age}; the dataplane may still be forwarding via its \
-             pins (§8.5).",
-            snapshot.pid
-        ),
-        // Neither shown. Saying "gone" here is what printed STALE over
-        // a live daemon on the shadow (2026-08-12), because the check
-        // asked whether the daemon ran this CLI's own binary.
-        // The record could not answer, but the SNAPSHOT can: it carries
-        // the publisher's own identity, and a match proves that exact
-        // process is running. Reachable whenever the pid record is
-        // missing or stale — a non-fatal write failure, or a
-        // replacement that has attached but not yet rewritten it — and
-        // without this the report reads CANNOT CONFIRM for that
-        // daemon's whole lifetime while the proof sits in the file
-        // being printed (review finding).
+        // The record could not answer — or answered WRONG — but the
+        // SNAPSHOT can: it carries the publisher's own identity, and a
+        // match against the live process proves that exact process is
+        // running. This override reaches `Gone` as well as `Unknown`,
+        // and has to: a daemon whose non-fatal record writes BOTH
+        // failed, running under a name the scan's prefix check does not
+        // admit, resolves to `Gone` — and printing STALE over its
+        // freshly published report is this PR's motivating bug again,
+        // surviving in the one arm the override skipped (review
+        // finding; the first version guarded only `Unknown`). Saying
+        // "gone" over a live daemon is what happened on the shadow,
+        // 2026-08-12.
+        //
+        // Safe for `status` precisely because status ACTS on nothing:
+        // matching identity is the strongest evidence there is, and it
+        // is only being used to label a report. `detach` and
+        // `reconfigure` do not read snapshots and keep their verdicts.
+        // Two arms rather than one, because the operator guidance
+        // differs and a single message would promise `detach` behaviour
+        // one of the two paths does not deliver (the #157 class):
+        // `detach` refuses on `Unknown` but proceeds on `Gone` — the
+        // documented residual — so the `Gone` text must warn, not
+        // reassure.
+        crate::daemon_presence::DaemonPresence::Gone { .. } if snapshot_matches_live(&snapshot) => {
+            println!(
+                "module health (pid {}, {age}) — confirmed by the report's own recorded \
+                 identity. WARNING: every record-based check reads this daemon as absent \
+                 (no pid file, no identity sidecar, and the process-table scan cannot see \
+                 it), so `packetframe detach` would proceed under it. Stop the daemon \
+                 before detaching.",
+                snapshot.pid
+            )
+        }
         crate::daemon_presence::DaemonPresence::Unknown { .. }
             if snapshot_matches_live(&snapshot) =>
         {
@@ -1871,6 +1887,12 @@ fn print_module_health(state_dir: &Path) {
                 snapshot.pid
             )
         }
+        crate::daemon_presence::DaemonPresence::Gone { why } => println!(
+            "module health: STALE — the daemon that wrote this (pid {}) is gone ({why}). The \
+             report below is history, {age}; the dataplane may still be forwarding via its \
+             pins (§8.5).",
+            snapshot.pid
+        ),
         crate::daemon_presence::DaemonPresence::Unknown { why } => println!(
             "module health (pid {}, {age}) — CANNOT CONFIRM the daemon is still running \
              ({why}). Read the report as possibly historical until it can be checked.",

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -969,6 +969,47 @@ pub fn reconfigure(_config_path: &Path) -> Result<(), ReconfigureError> {
     ))
 }
 
+/// Whether `pid`'s executable could be a packetframe daemon — this
+/// build's binary, or another copy of it deployed elsewhere.
+///
+/// Path equality alone answers "is it MY binary", which is exactly the
+/// question that made every check in this module wrong during an
+/// upgrade. A daemon from the previous bundle lives at a different
+/// path, so an exe-path scan cannot see it, and a scan that cannot see
+/// it must not be read as proving it absent.
+///
+/// So the basename counts too, and ONLY for finding. A false positive
+/// here refuses a `detach` and names the pid, which an operator can
+/// look at and resolve; a false negative unlinks pins under a live
+/// daemon, which is the 2026-04-21 outage. Those are not symmetric.
+///
+/// This deliberately widens what the May 2026 audit narrowed, and not
+/// as far back. That finding was about `comm`, settable to anything by
+/// any local process via `prctl` with no file involved. Matching
+/// `/proc/<pid>/exe`'s basename requires actually controlling a binary
+/// named `packetframe`, exec'ing it, and carrying `run` in argv — and
+/// the worst it buys is a refusal that says which pid to look at.
+#[cfg(target_os = "linux")]
+fn proc_exe_looks_like_a_daemon(pid: libc::pid_t) -> bool {
+    if proc_exe_matches_current(pid) {
+        return true;
+    }
+    let Ok(target) = std::fs::read_link(format!("/proc/{pid}/exe")) else {
+        return false;
+    };
+    let Ok(current) = std::env::current_exe() else {
+        return false;
+    };
+    // The kernel appends ` (deleted)` once the inode is unlinked, which
+    // is the state an upgraded-in-place daemon is in.
+    let target = target.to_string_lossy();
+    let target = target.strip_suffix(" (deleted)").unwrap_or(&target);
+    match (Path::new(target).file_name(), current.as_path().file_name()) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
 /// Find a process running this executable, if there is one.
 ///
 /// **Finds only.** This was `daemon_pid`, and its answer was read as
@@ -996,7 +1037,7 @@ fn scan_for_running_daemon() -> Option<i32> {
         if pid == self_pid {
             continue;
         }
-        if !proc_exe_matches_current(pid as libc::pid_t) {
+        if !proc_exe_looks_like_a_daemon(pid as libc::pid_t) {
             continue;
         }
         // And it must be the DAEMON, not another invocation of the same

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,6 +11,7 @@
 mod atomic;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod breaker;
+mod daemon_presence;
 mod feasibility;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod fib_cli;

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1154,6 +1154,12 @@ module's own deltas.
 >   daemon's record looks like mid-trouble. Conversely, a torn *pid
 >   file* next to a whole sidecar still identifies the daemon: the
 >   sidecar is consulted whenever the pid file cannot answer alone.
+> - If the pid file and the sidecar **disagree** and the sidecar's
+>   identity matches a live process, everything answers CANNOT CONFIRM
+>   ("two authenticated records disagree"). This is what a restart
+>   whose pid-file rewrite failed leaves behind: new sidecar, old pid
+>   file. Restart the daemon to re-record both, or remove the stale
+>   pid file.
 > - The scan has to *complete* to count as evidence of absence. If
 >   `/proc` cannot be listed, or a process in it cannot be examined
 >   (running `detach` as a non-root user is the ordinary cause), the

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1132,6 +1132,20 @@ module's own deltas.
 >   when its health snapshot matches the live process, and warns
 >   explicitly that `detach` would proceed under it — stop the daemon
 >   first.
+> - **The state directory itself must be root-owned and not group- or
+>   world-writable**, or every record in it is treated as plantable and
+>   live pids read as CANNOT CONFIRM. Per-file ownership is not enough:
+>   `rename` moves a root-owned record between directories without
+>   touching its contents, so a writable directory's records could have
+>   been replayed whole from another instance's state dir. The daemon
+>   clears the group/world-write bits on its state dir whenever it
+>   writes a record; if you hand-create a custom `state-dir`, make it
+>   `root:root` mode `0755` (or tighter).
+> - A sidecar that is present but unreadable or malformed is treated as
+>   "cannot tell", never as missing — a torn write is what a live
+>   daemon's record looks like mid-trouble. Conversely, a torn *pid
+>   file* next to a whole sidecar still identifies the daemon: the
+>   sidecar is consulted whenever the pid file cannot answer alone.
 > - The scan has to *complete* to count as evidence of absence. If
 >   `/proc` cannot be listed, or a process in it cannot be examined
 >   (running `detach` as a non-root user is the ordinary cause), the

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1095,6 +1095,30 @@ module's own deltas.
 
 ## Install and upgrade on the router
 
+> **`detach` and `status` can be run from a newly deployed bundle.**
+> Until 2026-08-12 they could not: every liveness check asked whether
+> some process ran *the CLI's own executable path*, which is false
+> whenever a command runs from a new bundle while the old daemon is up
+> — the shape every upgrade has. `status` printed `STALE` over a live
+> daemon, `reconfigure` refused, and `detach` found no daemon and
+> **proceeded**, unlinking pins while the daemon still held the
+> `bpf_link` FDs.
+>
+> The daemon now records `(pid, start_ticks, boot_id)` in its pid file
+> and the checks verify against that, so the CLI's own path no longer
+> matters. Two limits worth knowing:
+>
+> - A daemon that never wrote a pid file (the write is non-fatal, and
+>   happens after attach) is found by a `/proc` scan instead. That scan
+>   matches a binary named `packetframe` running `run`, so an unrelated
+>   process named the same way will make `detach` refuse and name the
+>   pid. That is deliberate — refusing is recoverable, unlinking under
+>   a live daemon is not.
+> - `detach` refuses on "cannot tell", not only on "daemon present". If
+>   it refuses and you have established there is no daemon, remove the
+>   stale pid file from the state dir.
+
+
 VPP is **not** bundled in packetframe's .deb — 100 MB against 1.3 MB,
 mismatched cadence, and independent rollback, which the failover design
 wants anyway. It ships on its own release tag, built from *unmodified*

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1128,7 +1128,10 @@ module's own deltas.
 >   removes both files on the way out and `detach` is the advertised
 >   recovery path. Closing it properly means checking whether any
 >   process holds the pinned links, which is evidence that never goes
->   through a pid; that is not built.
+>   through a pid; that is not built. `status` DOES see such a daemon
+>   when its health snapshot matches the live process, and warns
+>   explicitly that `detach` would proceed under it — stop the daemon
+>   first.
 > - The scan has to *complete* to count as evidence of absence. If
 >   `/proc` cannot be listed, or a process in it cannot be examined
 >   (running `detach` as a non-root user is the ordinary cause), the
@@ -1149,6 +1152,17 @@ module's own deltas.
 >   the sidecar, but only if the pids coincide across a reboot; the
 >   ordinary rollback leaves a sidecar naming a different pid, which is
 >   ignored.
+> - **Only a matching identity confirms.** A record that carries no
+>   identity — the pid-only file a pre-sidecar build writes — never
+>   resolves a *live* pid to "our daemon", even when a packetframe
+>   binary holds it: the executable check finds *a* daemon, not *the*
+>   one the record describes. The cost lands once, on the first upgrade
+>   from a pre-sidecar build: `reconfigure` refuses and `status` says
+>   CANNOT CONFIRM until the daemon restarts on a build that records
+>   identity. (`status` usually recovers sooner — the health snapshot
+>   carries the publisher's own identity, and a match against the live
+>   process confirms the report even when every pid record failed or
+>   is missing.)
 > - `detach` refuses on "cannot tell", not only on "daemon present".
 >   When the message names a pid that is **not** a packetframe daemon,
 >   and you have established there is none, remove the pid file and the

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1117,9 +1117,18 @@ module's own deltas.
 >   process named the same way will make `detach` refuse and name the
 >   pid. That is deliberate — refusing is recoverable, unlinking under
 >   a live daemon is not.
-> - `detach` refuses on "cannot tell", not only on "daemon present". If
->   it refuses and you have established there is no daemon, remove the
->   stale pid file from the state dir.
+> - The scan has to *complete* to count as evidence of absence. If
+>   `/proc` cannot be listed, or a process in it cannot be examined
+>   (running `detach` as a non-root user is the ordinary cause), the
+>   refusal says `the process table could not be searched` and names how
+>   many processes were unexaminable. Re-run as root; removing the pid
+>   file will not help, because the scan is what the missing record
+>   falls back to.
+> - `detach` refuses on "cannot tell", not only on "daemon present".
+>   When the message names a **stale record** — a pid that is not the
+>   recorded process and is not running a packetframe daemon — and you
+>   have established there is no daemon, remove the pid file and the
+>   identity sidecar from the state dir.
 
 
 VPP is **not** bundled in packetframe's .deb — 100 MB against 1.3 MB,

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1111,12 +1111,24 @@ module's own deltas.
 > bundles parse it whole, and a rollback has to keep working. Limits
 > worth knowing:
 >
-> - A daemon that never wrote a pid file (the write is non-fatal, and
->   happens after attach) is found by a `/proc` scan instead. That scan
->   matches a binary named `packetframe` running `run`, so an unrelated
->   process named the same way will make `detach` refuse and name the
->   pid. That is deliberate — refusing is recoverable, unlinking under
->   a live daemon is not.
+> - A daemon whose pid-file write failed (it is non-fatal, and happens
+>   after attach) is found by its **identity sidecar**, which the daemon
+>   goes on to write and which names its own pid — so nothing depends on
+>   what the binary is called. If that is missing too, a `/proc` scan is
+>   the last backstop. The scan matches a binary named `packetframe`
+>   running `run`, so an unrelated process named that way will make
+>   `detach` refuse and name the pid. That is deliberate — refusing is
+>   recoverable, unlinking under a live daemon is not.
+>
+>   **Residual, deliberate:** a daemon that wrote *neither* file — an
+>   unwritable state dir — *and* runs under a binary name sharing no
+>   prefix with `packetframe` is invisible to all three checks, and
+>   `detach` will proceed. Refusing on every recordless state instead
+>   would disable `detach` after every clean stop, since the daemon
+>   removes both files on the way out and `detach` is the advertised
+>   recovery path. Closing it properly means checking whether any
+>   process holds the pinned links, which is evidence that never goes
+>   through a pid; that is not built.
 > - The scan has to *complete* to count as evidence of absence. If
 >   `/proc` cannot be listed, or a process in it cannot be examined
 >   (running `detach` as a non-root user is the ordinary cause), the

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1108,8 +1108,8 @@ module's own deltas.
 > `packetframe.identity`, beside the pid file, and the checks verify
 > against that — so the CLI's own path no longer matters.
 > `packetframe.pid` stays a bare pid on purpose: CLIs from other
-> bundles parse it whole, and a rollback has to keep working. Two
-> limits worth knowing:
+> bundles parse it whole, and a rollback has to keep working. Limits
+> worth knowing:
 >
 > - A daemon that never wrote a pid file (the write is non-fatal, and
 >   happens after attach) is found by a `/proc` scan instead. That scan
@@ -1124,10 +1124,22 @@ module's own deltas.
 >   many processes were unexaminable. Re-run as root; removing the pid
 >   file will not help, because the scan is what the missing record
 >   falls back to.
+> - A recorded pid whose live identity **does not match** is never
+>   resolved either way: the pid was reused, or the record is stale, and
+>   nothing in the data separates them. `status` says CANNOT CONFIRM,
+>   `reconfigure` and `detach` refuse, and the message says whether a
+>   packetframe daemon holds that pid. It is deliberately not resolved
+>   by "well, it is *a* daemon" — a `packetframe run` from another
+>   bundle and another state dir satisfies that, and signalling it would
+>   reload a stranger's config. Restart the daemon to re-record the
+>   identity.
+>   This is reachable after a rollback to a build that does not write
+>   the sidecar, but only if the pids coincide across a reboot; the
+>   ordinary rollback leaves a sidecar naming a different pid, which is
+>   ignored.
 > - `detach` refuses on "cannot tell", not only on "daemon present".
->   When the message names a **stale record** — a pid that is not the
->   recorded process and is not running a packetframe daemon — and you
->   have established there is no daemon, remove the pid file and the
+>   When the message names a pid that is **not** a packetframe daemon,
+>   and you have established there is none, remove the pid file and the
 >   identity sidecar from the state dir.
 
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1141,6 +1141,14 @@ module's own deltas.
 >   clears the group/world-write bits on its state dir whenever it
 >   writes a record; if you hand-create a custom `state-dir`, make it
 >   `root:root` mode `0755` (or tighter).
+>   The same rule runs up the **ancestor chain**: every directory above
+>   the state dir must be root-owned and either not group/world-writable
+>   or sticky (`/tmp` qualifies) — otherwise the whole state dir could
+>   be renamed and another one swapped into its place without touching
+>   a file. And the configured `state-dir` path must contain **no
+>   symlinks** (a symlinked component is the same swap, done by
+>   repointing): on systems where `/var/run` links to `/run`, configure
+>   the real `/run/...` path.
 > - A sidecar that is present but unreadable or malformed is treated as
 >   "cannot tell", never as missing — a torn write is what a live
 >   daemon's record looks like mid-trouble. Conversely, a torn *pid

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1104,9 +1104,12 @@ module's own deltas.
 > **proceeded**, unlinking pins while the daemon still held the
 > `bpf_link` FDs.
 >
-> The daemon now records `(pid, start_ticks, boot_id)` in its pid file
-> and the checks verify against that, so the CLI's own path no longer
-> matters. Two limits worth knowing:
+> The daemon now records `(pid, start_ticks, boot_id)` in
+> `packetframe.identity`, beside the pid file, and the checks verify
+> against that — so the CLI's own path no longer matters.
+> `packetframe.pid` stays a bare pid on purpose: CLIs from other
+> bundles parse it whole, and a rollback has to keep working. Two
+> limits worth knowing:
 >
 > - A daemon that never wrote a pid file (the write is non-fatal, and
 >   happens after attach) is found by a `/proc` scan instead. That scan


### PR DESCRIPTION
Found on the shadow while deploying tonight's merges. One predicate, three callers, and the one that matters fails **open**.

## What was observed

`status`, run from a newly deployed bundle against a live daemon:

```
module health: STALE — the daemon that wrote this (pid 506140) is gone.
```

`ps` in the same session showed 506140 running, and its log was still ticking. The check is `proc_exe_matches_current` — *does some process run my exact executable path* — used to answer *is the daemon alive*.

## Why it matters beyond a wrong line

| caller | on a path mismatch | consequence |
|---|---|---|
| `status` | prints STALE | operator believes supervision died |
| `reconfigure` | "not a packetframe process (stale pidfile?)" | the canary lever fails mid-rollout |
| `detach` | finds no daemon, **proceeds** | unlinks pins under a live daemon |

The third is the one with a precedent, recorded in its own comment: *"Confirmed outage-adjacent on the reference EFG 2026-04-21, the detach ran, reported clean, but `ip link show` still had `xdpgeneric` attached."* The daemon holds the `bpf_link` FDs.

**And the trigger is the upgrade procedure itself.** Ship a bundle, run any of the three from it while the old daemon is up — the paths differ by construction.

It was also wrong in the other direction: the comparison is on the path *string* with a trailing ` (deleted)` stripped, so a daemon whose binary had been replaced under it read as "the same binary as me" while running different code. Which is what this box did all day.

## The fix

The daemon records the identity this codebase already uses for adoption — `(pid, start_ticks)` against a `boot_id` — in the root-owned state dir. No user-settable name is trusted anywhere, which is why the exe check existed (`comm` is settable via `prctl`, a prior audit finding).

Presence is **three-valued**, and each caller applies its own safe default, because theirs are opposite:

- `status` — "cannot confirm the daemon is still running (…); read the report as possibly historical". Useful without claiming.
- `reconfigure` — refuses to signal a pid it cannot identify.
- `detach` — refuses on anything but positive evidence of **absence**.

A legacy pid file (pid only) still works: the exe match may still *confirm* presence, it just may no longer *conclude* absence. `daemon_pid()` is deleted — replacing its one caller left it with none.

## Tests

The policy is a pure function (`decide`) with the `/proc` reads split out, and its table is asserted **on every host** — this is a safety guard, and a test that only runs under qemu is unverified on the machine the change is written on. Covers: the upgrade window, pid reuse, reuse across a reboot with identical ticks, an unreadable record, and no process at all.

Verified against a revert — restoring "failed identity ⇒ Gone" fails on the upgrade case.

The `detach` wiring test is Linux-gated (it needs `/proc`), so it runs in CI rather than here. That half of the original defect was never observed misfiring — doing so would have meant unlinking pins under a live daemon — so it is pinned by assertion rather than by observation, and I would rather say that than imply I watched it.

768 tests green, clippy clean on host and both cross targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)