### PR TITLE
fix(vpp-offload): a vetoing completeness authority could not be seen or said

### DIFF
--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -315,7 +315,8 @@ impl Completeness {
                 "the route mirror holds {mirror} routes but the authority reports only \
                  {authority} — that is not the authority feeding this mirror. Check which \
                  bird `birdc` is talking to; on a box whose routes come from elsewhere, \
-                 `require-table-complete off` is the right answer"
+                 `require-table-complete off` is the right answer — but it takes effect at \
+                 the next bring-up, so the daemon has to be restarted for it, not reloaded"
             ),
             Completeness::Stale { age } => format!(
                 "the last completeness check was {}s ago, too old to act on",

--- a/crates/common/src/fib/mod.rs
+++ b/crates/common/src/fib/mod.rs
@@ -243,7 +243,47 @@ pub enum Completeness {
     Unknown { why: &'static str },
 }
 
+/// Why an otherwise-successful sample still cannot judge completeness:
+/// the authority answered, and answered zero.
+///
+/// A named constant because two places need to agree on it —
+/// [`assess`] produces it and [`Completeness::authority_is_at_fault`]
+/// classifies it — and a string literal compared in one place against a
+/// literal written in another is a pair that drifts silently the first
+/// time someone rewords the message.
+pub const ZERO_ROUTE_AUTHORITY: &str = "the authority reports zero routes";
+
 impl Completeness {
+    /// Whether the AUTHORITY is the thing that is wrong — as opposed to
+    /// a check that has not run yet, a report that aged out, or a
+    /// mirror still filling.
+    ///
+    /// The distinction consumers actually act on, because it decides
+    /// what an operator is told: wait, or go and look at bird. Both
+    /// arms here describe an authority that is answering and whose
+    /// answer cannot describe this mirror — one holding far fewer
+    /// routes than the mirror, or none at all — and no amount of
+    /// waiting or converging changes either. Everything else resolves
+    /// as the system settles.
+    ///
+    /// `Unknown { ZERO_ROUTE_AUTHORITY }` belongs here rather than with
+    /// the transient unknowns, and that is the whole reason this
+    /// predicate exists: `assess` returns it BEFORE the mismatch
+    /// branch, so an empty bird against a full mirror — the fully-empty
+    /// form of the 2026-08-12 shadow incident, which survived only
+    /// because that box had 13 routes rather than 0 — was classified as
+    /// self-clearing and promised a wait that could never end (review
+    /// finding).
+    pub fn authority_is_at_fault(&self) -> bool {
+        match self {
+            Completeness::AuthorityMismatch { .. } => true,
+            Completeness::Unknown { why } => *why == ZERO_ROUTE_AUTHORITY,
+            Completeness::Converged { .. }
+            | Completeness::Incomplete { .. }
+            | Completeness::Stale { .. } => false,
+        }
+    }
+
     /// Whether traffic may be steered on the strength of this.
     ///
     /// Only `Converged` says yes. `Unknown` deliberately does **not** —
@@ -308,7 +348,7 @@ pub fn assess(
     }
     let Some(drift) = r.drift() else {
         return Completeness::Unknown {
-            why: "the authority reports zero routes",
+            why: ZERO_ROUTE_AUTHORITY,
         };
     };
     if drift <= max_drift {
@@ -778,6 +818,66 @@ impl std::error::Error for NeighError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Every variant is classified, and the zero-route unknown is a
+    /// fault rather than a wait.
+    ///
+    /// `assess` returns `Unknown { ZERO_ROUTE_AUTHORITY }` BEFORE it
+    /// can reach `AuthorityMismatch`, so an authority answering zero
+    /// against a populated mirror looks like a transient unknown while
+    /// being exactly as permanent as a mismatch — every later sample
+    /// says the same thing until bird itself gains routes. Consumers
+    /// that told an operator to wait on it recreated the 2026-08-12
+    /// shadow incident in its fully-empty form (review finding), which
+    /// is why the classification lives here beside the reason strings
+    /// and not in the consumer.
+    #[test]
+    fn a_zero_route_authority_is_a_fault_not_a_wait() {
+        assert!(Completeness::AuthorityMismatch {
+            authority: 13,
+            mirror: 1_303_920
+        }
+        .authority_is_at_fault());
+        assert!(Completeness::Unknown {
+            why: ZERO_ROUTE_AUTHORITY
+        }
+        .authority_is_at_fault());
+
+        // The genuinely transient ones, which a later sample clears.
+        assert!(!Completeness::Unknown {
+            why: "no check has run yet"
+        }
+        .authority_is_at_fault());
+        assert!(!Completeness::Stale {
+            age: std::time::Duration::from_secs(9_999)
+        }
+        .authority_is_at_fault());
+        assert!(!Completeness::Incomplete {
+            drift: 0.5,
+            authority: 1_000_000,
+            mirror: 500_000
+        }
+        .authority_is_at_fault());
+        assert!(!Completeness::Converged { drift: 0.0 }.authority_is_at_fault());
+
+        // And the constant is what `assess` actually emits — a literal
+        // compared against a literal written elsewhere is the pair this
+        // constant exists to prevent.
+        let verdict = assess(
+            Some(CompletenessReport {
+                authority_routes: 0,
+                mirror_routes: 1_000_000,
+                at: std::time::Instant::now(),
+            }),
+            std::time::Instant::now(),
+            STEER_MAX_DRIFT,
+            STEER_MAX_REPORT_AGE,
+        );
+        assert!(
+            verdict.authority_is_at_fault(),
+            "an empty authority against a full mirror must classify as a fault: {verdict:?}"
+        );
+    }
 
     /// The epoch counts down-to-up transitions and rides in the same
     /// word as the liveness it belongs to.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -150,13 +150,26 @@ impl VppOffloadConfig {
 
     /// What in `new` cannot be applied without a restart.
     ///
-    /// `Ok(())` means the only differences are ones `reconfigure` can
-    /// act on: the per-port `steer` flag and `require-table-complete`,
-    /// neither of which VPP knows about. Everything else is fixed at
-    /// VPP's start or at VF acquisition, so the honest answer is to
-    /// refuse and say so — the alternative is a daemon whose running
-    /// configuration silently differs from the file an operator just
-    /// edited, which is how the wrong thing gets debugged for an hour.
+    /// `Ok(())` means the only differences are ones a reload does not
+    /// have to refuse: the per-port `steer` flag and
+    /// `require-table-complete`, neither of which VPP knows about.
+    /// Everything else is fixed at VPP's start or at VF acquisition, so
+    /// the honest answer is to refuse and say so — the alternative is a
+    /// daemon whose running configuration silently differs from the
+    /// file an operator just edited, which is how the wrong thing gets
+    /// debugged for an hour.
+    ///
+    /// **Only the steer flag is actually APPLIED by `reconfigure`.**
+    /// This comment used to say both were, and they are not:
+    /// `require-table-complete` is read at bring-up
+    /// (`Runtime::require_table_complete` installs or withholds the
+    /// completeness handle) and `reconfigure` never touches that
+    /// handle, so a toggled value is stored in `cfg` and takes effect
+    /// only at the next start. The health text says so where it
+    /// recommends the toggle; making the reload apply it is filed
+    /// separately, since installing or removing the authority under a
+    /// deferral that is mid-flight is a release-semantics change and
+    /// not a message fix (review finding).
     ///
     /// A pure function over two configs so the rule is testable without
     /// a VPP, a NIC, or an attachment.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -849,15 +849,25 @@ fn authority_posture(
     demoted: bool,
     gate_consults_authority: bool,
     current: Option<bool>,
+    verdict: Option<packetframe_common::fib::Completeness>,
 ) -> AuthorityPosture {
+    use packetframe_common::fib::Completeness;
     if !configured {
         AuthorityPosture::Absent
     } else if demoted {
         AuthorityPosture::DemotedByFlap
-    } else if gate_consults_authority && current == Some(false) {
+    } else if !gate_consults_authority || current != Some(false) {
+        AuthorityPosture::Attesting
+    } else if matches!(verdict, Some(Completeness::AuthorityMismatch { .. })) {
+        // The ONLY verdict that waiting cannot fix: the mirror holds
+        // substantially more than the authority claims, so the
+        // authority is not the thing feeding this mirror. Every other
+        // non-permitting verdict is a report that has not arrived yet,
+        // has aged out, or describes a mirror still loading — all of
+        // which the next check can clear.
         AuthorityPosture::Vetoing
     } else {
-        AuthorityPosture::Attesting
+        AuthorityPosture::AwaitingAuthority
     }
 }
 
@@ -1135,6 +1145,7 @@ impl Runtime {
                 // not be able to disagree about whether the authority is
                 // currently permitting.
                 authority_current(&c.completeness, c.source.route_count()),
+                c.completeness.as_ref().map(|h| h.verdict()),
             ),
         }
     }
@@ -1185,7 +1196,27 @@ pub enum AuthorityPosture {
     /// `AwaitingFallback` consults the authority; the diff stage
     /// releases on floor-and-quiet and a disagreeing authority there is
     /// not blocking anything.
+    ///
+    /// And scoped to the PERSISTENT verdict, `AuthorityMismatch`.
+    /// `assess()` already draws that line — "short of the authority is a
+    /// mirror still loading — wait; larger than the authority cannot be
+    /// a loading state at all" — and the first version of this variant
+    /// flattened all four non-permitting verdicts into it, so a box
+    /// whose first integrity check had simply not run yet was told that
+    /// waiting would not help. That fires at every startup on a box
+    /// with an authority (review finding).
     Vetoing,
+    /// Configured, currently not permitting, for a reason that clears
+    /// itself: no report yet (`Unknown`), one that aged out (`Stale`),
+    /// or a mirror still short of the authority (`Incomplete`). The
+    /// integrity checker publishes a fresh report every interval and
+    /// the deferral releases on its own.
+    ///
+    /// Distinct from `Vetoing` because the operator action differs
+    /// completely — wait, versus go and find out which bird `birdc` is
+    /// talking to — and distinct from `Attesting` because release IS
+    /// currently blocked, which a line saying "attesting" would deny.
+    AwaitingAuthority,
 }
 
 /// One coherent snapshot of the runtime's observable state, for the
@@ -2298,27 +2329,32 @@ mod tests {
     /// fix, one stage over.
     #[test]
     fn a_veto_is_scoped_to_the_gate_that_consults_the_authority() {
+        use packetframe_common::fib::Completeness;
+        let mismatch = Some(Completeness::AuthorityMismatch {
+            authority: 13,
+            mirror: 1_303_920,
+        });
         // Absent beats everything: no handle, nothing to say.
         for consults in [true, false] {
             assert_eq!(
-                authority_posture(false, false, consults, None),
+                authority_posture(false, false, consults, None, None),
                 AuthorityPosture::Absent
             );
         }
         // A flap demotes regardless of the current word.
         assert_eq!(
-            authority_posture(true, true, true, Some(false)),
+            authority_posture(true, true, true, Some(false), mismatch.clone()),
             AuthorityPosture::DemotedByFlap
         );
         // THE RULE: same disagreeing authority, opposite verdicts,
         // decided only by whether this deferral's gate consults it.
         assert_eq!(
-            authority_posture(true, false, true, Some(false)),
+            authority_posture(true, false, true, Some(false), mismatch.clone()),
             AuthorityPosture::Vetoing,
             "AwaitingFallback consults the authority, so a false there IS the blocker"
         );
         assert_eq!(
-            authority_posture(true, false, false, Some(false)),
+            authority_posture(true, false, false, Some(false), mismatch.clone()),
             AuthorityPosture::Attesting,
             "AwaitingDiff never asks, so a disagreeing authority is not blocking it and \
              must not be reported as if it were"
@@ -2326,10 +2362,61 @@ mod tests {
         // A permitting or unknown authority is never a veto.
         for current in [Some(true), None] {
             assert_eq!(
-                authority_posture(true, false, true, current),
+                authority_posture(true, false, true, current, mismatch.clone()),
                 AuthorityPosture::Attesting
             );
         }
+    }
+
+    /// Only `AuthorityMismatch` is a veto; the rest clear themselves.
+    ///
+    /// `authority_current` returns false for EVERY non-permitting
+    /// verdict, so keying the veto on it alone told a box whose first
+    /// integrity check simply had not run yet that waiting would not
+    /// help — at every startup with an authority configured (review
+    /// finding). `assess()` already draws the line this test pins:
+    /// short of the authority is a mirror still loading; larger than
+    /// the authority cannot be a loading state at all.
+    #[test]
+    fn only_a_mismatched_authority_is_a_veto() {
+        use packetframe_common::fib::Completeness;
+        let self_clearing = [
+            Completeness::Unknown {
+                why: "no check has run yet",
+            },
+            Completeness::Stale {
+                age: Duration::from_secs(9_999),
+            },
+            Completeness::Incomplete {
+                drift: 0.5,
+                authority: 1_000_000,
+                mirror: 500_000,
+            },
+        ];
+        for verdict in self_clearing {
+            assert_eq!(
+                authority_posture(true, false, true, Some(false), Some(verdict.clone())),
+                AuthorityPosture::AwaitingAuthority,
+                "{verdict:?} is a report that has not arrived, aged out, or describes a \
+                 mirror still loading — the next check can clear all three, so this must \
+                 not be reported as a veto"
+            );
+        }
+        assert_eq!(
+            authority_posture(
+                true,
+                false,
+                true,
+                Some(false),
+                Some(Completeness::AuthorityMismatch {
+                    authority: 13,
+                    mirror: 1_303_920,
+                })
+            ),
+            AuthorityPosture::Vetoing,
+            "a mirror holding far more than the authority claims is not a loading state \
+             and no check will clear it"
+        );
     }
 
     /// Activity cannot divide away, however slowly the tick ran.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -886,42 +886,35 @@ fn authority_posture(
     }
 }
 
-/// The verdict as it applies to the mirror **as it is now** — the same
-/// substitution [`authority_current`] makes before deciding the veto.
+/// The verdict on the sample **as it was taken** — both counts from the
+/// same instant.
 ///
-/// `TableCompleteness::verdict()` assesses the report's own recorded
-/// `mirror_routes`, which is the mirror as it was when the checker ran.
-/// The gate does not: it swaps in the current count and recomputes
-/// drift. Classifying the block reason from the un-substituted verdict
-/// therefore reads a different mirror than the decision it is
-/// explaining, and the two part company in exactly the case that
-/// matters — a report that WAS converged, with a source that has since
-/// outgrown it, vetoes while still assessing `Converged`, so the reason
-/// came out `AwaitingAuthority` and promised a self-clearing wait for a
-/// mismatch that persists (review finding).
+/// This function briefly substituted the LIVE mirror count first, to
+/// match what [`authority_current`] does before deciding the veto. That
+/// was an over-correction, and the two review findings that produced
+/// and then removed it are worth keeping together, because they look
+/// contradictory and are not.
 ///
-/// Only the REASON is derived here. `authority_current` keeps deciding
-/// the veto, unchanged, because it additionally requires the cached
-/// verdict to permit and changing that would move release semantics,
-/// which this fix has no business doing.
-fn authority_verdict_now(
+/// The first was right that the reason and the decision were reading
+/// different mirrors. The wrong conclusion I drew was that the
+/// classification should therefore substitute too — because a live
+/// mirror measured against a STALE authority count manufactures an
+/// `AuthorityMismatch` out of ordinary loading: a sample of 1.0M/1.0M
+/// at T, a mirror at 1.3M by T+200s, and the substitution calls that
+/// "the authority is measuring a different table" when the next 300 s
+/// check simply re-measures both and agrees (review finding).
+///
+/// So the fault question — *is the authority itself wrong* — is asked
+/// of the sample, where both numbers describe the same moment. A
+/// mismatch that is real survives into the next sample and is
+/// classified then, within one interval; one created by the clock does
+/// not. What the substituted view legitimately shows is that release is
+/// blocked RIGHT NOW, and that belongs in the blocked-but-clearing
+/// message, which names it.
+fn authority_sample_verdict(
     completeness: &Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
-    mirror_now: u64,
 ) -> Option<packetframe_common::fib::Completeness> {
-    completeness.as_ref().map(|h| {
-        let substituted = h
-            .latest()
-            .map(|r| packetframe_common::fib::CompletenessReport {
-                mirror_routes: mirror_now,
-                ..r
-            });
-        packetframe_common::fib::assess(
-            substituted,
-            std::time::Instant::now(),
-            packetframe_common::fib::STEER_MAX_DRIFT,
-            packetframe_common::fib::STEER_MAX_REPORT_AGE,
-        )
-    })
+    completeness.as_ref().map(|h| h.verdict())
 }
 
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
@@ -1198,7 +1191,7 @@ impl Runtime {
                 // not be able to disagree about whether the authority is
                 // currently permitting.
                 authority_current(&c.completeness, c.source.route_count()),
-                authority_verdict_now(&c.completeness, c.source.route_count()),
+                authority_sample_verdict(&c.completeness),
             ),
         }
     }
@@ -2439,18 +2432,28 @@ mod tests {
         }
     }
 
-    /// The reason must be read off the SAME mirror the veto was
-    /// decided from.
+    /// A mirror that has moved since the last sample is not a faulty
+    /// authority.
     ///
-    /// `verdict()` assesses the report's recorded `mirror_routes`;
-    /// `authority_current` swaps in the live count first. A report that
-    /// was converged when it was taken, with a source that has since
-    /// outgrown its authority, therefore vetoes while still assessing
-    /// `Converged` — and the reason came out `AwaitingAuthority`,
-    /// promising a wait that clears itself for a mismatch that does not
-    /// (review finding).
+    /// **This test asserted the opposite one round earlier, and that
+    /// assertion was wrong.** It was written for a real finding — the
+    /// reason and the gate were reading different mirrors — but the
+    /// conclusion it encoded, that the classification should therefore
+    /// substitute the live count too, manufactures a permanent-sounding
+    /// verdict out of ordinary loading: the checker samples every 300 s,
+    /// a DFZ mirror grows past 1% drift in far less, and comparing that
+    /// live mirror against the stale authority number reads as "not the
+    /// authority feeding this mirror" when the next sample re-measures
+    /// both and agrees (review finding).
+    ///
+    /// The fault question is asked of the sample, where both numbers
+    /// describe one moment. A genuine mismatch survives into the next
+    /// sample and is classified then, within one interval; one created
+    /// by the clock does not. The gate still blocks meanwhile — that is
+    /// `authority_current`'s job and is unchanged — and the
+    /// blocked-but-clearing message is what says so.
     #[test]
-    fn the_verdict_is_reassessed_against_the_live_mirror() {
+    fn a_mirror_that_outgrew_its_sample_is_not_a_faulty_authority() {
         use packetframe_common::fib::{Completeness, CompletenessReport, TableCompleteness};
         let handle = std::sync::Arc::new(TableCompleteness::new());
         handle.publish(CompletenessReport {
@@ -2460,26 +2463,50 @@ mod tests {
         });
         let completeness = Some(handle);
 
-        // As reported: converged, and the cached verdict agrees.
+        // The sample itself: both counts from one instant, converged.
         assert!(matches!(
-            authority_verdict_now(&completeness, 1_000_000),
+            authority_sample_verdict(&completeness),
             Some(Completeness::Converged { .. })
         ));
 
-        // The source has since outgrown the authority. The gate vetoes
-        // on this, so the reason has to be the mismatch — not "no
-        // report yet".
+        // The source has grown since. The gate DOES block on the live
+        // count — unchanged, and correct.
         assert_eq!(authority_current(&completeness, 1_400_000), Some(false));
-        let verdict = authority_verdict_now(&completeness, 1_400_000);
-        assert!(
-            matches!(verdict, Some(Completeness::AuthorityMismatch { .. })),
-            "a mirror that has outgrown its authority is a mismatch, whatever the cached \
-             report said: {verdict:?}"
-        );
+
+        // But the authority is not what is wrong: nothing has asked it
+        // since, and the next check will. So the operator is told this
+        // clears itself, not to go restarting daemons.
         assert_eq!(
-            authority_posture(true, false, true, Some(false), verdict),
+            authority_posture(
+                true,
+                false,
+                true,
+                Some(false),
+                authority_sample_verdict(&completeness)
+            ),
+            AuthorityPosture::AwaitingAuthority,
+            "a stale authority count against a grown mirror is the clock, not a fault"
+        );
+
+        // And when the mismatch is real — both counts from the same
+        // sample — it is a fault, which is the shadow's actual case.
+        let real = std::sync::Arc::new(TableCompleteness::new());
+        real.publish(CompletenessReport {
+            authority_routes: 13,
+            mirror_routes: 1_303_920,
+            at: std::time::Instant::now(),
+        });
+        let real = Some(real);
+        assert_eq!(
+            authority_posture(
+                true,
+                false,
+                true,
+                Some(false),
+                authority_sample_verdict(&real)
+            ),
             AuthorityPosture::Vetoing,
-            "and it must reach the operator as a veto, not as a wait that clears itself"
+            "13 routes against 1.3M in ONE sample is the authority being wrong"
         );
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -882,6 +882,44 @@ fn authority_posture(
     }
 }
 
+/// The verdict as it applies to the mirror **as it is now** — the same
+/// substitution [`authority_current`] makes before deciding the veto.
+///
+/// `TableCompleteness::verdict()` assesses the report's own recorded
+/// `mirror_routes`, which is the mirror as it was when the checker ran.
+/// The gate does not: it swaps in the current count and recomputes
+/// drift. Classifying the block reason from the un-substituted verdict
+/// therefore reads a different mirror than the decision it is
+/// explaining, and the two part company in exactly the case that
+/// matters — a report that WAS converged, with a source that has since
+/// outgrown it, vetoes while still assessing `Converged`, so the reason
+/// came out `AwaitingAuthority` and promised a self-clearing wait for a
+/// mismatch that persists (review finding).
+///
+/// Only the REASON is derived here. `authority_current` keeps deciding
+/// the veto, unchanged, because it additionally requires the cached
+/// verdict to permit and changing that would move release semantics,
+/// which this fix has no business doing.
+fn authority_verdict_now(
+    completeness: &Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
+    mirror_now: u64,
+) -> Option<packetframe_common::fib::Completeness> {
+    completeness.as_ref().map(|h| {
+        let substituted = h
+            .latest()
+            .map(|r| packetframe_common::fib::CompletenessReport {
+                mirror_routes: mirror_now,
+                ..r
+            });
+        packetframe_common::fib::assess(
+            substituted,
+            std::time::Instant::now(),
+            packetframe_common::fib::STEER_MAX_DRIFT,
+            packetframe_common::fib::STEER_MAX_REPORT_AGE,
+        )
+    })
+}
+
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
 pub struct Runtime {
     core: Rc<RefCell<Core>>,
@@ -1156,7 +1194,7 @@ impl Runtime {
                 // not be able to disagree about whether the authority is
                 // currently permitting.
                 authority_current(&c.completeness, c.source.route_count()),
-                c.completeness.as_ref().map(|h| h.verdict()),
+                authority_verdict_now(&c.completeness, c.source.route_count()),
             ),
         }
     }
@@ -2395,6 +2433,50 @@ mod tests {
                 AuthorityPosture::Attesting
             );
         }
+    }
+
+    /// The reason must be read off the SAME mirror the veto was
+    /// decided from.
+    ///
+    /// `verdict()` assesses the report's recorded `mirror_routes`;
+    /// `authority_current` swaps in the live count first. A report that
+    /// was converged when it was taken, with a source that has since
+    /// outgrown its authority, therefore vetoes while still assessing
+    /// `Converged` — and the reason came out `AwaitingAuthority`,
+    /// promising a wait that clears itself for a mismatch that does not
+    /// (review finding).
+    #[test]
+    fn the_verdict_is_reassessed_against_the_live_mirror() {
+        use packetframe_common::fib::{Completeness, CompletenessReport, TableCompleteness};
+        let handle = std::sync::Arc::new(TableCompleteness::new());
+        handle.publish(CompletenessReport {
+            authority_routes: 1_000_000,
+            mirror_routes: 1_000_000,
+            at: std::time::Instant::now(),
+        });
+        let completeness = Some(handle);
+
+        // As reported: converged, and the cached verdict agrees.
+        assert!(matches!(
+            authority_verdict_now(&completeness, 1_000_000),
+            Some(Completeness::Converged { .. })
+        ));
+
+        // The source has since outgrown the authority. The gate vetoes
+        // on this, so the reason has to be the mismatch — not "no
+        // report yet".
+        assert_eq!(authority_current(&completeness, 1_400_000), Some(false));
+        let verdict = authority_verdict_now(&completeness, 1_400_000);
+        assert!(
+            matches!(verdict, Some(Completeness::AuthorityMismatch { .. })),
+            "a mirror that has outgrown its authority is a mismatch, whatever the cached \
+             report said: {verdict:?}"
+        );
+        assert_eq!(
+            authority_posture(true, false, true, Some(false), verdict),
+            AuthorityPosture::Vetoing,
+            "and it must reach the operator as a veto, not as a wait that clears itself"
+        );
     }
 
     /// Only `AuthorityMismatch` is a veto; the rest clear themselves.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -905,12 +905,27 @@ fn authority_posture(
 /// check simply re-measures both and agrees (review finding).
 ///
 /// So the fault question — *is the authority itself wrong* — is asked
-/// of the sample, where both numbers describe the same moment. A
-/// mismatch that is real survives into the next sample and is
-/// classified then, within one interval; one created by the clock does
-/// not. What the substituted view legitimately shows is that release is
-/// blocked RIGHT NOW, and that belongs in the blocked-but-clearing
-/// message, which names it.
+/// of the sample rather than of a live count measured against a stale
+/// one. A mismatch that is real survives into the next sample and is
+/// classified again; one created by the clock does not. What the
+/// substituted view legitimately shows is that release is blocked RIGHT
+/// NOW, and that belongs in the blocked-but-clearing message, which
+/// names it.
+///
+/// **A sample is not an instant, and the message must not pretend it
+/// is.** `IntegrityChecker::run_check` awaits the bird count, then a
+/// second `birdc` for protocols, then the mirror count — three
+/// sequential subprocess-scale steps — so the two numbers in one report
+/// are separated by at least one `birdc` invocation. Under a bulk
+/// withdrawal or reload that gap alone can read bird low and the mirror
+/// high, producing a single `AuthorityMismatch` that the next check
+/// does not reproduce (review finding). One sample is therefore enough
+/// to say quiescence is not the blocker — it never is, for a veto — but
+/// NOT enough to send someone to restart a daemon, which is why the
+/// veto text asks for the next check to confirm before acting.
+/// Requiring two mismatching samples before escalating the wording
+/// needs history the runtime does not keep; filed rather than bolted on
+/// here.
 fn authority_sample_verdict(
     completeness: &Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
 ) -> Option<packetframe_common::fib::Completeness> {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1096,6 +1096,13 @@ impl Runtime {
                 Some(DeferredResync::AwaitingFallback { demoted: true, .. })
             ) {
                 AuthorityPosture::DemotedByFlap
+            } else if authority_current(&c.completeness, c.source.route_count()) == Some(false) {
+                // The SAME recompute the release path applies, not a
+                // re-derivation of it: the health line and the gate must
+                // not be able to disagree about whether the authority is
+                // currently permitting. `Attesting` used to cover this
+                // case, so a veto was invisible to every surface.
+                AuthorityPosture::Vetoing
             } else {
                 AuthorityPosture::Attesting
             },
@@ -1124,12 +1131,25 @@ const STEER_AUDIT_EVERY: Duration = Duration::from_secs(30);
 pub enum AuthorityPosture {
     /// No `require-table-complete` handle; the proxies stand alone.
     Absent,
-    /// Configured and usable.
+    /// Configured, usable, and currently permitting.
     Attesting,
     /// Configured, but this deferral saw the feed flap and has not yet
     /// seen the current epoch reconciled, so the authority's word
     /// cannot be trusted to describe the current stream.
     DemotedByFlap,
+    /// Configured, usable, and currently saying NO: its report does not
+    /// describe the mirror as it is now, so `authority_current` vetoes
+    /// release regardless of floor, liveness or quiescence.
+    ///
+    /// Added because the posture could not express it, and that gap had
+    /// a measured cost. On the shadow (2026-08-12) a box whose local
+    /// bird holds 13 routes against a 1.3M-route mirror sat deferred
+    /// for 23 hours reading `Attesting`, while the health line told the
+    /// operator to wait for the source to go quiet — the one thing that
+    /// could never release it. A veto does not clear on its own: it
+    /// clears when the authority's report agrees with the mirror, or
+    /// not at all.
+    Vetoing,
 }
 
 /// One coherent snapshot of the runtime's observable state, for the

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -852,21 +852,32 @@ fn authority_posture(
     verdict: Option<packetframe_common::fib::Completeness>,
 ) -> AuthorityPosture {
     use packetframe_common::fib::Completeness;
+    let vetoing = gate_consults_authority
+        && current == Some(false)
+        && matches!(verdict, Some(Completeness::AuthorityMismatch { .. }));
     if !configured {
         AuthorityPosture::Absent
+    } else if vetoing {
+        // BEFORE the demotion, deliberately. `drain_batch` applies the
+        // veto regardless of epoch — "a NEGATIVE word still vetoes
+        // regardless of epoch; caution does not expire" — so when a
+        // flap and a mismatch coincide, clearing the flap only reveals
+        // the veto. Reporting the demotion there sends an operator to
+        // idle the feed for a deferral that the feed cannot release
+        // (review finding). The mismatch is the blocker that has to be
+        // fixed either way; once it is, a surviving demotion reports
+        // itself on the next snapshot.
+        AuthorityPosture::Vetoing
     } else if demoted {
         AuthorityPosture::DemotedByFlap
     } else if !gate_consults_authority || current != Some(false) {
         AuthorityPosture::Attesting
-    } else if matches!(verdict, Some(Completeness::AuthorityMismatch { .. })) {
-        // The ONLY verdict that waiting cannot fix: the mirror holds
-        // substantially more than the authority claims, so the
-        // authority is not the thing feeding this mirror. Every other
-        // non-permitting verdict is a report that has not arrived yet,
-        // has aged out, or describes a mirror still loading — all of
-        // which the next check can clear.
-        AuthorityPosture::Vetoing
     } else {
+        // Blocked, but by a verdict the next check can clear: no report
+        // yet, one that aged out, or a mirror still short of the
+        // authority. Only `AuthorityMismatch` — a mirror holding
+        // substantially MORE than the authority claims — is not a
+        // loading state, and that is `vetoing` above.
         AuthorityPosture::AwaitingAuthority
     }
 }
@@ -2341,10 +2352,28 @@ mod tests {
                 AuthorityPosture::Absent
             );
         }
-        // A flap demotes regardless of the current word.
+        // A flap demotes — but NOT over a persistent mismatch. The veto
+        // survives the demotion clearing (`drain_batch` applies it
+        // regardless of epoch), so reporting the flap there would send
+        // an operator to idle the feed for something the feed cannot
+        // release (review finding).
         assert_eq!(
             authority_posture(true, true, true, Some(false), mismatch.clone()),
-            AuthorityPosture::DemotedByFlap
+            AuthorityPosture::Vetoing,
+            "a mismatch outranks a flap: letting the feed settle only reveals the veto"
+        );
+        assert_eq!(
+            authority_posture(
+                true,
+                true,
+                true,
+                Some(false),
+                Some(packetframe_common::fib::Completeness::Unknown {
+                    why: "no check has run yet"
+                })
+            ),
+            AuthorityPosture::DemotedByFlap,
+            "but with a self-clearing verdict the flap IS the story worth telling"
         );
         // THE RULE: same disagreeing authority, opposite verdicts,
         // decided only by whether this deferral's gate consults it.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -851,10 +851,14 @@ fn authority_posture(
     current: Option<bool>,
     verdict: Option<packetframe_common::fib::Completeness>,
 ) -> AuthorityPosture {
-    use packetframe_common::fib::Completeness;
+    // `authority_is_at_fault` rather than a match on the variant: the
+    // zero-route case arrives as `Unknown` (assess returns it before the
+    // mismatch branch) and is just as permanent, so the classification
+    // has to live next to the variants and their reason strings rather
+    // than being re-derived here (review finding).
     let vetoing = gate_consults_authority
         && current == Some(false)
-        && matches!(verdict, Some(Completeness::AuthorityMismatch { .. }));
+        && verdict.as_ref().is_some_and(|v| v.authority_is_at_fault());
     if !configured {
         AuthorityPosture::Absent
     } else if vetoing {
@@ -2504,6 +2508,25 @@ mod tests {
                 mirror: 500_000,
             },
         ];
+        // An authority answering ZERO is not a transient unknown. It
+        // arrives as `Unknown` because `assess` returns that before the
+        // mismatch branch, and it is exactly as permanent as a
+        // mismatch — the fully-empty form of the shadow incident
+        // (review finding).
+        assert_eq!(
+            authority_posture(
+                true,
+                false,
+                true,
+                Some(false),
+                Some(packetframe_common::fib::Completeness::Unknown {
+                    why: packetframe_common::fib::ZERO_ROUTE_AUTHORITY
+                })
+            ),
+            AuthorityPosture::Vetoing,
+            "a bird with no routes at all cannot be waited out any more than a mismatched \
+             one can"
+        );
         for verdict in self_clearing {
             assert_eq!(
                 authority_posture(true, false, true, Some(false), Some(verdict.clone())),

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -830,6 +830,37 @@ fn authority_current(
     })
 }
 
+/// What the authority means **for the deferral that is actually
+/// running** — a pure function so the rule can be stated and tested
+/// rather than assembled inline in a struct literal.
+///
+/// Deferral-scoped, exactly like `DemotedByFlap`, and that is the whole
+/// point. The question is not "what does the authority say" but "what
+/// does THIS deferral's release path do with what it says", and the two
+/// stages differ: `AwaitingFallback` consults `authority_current` and a
+/// `false` there vetoes release outright, while `AwaitingDiff` releases
+/// on floor-and-quiet alone and never asks. Reporting a veto on the
+/// diff stage would tell an operator that waiting cannot clear a
+/// deferral that waiting clears perfectly well — the first version of
+/// this did exactly that (review finding), which is the same defect
+/// class as the message it was written to fix.
+fn authority_posture(
+    configured: bool,
+    demoted: bool,
+    gate_consults_authority: bool,
+    current: Option<bool>,
+) -> AuthorityPosture {
+    if !configured {
+        AuthorityPosture::Absent
+    } else if demoted {
+        AuthorityPosture::DemotedByFlap
+    } else if gate_consults_authority && current == Some(false) {
+        AuthorityPosture::Vetoing
+    } else {
+        AuthorityPosture::Attesting
+    }
+}
+
 /// Owner handle. Create once, then [`Runtime::views`] per tick.
 pub struct Runtime {
     core: Rc<RefCell<Core>>,
@@ -1089,23 +1120,22 @@ impl Runtime {
             steer_missing: c.steer_missing,
             steer_stray: c.steer_stray,
             steer_audit_error: c.steer_audit_error.clone(),
-            authority: if c.completeness.is_none() {
-                AuthorityPosture::Absent
-            } else if matches!(
-                &c.deferred_resync,
-                Some(DeferredResync::AwaitingFallback { demoted: true, .. })
-            ) {
-                AuthorityPosture::DemotedByFlap
-            } else if authority_current(&c.completeness, c.source.route_count()) == Some(false) {
+            authority: authority_posture(
+                c.completeness.is_some(),
+                matches!(
+                    &c.deferred_resync,
+                    Some(DeferredResync::AwaitingFallback { demoted: true, .. })
+                ),
+                matches!(
+                    &c.deferred_resync,
+                    Some(DeferredResync::AwaitingFallback { .. })
+                ),
                 // The SAME recompute the release path applies, not a
                 // re-derivation of it: the health line and the gate must
                 // not be able to disagree about whether the authority is
-                // currently permitting. `Attesting` used to cover this
-                // case, so a veto was invisible to every surface.
-                AuthorityPosture::Vetoing
-            } else {
-                AuthorityPosture::Attesting
-            },
+                // currently permitting.
+                authority_current(&c.completeness, c.source.route_count()),
+            ),
         }
     }
 }
@@ -1137,9 +1167,10 @@ pub enum AuthorityPosture {
     /// seen the current epoch reconciled, so the authority's word
     /// cannot be trusted to describe the current stream.
     DemotedByFlap,
-    /// Configured, usable, and currently saying NO: its report does not
-    /// describe the mirror as it is now, so `authority_current` vetoes
-    /// release regardless of floor, liveness or quiescence.
+    /// Configured, usable, currently saying NO — **and the running
+    /// deferral is one that asks.** Its report does not describe the
+    /// mirror as it is now, so `authority_current` vetoes release
+    /// regardless of floor, liveness or quiescence.
     ///
     /// Added because the posture could not express it, and that gap had
     /// a measured cost. On the shadow (2026-08-12) a box whose local
@@ -1149,6 +1180,11 @@ pub enum AuthorityPosture {
     /// could never release it. A veto does not clear on its own: it
     /// clears when the authority's report agrees with the mirror, or
     /// not at all.
+    ///
+    /// Scoped to the deferral by `authority_posture`, because only
+    /// `AwaitingFallback` consults the authority; the diff stage
+    /// releases on floor-and-quiet and a disagreeing authority there is
+    /// not blocking anything.
     Vetoing,
 }
 
@@ -2248,6 +2284,53 @@ mod tests {
     // Only the Linux-gated process tests need these.
     #[cfg(target_os = "linux")]
     use std::sync::{Arc, Mutex};
+
+    /// A veto is only a veto where the gate actually asks.
+    ///
+    /// `AwaitingFallback` consults `authority_current` and a `false`
+    /// there blocks release outright. `AwaitingDiff` releases on
+    /// floor-and-quiet and never asks — so a disagreeing authority
+    /// during the diff stage blocks nothing, and reporting `Vetoing`
+    /// there tells an operator that waiting cannot clear a deferral
+    /// that waiting clears perfectly well (review finding). The first
+    /// version of this posture keyed on the authority alone and did
+    /// exactly that, which is the same defect class it was written to
+    /// fix, one stage over.
+    #[test]
+    fn a_veto_is_scoped_to_the_gate_that_consults_the_authority() {
+        // Absent beats everything: no handle, nothing to say.
+        for consults in [true, false] {
+            assert_eq!(
+                authority_posture(false, false, consults, None),
+                AuthorityPosture::Absent
+            );
+        }
+        // A flap demotes regardless of the current word.
+        assert_eq!(
+            authority_posture(true, true, true, Some(false)),
+            AuthorityPosture::DemotedByFlap
+        );
+        // THE RULE: same disagreeing authority, opposite verdicts,
+        // decided only by whether this deferral's gate consults it.
+        assert_eq!(
+            authority_posture(true, false, true, Some(false)),
+            AuthorityPosture::Vetoing,
+            "AwaitingFallback consults the authority, so a false there IS the blocker"
+        );
+        assert_eq!(
+            authority_posture(true, false, false, Some(false)),
+            AuthorityPosture::Attesting,
+            "AwaitingDiff never asks, so a disagreeing authority is not blocking it and \
+             must not be reported as if it were"
+        );
+        // A permitting or unknown authority is never a veto.
+        for current in [Some(true), None] {
+            assert_eq!(
+                authority_posture(true, false, true, current),
+                AuthorityPosture::Attesting
+            );
+        }
+    }
 
     /// Activity cannot divide away, however slowly the tick ran.
     ///

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -656,7 +656,9 @@ impl StatusSnapshot {
                          table size. Waiting will not clear it. \
                          Check which bird `birdc` is talking to on THIS box; where the \
                          routes legitimately come from elsewhere, `require-table-complete \
-                         off` is the right answer. The adopted FIB keeps forwarding \
+                         off` is the right answer — but it is read at bring-up, so it \
+                         needs a daemon RESTART, and a reload will not do it (from here a \
+                         reload is refused outright). The adopted FIB keeps forwarding \
                          untouched meanwhile, and every steering change is refused while \
                          this holds"
                     )
@@ -2583,6 +2585,17 @@ mod tests {
         assert!(
             vetoed.contains("Waiting will not clear it"),
             "and say plainly that waiting is not the remedy: {vetoed}"
+        );
+        // The opt-out it recommends is read at bring-up, and
+        // `reconfigure` never installs or removes the completeness
+        // handle — so recommending it without saying RESTART sends an
+        // operator to edit a file and reload into no change at all,
+        // from a state where the reload is refused anyway (review
+        // finding).
+        assert!(
+            vetoed.contains("RESTART"),
+            "recommending `require-table-complete off` without saying it needs a restart \
+             is a remedy that silently does nothing: {vetoed}"
         );
 
         // The permitting posture keeps the quiescence wording, so this

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -653,14 +653,18 @@ impl StatusSnapshot {
                          completeness authority reports a route count that cannot describe \
                          this mirror (far fewer than it holds, or none at all), so it is \
                          not the authority feeding it, and that vetoes release at any \
-                         table size. Waiting will not clear it. \
-                         Check which bird `birdc` is talking to on THIS box; where the \
-                         routes legitimately come from elsewhere, `require-table-complete \
-                         off` is the right answer — but it is read at bring-up, so it \
-                         needs a daemon RESTART, and a reload will not do it (from here a \
-                         reload is refused outright). The adopted FIB keeps forwarding \
-                         untouched meanwhile, and every steering change is refused while \
-                         this holds"
+                         table size, so waiting for the source to go quiet will not clear \
+                         it — quiescence is never what releases a veto. CONFIRM BEFORE \
+                         ACTING: the checker reads bird and the mirror a few subprocess \
+                         calls apart, so one report can catch a bulk withdrawal mid-flight \
+                         and show a mismatch the next check does not. If the next check \
+                         (within 300 s) still reports one, it is real. Then: check which \
+                         bird `birdc` is talking to on THIS box; where the routes \
+                         legitimately come from elsewhere, `require-table-complete off` is \
+                         the right answer — but it is read at bring-up, so it needs a \
+                         daemon RESTART, and a reload will not do it (from here a reload \
+                         is refused outright). The adopted FIB keeps forwarding untouched \
+                         meanwhile, and every steering change is refused while this holds"
                     )
                 } else if self.authority == AuthorityPosture::AwaitingAuthority {
                     // Blocked, but self-clearing: no report yet, one that
@@ -2586,8 +2590,18 @@ mod tests {
             "and it must name the authority as the blocker: {vetoed}"
         );
         assert!(
-            vetoed.contains("Waiting will not clear it"),
-            "and say plainly that waiting is not the remedy: {vetoed}"
+            vetoed.contains("quiescence is never what releases a veto"),
+            "and say plainly that waiting for quiet is not the remedy: {vetoed}"
+        );
+        // But one sample is not proof of permanence: the checker reads
+        // bird and the mirror a few subprocess calls apart, so a bulk
+        // withdrawal caught mid-flight can produce a mismatch the next
+        // check does not reproduce. The line may say "stop waiting for
+        // quiet"; it may not say "go restart a daemon" on that evidence
+        // alone (review finding).
+        assert!(
+            vetoed.contains("CONFIRM BEFORE ACTING"),
+            "a single sample must not send an operator to restart anything: {vetoed}"
         );
         // The opt-out it recommends is read at bring-up, and
         // `reconfigure` never installs or removes the completeness

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -671,12 +671,15 @@ impl StatusSnapshot {
                     // "fixed" into a broken one.
                     format!(
                         "resync deferred: the completeness authority has not attested yet \
-                         — no report has arrived, the last one aged out, or the mirror is \
-                         still short of it — so release is blocked for now. The integrity \
-                         checker publishes a fresh report every interval (300 s) and this \
-                         releases itself once one agrees; the source holds {have} routes \
-                         against a floor of {want}. Nothing is dropping: the adopted FIB \
-                         keeps forwarding untouched"
+                         — no report has arrived, the last one aged out, the mirror is \
+                         still short of it, or the mirror has grown past the count the \
+                         last sample took (the checker measures both every 300 s, and a \
+                         loading DFZ moves further than that in between) — so release is \
+                         blocked for now. It releases itself once a sample agrees; the \
+                         source holds {have} routes against a floor of {want}. If the \
+                         authority really is behind rather than merely unasked, the next \
+                         sample says so and this line changes to name it. Nothing is \
+                         dropping: the adopted FIB keeps forwarding untouched"
                     )
                 } else if have < want && self.authority == AuthorityPosture::Attesting {
                     format!(

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -635,7 +635,47 @@ impl StatusSnapshot {
                 // feed passes through every count on its way to full
                 // and only quiescence says "done".
                 use crate::runtime::AuthorityPosture;
-                let msg = if have < want && self.authority == AuthorityPosture::Attesting {
+                // ORDER MATTERS, and every arm names its posture. The
+                // veto arm goes FIRST because it is the one case where
+                // the floor is irrelevant — the authority blocks release
+                // at any table size — and when it sat after the
+                // unconditional below-floor arm, a vetoing box below the
+                // floor was told it had "no authority" and should enable
+                // `require-table-complete`, which was already enabled and
+                // was the thing blocking it (review finding).
+                let msg = if self.authority == AuthorityPosture::Vetoing {
+                    // Persistent by construction: `Vetoing` is only
+                    // `AuthorityMismatch`, the one verdict waiting cannot
+                    // fix.
+                    format!(
+                        "resync deferred: the route source holds {have} routes (release \
+                         floor {want}) and the floor is not what is holding this — the \
+                         completeness authority reports a route count that cannot describe \
+                         this mirror, so it is not the authority feeding it, and that \
+                         vetoes release at any table size. Waiting will not clear it. \
+                         Check which bird `birdc` is talking to on THIS box; where the \
+                         routes legitimately come from elsewhere, `require-table-complete \
+                         off` is the right answer. The adopted FIB keeps forwarding \
+                         untouched meanwhile, and every steering change is refused while \
+                         this holds"
+                    )
+                } else if self.authority == AuthorityPosture::AwaitingAuthority {
+                    // Blocked, but self-clearing: no report yet, one that
+                    // aged out, or a mirror still short. Deliberately
+                    // does NOT tell the operator to go looking — the next
+                    // check releases it, and sending someone after a
+                    // startup transient is how a healthy box gets
+                    // "fixed" into a broken one.
+                    format!(
+                        "resync deferred: the completeness authority has not attested yet \
+                         — no report has arrived, the last one aged out, or the mirror is \
+                         still short of it — so release is blocked for now. The integrity \
+                         checker publishes a fresh report every interval (300 s) and this \
+                         releases itself once one agrees; the source holds {have} routes \
+                         against a floor of {want}. Nothing is dropping: the adopted FIB \
+                         keeps forwarding untouched"
+                    )
+                } else if have < want && self.authority == AuthorityPosture::Attesting {
                     format!(
                         "resync deferred: the route source holds {have} routes, below the \
                          release floor of {want}; the adopted FIB keeps forwarding \
@@ -660,6 +700,10 @@ impl StatusSnapshot {
                          table is loaded so the adoption starts unsteered"
                     )
                 } else if have < want {
+                    // Reachable only with NO authority now: every other
+                    // posture is claimed by an arm above, which is what
+                    // makes this text's "with no authority" accurate
+                    // rather than an assumption.
                     format!(
                         "resync deferred: the route source holds {have} routes, below the \
                          release floor of {want}; the adopted FIB keeps forwarding \
@@ -669,32 +713,6 @@ impl StatusSnapshot {
                          floor, by design. Size `expected-routes` within 16x of the real \
                          table, or give this box a bird and enable \
                          `require-table-complete`"
-                    )
-                } else if self.authority == AuthorityPosture::Vetoing {
-                    // The floor is met and quiescence is NOT the blocker:
-                    // `authority_current` is returning false, which vetoes
-                    // release unconditionally — no amount of quiet, floor
-                    // or liveness gets past it.
-                    //
-                    // This arm exists because the message below was
-                    // printed for 23 hours on a box whose local bird held
-                    // 13 routes against a 1.3M-route mirror (shadow,
-                    // 2026-08-12). It told the operator to wait for the
-                    // source to go quiet. The source going quiet could
-                    // never have released it, and nothing said so — the
-                    // posture had no way to express a veto, so every
-                    // surface read `Attesting`.
-                    format!(
-                        "resync deferred: the route source holds {have} routes (release \
-                         floor {want} met) and the source may well be quiet — but the \
-                         completeness authority currently reports that its own route count \
-                         does not describe this mirror, which vetoes the release outright. \
-                         Waiting will not clear it: the authority has to agree with the \
-                         mirror first. Check that bird on THIS box carries the table the \
-                         mirror was built from (a near-empty local bird against a full \
-                         mirror is the usual cause), or run without an authority. The \
-                         adopted FIB keeps forwarding untouched meanwhile, and every \
-                         steering change is refused while this holds"
                     )
                 } else {
                     format!(
@@ -2572,6 +2590,69 @@ mod tests {
         assert!(
             attesting.contains("gone quiet"),
             "a non-vetoed deferral above the floor IS waiting for quiet: {attesting}"
+        );
+
+        // A blocked-but-self-clearing authority must NOT inherit the
+        // veto's "waiting will not clear it" — that fires at every
+        // startup before the first integrity check lands (review
+        // finding).
+        let awaiting = deferred(AuthorityPosture::AwaitingAuthority);
+        assert!(
+            !awaiting.contains("Waiting will not clear it"),
+            "an authority that has merely not reported yet clears itself: {awaiting}"
+        );
+        assert!(
+            awaiting.contains("releases itself"),
+            "and the line must say so, or an operator goes looking for a fault that is a \
+             startup transient: {awaiting}"
+        );
+    }
+
+    /// A vetoing authority below the release floor must not be told it
+    /// has no authority.
+    ///
+    /// The below-floor arm was unconditional, so it consumed the
+    /// snapshot before the veto arm could be reached: a box that HAD
+    /// `require-table-complete` enabled and was being vetoed by it read
+    /// "with no authority ... give this box a bird and enable
+    /// `require-table-complete`" (review finding). Both halves of that
+    /// advice were already true and neither was the problem.
+    #[test]
+    fn a_vetoed_deferral_below_the_floor_is_not_an_absent_authority() {
+        use crate::runtime::AuthorityPosture;
+        let led = ledger_with(10, 0, 0);
+        let mut snap = snap_of(
+            &steered_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            FibSync::NeverVerified,
+            ports_up(),
+        );
+        // BELOW the floor and vetoing — the ordering trap.
+        snap.resync_deferred = Some((40_000, 156_734));
+        snap.authority = AuthorityPosture::Vetoing;
+        let msg = snap
+            .report()
+            .subsystems
+            .into_iter()
+            .find(|s| s.name == SUBSYS_FIB)
+            .and_then(|s| s.message)
+            .expect("a deferral always explains itself");
+
+        assert!(
+            !msg.contains("with no authority"),
+            "the authority is configured and is the thing blocking release: {msg}"
+        );
+        assert!(
+            !msg.contains("give this box a bird and enable"),
+            "and telling the operator to enable what is already enabled sends them \
+             nowhere: {msg}"
+        );
+        assert!(
+            msg.contains("not the authority feeding it"),
+            "it must name the real blocker instead: {msg}"
         );
     }
 

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -651,8 +651,9 @@ impl StatusSnapshot {
                         "resync deferred: the route source holds {have} routes (release \
                          floor {want}) and the floor is not what is holding this — the \
                          completeness authority reports a route count that cannot describe \
-                         this mirror, so it is not the authority feeding it, and that \
-                         vetoes release at any table size. Waiting will not clear it. \
+                         this mirror (far fewer than it holds, or none at all), so it is \
+                         not the authority feeding it, and that vetoes release at any \
+                         table size. Waiting will not clear it. \
                          Check which bird `birdc` is talking to on THIS box; where the \
                          routes legitimately come from elsewhere, `require-table-complete \
                          off` is the right answer. The adopted FIB keeps forwarding \

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -670,6 +670,32 @@ impl StatusSnapshot {
                          table, or give this box a bird and enable \
                          `require-table-complete`"
                     )
+                } else if self.authority == AuthorityPosture::Vetoing {
+                    // The floor is met and quiescence is NOT the blocker:
+                    // `authority_current` is returning false, which vetoes
+                    // release unconditionally — no amount of quiet, floor
+                    // or liveness gets past it.
+                    //
+                    // This arm exists because the message below was
+                    // printed for 23 hours on a box whose local bird held
+                    // 13 routes against a 1.3M-route mirror (shadow,
+                    // 2026-08-12). It told the operator to wait for the
+                    // source to go quiet. The source going quiet could
+                    // never have released it, and nothing said so — the
+                    // posture had no way to express a veto, so every
+                    // surface read `Attesting`.
+                    format!(
+                        "resync deferred: the route source holds {have} routes (release \
+                         floor {want} met) and the source may well be quiet — but the \
+                         completeness authority currently reports that its own route count \
+                         does not describe this mirror, which vetoes the release outright. \
+                         Waiting will not clear it: the authority has to agree with the \
+                         mirror first. Check that bird on THIS box carries the table the \
+                         mirror was built from (a near-empty local bird against a full \
+                         mirror is the usual cause), or run without an authority. The \
+                         adopted FIB keeps forwarding untouched meanwhile, and every \
+                         steering change is refused while this holds"
+                    )
                 } else {
                     format!(
                         "resync deferred: the route source holds {have} routes (release \
@@ -2483,6 +2509,70 @@ mod tests {
             FibSync::from_outcome(&good, Duration::ZERO),
             FibSync::Verified { sampled: 64, .. }
         ));
+    }
+
+    /// A vetoed deferral must not be described as waiting for quiet.
+    ///
+    /// Measured, not hypothesised: on the shadow (2026-08-12) a box
+    /// whose local bird held 13 routes against a 1.3M-route mirror sat
+    /// deferred for 23 hours printing "the diff runs once the source is
+    /// live and has gone quiet". The source going quiet could never
+    /// have released it — `authority_current` was returning false, which
+    /// vetoes the release outright — and no surface said so, because
+    /// `AuthorityPosture` had no variant for a veto and the snapshot
+    /// therefore read `Attesting`.
+    ///
+    /// The assertion is on the DIFFERENCE the operator acts on: the
+    /// vetoed message must not send them to watch quiescence, and must
+    /// name the authority as the blocker.
+    #[test]
+    fn a_vetoed_deferral_does_not_blame_quiescence() {
+        use crate::runtime::AuthorityPosture;
+        let led = ledger_with(10, 0, 0);
+        let deferred = |authority| {
+            let mut snap = snap_of(
+                &steered_supervisor(),
+                &led,
+                ApiHealth::Answering {
+                    silent_for: Duration::from_millis(200),
+                },
+                FibSync::NeverVerified,
+                ports_up(),
+            );
+            // Floor MET — so the only thing that can be holding this is
+            // quiescence or the authority.
+            snap.resync_deferred = Some((1_303_920, 156_734));
+            snap.authority = authority;
+            snap.report()
+                .subsystems
+                .into_iter()
+                .find(|s| s.name == SUBSYS_FIB)
+                .and_then(|s| s.message)
+                .expect("a deferral always explains itself")
+        };
+
+        let vetoed = deferred(AuthorityPosture::Vetoing);
+        assert!(
+            !vetoed.contains("gone quiet"),
+            "a vetoed deferral must not point at quiescence, which cannot release it: \
+             {vetoed}"
+        );
+        assert!(
+            vetoed.contains("completeness authority") && vetoed.contains("vetoes"),
+            "and it must name the authority as the blocker: {vetoed}"
+        );
+        assert!(
+            vetoed.contains("Waiting will not clear it"),
+            "and say plainly that waiting is not the remedy: {vetoed}"
+        );
+
+        // The permitting posture keeps the quiescence wording, so this
+        // test cannot pass by making every deferral message identical.
+        let attesting = deferred(AuthorityPosture::Attesting);
+        assert!(
+            attesting.contains("gone quiet"),
+            "a non-vetoed deferral above the floor IS waiting for quiet: {attesting}"
+        );
     }
 
     #[test]

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1046,6 +1046,36 @@ updates and which a live DFZ feed may never give. The deferral message
 says so explicitly when that is what is happening — read it before
 concluding the checker is broken. Nothing is dropping meanwhile.
 
+**A second unbounded case, and this one takes the rollback lever with
+it: no completeness authority configured at all.** With no bird for the
+checker to compare against, the release falls to the unattested gate,
+which tolerates an activity rate of exactly **zero** for 5 s
+(`UNATTESTED_QUIET_RATE_PER_SEC`) — deliberately, since without an
+authority nothing can tell slow churn from a throttled reload. A live
+DFZ feed may never be literally still for 5 s, so an adopted resync
+over a **steered** VPP can defer indefinitely. Measured on the shadow:
+**23 h and still deferred** (2026-08-11 → 2026-08-12), floor long since
+met, feed healthy, nothing dropping.
+
+What makes it more than cosmetic is what `AdoptedResyncing` refuses:
+**steering changes, which includes `steer off`.** For the length of the
+deferral an operator cannot roll traffic off VPP with `packetframe
+reconfigure` — it answers "not converged". The eBPF tier is not
+carrying that traffic; VPP still is.
+
+- **On a box with bird** (the fleet, the primary) this does not apply:
+  the authority carries completion truth and releases on its own word.
+- **On a box without one** (the shadow, any box where the checker is
+  unconfigured or `birdc` is unreachable), the only escape is a cold
+  restart — stop the daemon, `packetframe detach --all`, start. That
+  tears VPP down and costs the offload for a full resync, which is
+  exactly the trade the deferral exists to avoid, so it is a last
+  resort rather than a routine step.
+- **Before a rollout, verify the authority is live** (`fib-synced`
+  naming a completeness verdict rather than the unattested wording).
+  A box that adopts while steered with no authority has no fast
+  rollback, and that is worth knowing before the canary, not during it.
+
 ### A member port needs two things admin-up does not give it
 
 Both were found by tracing a live VPP on 2026-08-07, each hidden behind

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1092,6 +1092,12 @@ carrying that traffic; VPP still is.
   interval. Do **not** reach for a restart here — tearing down a
   working VPP to fix a transient read is strictly worse than the
   problem.
+  `fib-synced` tells the two apart, and the wording is the tell: *"the
+  completeness authority has not attested yet ... releases itself once
+  one agrees"* is the self-clearing case (no report yet, one aged out,
+  or a mirror still short — including every startup before the first
+  check lands). Only *"not the authority feeding it ... Waiting will
+  not clear it"* is the persistent one below.
 - **A persistent disagreement is the case that needs a decision**: a
   local bird that does not carry the mirror's table, or a mirror fed
   from a different source than the authority measures. Make them agree,

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1099,13 +1099,19 @@ carrying that traffic; VPP still is.
   check lands). Only *"not the authority feeding it ... Waiting will
   not clear it"* is the persistent one below.
 - **A persistent disagreement is the case that needs a decision**: a
-  local bird that does not carry the mirror's table, or a mirror fed
-  from a different source than the authority measures. Make them agree,
-  or run that box without an authority. Only if neither is possible is
-  the escape a cold restart (stop the daemon, `packetframe detach
-  --all`, start) — it tears VPP down and costs a full resync, the exact
-  trade the deferral exists to avoid, so it is a last resort and not a
-  troubleshooting step.
+  local bird that does not carry the mirror's table, a bird carrying no
+  routes at all, or a mirror fed from a different source than the
+  authority measures. Make them agree, or run that box without an
+  authority.
+  **`require-table-complete off` needs a restart, not a reload.** It is
+  read at bring-up, and `reconfigure` never touches the runtime's
+  completeness handle — so editing it and reloading stores the new
+  value and changes nothing, and from a vetoed adopted resync the
+  reload is refused outright anyway. Since a restart is required
+  regardless, the cold sequence below is the same operation: stop the
+  daemon, `packetframe detach --all`, start. It tears VPP down and
+  costs a full resync, the exact trade the deferral exists to avoid, so
+  it is a last resort and not a troubleshooting step.
 - **Before a rollout, check the authority AGREES — not that bird is
   running.** The two are different, and this box proved it: bird was up
   the whole time.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1108,18 +1108,32 @@ carrying that traffic; VPP still is.
   troubleshooting step.
 - **Before a rollout, check the authority AGREES — not that bird is
   running.** The two are different, and this box proved it: bird was up
-  the whole time. Compare directly, on the box that will steer:
+  the whole time.
+
+  **Do not hand-roll the comparison.** The checker compares bird's
+  `master4` **plus** `master6` against the fast-path mirror's v4+v6
+  count, and it already prints both numbers when they disagree. Read
+  that, on the box that will steer:
 
   ```bash
-  birdc show route count | grep master4     # the authority's own count
-  packetframe status | grep -E 'fib-synced' # routes the mirror installed
+  birdc show route count | grep -E 'in table master(4|6)'
+  grep 'integrity drift above threshold' /var/log/packetframe.log | tail -3
   ```
 
-  Those two numbers must be within the drift bound. `fib-synced` names
-  the veto explicitly when one is in force, but do not wait for a
-  deferral to find out: a box that adopts while steered under a vetoing
-  authority has no fast rollback, and that is worth knowing before the
-  canary rather than during it.
+  No drift warning in the last interval (300 s) means the checker
+  agrees. A warning prints `bird_routes` and `packetframe_routes` —
+  that pair **is** the evidence the gate acts on.
+
+  Two traps that make a hand-rolled check pass a box that will veto.
+  **`master6` counts**: a box whose `master4` matches but whose
+  `master6` is missing or wrong still fails the combined comparison, so
+  checking `master4` alone approves a rollout the gate will refuse.
+  And **`fib-synced`'s installed count is not the number to compare** —
+  that is VPP's table, which is v4-only by policy, against an authority
+  figure that includes v6.
+
+  A box that adopts while steered under a vetoing authority has no fast
+  rollback. Worth knowing before the canary rather than during it.
 
 ### A member port needs two things admin-up does not give it
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1047,15 +1047,29 @@ says so explicitly when that is what is happening — read it before
 concluding the checker is broken. Nothing is dropping meanwhile.
 
 **A second unbounded case, and this one takes the rollback lever with
-it: no completeness authority configured at all.** With no bird for the
-checker to compare against, the release falls to the unattested gate,
-which tolerates an activity rate of exactly **zero** for 5 s
-(`UNATTESTED_QUIET_RATE_PER_SEC`) — deliberately, since without an
-authority nothing can tell slow churn from a throttled reload. A live
-DFZ feed may never be literally still for 5 s, so an adopted resync
-over a **steered** VPP can defer indefinitely. Measured on the shadow:
-**23 h and still deferred** (2026-08-11 → 2026-08-12), floor long since
-met, feed healthy, nothing dropping.
+it: the completeness authority is VETOING.** `authority_current`
+compares the checker's report against the mirror as it is now, and a
+`false` there vetoes the release **outright** — no floor, liveness or
+quiescence gets past it, and unlike a quiet-wait it does not clear on
+its own. It clears when the authority's report agrees with the mirror,
+or never.
+
+Measured on the shadow, 2026-08-11 → 2026-08-12: **23 h deferred and
+still holding**, floor long since met, feed healthy, nothing dropping.
+The cause was mundane once looked at — that box's own bird carries
+**13 routes** in `master4` while the mirror holds 1.30M fed from the
+primary, so the checker could only ever report a mismatch:
+
+```
+$ birdc show route count
+13 of 13 routes for 13 networks in table master4      # <- the authority
+757074 ... in table rpki4                             # <- NOT routes
+```
+
+Two traps in that output, both of which cost time here. The `Total:`
+line counts RPKI tables and means nothing for this comparison — read
+`master4`. And a box can have bird *running* and still be useless as an
+authority, which is not the same as having no bird at all.
 
 What makes it more than cosmetic is what `AdoptedResyncing` refuses:
 **steering changes, which includes `steer off`.** For the length of the
@@ -1063,18 +1077,25 @@ deferral an operator cannot roll traffic off VPP with `packetframe
 reconfigure` — it answers "not converged". The eBPF tier is not
 carrying that traffic; VPP still is.
 
-- **On a box with bird** (the fleet, the primary) this does not apply:
-  the authority carries completion truth and releases on its own word.
-- **On a box without one** (the shadow, any box where the checker is
-  unconfigured or `birdc` is unreachable), the only escape is a cold
-  restart — stop the daemon, `packetframe detach --all`, start. That
-  tears VPP down and costs the offload for a full resync, which is
-  exactly the trade the deferral exists to avoid, so it is a last
-  resort rather than a routine step.
-- **Before a rollout, verify the authority is live** (`fib-synced`
-  naming a completeness verdict rather than the unattested wording).
-  A box that adopts while steered with no authority has no fast
-  rollback, and that is worth knowing before the canary, not during it.
+- **`fib-synced` now names the veto** rather than pointing at
+  quiescence. Until this was fixed the line read "the diff runs once the
+  source is live and has gone quiet" throughout — sending an operator to
+  watch a feed that could never release it, because `AuthorityPosture`
+  had no variant for a veto and every surface read `Attesting`.
+- **On a box whose bird carries the real table** (the fleet, the
+  primary) this does not arise: the report agrees with the mirror and
+  the authority releases on its own word.
+- **Where the authority cannot agree** — a near-empty local bird, a
+  `birdc` that fails, a mirror fed from somewhere else — the fix is to
+  make it agree or to run without one. Failing both, the escape is a
+  cold restart (stop the daemon, `packetframe detach --all`, start),
+  which tears VPP down and costs a full resync: the exact trade the
+  deferral exists to avoid, so it is a last resort.
+- **Before a rollout, verify the authority actually agrees.** Not that
+  bird is running — that `birdc show route count` on THAT box reports
+  the table the mirror was built from. A box that adopts while steered
+  under a vetoing authority has no fast rollback, and that is worth
+  knowing before the canary rather than during it.
 
 ### A member port needs two things admin-up does not give it
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1122,26 +1122,39 @@ carrying that traffic; VPP still is.
   time, or the log having rotated — which would approve a rollout onto
   a handle that is `Unknown` and will refuse.
 
-  Get positive, timestamped evidence instead. Set `log-level debug`,
-  wait one interval (300 s), and require a line **from the last
-  interval** carrying both counts:
+  **The cheapest positive evidence is the canary steer itself.** With
+  `require-table-complete on`, a steer the authority will not support
+  is *refused*, and the refusal names the verdict verbatim — "the route
+  mirror holds N routes but the authority reports only M — that is not
+  the authority feeding this mirror", or "completeness is unknown", or
+  "too old to act on". Nothing is steered when it refuses, so rung 0's
+  first `steer on` doubles as the test, and a refusal costs a message
+  rather than traffic. Read the reason it prints; do not retry past it.
+
+  To know *before* attempting, sample the checker directly. Both counts
+  come from `birdc`, and the comparison is logged — but only at debug,
+  and **`log-level` in the config does not control it**: the filter is
+  built from `RUST_LOG` at process start, so this costs a restart.
 
   ```bash
   birdc show route count | grep -E 'in table master(4|6)'
-  grep -E 'integrity check OK|integrity drift above threshold|integrity check:' \
-      /var/log/packetframe.log | tail -5
+  systemctl edit packetframe   # [Service] Environment=RUST_LOG=info,packetframe_fast_path::fib::integrity=debug
+  systemctl restart packetframe && sleep 310
+  journalctl -u packetframe --since '-6min' \
+      | grep -E 'integrity check OK|integrity drift above threshold|integrity check:'
   ```
 
-  `integrity check OK` with `bird_routes` and `packetframe_routes` is
-  the evidence the gate acts on. Anything else — a drift warning, a
-  failure line, or **no line at all** — is not a pass. Restore the log
-  level afterwards.
+  `integrity check OK` carrying `bird_routes` and `packetframe_routes`
+  is the evidence the gate acts on. A drift warning, one of the three
+  failure lines, or **no line at all** are each not a pass. Revert the
+  override afterwards.
 
-  > There is no `packetframe status` surface for this today:
-  > `IntegrityChecker`'s snapshot is published and never read, so the
-  > log is the only window onto the verdict outside a refusal message.
-  > That gap is worth closing; it is why this check is as awkward as it
-  > is.
+  > Both awkward parts of this — needing a restart, and reading a log
+  > rather than a command — come from one gap: `IntegrityChecker`'s
+  > snapshot is published and `RouteController::integrity_snapshot()`
+  > has no caller, so the verdict has no `status` surface outside a
+  > refusal message. Worth closing; until it is, prefer the canary
+  > refusal above, which needs neither.
 
   Two traps that make a hand-rolled check pass a box that will veto.
   **`master6` counts**: a box whose `master4` matches but whose

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1085,17 +1085,35 @@ carrying that traffic; VPP still is.
 - **On a box whose bird carries the real table** (the fleet, the
   primary) this does not arise: the report agrees with the mirror and
   the authority releases on its own word.
-- **Where the authority cannot agree** — a near-empty local bird, a
-  `birdc` that fails, a mirror fed from somewhere else — the fix is to
-  make it agree or to run without one. Failing both, the escape is a
-  cold restart (stop the daemon, `packetframe detach --all`, start),
-  which tears VPP down and costs a full resync: the exact trade the
-  deferral exists to avoid, so it is a last resort.
-- **Before a rollout, verify the authority actually agrees.** Not that
-  bird is running — that `birdc show route count` on THAT box reports
-  the table the mirror was built from. A box that adopts while steered
-  under a vetoing authority has no fast rollback, and that is worth
-  knowing before the canary rather than during it.
+- **A `birdc` that is temporarily unreachable is NOT this case, and
+  needs no intervention.** The integrity checker retries every interval
+  (300 s) and publishes a fresh report once it recovers, which releases
+  the deferral on its own. Restore bird or the checker and wait one
+  interval. Do **not** reach for a restart here — tearing down a
+  working VPP to fix a transient read is strictly worse than the
+  problem.
+- **A persistent disagreement is the case that needs a decision**: a
+  local bird that does not carry the mirror's table, or a mirror fed
+  from a different source than the authority measures. Make them agree,
+  or run that box without an authority. Only if neither is possible is
+  the escape a cold restart (stop the daemon, `packetframe detach
+  --all`, start) — it tears VPP down and costs a full resync, the exact
+  trade the deferral exists to avoid, so it is a last resort and not a
+  troubleshooting step.
+- **Before a rollout, check the authority AGREES — not that bird is
+  running.** The two are different, and this box proved it: bird was up
+  the whole time. Compare directly, on the box that will steer:
+
+  ```bash
+  birdc show route count | grep master4     # the authority's own count
+  packetframe status | grep -E 'fib-synced' # routes the mirror installed
+  ```
+
+  Those two numbers must be within the drift bound. `fib-synced` names
+  the veto explicitly when one is in force, but do not wait for a
+  deferral to find out: a box that adopts while steered under a vetoing
+  authority has no fast rollback, and that is worth knowing before the
+  canary rather than during it.
 
 ### A member port needs two things admin-up does not give it
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1110,19 +1110,38 @@ carrying that traffic; VPP still is.
   running.** The two are different, and this box proved it: bird was up
   the whole time.
 
-  **Do not hand-roll the comparison.** The checker compares bird's
-  `master4` **plus** `master6` against the fast-path mirror's v4+v6
-  count, and it already prints both numbers when they disagree. Read
-  that, on the box that will steer:
+  **Do not hand-roll the comparison, and do not read silence as
+  agreement.** The checker compares bird's `master4` **plus** `master6`
+  against the fast-path mirror's v4+v6 count. It logs the successful
+  comparison at **debug**; at the default `log-level info` a healthy
+  check prints *nothing at all*, and its three failure paths
+  (`integrity check: birdc route count failed`, `... birdc protocols
+  failed`, `... mirror_counts failed`) print something different again.
+  So an absent `integrity drift above threshold` line is equally
+  consistent with the checker never having run, `birdc` failing every
+  time, or the log having rotated — which would approve a rollout onto
+  a handle that is `Unknown` and will refuse.
+
+  Get positive, timestamped evidence instead. Set `log-level debug`,
+  wait one interval (300 s), and require a line **from the last
+  interval** carrying both counts:
 
   ```bash
   birdc show route count | grep -E 'in table master(4|6)'
-  grep 'integrity drift above threshold' /var/log/packetframe.log | tail -3
+  grep -E 'integrity check OK|integrity drift above threshold|integrity check:' \
+      /var/log/packetframe.log | tail -5
   ```
 
-  No drift warning in the last interval (300 s) means the checker
-  agrees. A warning prints `bird_routes` and `packetframe_routes` —
-  that pair **is** the evidence the gate acts on.
+  `integrity check OK` with `bird_routes` and `packetframe_routes` is
+  the evidence the gate acts on. Anything else — a drift warning, a
+  failure line, or **no line at all** — is not a pass. Restore the log
+  level afterwards.
+
+  > There is no `packetframe status` surface for this today:
+  > `IntegrityChecker`'s snapshot is published and never read, so the
+  > log is the only window onto the verdict outside a refusal message.
+  > That gap is worth closing; it is why this check is as awkward as it
+  > is.
 
   Two traps that make a hand-rolled check pass a box that will veto.
   **`master6` counts**: a box whose `master4` matches but whose


### PR DESCRIPTION
Found on the shadow while validating #164. **The first commit on this branch had the wrong diagnosis; the second corrects it and fixes the real defect.**

## What actually happened

The shadow deferred an adopted resync for **23 hours** — floor long since met, feed healthy, nothing dropping. I first attributed that to the *unattested* quiet gate (zero activity for 5 s with no authority). That was wrong: `completeness` is built whenever both modules are present (`loader.rs:275`), **independent of `require-table-complete`**, so the box was attested the whole time.

The real cause, once measured:

```
$ birdc show route count
13 of 13 routes for 13 networks in table master4     # the authority
757074 ... in table rpki4                            # NOT routes
```

13 routes against a 1.30M-route mirror fed from the primary ⇒ `authority_current` can only return `false` ⇒ **veto**, which blocks release outright regardless of floor, liveness or quiescence, and never clears on its own.

## The defect

**Nothing could express it.** `AuthorityPosture` had `Absent | Attesting | DemotedByFlap` — no variant for "currently vetoing" — so the snapshot read `Attesting` while release was unconditionally blocked, and the floor-met deferral message said:

> the diff runs once the source is live and has gone quiet

For 23 hours it pointed the operator at the one thing that could never release it. Same class as #157/#165: a line naming a condition that is not the blocker.

## The fix

- `AuthorityPosture::Vetoing`, computed from the **same** `authority_current` call the release path uses — not a re-derivation, so the health line and the gate cannot disagree.
- The floor-met deferral message names the veto, says plainly that **waiting will not clear it**, and names the usual cause (a near-empty local bird against a full mirror).
- Test asserts the difference an operator acts on: the vetoed message must not mention quiescence, the permitting one still must. **Fails against the reverted arm**, printing the exact line the shadow showed.
- Runbook rewritten around the measured cause, including two traps that cost time here: `birdc`'s `Total:` line counts RPKI tables and is meaningless for this comparison, and a box can have bird *running* and still be useless as an authority — not the same as having no bird.

## Why it matters for the primary ladder

`AdoptedResyncing` refuses steering changes, and that set includes `steer off`. A box that adopts while steered under a vetoing authority **has no fast rollback** for as long as the veto holds. The runbook now says to verify before a canary that `birdc show route count` on that box reports the table the mirror was built from — not merely that bird is running.

775 tests green, clippy clean on host + cross targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)