### PR TITLE
ci(qemu): a vendor repo we do not use must not fail the job

### DIFF
--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -97,9 +97,17 @@ jobs:
           # fails the whole job before qemu is even installed (observed
           # 2026-08-12: azure-cli and prod both 403, exit 100, no test
           # ever ran). Everything below comes from the Ubuntu archive.
-          sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
-                     /etc/apt/sources.list.d/azure*.list \
-                     /etc/apt/sources.list.d/google-chrome*.list
+          #
+          # Matched by CONTENT, not by filename. The 24.04 image writes
+          # azure-cli as deb822 `/etc/apt/sources.list.d/azure-cli.sources`,
+          # which a `*.list` glob silently misses — so a glob-based
+          # version of this step would have left the exact repo that
+          # broke the job enabled (review finding). Grepping for the
+          # hosts that failed covers .list and .sources alike, and keeps
+          # working when the image renames them again.
+          sudo grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
+              /etc/apt/sources.list.d/ 2>/dev/null | sudo xargs -r rm -f
+          ls -la /etc/apt/sources.list.d/ || true
           sudo apt-get update
           # virtme-ng is the maintained fork (classic virtme-run uses
           # -watchdog which QEMU 8.x dropped). Its `--run <deb>` accepts

--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -90,6 +90,16 @@ jobs:
       - name: Install QEMU + virtme-ng
         run: |
           set -eux
+          # Drop the vendor repos the hosted runner image ships and this
+          # job does not use. `apt-get update` exits non-zero if ANY
+          # configured source fails, so a 403 from packages.microsoft.com
+          # — which happens periodically and has nothing to do with us —
+          # fails the whole job before qemu is even installed (observed
+          # 2026-08-12: azure-cli and prod both 403, exit 100, no test
+          # ever ran). Everything below comes from the Ubuntu archive.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list \
+                     /etc/apt/sources.list.d/azure*.list \
+                     /etc/apt/sources.list.d/google-chrome*.list
           sudo apt-get update
           # virtme-ng is the maintained fork (classic virtme-run uses
           # -watchdog which QEMU 8.x dropped). Its `--run <deb>` accepts


### PR DESCRIPTION
The hosted runner image ships Microsoft's `azure-cli` and `prod` apt repos plus Google Chrome's. `apt-get update` exits non-zero if **any** configured source fails, so when both Microsoft repos returned `403 Forbidden` on 2026-08-12 the step failed with exit 100 and the v6.6 qemu job went red — before a single test ran.

```
E: Failed to fetch https://packages.microsoft.com/repos/azure-cli/dists/noble/InRelease  403  Forbidden
E: The repository 'https://packages.microsoft.com/ubuntu/24.04/prod noble InRelease' is no longer signed.
##[error]Process completed with exit code 100
```

It was diagnosable only because `qemu (kernel v5.15)` passed on the same commit; a re-run then passed as well. This will recur — those 403s are periodic and entirely outside our control.

Nothing this job installs (`qemu-system-x86`, `virtme-ng`, `busybox-static`) comes from those repos, so their source lists are removed before `apt-get update` and the step depends only on the Ubuntu archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)