### PR TITLE
fix(vpp-offload): the convergence remedy named a command that state refuses

### DIFF
--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1008,19 +1008,37 @@ impl Runtime {
                 match c.steering.missing_from_nic() {
                     Ok(audit) => {
                         if !audit.missing.is_empty() && c.steer_missing != audit.missing.len() {
+                            // NAMES NO REMEDY. The audit runs in every
+                            // state, and the remedy depends on the state:
+                            // `reconfigure` reconciles steering only from
+                            // `Ready`/`Steered`, so this line promised it
+                            // during adopted resyncs and backoffs, where
+                            // it answers "not converged" and changes
+                            // nothing (observed on the shadow,
+                            // 2026-08-12). `steering_health` already
+                            // selects the right remedy from the state and
+                            // is tested to; a second copy here is a copy
+                            // that cannot see what it needs and drifts
+                            // from the one that can.
                             tracing::warn!(
                                 missing = ?audit.missing,
                                 "steering rules this target needs are not in the NIC; \
                                  traffic for them is on the eBPF tier. `packetframe \
-                                 reconfigure` reinstalls them"
+                                 status` names the remedy for the current state"
                             );
                         }
                         c.steer_missing = audit.missing.len();
                         if !audit.stray.is_empty() && c.steer_stray != audit.stray.len() {
+                            // Same reason as the missing arm above, and
+                            // the stray remedy is the one that must not
+                            // be waited on — the health line says so,
+                            // with the by-hand `ethtool` removal for
+                            // where reconfigure will not run.
                             tracing::warn!(
                                 stray = ?audit.stray,
                                 "rules are still steering a port this config asks to leave \
-                                 unsteered; `packetframe reconfigure` removes them"
+                                 unsteered; `packetframe status` names the remedy for the \
+                                 current state"
                             );
                         }
                         c.steer_stray = audit.stray.len();

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -856,13 +856,27 @@ impl StatusSnapshot {
             // resync running yet, which is why this does not say "this
             // resync"), and the target it will reconcile to is non-empty,
             // so its stale-rule removal covers whatever is left over.
+            //
+            // This arm ends by saying `reconfigure` will NOT help, which
+            // is the opposite of what it shipped saying. Every state that
+            // reaches it — `Starting`, `Syncing`, `Verifying`,
+            // `AdoptedResyncing`, `Backoff` — fails
+            // `accepts_steering_changes()`, since the two that pass it
+            // took the first arm. So the promise that reconfigure "asks
+            // immediately" was wrong on every line it ever printed, not
+            // in a corner: measured on the shadow 2026-08-12, where an
+            // adopted resync deferred for 23 hours printed it and the
+            // reconfigure it named answered "not converged" and changed
+            // nothing. The comment at the top of this selection had
+            // already written down the rule; the last sentence of this
+            // arm broke it, and no test compared the two.
             "a convergence re-applies steering only if it verifies clean — one that ends \
              with routes withheld or unresolvable parks in the staging state and emits no \
              steer at all, and a steer that IS emitted can still be refused by the \
              completeness gate. Both settle in the staging state with the want \
              remembered, and from there the module re-attempts the steer by itself once \
-             both gates permit. `packetframe reconfigure` asks immediately rather than \
-             waiting"
+             both gates permit. Until it converges there is nothing to ask: `packetframe \
+             reconfigure` answers \"not converged\" from here and changes no steering"
                 .to_string()
         };
         // Stray rules do NOT share that remedy, and sharing it was a
@@ -1702,6 +1716,84 @@ mod tests {
             seen.len() >= 4,
             "the matrix must actually render commands, or this proves nothing: {seen:?}"
         );
+    }
+
+    /// A remedy may not present `packetframe reconfigure` as something
+    /// to run NOW from a state that refuses it.
+    ///
+    /// The rule, not the case. #157 split the remedy four ways for
+    /// exactly this reason and wrote the rule into the comment above
+    /// the selection — and the convergence arm's last sentence then
+    /// broke it, saying reconfigure "asks immediately rather than
+    /// waiting" from the only states that reach that arm, all of which
+    /// fail `accepts_steering_changes()`. It printed on the shadow for
+    /// 23 hours under an adopted resync, and the reconfigure it named
+    /// answered "not converged" (2026-08-12, hardware). No test
+    /// compared the message against the gate the module actually
+    /// applies, so this one does: the assertion is derived from
+    /// `accepts_steering_changes()` rather than from a list of states I
+    /// thought of, and it fails if a future arm regresses the same way.
+    #[test]
+    fn no_remedy_offers_reconfigure_where_the_module_refuses_it() {
+        for state in [
+            State::Stopped,
+            State::Backoff,
+            State::Starting,
+            State::Syncing,
+            State::Verifying,
+            State::Ready,
+            State::Steered,
+            State::AdoptedResyncing,
+        ] {
+            if state.accepts_steering_changes() {
+                continue;
+            }
+            for steer_configured in [true, false] {
+                for steering in steering_postures() {
+                    for (missing, stray) in [(1usize, 0usize), (0, 1), (1, 1)] {
+                        let led = ledger_with(10, 0, 0);
+                        let mut snap = snap_of(
+                            &steered_supervisor(),
+                            &led,
+                            ApiHealth::Answering {
+                                silent_for: Duration::from_millis(200),
+                            },
+                            verified(3),
+                            ports_up(),
+                        );
+                        snap.state = state;
+                        snap.steer_configured = steer_configured;
+                        (snap.steered, snap.steer_intended) = steering;
+                        snap.steer_missing = missing;
+                        snap.steer_stray = stray;
+
+                        for sub in snap.report().subsystems {
+                            let Some(msg) = sub.message else { continue };
+                            // The exact phrasing that was wrong, plus the
+                            // generic form of the same promise. A remedy
+                            // may still NAME reconfigure — the stray arm
+                            // does, hedged with "where reconfigure will
+                            // not run" — but it may not say it works now.
+                            for banned in [
+                                "asks immediately",
+                                "re-applies steering, and reports its own reason",
+                            ] {
+                                assert!(
+                                    !msg.contains(banned),
+                                    "{} in {state:?} (steer_configured={steer_configured}, \
+                                     missing={missing}, stray={stray}) offers reconfigure \
+                                     as an immediate remedy, but \
+                                     accepts_steering_changes() is false there, so the \
+                                     module answers \"not converged\" and changes nothing. \
+                                     Full line: {msg}",
+                                    sub.name
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     /// No health message contains a run of whitespace.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -423,9 +423,19 @@ steering  DEGRADED — 1 steering rule(s) ... a convergence re-applies
                      completeness gate. Both settle in the staging state
                      with the want remembered, and from there the module
                      re-attempts the steer by itself once both gates
-                     permit. `packetframe reconfigure` asks immediately
-                     rather than waiting
+                     permit. Until it converges there is nothing to ask:
+                     `packetframe reconfigure` answers "not converged"
+                     from here and changes no steering
 ```
+
+That last sentence used to read *"`packetframe reconfigure` asks
+immediately rather than waiting"* — which contradicted the paragraph
+directly above it, and was wrong on every line it ever printed: the
+only states that reach this arm are the ones that refuse steering
+changes. It printed on the shadow for 23 hours under a held deferral,
+and the reconfigure it named answered *"not converged"* (2026-08-12,
+hardware). Fixed, with an invariant test derived from
+`accepts_steering_changes()` rather than a list of states.
 
 **Read that second sentence.** There are two ways the automatic path
 declines. A verify that ends `VerifyIncomplete` — routes withheld or


### PR DESCRIPTION
Found on hardware, not in review.

## What happened

The shadow has been sitting in `AdoptedResyncing` for ~23 hours (a held deferral on a box with no completeness authority — working as designed). Its steering health line said:

> ... the module re-attempts the steer by itself once both gates permit. `packetframe reconfigure` asks immediately rather than waiting

Running exactly that:

```
ERROR reconfigure: daemon rejected the new config error=module: vpp-offload:
vpp-offload is AdoptedResyncing, not converged — steering changes apply only
from Ready or Steered.
```

## Why it matters

This is the #157 class — *a health line naming a remedy the module will refuse* — living inside #157's own fix. The remedy selection splits four ways specifically to prevent this and states the rule in a comment above itself. The convergence arm's last sentence broke it.

It is not a corner case. `accepts_steering_changes()` is `Ready | Steered`, and those two take the **first** arm — so every state that reaches the convergence arm (`Starting`, `Syncing`, `Verifying`, `AdoptedResyncing`, `Backoff`) refuses the command it was advertising. **The sentence was wrong on every line it ever printed.**

## The fix

- The arm now says the opposite: reconfigure answers "not converged" from here and changes no steering.
- **Invariant test** derived from `accepts_steering_changes()` rather than a list of states, so a future arm regressing the same way fails. Verified against the reverted string — it fails, with the message naming the state.
- The two audit `warn!` lines in `runtime.rs` had the same defect and no state in scope to fix it with, so they name no remedy and point at `packetframe status`, which selects one from the state and is tested to.
- The runbook quoted the false line one paragraph below the paragraph stating the correct rule; both now agree.

## Testing

774 workspace tests green, clippy clean on host + cross targets. The behaviour that produced this is reproducible on the shadow right now (`packetframe status` there still shows the deferral).

🤖 Generated with [Claude Code](https://claude.com/claude-code)