### PR TITLE
feat(fib): the integrity authority is a stated fact, not a hardcoded local birdc

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -204,6 +204,21 @@ module fast-path
   # route-source bgp 10.0.0.1:1179 local-as 401401 peer-as 401401 \
   #   allow-remote peer-from 10.0.0.0/24 peer-ip 10.0.0.5
 
+  # Which authority the integrity checker cross-checks the mirror
+  # against. Default (directive omitted) is `birdc` at /usr/sbin/birdc:
+  # correct when THIS box's own bird feeds the mirror.
+  #   integrity-authority birdc                 # default; local bird is the authority
+  #   integrity-authority birdc /opt/bird/birdc # non-standard birdc path
+  #   integrity-authority none                  # mirror is fed from a source
+  #                                             # ELSEWHERE — a local birdc would
+  #                                             # compare against the wrong RIB, so
+  #                                             # no comparison runs. `fib-integrity`
+  #                                             # reports "not attested here"
+  #                                             # (informational, not an alarm).
+  # `integrity-authority none` is incompatible with vpp-offload's
+  # `require-table-complete on` (there is no authority to require), and
+  # that combination is refused at load.
+
   # ECMP default hash mode (3/4/5-tuple). Applied globally today;
   # per-group overrides could come later if bird ever surfaces a
   # hint via BMP. Rarely needs changing from the default 5.

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -369,6 +369,13 @@ pub enum ModuleDirective {
     /// when this is set and `forwarding-mode` is `custom-fib` or
     /// `compare`. See [`RouteSourceSpec`] for the per-kind shape.
     RouteSource(RouteSourceSpec),
+    /// Which authority the integrity checker cross-checks the mirror
+    /// against — the thing that decides whether "the mirror disagrees
+    /// with the RIB" is a real alarm or a comparison against the wrong
+    /// reference. See [`IntegrityAuthoritySpec`]. Absent ⇒ `Birdc` with
+    /// the default path, which is the fleet's shape and preserves
+    /// every existing config.
+    IntegrityAuthority(IntegrityAuthoritySpec),
     /// Max entries for the custom-FIB LPM tries and side arrays.
     /// Accepted but **not yet runtime-applied**, aya / kernel
     /// allocate maps at compile-time sizes set in
@@ -435,6 +442,43 @@ impl FromStr for ForwardingMode {
 /// declare an `IpNet` ACL via one or more `peer-from <cidr>` sub-
 /// keywords. The BGP variant additionally accepts `peer-ip <ip>`
 /// to pin the configured `peer-as` to a specific source address.
+/// What the integrity checker treats as the authority for the mirror.
+///
+/// The checker compares packetframe's FIB mirror against an authority
+/// and calls the difference "drift". The only authority it ever knew
+/// was a local `birdc`, hardcoded — which is correct on a box whose own
+/// bird feeds the mirror, and simply wrong on a box fed from somewhere
+/// else. The shadow is the second kind: its route source is the
+/// PRIMARY's bird dialing in over TCP, so the local bird holds 19
+/// prefixes while the mirror holds 1.3M, and every check reported a
+/// 6.8-million-percent "drift" against a RIB that was never the feed.
+///
+/// So the authority is now a stated deployment fact rather than a
+/// guess. It is deliberately NOT inferred from the route-source address
+/// (loopback-vs-remote), because that is the same correlation-for-fact
+/// substitution that produced the bug: the operator knows which daemon
+/// feeds the box; make them say it.
+///
+/// Two authorities exist today, and the roadmap has two more that need
+/// no external process and work with any BGP daemon — **feed
+/// accounting** (the listener's own live-prefix count against the
+/// mirror) and **BMP stats reports** (RFC 7854 Loc-RIB counts in-band).
+/// Neither is built; the enum is left open for them rather than shimmed.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub enum IntegrityAuthoritySpec {
+    /// A local `birdc` is the authority. `None` path ⇒ the default
+    /// (`/usr/sbin/birdc`). This is the value assumed when the directive
+    /// is absent, so the fleet's existing configs behave unchanged.
+    Birdc { path: Option<PathBuf> },
+    /// Nothing local can attest completeness: the mirror is fed from a
+    /// route source elsewhere, so no comparison is run. The
+    /// `fib-integrity` row reports this as informational rather than an
+    /// alarm, and the second tier treats the mirror as unattested —
+    /// which is why `require-table-complete on` is refused alongside it,
+    /// there being no authority for it to require.
+    None,
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RouteSourceSpec {
     /// BMP station listen address. Bird dials out to this
@@ -1047,6 +1091,42 @@ impl Config {
                  its allowlist; the eBPF path is the failover tier)",
             ));
         };
+
+        // `require-table-complete on` demands a completeness authority,
+        // and `integrity-authority none` declares there is none. The two
+        // together are a config that can never permit a first steer: the
+        // gate waits for an attestation nothing will ever produce. Caught
+        // here rather than discovered as a canary that defers forever
+        // (the shadow's 23 h, in the shape an operator could actually
+        // configure by accident). `require-table-complete` defaults ON,
+        // so this fires whenever `integrity-authority none` is set on a
+        // steering box without an explicit `off`.
+        let require_complete = vpp
+            .directives
+            .iter()
+            .find_map(|d| match d {
+                ModuleDirective::VppRequireTableComplete(v) => Some(*v),
+                _ => None,
+            })
+            .unwrap_or(true);
+        let authority_is_none = fast_path.is_some_and(|fp| {
+            fp.directives.iter().any(|d| {
+                matches!(
+                    d,
+                    ModuleDirective::IntegrityAuthority(IntegrityAuthoritySpec::None)
+                )
+            })
+        });
+        if require_complete && authority_is_none {
+            return Err(ConfigError::parse(
+                0,
+                "module vpp-offload has `require-table-complete on` (the default) but module \
+                 fast-path has `integrity-authority none`: there is no authority to attest \
+                 completeness, so the first steer would defer forever. Either name an \
+                 authority (`integrity-authority birdc`) or opt the gate out \
+                 (`require-table-complete off`)",
+            ));
+        }
 
         let any_steer = ports.iter().any(|(_, steer, _)| *steer);
         if !any_steer {
@@ -1896,6 +1976,7 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             Ok(ModuleDirective::ForwardingMode(mode))
         }),
         "route-source" => parse_route_source(line, rest),
+        "integrity-authority" => parse_integrity_authority(line, rest),
         "fib-v4-max-entries" => parse_u32_directive(line, rest, "fib-v4-max-entries", |n| {
             ModuleDirective::FibSize(FibSizeDirective::FibV4MaxEntries(n))
         }),
@@ -1973,6 +2054,48 @@ where
         ));
     }
     Ok(wrap(n))
+}
+
+/// Parse `integrity-authority <birdc [path] | none>`.
+///
+/// `birdc` with no path uses the default; `birdc /some/birdc` overrides
+/// it. `none` declares that no local authority attests this mirror. See
+/// [`IntegrityAuthoritySpec`] for why this is a stated fact rather than
+/// something inferred from the route source.
+fn parse_integrity_authority<'a>(
+    line: usize,
+    mut rest: impl Iterator<Item = &'a str>,
+) -> Result<ModuleDirective, ConfigError> {
+    let kind = rest.next().ok_or_else(|| {
+        ConfigError::parse(
+            line,
+            "integrity-authority requires `birdc [path]` or `none`",
+        )
+    })?;
+    let spec = match kind {
+        "birdc" => {
+            let path = match rest.next() {
+                Some(raw) => Some(validate_safe_path(line, "integrity-authority birdc", raw)?),
+                None => None,
+            };
+            IntegrityAuthoritySpec::Birdc { path }
+        }
+        "none" => IntegrityAuthoritySpec::None,
+        other => {
+            return Err(ConfigError::parse(
+                line,
+                format!("integrity-authority expects `birdc [path]` or `none`, got `{other}`"),
+            ))
+        }
+    };
+    if rest.next().is_some() {
+        return Err(ConfigError::parse(
+            line,
+            "integrity-authority takes at most `birdc <path>` — extra arguments are not \
+             allowed",
+        ));
+    }
+    Ok(ModuleDirective::IntegrityAuthority(spec))
 }
 
 /// Parse `route-source <kind> <args...>`. Two kinds supported:
@@ -2767,6 +2890,81 @@ module fast-path
         assert!(Config::parse("module fast-path\n  fdb-pin maybe\n").is_err());
         assert!(Config::parse("module fast-path\n  fdb-pin\n").is_err());
         assert!(Config::parse("module fast-path\n  fdb-pin auto extra\n").is_err());
+    }
+
+    #[test]
+    fn integrity_authority_parses() {
+        let birdc_default = Config::parse("module fast-path\n  integrity-authority birdc\n")
+            .unwrap()
+            .modules[0]
+            .directives[0]
+            .clone();
+        assert_eq!(
+            birdc_default,
+            ModuleDirective::IntegrityAuthority(IntegrityAuthoritySpec::Birdc { path: None })
+        );
+
+        let birdc_path =
+            Config::parse("module fast-path\n  integrity-authority birdc /opt/bird/birdc\n")
+                .unwrap()
+                .modules[0]
+                .directives[0]
+                .clone();
+        assert!(matches!(
+            birdc_path,
+            ModuleDirective::IntegrityAuthority(IntegrityAuthoritySpec::Birdc { path: Some(_) })
+        ));
+
+        let none = Config::parse("module fast-path\n  integrity-authority none\n")
+            .unwrap()
+            .modules[0]
+            .directives[0]
+            .clone();
+        assert_eq!(
+            none,
+            ModuleDirective::IntegrityAuthority(IntegrityAuthoritySpec::None)
+        );
+
+        for bad in [
+            "module fast-path\n  integrity-authority\n",
+            "module fast-path\n  integrity-authority bmp\n",
+            "module fast-path\n  integrity-authority none extra\n",
+            "module fast-path\n  integrity-authority birdc /a /b\n",
+        ] {
+            assert!(Config::parse(bad).is_err(), "should reject: {bad}");
+        }
+    }
+
+    /// `require-table-complete on` + `integrity-authority none` is a
+    /// config that can never permit a first steer, so it is refused at
+    /// load rather than discovered as a canary that defers forever.
+    #[test]
+    fn require_table_complete_needs_an_authority() {
+        let base = "module fast-path\n  forwarding-mode custom-fib\n  \
+                    route-source bgp 127.0.0.1:1179 local-as 1 peer-as 1\n  \
+                    integrity-authority none\n\
+                    module vpp-offload\n  loopback-address 192.0.2.1/32\n  \
+                    port eth1 cores 1 steer off\n";
+
+        // `require-table-complete` defaults ON, so the bare config is
+        // already the conflict.
+        let cfg = Config::parse(base).unwrap();
+        let err = cfg.validate_vpp_offload().unwrap_err();
+        assert!(
+            format!("{err}").contains("no authority to attest completeness"),
+            "{err}"
+        );
+
+        // Opting the gate out resolves it.
+        let ok = base.replace(
+            "port eth1 cores 1 steer off\n",
+            "port eth1 cores 1 steer off\n  require-table-complete off\n",
+        );
+        Config::parse(&ok).unwrap().validate_vpp_offload().unwrap();
+
+        // Naming an authority resolves it too.
+        let ok2 = base.replace("integrity-authority none\n", "integrity-authority birdc\n");
+        Config::parse(&ok2).unwrap().validate_vpp_offload().unwrap();
     }
 
     #[test]

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -479,6 +479,35 @@ pub enum IntegrityAuthoritySpec {
     None,
 }
 
+impl IntegrityAuthoritySpec {
+    /// Whether a reload may move a running daemon from `self` to `new`.
+    ///
+    /// It may not: the directive is read once, when the route
+    /// controller starts and decides whether to spawn a checker and
+    /// with which `birdc`. A pure function over two values, mirroring
+    /// `VppOffloadConfig::restart_only_delta`, so the rule is testable
+    /// without an attach, a BPF object, or a running checker — the
+    /// module-side caller supplies the "is a controller actually
+    /// running" half.
+    ///
+    /// Refused rather than silently ignored because this is the
+    /// directive an operator edits *because a health line told them
+    /// to*: `integrity-authority none` is what the authority-mismatch
+    /// remedy recommends, and a reload that accepts it while the
+    /// checker keeps using the old authority leaves the false alarm
+    /// standing and the operator believing they fixed it.
+    pub fn restart_only_delta(&self, new: &Self) -> Result<(), String> {
+        if self == new {
+            return Ok(());
+        }
+        Err(format!(
+            "`integrity-authority` changed ({self:?} → {new:?}) and it is read once, when \
+             the route controller starts: a reload cannot move the running checker onto a \
+             different authority. Restart the daemon for it"
+        ))
+    }
+}
+
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub enum RouteSourceSpec {
     /// BMP station listen address. Bird dials out to this
@@ -2932,6 +2961,42 @@ module fast-path
             "module fast-path\n  integrity-authority birdc /a /b\n",
         ] {
             assert!(Config::parse(bad).is_err(), "should reject: {bad}");
+        }
+    }
+
+    /// A reload may not move the authority under a running checker.
+    ///
+    /// The directive is consumed once, when the route controller
+    /// starts. Accepting the edit and continuing to compare against the
+    /// old authority is the silent no-op class — and this is precisely
+    /// the directive the mismatch remedy tells an operator to change,
+    /// so "it returned OK" would read as "it took effect".
+    #[test]
+    fn integrity_authority_is_restart_only() {
+        let birdc = IntegrityAuthoritySpec::Birdc { path: None };
+        let none = IntegrityAuthoritySpec::None;
+        let other = IntegrityAuthoritySpec::Birdc {
+            path: Some(PathBuf::from("/opt/bird/birdc")),
+        };
+
+        // Unchanged reloads are fine — the common case, every SIGHUP
+        // that edits an allowlist.
+        birdc.restart_only_delta(&birdc).unwrap();
+        none.restart_only_delta(&none).unwrap();
+
+        // Every real change is refused, in both directions, including a
+        // path swap that keeps the same variant.
+        for (from, to) in [
+            (&birdc, &none),
+            (&none, &birdc),
+            (&birdc, &other),
+            (&other, &none),
+        ] {
+            let err = from.restart_only_delta(to).unwrap_err();
+            assert!(
+                err.contains("read once") && err.contains("Restart the daemon"),
+                "a refused change must say why and what to do: {err}"
+            );
         }
     }
 

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -37,6 +37,7 @@ use crate::fib::netlink_neigh::{
 use crate::fib::programmer::{FibProgrammer, FibProgrammerHandle, ProgrammerError};
 use crate::fib::route_source_bgp::{BgpListener, BgpListenerConfig};
 use crate::fib::route_source_bmp::BmpStation;
+use packetframe_common::config::IntegrityAuthoritySpec;
 
 /// Forwarding-feed source. The controller spawns at most one route
 /// source: operators pick `bmp` or `bgp` via `route-source ...`.
@@ -113,8 +114,31 @@ pub struct RouteController {
     neigh_handle: NeighborResolveHandle,
     prog_handle: FibProgrammerHandle,
     /// Shared snapshot from the integrity checker. `None` when the
-    /// checker isn't enabled (no BMP configured → no bird to ask).
+    /// checker isn't enabled (no route source → no bird to ask, or
+    /// `integrity-authority none` → nothing local to ask).
     integrity: Option<SharedSnapshot>,
+    /// The operator declared `integrity-authority none`: there is a
+    /// route source but no local authority for the mirror, so no
+    /// comparison runs. Distinct from `integrity: None` with no route
+    /// source, because the health surface says something different —
+    /// "not attested by choice" versus "nothing to attest".
+    authority_declared_none: bool,
+}
+
+/// The external route feed and the authority the integrity checker
+/// validates the resulting mirror against. One struct because they are
+/// two halves of one decision — where the routes come from, and what
+/// counts as the truth to check them against — and pairing them keeps
+/// `start()` under the argument-count lint (which only the cross-clippy
+/// job sees, since this file is `cfg(target_os = "linux")`).
+pub struct RouteFeed {
+    /// `Some(...)` when `route-source bmp|bgp ...` was configured;
+    /// `None` runs without a live feed (test harnesses).
+    pub source: Option<RouteSourceConfig>,
+    /// Which authority the integrity checker cross-checks against. See
+    /// [`IntegrityAuthoritySpec`]; absent in config ⇒ `Birdc` default,
+    /// resolved by the caller.
+    pub integrity_authority: IntegrityAuthoritySpec,
 }
 
 /// The handles a second forwarding tier registers before attach — how
@@ -140,13 +164,17 @@ impl RouteController {
     /// programmer directly via its `FibProgrammerHandle`.
     pub fn start(
         bpffs_root: &Path,
-        route_source: Option<RouteSourceConfig>,
+        feed: RouteFeed,
         local_prefixes: Vec<LocalPrefixSpec>,
         fallback_default: Option<FallbackDefaultSpec>,
         fdb_pin_chains: std::collections::HashMap<u32, (u32, u16)>,
         route_sink: Option<std::sync::Arc<dyn packetframe_common::fib::ResolvedRouteSink>>,
         signals: SecondTierSignals,
     ) -> Result<Self, ControllerError> {
+        let RouteFeed {
+            source: route_source,
+            integrity_authority,
+        } = feed;
         let SecondTierSignals {
             completeness,
             feed_session,
@@ -242,18 +270,31 @@ impl RouteController {
                 peer_acl,
             }) => {
                 let snapshot = shared_snapshot();
-                let mut checker = IntegrityChecker::new(
-                    IntegrityConfig::default(),
-                    snapshot.clone(),
-                    prog_handle.clone(),
-                    shutdown_token.clone(),
-                );
-                // The second tier's steering gate reads what this
-                // publishes; see `TableCompleteness`.
-                if let Some(h) = completeness.clone() {
-                    checker = checker.with_completeness(h);
+                // Spawn the checker only when a LOCAL authority is named.
+                // `integrity-authority none` still allocates the snapshot
+                // (the BMP stall gate reads it) but runs no comparison:
+                // there is no local RIB that is this mirror's authority,
+                // so a birdc comparison would be against the wrong
+                // reference — the 6.8-million-percent "drift" the shadow
+                // reported for months.
+                if let IntegrityAuthoritySpec::Birdc { path } = &integrity_authority {
+                    let mut icfg = IntegrityConfig::default();
+                    if let Some(p) = path {
+                        icfg.birdc_path = p.clone();
+                    }
+                    let mut checker = IntegrityChecker::new(
+                        icfg,
+                        snapshot.clone(),
+                        prog_handle.clone(),
+                        shutdown_token.clone(),
+                    );
+                    // The second tier's steering gate reads what this
+                    // publishes; see `TableCompleteness`.
+                    if let Some(h) = completeness.clone() {
+                        checker = checker.with_completeness(h);
+                    }
+                    tasks.push(runtime.spawn(async move { checker.run().await }));
                 }
-                tasks.push(runtime.spawn(async move { checker.run().await }));
 
                 // v0.2.2: spawn under a retry-with-backoff loop. Pre-fix,
                 // a `bind` failure (TIME_WAIT after a quick restart) would
@@ -314,18 +355,31 @@ impl RouteController {
                 expected_peer_ip,
             }) => {
                 let snapshot = shared_snapshot();
-                let mut checker = IntegrityChecker::new(
-                    IntegrityConfig::default(),
-                    snapshot.clone(),
-                    prog_handle.clone(),
-                    shutdown_token.clone(),
-                );
-                // The second tier's steering gate reads what this
-                // publishes; see `TableCompleteness`.
-                if let Some(h) = completeness.clone() {
-                    checker = checker.with_completeness(h);
+                // Spawn the checker only when a LOCAL authority is named.
+                // `integrity-authority none` still allocates the snapshot
+                // (the BMP stall gate reads it) but runs no comparison:
+                // there is no local RIB that is this mirror's authority,
+                // so a birdc comparison would be against the wrong
+                // reference — the 6.8-million-percent "drift" the shadow
+                // reported for months.
+                if let IntegrityAuthoritySpec::Birdc { path } = &integrity_authority {
+                    let mut icfg = IntegrityConfig::default();
+                    if let Some(p) = path {
+                        icfg.birdc_path = p.clone();
+                    }
+                    let mut checker = IntegrityChecker::new(
+                        icfg,
+                        snapshot.clone(),
+                        prog_handle.clone(),
+                        shutdown_token.clone(),
+                    );
+                    // The second tier's steering gate reads what this
+                    // publishes; see `TableCompleteness`.
+                    if let Some(h) = completeness.clone() {
+                        checker = checker.with_completeness(h);
+                    }
+                    tasks.push(runtime.spawn(async move { checker.run().await }));
                 }
-                tasks.push(runtime.spawn(async move { checker.run().await }));
 
                 // v0.2.2: same retry-with-backoff pattern as BmpStation
                 // above. See that comment for rationale.
@@ -410,6 +464,10 @@ impl RouteController {
             neigh_handle,
             prog_handle,
             integrity,
+            authority_declared_none: matches!(
+                integrity_authority,
+                packetframe_common::config::IntegrityAuthoritySpec::None
+            ),
         })
     }
 
@@ -434,6 +492,15 @@ impl RouteController {
     /// losing the race is vanishingly rare and says so when it happens
     /// rather than being mistaken for "no check yet".
     pub fn integrity_posture(&self) -> Option<IntegrityPosture> {
+        // `integrity-authority none`: a route source exists but no local
+        // authority attests it, so there is a checker-shaped hole to
+        // explain rather than a comparison to read. Reported as its own
+        // posture — informational, not an alarm — because silence here
+        // would read as "checker crashed", and a birdc comparison would
+        // be against the wrong RIB.
+        if self.authority_declared_none {
+            return Some(IntegrityPosture::NoAuthority);
+        }
         let snapshot = self.integrity.as_ref()?;
         Some(match snapshot.try_read() {
             Ok(snap) => IntegrityPosture::observe(&snap, Instant::now()),

--- a/crates/modules/fast-path/src/fib/integrity_status.rs
+++ b/crates/modules/fast-path/src/fib/integrity_status.rs
@@ -193,6 +193,13 @@ impl Sample {
 /// the first two must never print the same line.
 #[derive(Debug, Clone, PartialEq)]
 pub enum IntegrityPosture {
+    /// `integrity-authority none`: the operator declared this box has no
+    /// local authority for the mirror (it is fed from a route source
+    /// elsewhere), so no comparison runs. Informational, not an alarm —
+    /// the checker is not broken, it is correctly not guessing. The
+    /// second tier treats the mirror as unattested, which is why
+    /// `require-table-complete on` is refused alongside this at load.
+    NoAuthority,
     /// The checker is running and no check has finished yet. **Not
     /// agreement** — nothing has compared bird against the mirror.
     AwaitingFirstCheck,
@@ -250,6 +257,21 @@ impl IntegrityPosture {
     /// The row `packetframe status` prints.
     pub fn subsystem_health(&self) -> SubsystemHealth {
         let (state, message) = match self {
+            Self::NoAuthority => (
+                // Healthy: this is a stated deployment fact, not a
+                // fault. The box's routes come from a source elsewhere,
+                // so nothing local can attest the mirror — and the
+                // checker correctly does not compare against a RIB that
+                // is not the feed.
+                HealthState::Healthy,
+                "no integrity authority on this box (`integrity-authority none`): its routes \
+                 are fed from a source elsewhere, so a local birdc would compare the mirror \
+                 against the wrong RIB. No comparison is run and completeness is not \
+                 attested here — a second-tier steering gate treats the mirror as \
+                 unattested, which is why `require-table-complete on` is refused with this \
+                 setting"
+                    .to_string(),
+            ),
             Self::AwaitingFirstCheck => (
                 // Healthy: forwarding does not depend on this. The
                 // checker is a diagnostic safety net, and a box that has
@@ -291,7 +313,7 @@ impl IntegrityPosture {
     fn last_success_age(&self) -> Option<u64> {
         match self {
             Self::Checked { sample, .. } => sample.map(|s| s.age().as_secs()),
-            Self::AwaitingFirstCheck | Self::Unread => None,
+            Self::NoAuthority | Self::AwaitingFirstCheck | Self::Unread => None,
         }
     }
 
@@ -396,34 +418,52 @@ impl IntegrityPosture {
             s.bird_prefixes, s.packetframe_prefixes
         );
 
-        let diagnostic = match s.drift {
-            Some(d) => {
-                if d.above {
-                    state = state.worse_of(HealthState::Degraded);
+        let gate = s.gate_verdict();
+
+        // The drift PERCENTAGE is only worth printing when it is a
+        // drift. When the authority is at fault — the mirror holds far
+        // more than the authority claims, or the authority claims zero —
+        // `|bird - mirror| / bird` is the 6.8-million-percent figure the
+        // domain code explicitly decided not to print (see
+        // `Completeness::AuthorityMismatch`), and leading with it buries
+        // the real explanation under noise. In that case the diagnostic
+        // states the mismatch and leaves the number to the gate verdict.
+        let diagnostic = if gate.authority_is_at_fault() {
+            state = state.worse_of(HealthState::Degraded);
+            "the mirror holds far more than the authority reports (or the authority reports \
+             none) — this is a mismatch, not a drift, so no percentage is meaningful"
+                .to_string()
+        } else {
+            match s.drift {
+                Some(d) => {
+                    if d.above {
+                        state = state.worse_of(HealthState::Degraded);
+                    }
+                    format!(
+                        "drift {:.3}%, {} the {:.3}% warn threshold",
+                        d.fraction * 100.0,
+                        if d.above { "at or above" } else { "within" },
+                        d.threshold * 100.0
+                    )
                 }
-                format!(
-                    "drift {:.3}%, {} the {:.3}% warn threshold",
-                    d.fraction * 100.0,
-                    if d.above { "at or above" } else { "within" },
-                    d.threshold * 100.0
-                )
+                None => "no drift fraction is defined: bird reports NO prefixes in \
+                         master4/master6, and a fraction of zero says nothing"
+                    .to_string(),
             }
-            // Not "no drift". A zero authority cannot attest anything,
-            // and it is a real and documented state — a box running a
-            // bird that carries none of the table the mirror is fed.
-            None => "no drift fraction is defined: bird reports NO prefixes in \
-                     master4/master6, and a fraction of zero says nothing"
-                .to_string(),
         };
 
-        let gate = s.gate_verdict();
+        // SUBJUNCTIVE, deliberately. This row predicts what a steer
+        // WOULD do from this comparison; it is not a refusal that has
+        // happened. "would permit" / "would refuse" is accurate whether
+        // or not a gate is even consulting the comparison on this box —
+        // and on a `require-table-complete off` box none is — where
+        // "REFUSES" reads as an action that never occurred. Same
+        // discipline that separated "the record is stale" from "the
+        // daemon is gone".
         let rollout = if gate.permits_steering() {
-            // No `describe()` here: on the converged path it only
-            // restates the drift already printed. Refusals keep it
-            // verbatim, where it carries the reason and the remedy.
-            "A steering gate reads this same comparison and would permit a steer — this is the \
-             positive evidence a rollout needs, and the counts behind it are bird's master4 plus \
-             master6 against the mirror's v4+v6"
+            "a second-tier steering gate reads this same comparison and would permit a steer \
+             — this is the positive evidence a rollout needs, and the counts behind it are \
+             bird's master4 plus master6 against the mirror's v4+v6"
                 .to_string()
         } else {
             state = state.worse_of(HealthState::Degraded);
@@ -431,7 +471,7 @@ impl IntegrityPosture {
             // steer itself, verbatim — including the staleness case,
             // which `assess` checks before it will look at drift at all.
             format!(
-                "A steering gate reads this same comparison and REFUSES: {}",
+                "a second-tier steering gate reads this same comparison and would refuse: {}",
                 gate.describe()
             )
         };
@@ -557,7 +597,8 @@ mod tests {
             m.contains("would permit a steer"),
             "claimed a refusal the gate will not make: {m}"
         );
-        assert!(!m.contains("REFUSES"), "{m}");
+        assert!(!m.contains("would refuse"), "{m}");
+        assert!(m.contains("would permit a steer"), "{m}");
     }
 
     /// A tuned `drift-warn-fraction` is the range version of the same
@@ -572,7 +613,7 @@ mod tests {
         let h = IntegrityPosture::observe(&snap, at).subsystem_health();
         let m = h.message.clone().unwrap();
         assert!(m.contains("within the 5.000% warn threshold"), "{m}");
-        assert!(m.contains("REFUSES"), "{m}");
+        assert!(m.contains("would refuse"), "{m}");
         assert_eq!(
             h.state,
             HealthState::Degraded,
@@ -595,6 +636,49 @@ mod tests {
             .contains("within the 5.000% warn threshold"));
     }
 
+    /// `integrity-authority none` is informational, not an alarm, and
+    /// says why so an operator does not read it as a broken checker.
+    #[test]
+    fn no_authority_is_healthy_and_explains_itself() {
+        let h = IntegrityPosture::NoAuthority.subsystem_health();
+        assert_eq!(
+            h.state,
+            HealthState::Healthy,
+            "declaring no authority is a config fact, not a fault"
+        );
+        let m = h.message.unwrap();
+        assert!(m.contains("integrity-authority none"), "{m}");
+        assert!(m.contains("unattested"), "{m}");
+        // It must NOT print a comparison or a would-refuse verdict:
+        // there is nothing to compare.
+        assert!(!m.contains("would refuse"), "{m}");
+        assert!(!m.contains("would permit"), "{m}");
+    }
+
+    /// The shadow's exact case: bird 19 prefixes against a 1.3M mirror.
+    /// The `|bird-mirror|/bird` fraction is ~6.8 million percent, which
+    /// the domain code decided not to print. The row must state the
+    /// mismatch, not lead with that number.
+    #[test]
+    fn a_gross_mismatch_does_not_print_a_nonsense_percentage() {
+        let at = t0();
+        // A real drift was computed (bird != 0), yet the gate verdict is
+        // AuthorityMismatch, so the percentage is the meaningless one.
+        let d = drift((1_303_290.0 - 19.0) / 19.0, 0.01);
+        let h = IntegrityPosture::observe(&clean_run(at, 19, 1_303_290, d), at).subsystem_health();
+        assert_eq!(h.state, HealthState::Degraded);
+        let m = h.message.unwrap();
+        assert!(
+            m.contains("mismatch, not a drift"),
+            "a gross mismatch states itself: {m}"
+        );
+        assert!(
+            !m.contains("6859") && !m.contains("685916"),
+            "the 6.8-million-percent figure must not appear: {m}"
+        );
+        assert!(m.contains("would refuse"), "{m}");
+    }
+
     /// The runbook's measured case: bird up, carrying 13 routes against
     /// a 1.3M mirror. Here the degenerate end of it — a bird with none.
     #[test]
@@ -604,7 +688,10 @@ mod tests {
             IntegrityPosture::observe(&clean_run(at, 0, 1_300_000, None), at).subsystem_health();
         assert_eq!(h.state, HealthState::Degraded);
         let m = h.message.unwrap();
-        assert!(m.contains("NO prefixes in master4/master6"), "{m}");
+        assert!(
+            m.contains("mismatch, not a drift"),
+            "a zero authority is a mismatch, not a drift figure: {m}"
+        );
         assert!(
             !m.contains("drift 0"),
             "a zero authority must not read as agreement: {m}"
@@ -627,7 +714,7 @@ mod tests {
         .subsystem_health();
         assert_eq!(stale.state, HealthState::Degraded);
         let m = stale.message.unwrap();
-        assert!(m.contains("REFUSES"), "{m}");
+        assert!(m.contains("would refuse"), "{m}");
         // Verbatim from `Completeness::describe()`, so the row prints
         // the refusal the steer itself would print.
         assert!(m.contains("too old to act on"), "{m}");

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -600,6 +600,14 @@ pub struct ActiveState {
     /// stack on rvu-nicpf hardware (kernel panic, full reboot);
     /// this is the same class of bug §11.8 calls out for attach.
     pub attach_settle_time: std::time::Duration,
+    /// The `integrity-authority` in force, as attach resolved it
+    /// (absent directive ⇒ `Birdc` default). Retained for the same
+    /// reason `attach_settle_time` is: the value is consumed once, when
+    /// the `RouteController` is built, so a later SIGHUP has nothing to
+    /// compare against unless the attach-time answer is kept. Without
+    /// it a reload that changes the authority returns OK and changes
+    /// nothing — the checker keeps using the old one (review finding).
+    pub integrity_authority: packetframe_common::config::IntegrityAuthoritySpec,
 }
 
 /// One XDP attach. `effective_mode` records what actually stuck in
@@ -646,6 +654,26 @@ impl LinkHandle {
     pub fn persists_across_exit(&self) -> bool {
         matches!(self, LinkHandle::Pinned(_) | LinkHandle::Tc { .. })
     }
+}
+
+/// The `integrity-authority` a config asks for, with the default
+/// applied.
+///
+/// ONE derivation, three readers — `load` records it, `attach` builds
+/// the checker from it, and `reconcile` compares against it. Three
+/// copies of "absent means birdc" is how a reload comes to disagree
+/// with the running daemon about which authority is in force.
+pub fn integrity_authority_from_cfg(
+    cfg: &ModuleConfig<'_>,
+) -> packetframe_common::config::IntegrityAuthoritySpec {
+    cfg.section
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::IntegrityAuthority(spec) => Some(spec.clone()),
+            _ => None,
+        })
+        .unwrap_or(packetframe_common::config::IntegrityAuthoritySpec::Birdc { path: None })
 }
 
 pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveState> {
@@ -698,6 +726,7 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
         bpffs_root: ctx.bpffs_root.to_path_buf(),
         route_controller: None,
         attach_settle_time: cfg.global.attach_settle_time,
+        integrity_authority: integrity_authority_from_cfg(cfg),
     })
 }
 
@@ -1536,15 +1565,7 @@ pub fn attach(
         // no local authority (the mirror is fed from elsewhere) and the
         // checker does not run a comparison it knows is against the wrong
         // RIB.
-        let integrity_authority = cfg
-            .section
-            .directives
-            .iter()
-            .find_map(|d| match d {
-                ModuleDirective::IntegrityAuthority(spec) => Some(spec.clone()),
-                _ => None,
-            })
-            .unwrap_or(packetframe_common::config::IntegrityAuthoritySpec::Birdc { path: None });
+        let integrity_authority = integrity_authority_from_cfg(cfg);
         // v0.2.1: collect operator-declared `local-prefix` directives
         // and pass them to the controller. Empty list = feature off
         // (back-compat with v0.2.0 configs that never had this).
@@ -3467,6 +3488,9 @@ mod tests {
             bpffs_root: tmp,
             route_controller: None,
             attach_settle_time: std::time::Duration::ZERO,
+            integrity_authority: packetframe_common::config::IntegrityAuthoritySpec::Birdc {
+                path: None,
+            },
         };
 
         let bridge_idx = if_nametoindex(BRIDGE).unwrap();

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1530,6 +1530,21 @@ pub fn attach(
             }
             _ => None,
         });
+        // Which authority the integrity checker cross-checks against.
+        // Absent ⇒ `Birdc` with the default path, so every existing
+        // config behaves exactly as before; `none` declares this box has
+        // no local authority (the mirror is fed from elsewhere) and the
+        // checker does not run a comparison it knows is against the wrong
+        // RIB.
+        let integrity_authority = cfg
+            .section
+            .directives
+            .iter()
+            .find_map(|d| match d {
+                ModuleDirective::IntegrityAuthority(spec) => Some(spec.clone()),
+                _ => None,
+            })
+            .unwrap_or(packetframe_common::config::IntegrityAuthoritySpec::Birdc { path: None });
         // v0.2.1: collect operator-declared `local-prefix` directives
         // and pass them to the controller. Empty list = feature off
         // (back-compat with v0.2.0 configs that never had this).
@@ -1632,7 +1647,10 @@ pub fn attach(
         };
         let ctrl = crate::fib::controller::RouteController::start(
             &state.bpffs_root,
-            route_source,
+            crate::fib::controller::RouteFeed {
+                source: route_source,
+                integrity_authority,
+            },
             local_prefixes,
             fallback_default,
             fdb_pin_chains,

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -30,6 +30,52 @@ use crate::linux_impl::{
 };
 use crate::MODULE_NAME;
 
+/// Refuse a reload that changes `integrity-authority`, by name.
+///
+/// The directive is consumed once, when `attach` builds the
+/// `RouteController` and decides whether to spawn a checker and with
+/// which `birdc`. Nothing here can move that decision under a running
+/// controller: the checker is a spawned task holding its own config.
+/// So a reload that edits it would return OK while the daemon kept
+/// comparing against the old authority — the false drift alarm
+/// persisting after the operator "fixed" it, or attestation staying
+/// off after they turned it back on (review finding).
+///
+/// Refusing rather than reconciling, and the choice is the same one
+/// `VppOffloadConfig::restart_only_delta` makes for
+/// `require-table-complete`: a directive an operator edits *because a
+/// health line told them to* must not silently do nothing, and the two
+/// cases interact — `integrity-authority none` is exactly what the
+/// mismatch remedy recommends. Wiring a live swap would mean stopping a
+/// checker task, rebuilding it, and deciding what happens to the
+/// completeness handle a second tier may be mid-deferral on; that is a
+/// release-semantics change, not a reload.
+///
+/// Only when a controller exists. In `kernel-fib` mode nothing consumes
+/// the directive, so there is no divergence to refuse — and reaching
+/// custom-fib from there is itself a restart.
+fn refuse_integrity_authority_change(
+    state: &ActiveState,
+    cfg: &ModuleConfig<'_>,
+) -> ModuleResult<()> {
+    if state.route_controller.is_none() {
+        return Ok(());
+    }
+    let wanted = crate::linux_impl::integrity_authority_from_cfg(cfg);
+    state
+        .integrity_authority
+        .restart_only_delta(&wanted)
+        .map_err(|why| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!(
+                    "{why}. Refused by name rather than accepted and ignored, because this \
+                     is the directive the authority-mismatch remedy tells operators to edit"
+                ),
+            )
+        })
+}
+
 /// Per-map count of entries added and removed during reconcile.
 #[derive(Default, Debug)]
 pub struct DeltaCount {
@@ -38,6 +84,7 @@ pub struct DeltaCount {
 }
 
 pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+    refuse_integrity_authority_change(state, cfg)?;
     reconcile_cfg(state, cfg)?;
     let v4 = reconcile_allow_v4(state, cfg)?;
     let v6 = reconcile_allow_v6(state, cfg)?;

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1186,12 +1186,20 @@ carrying that traffic; VPP still is.
   | --- | --- |
   | `would permit a steer` | Agreement. Proceed. |
   | `no comparison has completed yet` | The checker has not reached its first interval, or has only just started. **Not agreement** — wait 300 s and read it again. |
-  | `REFUSES: the route mirror holds N of the authority's M routes` | The mirror is short — usually still loading. |
-  | `REFUSES: ... that is not the authority feeding this mirror` | The 23 h deferral above: bird up, carrying a table that is not this one. |
-  | `REFUSES: completeness is unknown: the authority reports zero routes` | The degenerate form of the same thing — bird answering, and answering nothing. |
-  | `REFUSES: the last completeness check was Ns ago, too old to act on` | Aged past the 900 s window. Comparisons have stopped landing; with no error beside it, they are not being attempted. |
+  | `no integrity authority on this box (integrity-authority none)` | The operator declared this box is fed from elsewhere, so nothing local attests the mirror. Informational, **not** a pass and **not** an alarm — a steering gate treats the mirror as unattested, which is only valid with `require-table-complete off`. This is the shadow's correct state. |
+  | `would refuse: the route mirror holds N of the authority's M routes` | The mirror is short — usually still loading. |
+  | `... mismatch, not a drift ... would refuse: ... that is not the authority feeding this mirror` | Bird up, carrying a table that is not this one — the 23 h deferral above. If this box is *meant* to be fed from elsewhere, set `integrity-authority none` and it becomes the informational row above rather than a false alarm. |
+  | `would refuse: completeness is unknown: the authority reports zero routes` | The degenerate form of the same thing — bird answering, and answering nothing. |
+  | `would refuse: the last completeness check was Ns ago, too old to act on` | Aged past the 900 s window. Comparisons have stopped landing; with no error beside it, they are not being attempted. |
   | `could not complete: <error>` with `HISTORY` | `birdc` or the mirror read is failing. Any numbers shown are the previous comparison, ageing. |
   | no `fib-integrity` row at all | Nothing is checking on this box — kernel-fib mode, or a control plane with no route source. The authority will read `Absent`. |
+
+  > The verdict is **subjunctive** — "would permit" / "would refuse" —
+  > because it predicts what a steer would do from this comparison, not
+  > something that has happened. On a `require-table-complete off` box no
+  > gate consults it at all; the row still tells you what one *would*
+  > decide, which is exactly the pre-flight signal you want before
+  > turning the gate on.
 
   The row appears whenever a checker exists, *including before its
   first comparison*, and that is the distinction the check turns on:


### PR DESCRIPTION
Found on the shadow during the latest-build re-verify (the four merged task PRs). The new `fib-integrity` row rendered three things wrong, all rooted in one assumption: **that a local `birdc` is always the authority for the mirror.**

## The problem

The checker compares packetframe’s FIB mirror against an authority and calls the difference "drift". The only authority it ever knew was a local `birdc`, hardcoded. That is right where the box’s own bird feeds the mirror — the fleet, the primary — and wrong where the feed comes from elsewhere. The shadow is the second kind: its route source is the **primary’s** bird dialing in over TCP.

So on the shadow, right now:

```
fast-path: DEGRADED
  fib-integrity  DEGRADED — bird 19 prefixes, mirror 1303184 — drift 6858763.158%,
                 ... A steering gate reads this same comparison and REFUSES: ...
```

Three things wrong there, each provable:
1. **`REFUSES` is counterfactual.** The shadow runs `require-table-complete off`, so no steering gate consults the comparison — we proved it hours ago: the canary ladder installed 4 rules under this exact 19-vs-1.3M bird.
2. **`fast-path: DEGRADED` permanently**, on a box deliberately fed from elsewhere — which would make every overnight soak start from a not-healthy baseline and break "did anything break?".
3. **`drift 6858763.158%`** — a figure the domain code (`Completeness::AuthorityMismatch`) explicitly decided not to print.

Once you admit the feed could be FRR, GoBGP, a route server, or a bird on another box, local `birdc` stops being *the* authority and becomes *one possible* authority, currently wired in as a silent default.

## The fix

The authority is now a declared deployment fact:

```
integrity-authority birdc [path]   # default; local bird is the authority
integrity-authority none           # fed from elsewhere — do not compare
```

- **Absent ⇒ `Birdc` default**, so every existing config behaves unchanged — the fleet and the primary are untouched.
- Deliberately **not** inferred from the route-source address (loopback-vs-remote). That is the same correlation-for-fact substitution that produced the bug; the operator knows which daemon feeds the box, so they state it.
- **`none`** runs no comparison, publishes nothing to the second tier (the mirror is unattested — the already-designed path), and renders a `NoAuthority` row: Healthy, informational, self-explaining so it is not read as a broken checker.
- **`require-table-complete on` + `integrity-authority none` is refused at load** — no authority to require means the first steer would defer forever.

Rendering fixes that rode along (each wrong on the shadow’s output today):
- verdict is **subjunctive** — "would refuse" / "would permit" — a prediction, not "REFUSES" which reads as an action that never happened;
- a gross mismatch **states itself** instead of leading with the 6.8-million-percent figure;
- still separated from the drift-catch diagnostic, which keeps its own configurable threshold.

Enum left open (not shimmed) for the two roadmap authorities that need no external process and work with any BGP daemon: **feed accounting** (listener’s own live-prefix count) and **BMP stats reports** (RFC 7854 Loc-RIB in-band).

## Testing

810 workspace tests (was 806; +4 new: `no_authority_is_healthy_and_explains_itself`, `a_gross_mismatch_does_not_print_a_nonsense_percentage`, `integrity_authority_parses`, `require_table_complete_needs_an_authority`; existing wording assertions updated). Clippy clean on host **and** cross targets — the `too_many_arguments` on `start()` was visible only to cross-clippy (the file is `cfg(target_os = "linux")`), fixed by pairing source+authority in a `RouteFeed` struct.

Once merged, the shadow gains `integrity-authority none` and its `fib-integrity` row becomes the informational "not attested here" line instead of a false alarm; the primary gains nothing (default correct) and the pre-flight check stays "read the row, look for would permit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)