### PR TITLE
fix(cli): a log level that parses and validates and then does nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ sudo packetframe reconfigure                # synchronous; exits non-zero on par
 sudo systemctl reload packetframe           # equivalent under systemd; both end up sending SIGHUP
 ```
 
-What's hot-reloadable: `allow-prefix*`, `block-prefix`, `dry-run`, `forwarding-mode`, `mss-clamp`, VLAN-subif resolution, and the redirect devmap. Attach-set changes (interfaces added/removed), `route-source` config, `circuit-breaker` thresholds, and `local-prefix`/`local-prefix6` still require a full restart. See [docs/runbooks/reconfigure.md](docs/runbooks/reconfigure.md).
+What's hot-reloadable: `allow-prefix*`, `block-prefix`, `dry-run`, `forwarding-mode`, `mss-clamp`, `log-level`, VLAN-subif resolution, and the redirect devmap. Attach-set changes (interfaces added/removed), `route-source` config, `circuit-breaker` thresholds, and `local-prefix`/`local-prefix6` still require a full restart. See [docs/runbooks/reconfigure.md](docs/runbooks/reconfigure.md).
 
 ### 6. Tear down
 
@@ -314,7 +314,7 @@ Quick directive index:
 - `hugepages <n>`, `vpp-binary <path>`
 - `require-table-complete {on|off}`: wait for the routing table to finish loading before steering (default on)
 
-`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, forwarding-mode bits, and vpp-offload's `steer` switches. Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, editing `local-prefix`/`local-prefix6`, or changing any vpp-offload directive other than `steer` requires a restart.
+`SIGHUP` (or `packetframe reconfigure` / `systemctl reload packetframe`) applies delta-only changes to allowlists, block-prefix, VLAN-resolve, devmap, mss-clamp, dry-run, forwarding-mode bits, `log-level`, and vpp-offload's `steer` switches. (`log-level` is the daemon's tracing filter, and `RUST_LOG` in its environment overrides it for the life of the process.) Adding or removing an `attach`, changing `route-source`, mutating `circuit-breaker` thresholds, editing `local-prefix`/`local-prefix6`, or changing any vpp-offload directive other than `steer` requires a restart.
 
 ## Operator tools
 

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -8,6 +8,17 @@
 
 global
   metrics-textfile /var/lib/node_exporter/textfile/packetframe.prom
+
+  # trace | debug | info | warn | error. Hot-reloadable: edit and
+  # `packetframe reconfigure` to change the running daemon's level
+  # without a restart.
+  #
+  # `RUST_LOG` in the daemon's environment overrides this for the whole
+  # life of the process (env beats file) and is the only way to ask for
+  # a single module — `RUST_LOG=info,packetframe_fast_path::fib::integrity=debug`
+  # — which this whole-process level cannot express. While it is set the
+  # daemon says so once at startup rather than ignoring this line
+  # silently.
   log-level info
   bpffs-root /sys/fs/bpf/packetframe
   state-dir /var/lib/packetframe/state

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -105,6 +105,14 @@ const RECONFIGURE_TIMEOUT_MS: u64 = 5_000;
 pub fn run(config_path: &Path) -> Result<(), RunError> {
     let config = Config::from_file(config_path)
         .map_err(|e| RunError::Startup(format!("config parse: {e}")))?;
+
+    // First thing after the parse, so the level the operator asked for
+    // covers the whole of startup — the feasibility gate, the attach,
+    // and the route-source bring-up are where the debug lines that are
+    // worth turning on actually live. A parse failure above keeps the
+    // startup default, which is how its own error message got printed.
+    crate::logging::apply_config_level(config.global.log_level);
+
     config
         .validate_interfaces()
         .map_err(|e| RunError::Startup(e.to_string()))?;
@@ -1002,6 +1010,14 @@ fn reconfigure_from_signal(
         write_reconfigure_marker(&marker_path, &format!("ERR validate: {e}"));
         return Published::No;
     }
+
+    // After the two refusals above and before the module loop: a
+    // rejected reload changes nothing, including this, and a module
+    // reconcile that is about to run at debug should say so under the
+    // level the operator just asked for. Hot-reloading the level is the
+    // point — raising to debug to watch a canary steer, or a route
+    // mirror converge, must not cost a restart of the data plane.
+    crate::logging::apply_config_level(new_config.global.log_level);
 
     // Before the module loop, and for the WHOLE config rather than per
     // module. vpp-offload's steering target is derived from fast-path's

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -129,10 +129,18 @@ impl LogControl {
     fn apply(&self, level: LogLevel) {
         if self.source == FilterSource::Env {
             if !self.env_notice_said.swap(true, Ordering::Relaxed) {
+                // "for this process" is the whole of it: the source is
+                // decided in `init` and the environment is never read
+                // again, so clearing RUST_LOG needs a restart. Saying
+                // "reload" here would be this module's own defect —
+                // pointing an operator at an action that changes
+                // nothing — one layer up from the one it fixes.
                 tracing::info!(
                     config_log_level = level.as_str(),
                     "RUST_LOG is set; the config's log-level is ignored for this process \
-                     (env beats file). Unset it and reload to hand the level back to the config."
+                     (env beats file). Overriding it needs a narrower RUST_LOG, not this \
+                     directive; handing the level back to the config needs RUST_LOG cleared \
+                     and the daemon restarted."
                 );
             }
             return;

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -1,0 +1,301 @@
+//! Process log filter: installed at startup, updated from
+//! `global.log-level` (SPEC.md §6) once the config has been read.
+//!
+//! The subscriber has to exist before the config does — a config parse
+//! failure is itself something we log — so the filter cannot simply be
+//! built from `global.log_level`. Instead it is installed *reloadable*
+//! at the built-in default, and [`apply_config_level`] swaps it as soon
+//! as a config is in hand: at startup in `loader::run`, and again on
+//! every accepted SIGHUP, which is what makes the level hot-reloadable.
+//!
+//! Precedence is env-beats-file. `RUST_LOG`, when set and parseable,
+//! pins the filter for the life of the process and the config directive
+//! is ignored (said once, out loud — a silently discarded directive is
+//! the bug this module exists to fix). That keeps the documented
+//! per-module escape hatches working, including the one for
+//! bgpkit-parser noise below, which no whole-process level can express.
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, OnceLock};
+
+use packetframe_common::config::LogLevel;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::{reload, EnvFilter, Registry};
+
+/// One upstream noise source, suppressed in every filter we build from
+/// a level. `bgpkit_parser::parser::bgp::messages` emits a `WARN seeing
+/// strange one-byte NLRI field` whenever a BGP UPDATE arrives with a
+/// 1-byte NLRI section, which is the valid wire encoding of a default
+/// route (`0.0.0.0/0`: prefix-length byte = 0, zero prefix bytes
+/// follow). bgpkit-parser conservatively treats it as malformed and
+/// skips. For our use case (bird with `accept-default: false`, no
+/// defaults in the RIB) the warning fires once per session when bird
+/// emits a withdraw of the default and is otherwise misleading noise.
+/// Demoting that one module to `error` keeps genuine bgpkit-parser
+/// failures visible without the cosmetic line.
+///
+/// Operators who want the raw parser warnings back set
+/// `RUST_LOG=info,bgpkit_parser::parser::bgp::messages=warn`, which
+/// takes the whole filter with it — see the module docs on precedence.
+const BGPKIT_NLRI_NOISE: &str = "bgpkit_parser::parser::bgp::messages=error";
+
+/// The filter spec for a config-supplied level.
+fn spec_for(level: LogLevel) -> String {
+    format!("{},{BGPKIT_NLRI_NOISE}", level.as_str())
+}
+
+/// Where the live filter came from, which decides whether the config
+/// gets to touch it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FilterSource {
+    /// `RUST_LOG` was set and parsed. The config never overrides it.
+    Env,
+    /// No usable `RUST_LOG`; `global.log-level` owns the filter.
+    Config,
+}
+
+/// A resolved startup filter plus how it was chosen.
+struct Resolved {
+    filter: EnvFilter,
+    source: FilterSource,
+    /// Deferred complaint about a malformed `RUST_LOG`. Resolution runs
+    /// before the subscriber exists, so it cannot be logged in place.
+    warning: Option<String>,
+}
+
+/// Pick the startup filter from `RUST_LOG` (already read, so this is
+/// testable without touching the process environment) falling back to
+/// `default_level` — which is [`LogLevel::Info`] in practice, since the
+/// real config level is only known later.
+///
+/// A `RUST_LOG` that is set but does not parse falls back rather than
+/// aborting startup, and leaves the config in charge: a typo in a
+/// systemd drop-in should not also cost the operator their config's
+/// level, and it should not be silent either.
+fn resolve(env: Option<String>, default_level: LogLevel) -> Resolved {
+    match env {
+        Some(spec) => match EnvFilter::try_new(&spec) {
+            Ok(filter) => Resolved {
+                filter,
+                source: FilterSource::Env,
+                warning: None,
+            },
+            Err(e) => Resolved {
+                filter: EnvFilter::new(spec_for(default_level)),
+                source: FilterSource::Config,
+                warning: Some(format!(
+                    "RUST_LOG=`{spec}` did not parse ({e}); \
+                     falling back to the config's log-level"
+                )),
+            },
+        },
+        None => Resolved {
+            filter: EnvFilter::new(spec_for(default_level)),
+            source: FilterSource::Config,
+            warning: None,
+        },
+    }
+}
+
+/// The live filter's reload handle plus the precedence decision.
+struct LogControl {
+    handle: reload::Handle<EnvFilter, Registry>,
+    source: FilterSource,
+    /// Level currently installed from the config. Guards against
+    /// rebuilding the callsite interest cache on every SIGHUP that
+    /// leaves `log-level` alone, which is nearly all of them.
+    applied: Mutex<LogLevel>,
+    /// Whether the "your config directive is being ignored" notice has
+    /// been emitted. Once per process is enough; SIGHUP would otherwise
+    /// repeat it forever.
+    env_notice_said: AtomicBool,
+}
+
+impl LogControl {
+    fn new(
+        handle: reload::Handle<EnvFilter, Registry>,
+        source: FilterSource,
+        installed: LogLevel,
+    ) -> Self {
+        Self {
+            handle,
+            source,
+            applied: Mutex::new(installed),
+            env_notice_said: AtomicBool::new(false),
+        }
+    }
+
+    fn apply(&self, level: LogLevel) {
+        if self.source == FilterSource::Env {
+            if !self.env_notice_said.swap(true, Ordering::Relaxed) {
+                tracing::info!(
+                    config_log_level = level.as_str(),
+                    "RUST_LOG is set; the config's log-level is ignored for this process \
+                     (env beats file). Unset it and reload to hand the level back to the config."
+                );
+            }
+            return;
+        }
+
+        // Poisoning here means a previous caller panicked mid-apply,
+        // which loses at most the last-applied bookkeeping. Recovering
+        // is strictly better than taking the daemon down over a log
+        // filter.
+        let mut applied = self.applied.lock().unwrap_or_else(|e| e.into_inner());
+        if *applied == level {
+            return;
+        }
+        match self.handle.reload(EnvFilter::new(spec_for(level))) {
+            Ok(()) => {
+                *applied = level;
+                tracing::info!(log_level = level.as_str(), "log level applied from config");
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "could not update the log filter; level unchanged");
+            }
+        }
+    }
+}
+
+static CONTROL: OnceLock<LogControl> = OnceLock::new();
+
+/// The level the filter starts at, before any config is read.
+const STARTUP_LEVEL: LogLevel = LogLevel::Info;
+
+/// Install the process subscriber. Call once, first thing in `main`.
+pub fn init() {
+    let resolved = resolve(std::env::var(EnvFilter::DEFAULT_ENV).ok(), STARTUP_LEVEL);
+    let source = resolved.source;
+    let (filter_layer, handle) = reload::Layer::new(resolved.filter);
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_writer(std::io::stderr)
+                .with_target(false)
+                .compact(),
+        )
+        .init();
+
+    let _ = CONTROL.set(LogControl::new(handle, source, STARTUP_LEVEL));
+
+    if let Some(w) = resolved.warning {
+        tracing::warn!("{w}");
+    }
+}
+
+/// Point the filter at a config-supplied level. Idempotent, cheap when
+/// the level is unchanged, and a no-op when `RUST_LOG` owns the filter
+/// or [`init`] was never called.
+pub fn apply_config_level(level: LogLevel) {
+    if let Some(control) = CONTROL.get() {
+        control.apply(level);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing::subscriber::DefaultGuard;
+    use tracing_subscriber::filter::LevelFilter;
+
+    /// Build the same layer stack [`init`] does, but scoped to this
+    /// thread instead of the process, so the precedence rules can be
+    /// exercised end-to-end (real `EnvFilter`, real reload handle)
+    /// without a global subscriber that only one test could own.
+    ///
+    /// The guard keeps the subscriber — and with it the layer the
+    /// handle points at — alive for the caller's lifetime.
+    fn control_with(env: Option<&str>) -> (LogControl, DefaultGuard) {
+        let resolved = resolve(env.map(str::to_owned), STARTUP_LEVEL);
+        let source = resolved.source;
+        let (filter_layer, handle) = reload::Layer::new(resolved.filter);
+        let guard =
+            tracing::subscriber::set_default(tracing_subscriber::registry().with(filter_layer));
+        (LogControl::new(handle, source, STARTUP_LEVEL), guard)
+    }
+
+    /// The most permissive level the live filter will admit.
+    fn live_max(control: &LogControl) -> Option<LevelFilter> {
+        control.handle.with_current(|f| f.max_level_hint()).unwrap()
+    }
+
+    /// The live filter's directives, as written back out.
+    fn live_spec(control: &LogControl) -> String {
+        control.handle.with_current(|f| f.to_string()).unwrap()
+    }
+
+    #[test]
+    fn config_level_reaches_the_filter() {
+        let (control, _guard) = control_with(None);
+        assert_eq!(live_max(&control), Some(LevelFilter::INFO));
+
+        control.apply(LogLevel::Debug);
+        assert_eq!(live_max(&control), Some(LevelFilter::DEBUG));
+
+        // …and back down again: hot-reload is not one-way.
+        control.apply(LogLevel::Error);
+        assert_eq!(live_max(&control), Some(LevelFilter::ERROR));
+    }
+
+    #[test]
+    fn rust_log_beats_the_config_level() {
+        let (control, _guard) = control_with(Some("warn"));
+        assert_eq!(live_max(&control), Some(LevelFilter::WARN));
+
+        control.apply(LogLevel::Debug);
+        assert_eq!(
+            live_max(&control),
+            Some(LevelFilter::WARN),
+            "RUST_LOG must pin the filter for the life of the process"
+        );
+    }
+
+    /// `EnvFilter` accepts a lot — a bare `nonsense` is a target at
+    /// trace, not an error — so this uses a spec it genuinely rejects:
+    /// a directive with a level that is not a level.
+    #[test]
+    fn unparseable_rust_log_leaves_the_config_in_charge() {
+        let (control, _guard) = control_with(Some("debug,fast_path=bananas"));
+        assert_eq!(control.source, FilterSource::Config);
+        assert_eq!(live_max(&control), Some(LevelFilter::INFO));
+
+        control.apply(LogLevel::Trace);
+        assert_eq!(live_max(&control), Some(LevelFilter::TRACE));
+    }
+
+    #[test]
+    fn bgpkit_noise_stays_suppressed_at_every_level() {
+        for level in [
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+        ] {
+            let spec = spec_for(level);
+            assert!(spec.starts_with(level.as_str()), "{spec}");
+            assert!(spec.contains(BGPKIT_NLRI_NOISE), "{spec}");
+        }
+
+        // Not just in the string we hand over — in the filter that
+        // comes back out after a reload.
+        let (control, _guard) = control_with(None);
+        control.apply(LogLevel::Trace);
+        assert!(
+            live_spec(&control).contains("bgpkit_parser::parser::bgp::messages=error"),
+            "{}",
+            live_spec(&control)
+        );
+    }
+
+    #[test]
+    fn re_applying_the_same_level_is_a_no_op() {
+        let (control, _guard) = control_with(None);
+        control.apply(LogLevel::Info);
+        assert_eq!(live_max(&control), Some(LevelFilter::INFO));
+        assert_eq!(*control.applied.lock().unwrap(), LogLevel::Info);
+    }
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -18,6 +18,7 @@ mod fib_cli;
 #[cfg(feature = "fast-path")]
 mod health;
 mod loader;
+pub(crate) mod logging;
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
 mod metrics;
 #[cfg(feature = "probe")]
@@ -30,7 +31,6 @@ use std::time::Duration;
 
 use clap::{Parser, Subcommand};
 use packetframe_common::config::Config;
-use tracing_subscriber::EnvFilter;
 
 /// Exit codes per SPEC.md §7.3.
 pub(crate) const EXIT_OK: u8 = 0;
@@ -111,8 +111,10 @@ enum Command {
     },
 
     /// Re-read config and apply hot-reloadable changes (allow-prefix,
-    /// block-prefix, dry-run, forwarding-mode, mss-clamp, etc.) on the
-    /// running daemon without touching attach state. Reads the
+    /// block-prefix, dry-run, forwarding-mode, mss-clamp, log-level,
+    /// etc.) on the running daemon without touching attach state. Note
+    /// that `log-level` does nothing while `RUST_LOG` is set in the
+    /// daemon's environment: env beats file. Reads the
     /// daemon's PID file, sends SIGHUP, then polls the
     /// `last-reconfigure.timestamp` marker for confirmation.
     /// Equivalent to `systemctl reload packetframe` under systemd.
@@ -259,31 +261,10 @@ fn restore_default_sigpipe() {}
 fn main() -> ExitCode {
     restore_default_sigpipe();
 
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
-        // Default: info from our crates, plus suppress one upstream
-        // noise source. `bgpkit_parser::parser::bgp::messages`
-        // emits a `WARN seeing strange one-byte NLRI field` whenever
-        // a BGP UPDATE arrives with a 1-byte NLRI section, which is
-        // the valid wire encoding of a default route (`0.0.0.0/0`:
-        // prefix-length byte = 0, zero prefix bytes follow).
-        // bgpkit-parser conservatively treats it as malformed and
-        // skips. For our use case (bird with `accept-default: false`,
-        // no defaults in the RIB), the warning fires once per session
-        // when bird emits a withdraw of the default and is otherwise
-        // misleading noise. Demote that one module's warnings to
-        // error level so genuine bgpkit-parser failures still
-        // surface but the cosmetic noise is gone.
-        //
-        // Operators who want the raw parser warnings back: set
-        // `RUST_LOG=info,bgpkit_parser::parser::bgp::messages=warn`.
-        EnvFilter::new("info,bgpkit_parser::parser::bgp::messages=error")
-    });
-    tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .with_target(false)
-        .compact()
-        .init();
+    // Reloadable, at the built-in default. `global.log-level` from the
+    // config takes over once there is a config to read it from; see
+    // [`logging`] for the ordering and the `RUST_LOG` precedence.
+    logging::init();
 
     let cli = Cli::parse();
     match cli.command {

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -115,6 +115,21 @@ pub enum LogLevel {
     Error,
 }
 
+impl LogLevel {
+    /// The lowercase spelling: the one [`FromStr`] accepts, the one
+    /// `Serialize` emits, and the one a `tracing` filter directive
+    /// wants. Kept as one function so those three can't drift.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
 impl FromStr for LogLevel {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -2601,6 +2616,19 @@ module fast-path
     fn attach_settle_time_bad_number_errors() {
         let err = Config::parse("global\n  attach-settle-time abcs\n").expect_err("must fail");
         assert!(format!("{err}").contains("bad duration"));
+    }
+
+    #[test]
+    fn log_level_as_str_round_trips_through_from_str() {
+        for level in [
+            LogLevel::Trace,
+            LogLevel::Debug,
+            LogLevel::Info,
+            LogLevel::Warn,
+            LogLevel::Error,
+        ] {
+            assert_eq!(level.as_str().parse::<LogLevel>(), Ok(level));
+        }
     }
 
     #[test]

--- a/docs/runbooks/reconfigure.md
+++ b/docs/runbooks/reconfigure.md
@@ -40,6 +40,25 @@ These directives can be added, removed, or changed under SIGHUP without re-attac
 | `mss-clamp …` (all four grammars) | `MSS_CLAMP_V4/V6` + `MSS_CLAMP_BY_IFACE` + `CFG.mss_clamp_global` | v0.2.4+; value changes also pick up |
 | (auto) VLAN-subif resolution | `VLAN_RESOLVE` | Re-scanned from `/proc/net/vlan/config` |
 | (auto) Redirect devmap | `REDIRECT_DEVMAP` | Re-scanned from `/sys/class/net` |
+| `log-level` | (none — userspace tracing filter) | v0.2.7+; applied before the module loop, so the reconcile it is on logs at the new level. **No effect while `RUST_LOG` is set** — see below |
+
+`log-level` is the one entry here that touches no BPF map: it swaps the
+daemon's tracing filter in place. Raising to `debug` to watch a canary
+steer or a route mirror converge, and dropping back after, is a reload
+rather than a restart.
+
+Two things to know about it:
+
+- **`RUST_LOG` in the daemon's environment wins, for the life of the
+  process.** Env beats file, which keeps per-module overrides like
+  `RUST_LOG=info,packetframe_fast_path::fib::integrity=debug` working —
+  no whole-process level can express those. A daemon started with
+  `RUST_LOG` set logs a single line saying the config directive is being
+  ignored, the first time it would have applied one; clearing the
+  environment variable needs a restart, since only a restart re-reads it.
+- **`log-level debug` on a forwarding box is loud.** It is a whole-process
+  level, not a per-module one. Reload it back down when you are done
+  rather than leaving it on.
 
 Adds-before-removes ordering: a renamed prefix (remove + add of the same value) never has a window where neither exists.
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1139,24 +1139,46 @@ carrying that traffic; VPP still is.
 
   To know *before* attempting, sample the checker directly. Both counts
   come from `birdc`, and the comparison is logged — but only at debug,
-  and **`log-level` in the config does not control it**: the filter is
-  built from `RUST_LOG` at process start, so this costs a restart.
+  so the level has to come up first. `log-level` in the config is
+  hot-reloadable (v0.2.7+), so this costs a reload rather than a
+  restart: the checker keeps its 300 s cadence across it, and nothing is
+  detached.
 
   ```bash
   birdc show route count | grep -E 'in table master(4|6)'
-  systemctl edit packetframe   # [Service] Environment=RUST_LOG=info,packetframe_fast_path::fib::integrity=debug
-  systemctl restart packetframe && sleep 310
+  # /etc/packetframe/packetframe.conf: global -> log-level debug
+  packetframe reconfigure && sleep 310
   journalctl -u packetframe --since '-6min' \
       | grep -E 'integrity check OK|integrity drift above threshold|integrity check:'
+  # then put log-level back and reload again — whole-process debug on a
+  # forwarding box is loud, and nothing above needs it to stay on.
   ```
 
   `integrity check OK` carrying `bird_routes` and `packetframe_routes`
   is the evidence the gate acts on. A drift warning, one of the three
-  failure lines, or **no line at all** are each not a pass. Revert the
-  override afterwards.
+  failure lines, or **no line at all** are each not a pass.
 
-  > Both awkward parts of this — needing a restart, and reading a log
-  > rather than a command — come from one gap: `IntegrityChecker`'s
+  **Two ways this reload can no-op.** `RUST_LOG` in the daemon's
+  environment overrides the config for the whole life of the process —
+  including a drop-in some earlier bring-up left behind — and the daemon
+  says so, once, the first time the config would have applied a level:
+  *"RUST_LOG is set; the config's log-level is ignored for this
+  process"*. Clearing it is the one case that still costs a restart
+  (`systemctl edit packetframe`, drop the `Environment=` line, then the
+  cold sequence — a plain `systemctl restart` crash-loops on surviving
+  pins, see [reconfigure.md](reconfigure.md)). If you would rather keep
+  it, override with the narrower filter instead and skip the config
+  entirely: `RUST_LOG=info,packetframe_fast_path::fib::integrity=debug`
+  is the one thing a whole-process level cannot express, and it is
+  quieter than `debug`. Second: a reload the daemon *refuses* (a config
+  that does not parse, or one `validate_vpp_offload` rejects) applies no
+  part of itself, level included. `packetframe reconfigure` exits
+  non-zero and names the reason — read it rather than moving on to the
+  `journalctl` line, which would show the same empty output as a healthy
+  checker at info.
+
+  > What is still awkward here — turning a log level up and reading a
+  > log, rather than asking — comes from one gap: `IntegrityChecker`'s
   > snapshot is published and `RouteController::integrity_snapshot()`
   > has no caller, so the verdict has no `status` surface outside a
   > refusal message. Worth closing; until it is, prefer the canary


### PR DESCRIPTION
## What

`global.log-level` (`crates/common/src/config.rs`) had **no runtime consumer anywhere in the tree**. `main` built the tracing `EnvFilter` from `RUST_LOG` (or a hardcoded default) and installed it *before* the config file was read at all, so an operator setting `log-level debug` in `/etc/packetframe/packetframe.conf` got no error, no warning, and no change in output. The directive parsed, validated, and round-tripped in tests the whole way to being discarded.

This wires it up, and makes it hot-reloadable.

## Why

Found from the other end. #166's rollout pre-flight told operators to set `log-level debug` to surface the integrity checker's debug-level comparison — an instruction that could never have worked. The correction there had to send them to a `RUST_LOG` systemd drop-in plus a restart instead, on the one procedure whose whole point is not disturbing a steered VPP.

## How

- **Reloadable filter** (`crates/cli/src/logging.rs`, new). Installed at the built-in default, then pointed at `global.log_level` as soon as a config exists: after the parse in `loader::run`, and again on every **accepted** SIGHUP.
  Reloading rather than parse-first is what buys the SIGHUP case, and it keeps a config parse error logged through a real subscriber rather than a temporary one — that error message is itself the reason the subscriber cannot wait for the config.
- **Precedence is env-beats-file.** `RUST_LOG`, set and parseable, pins the filter for the life of the process. Conventional direction, and it preserves the per-module escape hatches that no whole-process level can express (`RUST_LOG=info,packetframe_fast_path::fib::integrity=debug`), including the bgpkit-parser NLRI suppression — now appended to every filter built from a level, so `debug` does not resurrect that noise. What changes is that the ignored directive is **said out loud, once**: a silently discarded knob is the defect here, and inverting the precedence would only move it to the other knob.
- A `RUST_LOG` that is set but does not parse falls back to the config level **and warns**, rather than costing the operator both.
- Re-applying an unchanged level is a no-op, so the common SIGHUP (a `steer` flip) does not rebuild the callsite interest cache.

## Reviewer notes

- **SIGHUP placement** is after both refusal gates and before the module loop in `reconfigure_from_signal`: a rejected reload changes nothing, level included, and a module about to reconcile at debug should log under the level just asked for.
- **Tests** drive a real `EnvFilter` behind a real reload handle on a *thread-local* subscriber, so both directions are asserted end-to-end without contending for the process-global one: `config_level_reaches_the_filter` and `rust_log_beats_the_config_level`, plus unparseable-`RUST_LOG` fallback, noise suppression at every level, and a `LogLevel::as_str`/`FromStr` round-trip.
- **Deliberately left alone**: `status`/`detach`/`feasibility` read a config but do not apply its level — they print to stdout and use tracing only for errors. And clearing a `RUST_LOG` drop-in still costs a restart, since only process start reads the environment; the runbooks say so.
- **Docs**: `log-level` joins the hot-reloadable lists in `README.md`, the `reconfigure.md` table, and `reconfigure --help`. The vpp-offload pre-flight loses its restart — doubly wrong there, since a plain `systemctl restart` crash-loops on surviving pins — and gains the two ways the reload can still no-op.

## Verification

`make lint` + `make test` clean, and `cargo clippy --target x86_64-unknown-linux-gnu -- -D warnings` on the CLI so the Linux-gated SIGHUP edit is actually covered (host checks skip it). Also ran the binary three ways against a scratch config: config `debug` applies and logs it, `RUST_LOG=warn` suppresses that line, `RUST_LOG=info` prints the ignored-directive notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)