### PR TITLE
fix(fast-path): surface the integrity verdict in `packetframe status`

### DIFF
--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -21,14 +21,16 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::path::Path;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
-use crate::fib::integrity::{shared_snapshot, IntegrityChecker, IntegrityConfig, SharedSnapshot};
+use crate::fib::integrity::{
+    shared_snapshot, IntegrityChecker, IntegrityConfig, IntegrityPosture, SharedSnapshot,
+};
 use crate::fib::netlink_neigh::{
     FallbackDefaultSpec, LocalPrefixSpec, NeighborResolveHandle, NetlinkNeighborResolver,
 };
@@ -411,12 +413,32 @@ impl RouteController {
         })
     }
 
-    /// Shared snapshot from the integrity checker. `None` when BMP
-    /// isn't configured. Callers read the snapshot to diagnose drift
-    /// or to gate a BmpStalled alert on "bird still thinks there are
-    /// peers to hear from."
-    pub fn integrity_snapshot(&self) -> Option<SharedSnapshot> {
-        self.integrity.clone()
+    /// The last integrity check, for the module's health surface.
+    ///
+    /// `None` when no checker is running — no route source is
+    /// configured, so there is no bird to cross-check against and no
+    /// verdict to report. That is the one case the health surface
+    /// prints no row for; every other case has something to say,
+    /// including "nothing has compared yet".
+    ///
+    /// Replaces an `integrity_snapshot()` getter that had no caller
+    /// anywhere in the tree: the checker compared bird against the
+    /// mirror every 300 s and threw the result away, leaving a debug
+    /// log as the only way to see it.
+    ///
+    /// `try_read` rather than a blocking one. This is called from the
+    /// daemon's sync signal loop today, where blocking would be safe,
+    /// but `Module::health_check` is a public surface and a blocking
+    /// tokio read panics inside an async context. The writer holds this
+    /// lock for a handful of field assignments once per interval, so
+    /// losing the race is vanishingly rare and says so when it happens
+    /// rather than being mistaken for "no check yet".
+    pub fn integrity_posture(&self) -> Option<IntegrityPosture> {
+        let snapshot = self.integrity.as_ref()?;
+        Some(match snapshot.try_read() {
+            Ok(snap) => IntegrityPosture::observe(&snap, Instant::now()),
+            Err(_) => IntegrityPosture::Unread,
+        })
     }
 
     /// Cooperative shutdown. Signals the cancellation token, awaits

--- a/crates/modules/fast-path/src/fib/integrity.rs
+++ b/crates/modules/fast-path/src/fib/integrity.rs
@@ -31,10 +31,12 @@ use tracing::{debug, info, warn};
 
 use super::programmer::FibProgrammerHandle;
 
-/// Default interval between integrity checks. Slow enough to be
-/// cheap, fast enough that a drift window of "up to 5 minutes"
-/// is acceptable.
-pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(300);
+/// The result types and their rendering live in a platform-independent
+/// module so `packetframe status`'s view of this check is testable off
+/// Linux; re-exported here because this is where callers expect them.
+pub use crate::fib::integrity_status::{
+    Comparison, Drift, IntegrityPosture, IntegritySnapshot, DEFAULT_INTERVAL, SUBSYS_FIB_INTEGRITY,
+};
 
 /// Drift threshold above which the checker warns (as a fraction:
 /// `0.01` = 1%). BGP convergence can transiently drift by several
@@ -67,19 +69,6 @@ impl Default for IntegrityConfig {
             drift_warn_fraction: DEFAULT_DRIFT_WARN_FRACTION,
         }
     }
-}
-
-/// Snapshot of the most recent integrity-check result. Readers
-/// specifically the BmpStalled gate, consult this to decide whether
-/// a stall warrants an alert.
-#[derive(Debug, Clone, Default)]
-pub struct IntegritySnapshot {
-    pub last_run: Option<Instant>,
-    pub bird_route_count: Option<usize>,
-    pub packetframe_route_count: Option<usize>,
-    pub bird_established_peers: Option<usize>,
-    pub drift_fraction: Option<f64>,
-    pub last_error: Option<String>,
 }
 
 pub type SharedSnapshot = Arc<RwLock<IntegritySnapshot>>;
@@ -164,88 +153,110 @@ impl IntegrityChecker {
         let bird_peers = run_birdc_protocols(&self.config.birdc_path).await;
         let pf_route = self.prog.mirror_counts().await;
 
-        // Captured from THIS run's results, before they are folded into
-        // the snapshot.
+        // Captured from THIS run's results, before anything is folded
+        // into the snapshot.
         //
-        // The snapshot's count fields are sticky — a failed `birdc` or a
-        // failed `mirror_counts` leaves the previous run's number in
-        // place, which is right for a drift-catch display and wrong as
-        // the basis of a steering decision. Reading them back below
-        // would publish a report built from one fresh number and one
-        // five minutes old, and the reader acts on it.
+        // Nothing derived from a mix of runs ever reaches the snapshot:
+        // a failed `birdc` or a failed `mirror_counts` used to leave the
+        // previous run's number in a sticky per-count field, so a drift
+        // fraction could be computed from one fresh number and one five
+        // minutes old. That was tolerable while the only reader was a
+        // log line; it is not, now that `packetframe status` prints the
+        // verdict and a rollout is gated on it. A partial run records
+        // its error and leaves the previous COMPARISON standing whole,
+        // aged, and labelled as history.
         let fresh_bird = bird_route.as_ref().ok().copied();
         let fresh_mirror = pf_route.as_ref().ok().map(|(v4, v6)| v4 + v6);
 
+        // One `Instant` for the whole run, written to `last_run` and to
+        // the comparison alike. That equality is load-bearing:
+        // `IntegrityPosture` tells a current comparison from a retained
+        // one by comparing the two, so two separate `now()` calls would
+        // make every comparison read as history.
+        let at = Instant::now();
         let mut snap = self.snapshot.write().await;
-        snap.last_run = Some(Instant::now());
+        snap.last_run = Some(at);
         snap.last_error = None;
 
-        match bird_route {
-            Ok(n) => snap.bird_route_count = Some(n),
-            Err(e) => {
-                snap.last_error = Some(format!("birdc show route count: {e}"));
-                warn!(error = %e, "integrity check: birdc route count failed");
-            }
+        if let Err(e) = &bird_route {
+            snap.last_error = Some(format!("birdc show route count: {e}"));
+            warn!(error = %e, "integrity check: birdc route count failed");
         }
         match bird_peers {
             Ok(n) => snap.bird_established_peers = Some(n),
             Err(e) => {
                 // Non-fatal for the route-count side, but the stall
                 // gate relies on this so surface it.
-                let msg = format!("birdc show protocols: {e}");
                 if snap.last_error.is_none() {
-                    snap.last_error = Some(msg.clone());
+                    snap.last_error = Some(format!("birdc show protocols: {e}"));
                 }
                 warn!(error = %e, "integrity check: birdc protocols failed");
             }
         }
-        match pf_route {
-            Ok((v4, v6)) => snap.packetframe_route_count = Some(v4 + v6),
-            Err(e) => {
-                snap.last_error = Some(format!("programmer mirror_counts: {e}"));
-                warn!(error = %e, "integrity check: mirror_counts failed");
-            }
+        if let Err(e) = &pf_route {
+            snap.last_error = Some(format!("programmer mirror_counts: {e}"));
+            warn!(error = %e, "integrity check: mirror_counts failed");
         }
 
-        // Republished for the steering gate, and only when BOTH counts
-        // came from THIS run.
+        // Recorded, and republished to the steering gate, only when BOTH
+        // counts came from THIS run.
         //
         // A partial run publishes nothing rather than a mixed report:
         // the reader treats an absent report as "refuse to steer", which
         // is the safe reading, while a fabricated one would be acted on.
         // Leaving the previous report in place is correct — it ages out
         // on its own, and its own timestamp says how far behind it is.
-        if let (Some(handle), Some(bird), Some(pf)) =
-            (self.completeness.as_ref(), fresh_bird, fresh_mirror)
-        {
-            handle.publish(packetframe_common::fib::CompletenessReport {
-                authority_routes: bird as u64,
-                mirror_routes: pf as u64,
-                at: Instant::now(),
-            });
-        }
-
-        if let (Some(bird), Some(pf)) = (snap.bird_route_count, snap.packetframe_route_count) {
-            if bird == 0 {
-                snap.drift_fraction = None;
-            } else {
-                let frac = (bird as f64 - pf as f64).abs() / bird as f64;
-                snap.drift_fraction = Some(frac);
-                if frac >= self.config.drift_warn_fraction {
-                    warn!(
-                        bird_routes = bird,
-                        packetframe_routes = pf,
-                        drift_fraction = frac,
-                        "integrity drift above threshold"
-                    );
-                } else {
-                    debug!(
-                        bird_routes = bird,
-                        packetframe_routes = pf,
-                        drift_fraction = frac,
-                        "integrity check OK"
-                    );
+        if let (Some(bird), Some(pf)) = (fresh_bird, fresh_mirror) {
+            // `above` is decided here, in the same place that decides
+            // whether to warn, and carried on the comparison. The health
+            // surface reports that verdict rather than re-applying the
+            // threshold, so the log and `packetframe status` cannot
+            // disagree about whether a box has drifted.
+            let drift = (bird != 0).then(|| {
+                let fraction = (bird as f64 - pf as f64).abs() / bird as f64;
+                Drift {
+                    fraction,
+                    threshold: self.config.drift_warn_fraction,
+                    above: fraction >= self.config.drift_warn_fraction,
                 }
+            });
+            match drift {
+                Some(d) if d.above => warn!(
+                    bird_routes = bird,
+                    packetframe_routes = pf,
+                    drift_fraction = d.fraction,
+                    "integrity drift above threshold"
+                ),
+                Some(d) => debug!(
+                    bird_routes = bird,
+                    packetframe_routes = pf,
+                    drift_fraction = d.fraction,
+                    "integrity check OK"
+                ),
+                // A zero authority used to record `drift_fraction =
+                // None` and log nothing at all — the quietest possible
+                // treatment of a bird that cannot attest anything. It is
+                // the degenerate end of the case the vpp-offload runbook
+                // measured (a box whose own bird carried 13 routes
+                // against a 1.3M mirror), so it warns like drift does.
+                None => warn!(
+                    bird_routes = bird,
+                    packetframe_routes = pf,
+                    "integrity check: bird reports no routes in master4/master6"
+                ),
+            }
+            snap.last_comparison = Some(Comparison {
+                at,
+                bird_routes: bird,
+                packetframe_routes: pf,
+                drift,
+            });
+            if let Some(handle) = self.completeness.as_ref() {
+                handle.publish(packetframe_common::fib::CompletenessReport {
+                    authority_routes: bird as u64,
+                    mirror_routes: pf as u64,
+                    at,
+                });
             }
         }
     }

--- a/crates/modules/fast-path/src/fib/integrity_status.rs
+++ b/crates/modules/fast-path/src/fib/integrity_status.rs
@@ -325,6 +325,39 @@ impl IntegrityPosture {
             "bird {} routes, mirror {}",
             s.bird_routes, s.packetframe_routes
         );
+        // Age first, and against the consumer's own constant rather than
+        // a second copy of the number — for exactly the reason
+        // `packetframe_common::fib::assess` gives for checking it first:
+        // "a report whose drift looks fine but which predates anything
+        // we care about is not evidence, and reporting its drift would
+        // invite acting on it."
+        //
+        // Without this the row was the *inverse* of useful. A checker
+        // task that stalls or exits after one good comparison stops
+        // advancing `last_run` and records no error, so neither age
+        // affected the verdict and the row went on printing "the
+        // positive evidence a rollout needs" forever — while `assess`,
+        // reading the same comparison through the completeness handle,
+        // had already called it `Stale` and was refusing the steer. A
+        // status surface that contradicts the gate it exists to predict
+        // is worse than the silence it replaced (review finding).
+        //
+        // The drift is deliberately NOT printed here. It is the number
+        // an operator would act on, and it is precisely what has expired.
+        if s.age > packetframe_common::fib::STEER_MAX_REPORT_AGE {
+            return (
+                HealthState::Degraded,
+                format!(
+                    "{counts} — but that comparison is {:.0}s old, past the {:.0}s window a \
+                     steering gate acts within, so it is NOT evidence for a rollout: the gate \
+                     reads this same report as `Stale` and refuses. Comparisons have stopped \
+                     landing; where no error is reported alongside this, they are not even \
+                     being attempted, so look at the daemon's checker task rather than at bird",
+                    s.age.as_secs_f64(),
+                    packetframe_common::fib::STEER_MAX_REPORT_AGE.as_secs_f64()
+                ),
+            );
+        }
         match s.drift {
             Some(d) if d.above => (
                 HealthState::Degraded,
@@ -479,6 +512,77 @@ mod tests {
             !m.contains("drift 0"),
             "a zero authority must not read as agreement: {m}"
         );
+    }
+
+    /// A comparison that has aged out is not evidence, however well the
+    /// two counts agreed when it was taken. Without this the row printed
+    /// "the positive evidence a rollout needs" indefinitely after the
+    /// checker task stopped, because nothing recorded an error and no
+    /// age fed the verdict.
+    #[test]
+    fn stale_sample_does_not_read_as_agreement() {
+        let at = t0();
+        let snap = clean_run(at, 1_272_306, 1_272_281, drift(0.0000196, 0.01));
+        let stale = IntegrityPosture::observe(
+            &snap,
+            at + packetframe_common::fib::STEER_MAX_REPORT_AGE + Duration::from_secs(1),
+        )
+        .subsystem_health();
+        assert_eq!(stale.state, HealthState::Degraded);
+        let m = stale.message.unwrap();
+        assert!(m.contains("NOT evidence for a rollout"), "{m}");
+        assert!(m.contains("`Stale`"), "{m}");
+        // The drift is what an operator would act on, and it is what has
+        // expired. `assess` withholds it for the same reason.
+        assert!(!m.contains("within the"), "expired drift still shown: {m}");
+        // Still a real completed comparison, so its age is still
+        // reported — that number is the whole diagnosis here.
+        assert_eq!(
+            stale.last_success_age_seconds,
+            Some(packetframe_common::fib::STEER_MAX_REPORT_AGE.as_secs() + 1)
+        );
+    }
+
+    /// The row and the gate must flip at the same instant. They read the
+    /// same comparison — the checker publishes it to both — so a status
+    /// surface that says "proceed" while `assess` says `Stale` is worse
+    /// than no surface at all. Pinned to the consumer's own constant, so
+    /// changing one side without the other fails here.
+    #[test]
+    fn freshness_window_matches_the_steering_gate() {
+        use packetframe_common::fib::{
+            assess, Completeness, CompletenessReport, STEER_MAX_DRIFT, STEER_MAX_REPORT_AGE,
+        };
+        let at = t0();
+        // Drift far below either threshold, so age is the only variable.
+        let snap = clean_run(at, 1_000_000, 1_000_000, drift(0.0, 0.01));
+        let report = CompletenessReport {
+            authority_routes: 1_000_000,
+            mirror_routes: 1_000_000,
+            at,
+        };
+        for offset in [
+            Duration::from_secs(0),
+            STEER_MAX_REPORT_AGE - Duration::from_secs(1),
+            STEER_MAX_REPORT_AGE,
+            STEER_MAX_REPORT_AGE + Duration::from_secs(1),
+            STEER_MAX_REPORT_AGE * 3,
+        ] {
+            let now = at + offset;
+            let row_says_go = IntegrityPosture::observe(&snap, now)
+                .subsystem_health()
+                .state
+                == HealthState::Healthy;
+            let gate_says_go = matches!(
+                assess(Some(report), now, STEER_MAX_DRIFT, STEER_MAX_REPORT_AGE),
+                Completeness::Converged { .. }
+            );
+            assert_eq!(
+                row_says_go, gate_says_go,
+                "row and gate disagree at age {offset:?}: status healthy={row_says_go}, \
+                 gate converged={gate_says_go}"
+            );
+        }
     }
 
     #[test]

--- a/crates/modules/fast-path/src/fib/integrity_status.rs
+++ b/crates/modules/fast-path/src/fib/integrity_status.rs
@@ -125,7 +125,13 @@ pub struct IntegritySnapshot {
 /// whether it came from the most recent run.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Sample {
-    pub age: Duration,
+    /// When the comparison was recorded, and when it was read. Both,
+    /// rather than a precomputed age, because [`Self::gate_verdict`]
+    /// needs to hand the real decision function the same two instants
+    /// it would get in production. `age` is derived from them so the
+    /// two cannot disagree.
+    pub at: Instant,
+    pub observed_at: Instant,
     pub bird_routes: usize,
     pub packetframe_routes: usize,
     pub drift: Option<Drift>,
@@ -133,6 +139,52 @@ pub struct Sample {
     /// one retained across a run that failed. A retained sample is
     /// history and must be labelled as such.
     pub current: bool,
+}
+
+impl Sample {
+    pub fn age(&self) -> Duration {
+        self.observed_at.saturating_duration_since(self.at)
+    }
+
+    /// The comparison as the second tier's steering gate receives it.
+    ///
+    /// Field-for-field what [`crate::fib::integrity::IntegrityChecker`]
+    /// publishes to `TableCompleteness` in the same breath that it
+    /// records the comparison — same counts, same `at`. Reconstructed
+    /// rather than read back off the handle because the handle is
+    /// `None` in every single-module deployment, and this row has to
+    /// work there too.
+    fn report(&self) -> packetframe_common::fib::CompletenessReport {
+        packetframe_common::fib::CompletenessReport {
+            authority_routes: self.bird_routes as u64,
+            mirror_routes: self.packetframe_routes as u64,
+            at: self.at,
+        }
+    }
+
+    /// What a steering gate would decide from this comparison —
+    /// obtained by **calling the decision function**, not by
+    /// reimplementing its rules.
+    ///
+    /// This surface exists to predict the gate, so any rule restated
+    /// here is a rule that can drift out from under it. It already did,
+    /// twice, and both were caught in review rather than by a test:
+    /// staleness was not considered at all, and the drift comparison
+    /// used the checker's configurable **warn** threshold with a `>=`
+    /// where the gate uses its own fixed `STEER_MAX_DRIFT` with a `<=`.
+    /// The boundary was the visible symptom; the real defect was that
+    /// two different thresholds were being passed off as one, so any
+    /// operator who tuned `drift-warn-fraction` away from the default
+    /// got a row that advertised a rollout across a whole range the
+    /// gate refuses.
+    pub fn gate_verdict(&self) -> packetframe_common::fib::Completeness {
+        packetframe_common::fib::assess(
+            Some(self.report()),
+            self.observed_at,
+            packetframe_common::fib::STEER_MAX_DRIFT,
+            packetframe_common::fib::STEER_MAX_REPORT_AGE,
+        )
+    }
 }
 
 /// The integrity check's standing, as `packetframe status` reports it.
@@ -181,7 +233,8 @@ impl IntegrityPosture {
         Self::Checked {
             run_age: now.saturating_duration_since(last_run),
             sample: snap.last_comparison.map(|c| Sample {
-                age: now.saturating_duration_since(c.at),
+                at: c.at,
+                observed_at: now,
                 bird_routes: c.bird_routes,
                 packetframe_routes: c.packetframe_routes,
                 drift: c.drift,
@@ -237,7 +290,7 @@ impl IntegrityPosture {
     /// and reporting its age would read as freshness on a dashboard.
     fn last_success_age(&self) -> Option<u64> {
         match self {
-            Self::Checked { sample, .. } => sample.map(|s| s.age.as_secs()),
+            Self::Checked { sample, .. } => sample.map(|s| s.age().as_secs()),
             Self::AwaitingFirstCheck | Self::Unread => None,
         }
     }
@@ -320,78 +373,70 @@ impl IntegrityPosture {
     }
 
     /// The comparison itself, without regard to what else the run did.
+    ///
+    /// **Two facts, from two authorities, and neither speaks for the
+    /// other.** They were one fact once, and that was the bug:
+    ///
+    /// - The **drift-catch diagnostic** is fast-path's own alarm,
+    ///   measured against the `drift-warn-fraction` the run applied.
+    ///   Configurable, and nothing outside this module acts on it.
+    /// - The **rollout verdict** is what a second tier's steering gate
+    ///   will decide, and it is obtained by calling
+    ///   [`Sample::gate_verdict`] rather than by restating its rules.
+    ///
+    /// Conflating them let the row print "the positive evidence a
+    /// rollout needs" from a threshold the gate does not use — exactly
+    /// at the boundary where the two comparisons differ (`>=` here,
+    /// `<=` there), and across the entire range between them for any
+    /// operator who had tuned the warn fraction (review finding).
     fn verdict(s: &Sample) -> (HealthState, String) {
+        let mut state = HealthState::Healthy;
         let counts = format!(
             "bird {} routes, mirror {}",
             s.bird_routes, s.packetframe_routes
         );
-        // Age first, and against the consumer's own constant rather than
-        // a second copy of the number — for exactly the reason
-        // `packetframe_common::fib::assess` gives for checking it first:
-        // "a report whose drift looks fine but which predates anything
-        // we care about is not evidence, and reporting its drift would
-        // invite acting on it."
-        //
-        // Without this the row was the *inverse* of useful. A checker
-        // task that stalls or exits after one good comparison stops
-        // advancing `last_run` and records no error, so neither age
-        // affected the verdict and the row went on printing "the
-        // positive evidence a rollout needs" forever — while `assess`,
-        // reading the same comparison through the completeness handle,
-        // had already called it `Stale` and was refusing the steer. A
-        // status surface that contradicts the gate it exists to predict
-        // is worse than the silence it replaced (review finding).
-        //
-        // The drift is deliberately NOT printed here. It is the number
-        // an operator would act on, and it is precisely what has expired.
-        if s.age > packetframe_common::fib::STEER_MAX_REPORT_AGE {
-            return (
-                HealthState::Degraded,
+
+        let diagnostic = match s.drift {
+            Some(d) => {
+                if d.above {
+                    state = state.worse_of(HealthState::Degraded);
+                }
                 format!(
-                    "{counts} — but that comparison is {:.0}s old, past the {:.0}s window a \
-                     steering gate acts within, so it is NOT evidence for a rollout: the gate \
-                     reads this same report as `Stale` and refuses. Comparisons have stopped \
-                     landing; where no error is reported alongside this, they are not even \
-                     being attempted, so look at the daemon's checker task rather than at bird",
-                    s.age.as_secs_f64(),
-                    packetframe_common::fib::STEER_MAX_REPORT_AGE.as_secs_f64()
-                ),
-            );
-        }
-        match s.drift {
-            Some(d) if d.above => (
-                HealthState::Degraded,
-                format!(
-                    "{counts} — drift {:.3}%, at or above the {:.3}% warn threshold. The \
-                     mirror is not carrying what bird holds; a second-tier steering gate \
-                     reads this same comparison and refuses to steer while the two disagree",
+                    "drift {:.3}%, {} the {:.3}% warn threshold",
                     d.fraction * 100.0,
+                    if d.above { "at or above" } else { "within" },
                     d.threshold * 100.0
-                ),
-            ),
-            Some(d) => (
-                HealthState::Healthy,
-                format!(
-                    "{counts} — drift {:.3}%, within the {:.3}% warn threshold. This is the \
-                     positive evidence a rollout needs: the counts are bird's master4 plus \
-                     master6 against the mirror's v4+v6",
-                    d.fraction * 100.0,
-                    d.threshold * 100.0
-                ),
-            ),
+                )
+            }
             // Not "no drift". A zero authority cannot attest anything,
             // and it is a real and documented state — a box running a
             // bird that carries none of the table the mirror is fed.
-            None => (
-                HealthState::Degraded,
-                format!(
-                    "{counts} — bird reports NO routes in master4/master6, so no drift \
-                     fraction is defined and nothing here attests completeness. Check which \
-                     bird `birdc` reaches on this box: a bird that is running but carries \
-                     none of this mirror's table is not the same as having no bird at all"
-                ),
-            ),
-        }
+            None => "no drift fraction is defined: bird reports NO routes in \
+                     master4/master6, and a fraction of zero says nothing"
+                .to_string(),
+        };
+
+        let gate = s.gate_verdict();
+        let rollout = if gate.permits_steering() {
+            // No `describe()` here: on the converged path it only
+            // restates the drift already printed. Refusals keep it
+            // verbatim, where it carries the reason and the remedy.
+            "A steering gate reads this same comparison and would permit a steer — this is the \
+             positive evidence a rollout needs, and the counts behind it are bird's master4 plus \
+             master6 against the mirror's v4+v6"
+                .to_string()
+        } else {
+            state = state.worse_of(HealthState::Degraded);
+            // `describe()` is the refusal an operator would see from the
+            // steer itself, verbatim — including the staleness case,
+            // which `assess` checks before it will look at drift at all.
+            format!(
+                "A steering gate reads this same comparison and REFUSES: {}",
+                gate.describe()
+            )
+        };
+
+        (state, format!("{counts} — {diagnostic}. {rollout}"))
     }
 }
 
@@ -483,6 +528,58 @@ mod tests {
         assert_eq!(h.last_success_age_seconds, Some(12));
     }
 
+    /// Drift exactly ON the threshold. The checker's warn fires at
+    /// `>=` while the gate converges at `<=`, so this is the one drift
+    /// where the diagnostic and the rollout verdict legitimately
+    /// disagree — the row must report both rather than let the warn
+    /// speak for the gate. Reported Degraded either way, but the text
+    /// must not claim a refusal that will not happen.
+    #[test]
+    fn drift_exactly_on_the_threshold_does_not_claim_a_refusal() {
+        use packetframe_common::fib::STEER_MAX_DRIFT;
+        let at = t0();
+        // bird=1000, mirror=990 → drift exactly 0.01.
+        let snap = clean_run(at, 1000, 990, drift(STEER_MAX_DRIFT, STEER_MAX_DRIFT));
+        let s = match IntegrityPosture::observe(&snap, at) {
+            IntegrityPosture::Checked { sample, .. } => sample.expect("a comparison"),
+            other => panic!("expected Checked, got {other:?}"),
+        };
+        // The gate permits at the boundary; the warn fires at it.
+        assert!(s.gate_verdict().permits_steering());
+        assert!(s.drift.unwrap().above);
+
+        let m = IntegrityPosture::observe(&snap, at)
+            .subsystem_health()
+            .message
+            .unwrap();
+        assert!(m.contains("at or above the 1.000% warn threshold"), "{m}");
+        assert!(
+            m.contains("would permit a steer"),
+            "claimed a refusal the gate will not make: {m}"
+        );
+        assert!(!m.contains("REFUSES"), "{m}");
+    }
+
+    /// A tuned `drift-warn-fraction` is the range version of the same
+    /// defect, and the reason aligning the two comparison operators
+    /// would not have been enough: at a 5% warn threshold, a 3% drift
+    /// is "within" fast-path's alarm while the gate — which uses its
+    /// own fixed `STEER_MAX_DRIFT` — refuses outright.
+    #[test]
+    fn a_tuned_warn_threshold_does_not_speak_for_the_gate() {
+        let at = t0();
+        let snap = clean_run(at, 1_000_000, 970_000, drift(0.03, 0.05));
+        let h = IntegrityPosture::observe(&snap, at).subsystem_health();
+        let m = h.message.clone().unwrap();
+        assert!(m.contains("within the 5.000% warn threshold"), "{m}");
+        assert!(m.contains("REFUSES"), "{m}");
+        assert_eq!(
+            h.state,
+            HealthState::Degraded,
+            "the gate refuses, so the row cannot be healthy: {m}"
+        );
+    }
+
     /// The threshold travels with the comparison, so a non-default
     /// `drift_warn_fraction` is reported as the one actually applied
     /// rather than a constant re-read at render time.
@@ -530,11 +627,10 @@ mod tests {
         .subsystem_health();
         assert_eq!(stale.state, HealthState::Degraded);
         let m = stale.message.unwrap();
-        assert!(m.contains("NOT evidence for a rollout"), "{m}");
-        assert!(m.contains("`Stale`"), "{m}");
-        // The drift is what an operator would act on, and it is what has
-        // expired. `assess` withholds it for the same reason.
-        assert!(!m.contains("within the"), "expired drift still shown: {m}");
+        assert!(m.contains("REFUSES"), "{m}");
+        // Verbatim from `Completeness::describe()`, so the row prints
+        // the refusal the steer itself would print.
+        assert!(m.contains("too old to act on"), "{m}");
         // Still a real completed comparison, so its age is still
         // reported — that number is the whole diagnosis here.
         assert_eq!(

--- a/crates/modules/fast-path/src/fib/integrity_status.rs
+++ b/crates/modules/fast-path/src/fib/integrity_status.rs
@@ -1,0 +1,600 @@
+//! What the integrity check *says*, and how an operator reads it.
+//!
+//! The comparison itself lives in [`crate::fib::integrity`], which is
+//! Linux-only because it shells out to `birdc`. Everything here is the
+//! result and its rendering: plain data, no syscalls, **deliberately not
+//! behind the platform gate** so it compiles and its tests run on the
+//! macOS dev loop rather than only inside the qemu job. The same reason
+//! `crates/cli/src/health.rs` is portable — a `#[cfg(target_os =
+//! "linux")]` test is invisible to every host gate.
+//!
+//! ## Why this module exists at all
+//!
+//! The checker published an [`IntegritySnapshot`] every 300 s and
+//! nothing read it: `RouteController::integrity_snapshot()` had no
+//! caller anywhere in the tree. A successful comparison logs at
+//! **debug**, and only above-threshold drift logs at warn — so at the
+//! default `log-level info` a healthy check printed *nothing*, and the
+//! only way to see the verdict was to raise the log level (which costs a
+//! restart: the filter is built from `RUST_LOG` at process start) and
+//! grep for `integrity check OK`.
+//!
+//! That mattered beyond tidiness. vpp-offload's steering gate and its
+//! adopted-resync release both act on this comparison — a box whose
+//! authority disagrees refuses to steer and defers indefinitely — so the
+//! operator's pre-flight check for a rollout was log archaeology.
+//!
+//! ## Silence is not agreement
+//!
+//! The one rule this file follows, and the defect the vpp-offload
+//! runbook had to work around: **"no check has completed yet" and "a
+//! check completed and they agree" must not render identically.** They
+//! lead somewhere completely different — one is a startup transient that
+//! clears itself within an interval, the other is positive evidence a
+//! rollout can proceed on — and an absent line was equally consistent
+//! with the checker never having run, `birdc` failing every time, or the
+//! log having rotated.
+//!
+//! Same care as [`crate::fib::integrity`]'s own rule about what it
+//! republishes to the second tier: a partial run publishes nothing
+//! rather than a mixed report. [`IntegrityPosture`] extends that rule to
+//! the reader — a comparison is either from the most recent run or is
+//! labelled as history, never presented as current because it happens to
+//! be the newest thing in the struct.
+
+use std::time::{Duration, Instant};
+
+use packetframe_common::module::{HealthState, SubsystemHealth};
+
+/// Stable subsystem name. Append-safe, rename-unsafe: `packetframe
+/// status` and operator dashboards key on this string, exactly as the
+/// `stats` counter indices are append-only once shipped.
+pub const SUBSYS_FIB_INTEGRITY: &str = "fib-integrity";
+
+/// Default interval between integrity checks. Slow enough to be
+/// cheap, fast enough that a drift window of "up to 5 minutes"
+/// is acceptable.
+///
+/// Lives here rather than next to the checker so the health surface can
+/// name the wait without a second copy of the number.
+pub const DEFAULT_INTERVAL: Duration = Duration::from_secs(300);
+
+/// How far the mirror is from the authority, and whether that cleared
+/// the configured warn threshold.
+///
+/// One struct rather than a bare fraction plus a threshold the reader
+/// re-applies: `above` is recorded by the same branch that decides
+/// whether to emit the warn log, so the log and the health line cannot
+/// disagree about the verdict. Same discipline as vpp-offload's
+/// `FibSync::from_outcome` deferring to `VerifyOutcome::passed`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Drift {
+    /// `|bird - mirror| / bird`, as a fraction.
+    pub fraction: f64,
+    /// The threshold in force for the run that produced `fraction`.
+    pub threshold: f64,
+    pub above: bool,
+}
+
+/// One completed comparison: **both counts from the same run**.
+///
+/// The counts are not stored separately on the snapshot any more, and
+/// that is the point. They used to be, and they were sticky — a failed
+/// `birdc` or a failed `mirror_counts` left the previous run's number in
+/// place — so a drift fraction could be computed from one fresh number
+/// and one five minutes old. That is tolerable for a log line nobody
+/// gates on and wrong for a surface an operator reads before a rollout.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Comparison {
+    /// When the run that produced it recorded its result. Shared with
+    /// [`IntegritySnapshot::last_run`] for that same run, which is what
+    /// lets a reader tell a current comparison from a retained one.
+    pub at: Instant,
+    pub bird_routes: usize,
+    pub packetframe_routes: usize,
+    /// `None` when bird reported zero routes, where a fraction of the
+    /// authority's count is undefined. Not "no drift" — see
+    /// [`IntegrityPosture::subsystem_health`], which reports a zero
+    /// authority as its own condition.
+    pub drift: Option<Drift>,
+}
+
+/// Snapshot of the most recent integrity-check result.
+///
+/// Two readers, asking different questions. The BmpStalled gate wants
+/// `bird_established_peers` — "does bird still think there are peers to
+/// hear from?" — before it calls a quiet feed a stall. The health
+/// surface wants the comparison, via [`IntegrityPosture`]. Neither
+/// reads a field the other writes, which is why the counts live inside
+/// [`Comparison`] rather than loose alongside the peer count.
+#[derive(Debug, Clone, Default)]
+pub struct IntegritySnapshot {
+    /// The most recent run, whether or not it produced a comparison.
+    pub last_run: Option<Instant>,
+    /// The most recent run that did. Retained across a failed run, so it
+    /// can be older than `last_run`.
+    pub last_comparison: Option<Comparison>,
+    pub bird_established_peers: Option<usize>,
+    /// Why the most recent run could not complete. Cleared at the start
+    /// of every run, so it always describes `last_run` and never an
+    /// older one.
+    pub last_error: Option<String>,
+}
+
+/// A comparison as the health surface reads it: aged, and knowing
+/// whether it came from the most recent run.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Sample {
+    pub age: Duration,
+    pub bird_routes: usize,
+    pub packetframe_routes: usize,
+    pub drift: Option<Drift>,
+    /// This comparison is the most recent run's own result, rather than
+    /// one retained across a run that failed. A retained sample is
+    /// history and must be labelled as such.
+    pub current: bool,
+}
+
+/// The integrity check's standing, as `packetframe status` reports it.
+///
+/// Three arms because there are three genuinely different answers, and
+/// the first two must never print the same line.
+#[derive(Debug, Clone, PartialEq)]
+pub enum IntegrityPosture {
+    /// The checker is running and no check has finished yet. **Not
+    /// agreement** — nothing has compared bird against the mirror.
+    AwaitingFirstCheck,
+    /// At least one check has run. Composed rather than matched: a run
+    /// can produce a comparison, an error, or both (the route counts
+    /// succeed while `birdc show protocols` fails), and each fact is
+    /// reported on its own.
+    Checked {
+        /// Age of the most recent run.
+        run_age: Duration,
+        /// The most recent completed comparison, if any has ever
+        /// completed.
+        sample: Option<Sample>,
+        /// Why the most recent run could not complete.
+        error: Option<String>,
+    },
+    /// The snapshot was being written at the instant status sampled it.
+    ///
+    /// The write happens once per interval and holds the lock for a
+    /// handful of field assignments, so this is vanishingly rare — but a
+    /// contended lock is a condition that *can* occur, and the two
+    /// alternatives were both worse: a blocking read panics if this is
+    /// ever called from an async context, and rendering it as
+    /// [`Self::AwaitingFirstCheck`] would be the exact silence-as-a-state
+    /// confusion this file exists to prevent.
+    Unread,
+}
+
+impl IntegrityPosture {
+    /// Read a snapshot. `now` is a parameter so the ages are testable.
+    pub fn observe(snap: &IntegritySnapshot, now: Instant) -> Self {
+        let Some(last_run) = snap.last_run else {
+            // `last_run` is stamped by every run before anything else it
+            // records, so its absence is the one unambiguous "nothing has
+            // happened yet".
+            return Self::AwaitingFirstCheck;
+        };
+        Self::Checked {
+            run_age: now.saturating_duration_since(last_run),
+            sample: snap.last_comparison.map(|c| Sample {
+                age: now.saturating_duration_since(c.at),
+                bird_routes: c.bird_routes,
+                packetframe_routes: c.packetframe_routes,
+                drift: c.drift,
+                // Instant equality, not an age comparison: the checker
+                // stamps one `Instant` per run and writes it to both
+                // fields, so this is exact rather than a tolerance.
+                current: c.at == last_run,
+            }),
+            error: snap.last_error.clone(),
+        }
+    }
+
+    /// The row `packetframe status` prints.
+    pub fn subsystem_health(&self) -> SubsystemHealth {
+        let (state, message) = match self {
+            Self::AwaitingFirstCheck => (
+                // Healthy: forwarding does not depend on this. The
+                // checker is a diagnostic safety net, and a box that has
+                // simply not reached its first interval is not impaired.
+                // The message carries the whole content of this state.
+                HealthState::Healthy,
+                format!(
+                    "no comparison has completed yet — the first lands one interval ({}s by \
+                     default) after the control plane starts. This is NOT agreement: nothing \
+                     has yet compared bird's RIB against the mirror, and a second-tier \
+                     steering gate that consults it holds until something does",
+                    DEFAULT_INTERVAL.as_secs()
+                ),
+            ),
+            Self::Unread => (
+                HealthState::Degraded,
+                "the integrity snapshot was being written at the moment this was sampled, so \
+                 the last comparison could not be read. Self-clearing: the next health poll \
+                 (5 s) carries it. Nothing about the comparison itself is implied either way"
+                    .to_string(),
+            ),
+            Self::Checked {
+                run_age,
+                sample,
+                error,
+            } => Self::checked_health(*run_age, sample.as_ref(), error.as_deref()),
+        };
+        SubsystemHealth {
+            name: SUBSYS_FIB_INTEGRITY.into(),
+            state,
+            message: Some(message),
+            last_success_age_seconds: self.last_success_age(),
+        }
+    }
+
+    /// Age of the last **completed comparison**, which is the only thing
+    /// here that is a success. A run that could not compare is not one,
+    /// and reporting its age would read as freshness on a dashboard.
+    fn last_success_age(&self) -> Option<u64> {
+        match self {
+            Self::Checked { sample, .. } => sample.map(|s| s.age.as_secs()),
+            Self::AwaitingFirstCheck | Self::Unread => None,
+        }
+    }
+
+    /// The composed form: the verdict, then whatever the most recent run
+    /// could not do. Clauses rather than a match over combinations —
+    /// vpp-offload's `steering_health` arrived at the same shape after a
+    /// review finding that ordering arms hid whichever fact came second.
+    fn checked_health(
+        run_age: Duration,
+        sample: Option<&Sample>,
+        error: Option<&str>,
+    ) -> (HealthState, String) {
+        let mut state = HealthState::Healthy;
+        let mut clauses: Vec<String> = Vec::new();
+
+        match sample {
+            Some(s) => {
+                let (verdict_state, verdict) = Self::verdict(s);
+                state = state.worse_of(verdict_state);
+                clauses.push(verdict);
+            }
+            None => {
+                // A run finished and produced nothing to compare. With an
+                // error alongside it this is the ordinary "birdc is
+                // unreachable" case; the clause below says what that
+                // costs rather than restating the error.
+                state = state.worse_of(HealthState::Degraded);
+                clauses.push(format!(
+                    "no comparison has ever completed ({:.0}s since the last attempt), so \
+                     there is no verdict to read — this is NOT agreement",
+                    run_age.as_secs_f64()
+                ));
+            }
+        }
+
+        if let Some(e) = error {
+            state = state.worse_of(HealthState::Degraded);
+            // Whether the numbers above survive this is the whole
+            // question, and the answer is not the same in the two cases:
+            // a run that failed outright left the previous comparison
+            // standing as history, while a run that compared fine and
+            // then failed on `birdc show protocols` leaves the comparison
+            // current. Presenting a retained sample as though the check
+            // had just confirmed it is the failure this surface exists to
+            // avoid.
+            clauses.push(match sample {
+                Some(s) if s.current => format!(
+                    "the same run reported an error: {e} — the comparison above is from this \
+                     run and stands"
+                ),
+                Some(_) => format!(
+                    "the most recent check ({:.0}s ago) could not complete: {e} — so the \
+                     comparison above is HISTORY, not the current state, and it ages until a \
+                     check succeeds. Forwarding is unaffected; what is degraded is the \
+                     ability to attest completeness at all, which a second-tier steering gate \
+                     will refuse on",
+                    run_age.as_secs_f64()
+                ),
+                None => format!(
+                    "the most recent check ({:.0}s ago) could not complete: {e}. Forwarding is \
+                     unaffected; what is degraded is the ability to attest completeness at \
+                     all, which a second-tier steering gate will refuse on",
+                    run_age.as_secs_f64()
+                ),
+            });
+        } else if sample.is_none() {
+            // Unreachable from the checker, which records an error on
+            // every path that produces no comparison. Stated rather than
+            // asserted: a surface that panics is worse than one that says
+            // it does not understand what it read.
+            clauses.push(
+                "the run recorded neither a comparison nor a reason, which the checker has no \
+                 path to produce — read this as a malformed snapshot rather than as a verdict"
+                    .to_string(),
+            );
+        }
+
+        (state, clauses.join(". "))
+    }
+
+    /// The comparison itself, without regard to what else the run did.
+    fn verdict(s: &Sample) -> (HealthState, String) {
+        let counts = format!(
+            "bird {} routes, mirror {}",
+            s.bird_routes, s.packetframe_routes
+        );
+        match s.drift {
+            Some(d) if d.above => (
+                HealthState::Degraded,
+                format!(
+                    "{counts} — drift {:.3}%, at or above the {:.3}% warn threshold. The \
+                     mirror is not carrying what bird holds; a second-tier steering gate \
+                     reads this same comparison and refuses to steer while the two disagree",
+                    d.fraction * 100.0,
+                    d.threshold * 100.0
+                ),
+            ),
+            Some(d) => (
+                HealthState::Healthy,
+                format!(
+                    "{counts} — drift {:.3}%, within the {:.3}% warn threshold. This is the \
+                     positive evidence a rollout needs: the counts are bird's master4 plus \
+                     master6 against the mirror's v4+v6",
+                    d.fraction * 100.0,
+                    d.threshold * 100.0
+                ),
+            ),
+            // Not "no drift". A zero authority cannot attest anything,
+            // and it is a real and documented state — a box running a
+            // bird that carries none of the table the mirror is fed.
+            None => (
+                HealthState::Degraded,
+                format!(
+                    "{counts} — bird reports NO routes in master4/master6, so no drift \
+                     fraction is defined and nothing here attests completeness. Check which \
+                     bird `birdc` reaches on this box: a bird that is running but carries \
+                     none of this mirror's table is not the same as having no bird at all"
+                ),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    fn drift(fraction: f64, threshold: f64) -> Option<Drift> {
+        Some(Drift {
+            fraction,
+            threshold,
+            above: fraction >= threshold,
+        })
+    }
+
+    /// A snapshot as the checker leaves it after one clean run: the same
+    /// `Instant` in `last_run` and in the comparison.
+    fn clean_run(at: Instant, bird: usize, mirror: usize, d: Option<Drift>) -> IntegritySnapshot {
+        IntegritySnapshot {
+            last_run: Some(at),
+            last_comparison: Some(Comparison {
+                at,
+                bird_routes: bird,
+                packetframe_routes: mirror,
+                drift: d,
+            }),
+            bird_established_peers: Some(2),
+            last_error: None,
+        }
+    }
+
+    #[test]
+    fn no_check_yet_is_its_own_state() {
+        let p = IntegrityPosture::observe(&IntegritySnapshot::default(), t0());
+        assert_eq!(p, IntegrityPosture::AwaitingFirstCheck);
+        let h = p.subsystem_health();
+        assert_eq!(h.name, SUBSYS_FIB_INTEGRITY);
+        // No comparison has happened, so there is no success to age.
+        assert_eq!(h.last_success_age_seconds, None);
+    }
+
+    /// The defect the vpp-offload runbook worked around: an operator
+    /// could not tell "nothing has checked" from "checked and they
+    /// agree". Both are Healthy; they must not read the same.
+    #[test]
+    fn no_check_yet_does_not_render_like_agreement() {
+        let waiting =
+            IntegrityPosture::observe(&IntegritySnapshot::default(), t0()).subsystem_health();
+        let at = t0();
+        let agreeing = IntegrityPosture::observe(
+            &clean_run(at, 1_272_306, 1_272_281, drift(0.0000196, 0.01)),
+            at + Duration::from_secs(30),
+        )
+        .subsystem_health();
+
+        assert_eq!(waiting.state, HealthState::Healthy);
+        assert_eq!(agreeing.state, HealthState::Healthy);
+        assert_ne!(waiting.message, agreeing.message);
+
+        let waiting_msg = waiting.message.unwrap();
+        assert!(waiting_msg.contains("NOT agreement"), "{waiting_msg}");
+        assert!(waiting_msg.contains("300s"), "{waiting_msg}");
+        // The freshness field is the other half of the distinction.
+        assert_eq!(waiting.last_success_age_seconds, None);
+        assert_eq!(agreeing.last_success_age_seconds, Some(30));
+
+        let agreeing_msg = agreeing.message.unwrap();
+        assert!(agreeing_msg.contains("bird 1272306 routes, mirror 1272281"));
+        assert!(agreeing_msg.contains("within the 1.000% warn threshold"));
+    }
+
+    #[test]
+    fn drift_above_threshold_degrades_and_names_both_numbers() {
+        let at = t0();
+        let h = IntegrityPosture::observe(
+            &clean_run(at, 1_272_306, 1_100_000, drift(0.1354, 0.01)),
+            at + Duration::from_secs(12),
+        )
+        .subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        let m = h.message.unwrap();
+        assert!(m.contains("drift 13.540%"), "{m}");
+        assert!(m.contains("1.000% warn threshold"), "{m}");
+        // Still a completed comparison, so it still has an age.
+        assert_eq!(h.last_success_age_seconds, Some(12));
+    }
+
+    /// The threshold travels with the comparison, so a non-default
+    /// `drift_warn_fraction` is reported as the one actually applied
+    /// rather than a constant re-read at render time.
+    #[test]
+    fn threshold_reported_is_the_one_the_run_applied() {
+        let at = t0();
+        let h = IntegrityPosture::observe(&clean_run(at, 1000, 995, drift(0.005, 0.05)), at)
+            .subsystem_health();
+        assert_eq!(h.state, HealthState::Healthy);
+        assert!(h
+            .message
+            .unwrap()
+            .contains("within the 5.000% warn threshold"));
+    }
+
+    /// The runbook's measured case: bird up, carrying 13 routes against
+    /// a 1.3M mirror. Here the degenerate end of it — a bird with none.
+    #[test]
+    fn zero_authority_is_not_zero_drift() {
+        let at = t0();
+        let h =
+            IntegrityPosture::observe(&clean_run(at, 0, 1_300_000, None), at).subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        let m = h.message.unwrap();
+        assert!(m.contains("NO routes in master4/master6"), "{m}");
+        assert!(
+            !m.contains("drift 0"),
+            "a zero authority must not read as agreement: {m}"
+        );
+    }
+
+    #[test]
+    fn failed_check_with_no_history_says_there_is_no_verdict() {
+        let at = t0();
+        let snap = IntegritySnapshot {
+            last_run: Some(at),
+            last_comparison: None,
+            bird_established_peers: None,
+            last_error: Some("birdc show route count: spawn /usr/sbin/birdc: No such file".into()),
+        };
+        let h = IntegrityPosture::observe(&snap, at + Duration::from_secs(4)).subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        assert_eq!(h.last_success_age_seconds, None);
+        let m = h.message.unwrap();
+        assert!(m.contains("no comparison has ever completed"), "{m}");
+        assert!(m.contains("No such file"), "{m}");
+    }
+
+    /// A retained comparison must be labelled history. Presenting it as
+    /// current is how an operator approves a rollout on a five-minute-old
+    /// number from a checker that has since gone dark.
+    #[test]
+    fn retained_comparison_across_a_failed_run_is_labelled_history() {
+        let compared_at = t0();
+        let snap = IntegritySnapshot {
+            last_run: Some(compared_at + Duration::from_secs(300)),
+            last_comparison: Some(Comparison {
+                at: compared_at,
+                bird_routes: 1_272_306,
+                packetframe_routes: 1_272_281,
+                drift: drift(0.0000196, 0.01),
+            }),
+            bird_established_peers: Some(2),
+            last_error: Some("programmer mirror_counts: channel closed".into()),
+        };
+        let p = IntegrityPosture::observe(&snap, compared_at + Duration::from_secs(305));
+        match &p {
+            IntegrityPosture::Checked { sample, .. } => {
+                assert!(!sample.expect("a retained comparison").current)
+            }
+            other => panic!("expected Checked, got {other:?}"),
+        }
+        let h = p.subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        // The age is the comparison's own, not the failed run's.
+        assert_eq!(h.last_success_age_seconds, Some(305));
+        let m = h.message.unwrap();
+        assert!(m.contains("HISTORY"), "{m}");
+        assert!(m.contains("channel closed"), "{m}");
+    }
+
+    /// The partial case: both route counts succeeded and `birdc show
+    /// protocols` did not. The comparison is current and says so, and the
+    /// error is still reported.
+    #[test]
+    fn error_alongside_a_current_comparison_keeps_the_comparison() {
+        let at = t0();
+        let mut snap = clean_run(at, 1000, 1000, drift(0.0, 0.01));
+        snap.bird_established_peers = None;
+        snap.last_error = Some("birdc show protocols: exit 1".into());
+        let p = IntegrityPosture::observe(&snap, at + Duration::from_secs(2));
+        match &p {
+            IntegrityPosture::Checked { sample, .. } => {
+                assert!(sample.expect("a comparison").current)
+            }
+            other => panic!("expected Checked, got {other:?}"),
+        }
+        let h = p.subsystem_health();
+        // An error is an error, even beside a good comparison.
+        assert_eq!(h.state, HealthState::Degraded);
+        let m = h.message.unwrap();
+        assert!(m.contains("is from this run and stands"), "{m}");
+        assert!(!m.contains("HISTORY"), "{m}");
+        assert!(m.contains("exit 1"), "{m}");
+    }
+
+    #[test]
+    fn unread_snapshot_is_not_reported_as_never_checked() {
+        let h = IntegrityPosture::Unread.subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        assert_eq!(h.last_success_age_seconds, None);
+        let m = h.message.unwrap();
+        assert!(m.contains("Self-clearing"), "{m}");
+        assert_ne!(
+            Some(m),
+            IntegrityPosture::AwaitingFirstCheck
+                .subsystem_health()
+                .message
+        );
+    }
+
+    /// Every arm renders a message. A row with a state and no text is
+    /// the silence this module was written to remove.
+    #[test]
+    fn every_posture_says_something() {
+        let at = t0();
+        for p in [
+            IntegrityPosture::AwaitingFirstCheck,
+            IntegrityPosture::Unread,
+            IntegrityPosture::observe(&clean_run(at, 10, 10, drift(0.0, 0.01)), at),
+            IntegrityPosture::observe(
+                &IntegritySnapshot {
+                    last_run: Some(at),
+                    ..Default::default()
+                },
+                at,
+            ),
+        ] {
+            let h = p.subsystem_health();
+            let m = h.message.unwrap_or_default();
+            assert!(!m.trim().is_empty(), "empty message for {p:?}");
+            // Continuation lines in the source must not leak runs of
+            // indentation into an operator's terminal — the same defect
+            // vpp-offload's status arms shipped once.
+            assert!(!m.contains("   "), "indentation leaked into {p:?}: {m}");
+        }
+    }
+}

--- a/crates/modules/fast-path/src/fib/mod.rs
+++ b/crates/modules/fast-path/src/fib/mod.rs
@@ -11,6 +11,12 @@
 pub mod hash;
 pub mod types;
 
+/// Ungated deliberately: it is the integrity check's *result* and its
+/// operator-facing rendering, with no syscalls in it, so the tests run
+/// on a macOS dev loop instead of only in the qemu job. See the module
+/// docs.
+pub mod integrity_status;
+
 #[cfg(target_os = "linux")]
 pub mod controller;
 

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -249,13 +249,48 @@ impl Module for FastPathModule {
         Ok(())
     }
 
+    /// Subsystem health for the custom-FIB control plane.
+    ///
+    /// One row so far: the integrity check's verdict, which was
+    /// computed every 300 s and discarded — `packetframe status` had
+    /// nothing to say about whether the mirror matches bird, and the
+    /// second tier's steering gate acts on exactly that comparison.
+    /// BmpStation and NeighborResolver freshness are the obvious next
+    /// rows; neither publishes anything readable yet, and a row that
+    /// reported "fine" from an unread source would be worse than none.
+    ///
+    /// The row is absent only when nothing is checking (kernel-fib
+    /// mode, or a control plane with no route source). Whenever a
+    /// checker exists the row appears, including before its first
+    /// check completes — the whole point being that silence must not
+    /// be readable as agreement.
+    #[cfg(target_os = "linux")]
     fn health_check(&self, _ctx: &HealthCtx) -> ModuleResult<HealthReport> {
-        // Phase 1 (Option F): structured health reporting is now the
-        // trait surface, but fast-path has no live subsystems yet
-        // RouteController / BmpStation / NeighborResolver land in
-        // Phase 2-3 and will populate `subsystems`. For now, always
-        // report healthy with no subsystems. Circuit-breaker wiring
-        // stays as-is until the reporting contract is consumed.
+        let subsystems: Vec<_> = self
+            .state
+            .as_ref()
+            .and_then(linux_impl::integrity_posture)
+            .map(|p| p.subsystem_health())
+            .into_iter()
+            .collect();
+        // `worse_of` rather than a hand-rolled escalation: a module that
+        // reports Healthy over a Degraded subsystem disagrees with its
+        // own report, which is the defect vpp-offload's `nominal()`
+        // documents at length.
+        let overall = subsystems.iter().fold(
+            packetframe_common::module::HealthState::Healthy,
+            |acc, s| acc.worse_of(s.state),
+        );
+        Ok(HealthReport {
+            overall,
+            subsystems,
+        })
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    fn health_check(&self, _ctx: &HealthCtx) -> ModuleResult<HealthReport> {
+        // Nothing runs here to report on: the control plane is
+        // Linux-only, so there is no check whose silence could mislead.
         Ok(HealthReport::healthy())
     }
 }
@@ -289,6 +324,23 @@ mod tests {
         let mut w = MetricsWriter::new(&mut buf, "fast-path");
         assert!(m.sample_metrics(&mut w).is_ok());
         assert!(m.health_check(&HealthCtx::new()).is_ok());
+    }
+
+    /// With nothing loaded there is no control plane, so there is no
+    /// integrity row — and its absence is deliberate rather than the
+    /// old unconditional `healthy()`. Whenever a checker DOES exist the
+    /// row is present even before its first comparison; that
+    /// distinction is covered in `fib::integrity_status`.
+    #[test]
+    fn unloaded_module_reports_no_integrity_row() {
+        let m = FastPathModule::new();
+        let r = m.health_check(&HealthCtx::new()).unwrap();
+        assert!(r.subsystems.is_empty());
+        assert_eq!(
+            r.overall,
+            packetframe_common::module::HealthState::Healthy,
+            "nothing is running, so nothing is impaired"
+        );
     }
 
     #[test]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -2870,6 +2870,16 @@ pub fn snapshot_links(state: &ActiveState) -> Vec<(String, u32, AttachMode)> {
         .collect()
 }
 
+/// The custom-FIB control plane's last integrity check, for the
+/// module's health surface.
+///
+/// `None` in kernel-fib mode, where no control plane runs at all, and
+/// on a control plane with no route source — neither has a bird to
+/// compare against, so neither has a verdict to withhold.
+pub fn integrity_posture(state: &ActiveState) -> Option<crate::fib::integrity::IntegrityPosture> {
+    state.route_controller.as_ref()?.integrity_posture()
+}
+
 // Read current stats, aggregated across all CPUs.
 pub fn snapshot_stats(state: &ActiveState) -> ModuleResult<Vec<u64>> {
     use aya::maps::PerCpuArray;

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -222,8 +222,18 @@ applied, the sample's age, and any error:
 ```
   fast-path: healthy
     fib-integrity  healthy — bird 1272306 routes, mirror 1272281 — drift 0.002%,
-                   within the 1.000% warn threshold ... (last ok 41s ago)
+                   within the 1.000% warn threshold. A steering gate reads this same
+                   comparison and would permit a steer ... (last ok 41s ago)
 ```
+
+Two facts, and they are not interchangeable. The drift against the
+warn threshold is **this module's** alarm, and `drift-warn-fraction`
+tunes it. The sentence after it is what a second tier's steering gate
+would decide from the same comparison, obtained by calling that gate's
+own decision function — which uses its own fixed threshold and its own
+900 s freshness window, so at a tuned warn fraction the two verdicts
+legitimately differ. For a rollout, the second one is the one that
+matters.
 
 The row is present whenever a checker is running, **including before
 its first comparison completes** — "no comparison has completed yet"

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -209,6 +209,28 @@ WARN integrity drift above threshold bird_routes=1048587 packetframe_routes=1048
 
 The drift threshold is `IntegrityConfig::drift_warn_fraction`
 (default `0.01` = 1%). Below threshold goes to `DEBUG` level only.
+A bird reporting **zero** routes in `master4`/`master6` warns on its
+own line (`integrity check: bird reports no routes in master4/master6`)
+rather than passing silently — an authority with no routes cannot
+attest anything, and it used to log nothing at all.
+
+**Read the verdict from `packetframe status`, not from the log.** The
+same comparison is the `fib-integrity` subsystem row on the fast-path
+module, carrying both counts, the drift against the threshold that was
+applied, the sample's age, and any error:
+
+```
+  fast-path: healthy
+    fib-integrity  healthy — bird 1272306 routes, mirror 1272281 — drift 0.002%,
+                   within the 1.000% warn threshold ... (last ok 41s ago)
+```
+
+The row is present whenever a checker is running, **including before
+its first comparison completes** — "no comparison has completed yet"
+and "compared, and they agree" are deliberately different lines,
+because a rollout is gated on the difference (see
+`docs/runbooks/vpp-offload.md`). No row at all means no checker: either
+`kernel-fib` mode or a control plane with no `route-source`.
 
 BmpStalled:
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1142,6 +1142,7 @@ carrying that traffic; VPP still is.
   | `drift N%, at or above the M% warn threshold` | Real disagreement. The gate reads the same comparison and will refuse. |
   | `bird reports NO routes in master4/master6` | The degenerate authority: bird up, carrying none of this mirror's table. This is the 23 h deferral above. |
   | `could not complete: <error>` with `HISTORY` | `birdc` or the mirror read is failing. Any numbers shown are the previous comparison, ageing. |
+  | `NOT evidence for a rollout ... reads this same report as Stale` | The comparison has aged past the 900 s window the gate acts within. Comparisons have stopped landing; with no error beside it, they are not being attempted. |
   | no `fib-integrity` row at all | Nothing is checking on this box — kernel-fib mode, or a control plane with no route source. The authority will read `Absent`. |
 
   The row appears whenever a checker exists, *including before its
@@ -1159,6 +1160,14 @@ carrying that traffic; VPP still is.
   with **no** error alongside it means checks have stopped landing
   altogether rather than failing — look for the checker task, not for
   bird.
+
+  You do not have to watch that number to stay safe. At `STEER_MAX_REPORT_AGE`
+  (900 s) the row stops reporting agreement on its own and says so, on
+  the same constant and the same `>` the steering gate applies — so the
+  row and the gate flip together, and `status` cannot advertise the
+  evidence for a rollout the gate is already refusing. A parity test
+  pins the two. Reading the age is for catching the problem in the
+  ~10 minutes before that, not for avoiding a bad rollout.
 
   **The other positive evidence is the canary steer itself**, and it
   costs nothing to lean on. With `require-table-complete on`, a steer

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1129,20 +1129,36 @@ carrying that traffic; VPP still is.
   $ packetframe status                     # message wrapped here; it prints on one line
     fast-path: healthy
       fib-integrity  healthy — bird 1272306 routes, mirror 1272281 — drift 0.002%,
-                     within the 1.000% warn threshold ... (last ok 41s ago)
+                     within the 1.000% warn threshold. A steering gate reads this same
+                     comparison and would permit a steer — this is the positive evidence
+                     a rollout needs ... (last ok 41s ago)
   ```
 
-  That line is the pass. **Every other line is not**, and each says
-  which of the several ways it is not:
+  **`would permit a steer` is the pass, and it is the only one.** The
+  row carries two separate facts and you want the second:
+
+  - The **drift-catch diagnostic** — `drift N%, within/at or above the
+    M% warn threshold` — is fast-path's own alarm against the
+    configurable `drift-warn-fraction`. It is a good thing to watch and
+    it is **not** the rollout verdict. At a tuned warn fraction the two
+    part company by design: 3% drift is "within" a 5% warn threshold
+    while the gate, on its own fixed `STEER_MAX_DRIFT`, refuses.
+  - The **rollout verdict** — `A steering gate reads this same
+    comparison and would permit a steer` / `and REFUSES: <reason>` — is
+    produced by calling the gate's own decision function on the same
+    report the gate receives, so it cannot disagree with what the steer
+    will actually do. On a refusal the reason is the refusal message
+    verbatim, remedy included.
 
   | The row says | What it means |
   | --- | --- |
-  | `drift N%, within the M% warn threshold` | Agreement. Proceed. |
+  | `would permit a steer` | Agreement. Proceed. |
   | `no comparison has completed yet` | The checker has not reached its first interval, or has only just started. **Not agreement** — wait 300 s and read it again. |
-  | `drift N%, at or above the M% warn threshold` | Real disagreement. The gate reads the same comparison and will refuse. |
-  | `bird reports NO routes in master4/master6` | The degenerate authority: bird up, carrying none of this mirror's table. This is the 23 h deferral above. |
+  | `REFUSES: the route mirror holds N of the authority's M routes` | The mirror is short — usually still loading. |
+  | `REFUSES: ... that is not the authority feeding this mirror` | The 23 h deferral above: bird up, carrying a table that is not this one. |
+  | `REFUSES: completeness is unknown: the authority reports zero routes` | The degenerate form of the same thing — bird answering, and answering nothing. |
+  | `REFUSES: the last completeness check was Ns ago, too old to act on` | Aged past the 900 s window. Comparisons have stopped landing; with no error beside it, they are not being attempted. |
   | `could not complete: <error>` with `HISTORY` | `birdc` or the mirror read is failing. Any numbers shown are the previous comparison, ageing. |
-  | `NOT evidence for a rollout ... reads this same report as Stale` | The comparison has aged past the 900 s window the gate acts within. Comparisons have stopped landing; with no error beside it, they are not being attempted. |
   | no `fib-integrity` row at all | Nothing is checking on this box — kernel-fib mode, or a control plane with no route source. The authority will read `Absent`. |
 
   The row appears whenever a checker exists, *including before its
@@ -1161,12 +1177,13 @@ carrying that traffic; VPP still is.
   altogether rather than failing — look for the checker task, not for
   bird.
 
-  You do not have to watch that number to stay safe. At `STEER_MAX_REPORT_AGE`
-  (900 s) the row stops reporting agreement on its own and says so, on
-  the same constant and the same `>` the steering gate applies — so the
-  row and the gate flip together, and `status` cannot advertise the
-  evidence for a rollout the gate is already refusing. A parity test
-  pins the two. Reading the age is for catching the problem in the
+  You do not have to watch that number to stay safe. Past
+  `STEER_MAX_REPORT_AGE` (900 s) the rollout verdict becomes `REFUSES:
+  ... too old to act on` on its own — the row asks the gate's own
+  decision function rather than re-deriving the rule, so the two cannot
+  disagree, and `status` cannot advertise evidence for a rollout the
+  gate is already refusing. A parity test pins them across the
+  boundary. Reading the age is for catching the problem in the
   ~10 minutes before that, not for avoiding a bad rollout.
 
   **The other positive evidence is the canary steer itself**, and it

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1098,6 +1098,10 @@ carrying that traffic; VPP still is.
   or a mirror still short — including every startup before the first
   check lands). Only *"not the authority feeding it ... Waiting will
   not clear it"* is the persistent one below.
+  Fast-path's `fib-integrity` row answers it from the other side, and
+  more directly: an unreachable `birdc` shows there as `could not
+  complete: <error>`, a bird carrying the wrong table as a drift or
+  zero-authority verdict.
 - **A persistent disagreement is the case that needs a decision**: a
   local bird that does not carry the mirror's table, a bird carrying no
   routes at all, or a mirror fed from a different source than the
@@ -1116,59 +1120,65 @@ carrying that traffic; VPP still is.
   running.** The two are different, and this box proved it: bird was up
   the whole time.
 
-  **Do not hand-roll the comparison, and do not read silence as
-  agreement.** The checker compares bird's `master4` **plus** `master6`
-  against the fast-path mirror's v4+v6 count. It logs the successful
-  comparison at **debug**; at the default `log-level info` a healthy
-  check prints *nothing at all*, and its three failure paths
-  (`integrity check: birdc route count failed`, `... birdc protocols
-  failed`, `... mirror_counts failed`) print something different again.
-  So an absent `integrity drift above threshold` line is equally
-  consistent with the checker never having run, `birdc` failing every
-  time, or the log having rotated — which would approve a rollout onto
-  a handle that is `Unknown` and will refuse.
+  **Read `fib-integrity` in `packetframe status`.** It is the fast-path
+  module's own row and it carries the last comparison verbatim — both
+  counts, the drift against the threshold that was actually applied,
+  and the age beside it:
 
-  **The cheapest positive evidence is the canary steer itself.** With
-  `require-table-complete on`, a steer the authority will not support
-  is *refused*, and the refusal names the verdict verbatim — "the route
-  mirror holds N routes but the authority reports only M — that is not
-  the authority feeding this mirror", or "completeness is unknown", or
-  "too old to act on". Nothing is steered when it refuses, so rung 0's
-  first `steer on` doubles as the test, and a refusal costs a message
-  rather than traffic. Read the reason it prints; do not retry past it.
-
-  To know *before* attempting, sample the checker directly. Both counts
-  come from `birdc`, and the comparison is logged — but only at debug,
-  and **`log-level` in the config does not control it**: the filter is
-  built from `RUST_LOG` at process start, so this costs a restart.
-
-  ```bash
-  birdc show route count | grep -E 'in table master(4|6)'
-  systemctl edit packetframe   # [Service] Environment=RUST_LOG=info,packetframe_fast_path::fib::integrity=debug
-  systemctl restart packetframe && sleep 310
-  journalctl -u packetframe --since '-6min' \
-      | grep -E 'integrity check OK|integrity drift above threshold|integrity check:'
+  ```
+  $ packetframe status                     # message wrapped here; it prints on one line
+    fast-path: healthy
+      fib-integrity  healthy — bird 1272306 routes, mirror 1272281 — drift 0.002%,
+                     within the 1.000% warn threshold ... (last ok 41s ago)
   ```
 
-  `integrity check OK` carrying `bird_routes` and `packetframe_routes`
-  is the evidence the gate acts on. A drift warning, one of the three
-  failure lines, or **no line at all** are each not a pass. Revert the
-  override afterwards.
+  That line is the pass. **Every other line is not**, and each says
+  which of the several ways it is not:
 
-  > Both awkward parts of this — needing a restart, and reading a log
-  > rather than a command — come from one gap: `IntegrityChecker`'s
-  > snapshot is published and `RouteController::integrity_snapshot()`
-  > has no caller, so the verdict has no `status` surface outside a
-  > refusal message. Worth closing; until it is, prefer the canary
-  > refusal above, which needs neither.
+  | The row says | What it means |
+  | --- | --- |
+  | `drift N%, within the M% warn threshold` | Agreement. Proceed. |
+  | `no comparison has completed yet` | The checker has not reached its first interval, or has only just started. **Not agreement** — wait 300 s and read it again. |
+  | `drift N%, at or above the M% warn threshold` | Real disagreement. The gate reads the same comparison and will refuse. |
+  | `bird reports NO routes in master4/master6` | The degenerate authority: bird up, carrying none of this mirror's table. This is the 23 h deferral above. |
+  | `could not complete: <error>` with `HISTORY` | `birdc` or the mirror read is failing. Any numbers shown are the previous comparison, ageing. |
+  | no `fib-integrity` row at all | Nothing is checking on this box — kernel-fib mode, or a control plane with no route source. The authority will read `Absent`. |
 
-  Two traps that make a hand-rolled check pass a box that will veto.
-  **`master6` counts**: a box whose `master4` matches but whose
-  `master6` is missing or wrong still fails the combined comparison, so
-  checking `master4` alone approves a rollout the gate will refuse.
-  And **`fib-synced`'s installed count is not the number to compare** —
-  that is VPP's table, which is v4-only by policy, against an authority
-  figure that includes v6.
+  The row appears whenever a checker exists, *including before its
+  first comparison*, and that is the distinction the check turns on:
+  silence used to be equally consistent with the checker never having
+  run, `birdc` failing every time, or the log having rotated — and
+  would approve a rollout onto a handle that is `Unknown` and will
+  refuse.
+
+  `packetframe status` reads a snapshot the daemon publishes every 5 s,
+  so the row is at most that stale — but the comparison behind it is up
+  to one interval (300 s) old by design, which is what the `last ok Ns
+  ago` beside it is for. Its ceiling in normal operation is ~320 s (the
+  interval plus two 10 s `birdc` budgets), so an age climbing past that
+  with **no** error alongside it means checks have stopped landing
+  altogether rather than failing — look for the checker task, not for
+  bird.
+
+  **The other positive evidence is the canary steer itself**, and it
+  costs nothing to lean on. With `require-table-complete on`, a steer
+  the authority will not support is *refused*, and the refusal names
+  the verdict verbatim — "the route mirror holds N routes but the
+  authority reports only M — that is not the authority feeding this
+  mirror", or "completeness is unknown", or "too old to act on".
+  Nothing is steered when it refuses, so rung 0's first `steer on`
+  doubles as the test, and a refusal costs a message rather than
+  traffic. Read the reason it prints; do not retry past it.
+
+  **Do not hand-roll the comparison from `birdc` output.** Two traps
+  make a hand-rolled check pass a box that will veto. **`master6`
+  counts**: the checker compares bird's `master4` **plus** `master6`
+  against the mirror's v4+v6, so a box whose `master4` matches while
+  its `master6` is missing or wrong still fails the combined
+  comparison, and checking `master4` alone approves a rollout the gate
+  will refuse. And **`fib-synced`'s installed count is not the number
+  to compare** — that is VPP's table, which is v4-only by policy,
+  against an authority figure that includes v6.
 
   A box that adopts while steered under a vetoing authority has no fast
   rollback. Worth knowing before the canary rather than during it.


### PR DESCRIPTION
## Why

`IntegrityChecker` maintains an `IntegritySnapshot` behind `SharedSnapshot`, and `RouteController::integrity_snapshot()` exposed it — but **that getter had no caller anywhere in the repo**. The comparison ran every 300 s and the result was thrown away.

Found while writing the vpp-offload rollout runbook (#166): there was no way for an operator to see the completeness verdict except by raising `log-level` to debug and grepping for `integrity check OK`, because a successful comparison logs at debug and only above-threshold drift logs at warn. At the default `log-level info` a healthy check printed *nothing at all*.

That matters because vpp-offload's steering gate and its adopted-resync release both act on that verdict — a box whose authority disagrees refuses to steer and defers indefinitely (measured: 23 h and still holding, 2026-08-11 → 08-12) — so the operator's only pre-flight check was log archaeology, and it cost a daemon restart because the filter is built from `RUST_LOG` at process start.

## What changed

**`fib-integrity` is now a subsystem row on fast-path's `health_check`**, carrying both counts, the drift fraction against the threshold that was actually applied, the age of the sample, and any `last_error`:

```
  fast-path: healthy
    fib-integrity  healthy — bird 1272306 routes, mirror 1272281 — drift 0.002%,
                   within the 1.000% warn threshold ... (last ok 41s ago)
```

The row is present **whenever a checker exists, including before its first comparison completes**. That is the whole point: "no check has completed yet" and "a check completed and they agree" must not render identically, which is exactly the defect the runbook worked around, and the same care `crates/modules/vpp-offload/src/status.rs` already takes with `AuthorityPosture`. The row is absent only when nothing is checking at all — kernel-fib mode, or a control plane with no route source.

`overall` escalates via `HealthState::worse_of`, so the module cannot report Healthy over a Degraded subsystem.

### Three supporting changes the surface forced

- **The per-count snapshot fields were sticky.** A failed `birdc` or a failed `mirror_counts` left the previous run's number in place, so a drift fraction could be built from one fresh number and one five minutes old. Tolerable while the only reader was a log line nobody gates on; wrong for a surface a rollout is gated on — and it is the same rule [`integrity.rs`](https://github.com/unredacted/packetframe/blob/main/crates/modules/fast-path/src/fib/integrity.rs) already applies to what it republishes to the second tier. Both counts now live in a `Comparison` recorded only when they come from one run. A comparison retained across a failed run renders as `HISTORY` with its own age, never as the current state.
- **The drift verdict travels with the comparison.** `Drift { fraction, threshold, above }` is decided in the branch that decides whether to warn, so the log and `packetframe status` cannot disagree about whether a box has drifted, and a non-default `drift_warn_fraction` is reported as the one actually applied.
- **A zero authority no longer passes silently.** Bird reporting 0 routes in `master4`/`master6` recorded `drift_fraction = None` and logged nothing — the degenerate end of the case measured on the shadow (bird *running*, carrying 13 routes against a 1.3M mirror). It now warns and reports as its own condition rather than as "no drift".

`RouteController::integrity_snapshot()` is replaced by `integrity_posture()`, which is actually called.

### Why the new file is not behind the platform gate

The result types and their rendering live in a new **ungated** `fib/integrity_status.rs`. There are no syscalls in them, so its 9 tests compile and run on a macOS dev loop rather than only inside the qemu job — the same reasoning `crates/cli/src/health.rs` already carries in its own comment ("a `#[cfg(target_os = "linux")]` test is invisible to every host gate"). The checker itself, which shells out to `birdc`, stays gated and re-exports the types from where callers expect them.

### Docs

- `docs/runbooks/vpp-offload.md`: the "Before a rollout, check the authority AGREES" bullet now reads the status row, with a table mapping each possible line to its verdict. Drops the `systemctl edit` → `RUST_LOG` → restart → `sleep 310` → `journalctl | grep` sequence and the note about the missing caller. The canary-steer refusal is kept as the other positive evidence, and the two hand-rolling traps (`master6` counts; `fib-synced`'s installed count is v4-only) are kept.
- `docs/runbooks/custom-fib.md`: the integrity section gains the status row and the new zero-authority warn.

## Reviewer notes

- **`try_read`, not a blocking read**, in `integrity_posture()`. This is called from the daemon's sync signal loop today where blocking would be safe, but `Module::health_check` is a public surface and a blocking tokio read panics inside an async context. Losing that race is vanishingly rare — the writer holds the lock for a handful of field assignments once per interval — and it reports `Unread` rather than being mistaken for "no check yet".
- **Behaviour change worth a look:** drift is now computed only when *both* counts are fresh, so a run where `mirror_counts` fails no longer emits a drift warn built from mixed-age numbers. I read that as a fix, but it does change when the existing warn fires.
- **Subsystem name `fib-integrity` is rename-unsafe** once shipped, same as the `stats` counter indices.

## Verification

| Gate | Result |
| --- | --- |
| `cargo fmt --all -- --check` | pass |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | pass |
| `cargo test --workspace` (52 fast-path lib tests) | pass |
| Cross clippy, all 4 published targets, `-D warnings` | pass |

The cross-target clippy is what actually compiles the gated `integrity.rs` / `controller.rs` / `linux_impl.rs` changes; host gates alone would not have seen them.

**Not covered locally:** the sudo-gated qemu integration tests, and the loaded-module path through `health_check` — that needs a live `RouteController` (netlink, bpffs), so its first real exercise is CI or hardware. The posture logic it delegates to is fully covered, including the no-sample-vs-agreement distinction, drift above threshold, the zero authority, a failed check with and without prior history, and an error alongside a current comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
