### PR TITLE
fix(vpp-offload): first-primary-attach incident — silent kills, orphaned birdc, unchecked IRQ overlap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1057,6 +1057,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,9 +63,13 @@ aya-build = "=0.1.3"
 # feature set needed by NeighborResolver + RouteController: async TCP
 # for BMP (Phase 3), netlink I/O for neighbor events, bounded mpsc
 # channels between subsystems, cooperative shutdown. `full` pulls in
-# tokio-fs and process machinery we don't need; keeping this lean keeps
-# build times and binary size reasonable on cross targets.
-tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "net", "sync", "time", "macros", "io-util"] }
+# tokio-fs and machinery we don't need; keeping this lean keeps
+# build times and binary size reasonable on cross targets. `process`
+# earned its place the hard way: the integrity checker's birdc was
+# std::process inside spawn_blocking, so a timed-out call orphaned the
+# child (systemd SIGKILLed one at daemon stop, primary 2026-08-13) —
+# tokio::process + kill_on_drop is the fix, and it needs the feature.
+tokio = { version = "1.52", default-features = false, features = ["rt-multi-thread", "net", "sync", "time", "macros", "io-util", "process"] }
 tokio-util = { version = "0.7", default-features = false }
 # rtnetlink is our async netlink client for RTM_NEWNEIGH / RTM_DELNEIGH
 # and link-state events. It layers on netlink-packet-route which we also

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -52,6 +52,25 @@ pub fn vpp_ports_from_config(config: &Config) -> Vec<String> {
     ports
 }
 
+/// Total VPP workers the config asks for — the sum of every `port`
+/// line's `cores`. The IRQ-affinity probe needs it to derive the same
+/// core map attach would, so the probe and the attach refusal cannot
+/// disagree about which CPUs are at stake.
+pub fn vpp_workers_from_config(config: &Config) -> u32 {
+    let mut workers = 0u32;
+    for m in &config.modules {
+        if m.name != "vpp-offload" {
+            continue;
+        }
+        for d in &m.directives {
+            if let ModuleDirective::VppPort { cores, .. } = d {
+                workers += u32::from(*cores);
+            }
+        }
+    }
+    workers
+}
+
 /// The fast-path allowlist, as the steering probe needs it.
 ///
 /// It comes from the **fast-path** section, not vpp-offload's: steered
@@ -99,6 +118,7 @@ pub fn probe_and_render(
     bpffs_root: &Path,
     attach_ifaces: &[String],
     vpp_ports: &[String],
+    vpp_workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[IpPrefix],
     human: bool,
@@ -126,13 +146,17 @@ pub fn probe_and_render(
     // the module's attach enforces.
     #[cfg(feature = "vpp-offload")]
     if !vpp_ports.is_empty() {
-        for cap in packetframe_vpp_offload::run_feasibility_probes(vpp_ports, vpp_binary, allowlist)
-        {
+        for cap in packetframe_vpp_offload::run_feasibility_probes(
+            vpp_ports,
+            vpp_workers,
+            vpp_binary,
+            allowlist,
+        ) {
             report.capabilities.push(cap);
         }
     }
     #[cfg(not(feature = "vpp-offload"))]
-    let _ = (vpp_ports, vpp_binary, allowlist);
+    let _ = (vpp_ports, vpp_workers, vpp_binary, allowlist);
     // `passed` needs recomputing after the iface probes; the trial
     // attach caps are non-required (a native-XDP failure shouldn't
     // abort startup), but we preserve the existing `passed` logic.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -352,7 +352,7 @@ fn main() -> ExitCode {
 }
 
 fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
-    let (bpffs_root, attach_ifaces, vpp_ports, vpp_binary, allowlist) = match &config {
+    let (bpffs_root, attach_ifaces, vpp_ports, vpp_workers, vpp_binary, allowlist) = match &config {
         Some(path) => match Config::from_file(path) {
             Ok(c) => {
                 if let Err(e) = c.validate_interfaces() {
@@ -365,12 +365,14 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                 }
                 let ifaces = feasibility::attach_ifaces_from_config(&c);
                 let vpp_ports = feasibility::vpp_ports_from_config(&c);
+                let vpp_workers = feasibility::vpp_workers_from_config(&c);
                 let vpp_binary = feasibility::vpp_binary_from_config(&c);
                 let allowlist = feasibility::allowlist_from_config(&c);
                 (
                     c.global.bpffs_root,
                     ifaces,
                     vpp_ports,
+                    vpp_workers,
                     vpp_binary,
                     allowlist,
                 )
@@ -384,6 +386,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             std::path::PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
             Vec::new(),
             Vec::new(),
+            0,
             None,
             Vec::new(),
         ),
@@ -393,6 +396,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
         &bpffs_root,
         &attach_ifaces,
         &vpp_ports,
+        vpp_workers,
         vpp_binary.as_deref(),
         &allowlist,
         human,

--- a/crates/modules/fast-path/src/fib/integrity.rs
+++ b/crates/modules/fast-path/src/fib/integrity.rs
@@ -21,7 +21,6 @@
 #![cfg(target_os = "linux")]
 
 use std::path::PathBuf;
-use std::process::Command;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -419,18 +418,26 @@ async fn run_birdc_protocols(birdc: &std::path::Path) -> Result<usize, String> {
 const BIRDC_OUTPUT_CAP: usize = 1024 * 1024;
 
 async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, String> {
-    let birdc = birdc.to_path_buf();
-    let args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
     let args_display = format!("{args:?}");
-    let join = tokio::task::spawn_blocking(move || -> Result<BirdcOutput, String> {
-        // `Read` is in scope inside `read_capped` via its `R: Read`
-        // bound, no need to pull it in here.
+    // `tokio::process`, NOT `std::process` in `spawn_blocking`. The
+    // first shape put the timeout around the JoinHandle — but a blocking
+    // task cannot be cancelled, so a timeout dropped the handle and
+    // walked away from BOTH the parked thread and the child process. A
+    // bird slow enough to blow the 10s budget (observed on the primary
+    // 2026-08-13, under IRQ-contention load) left a birdc orphan that
+    // outlived the check, blocked daemon shutdown past systemd's
+    // stop-sigterm window, and got SIGKILLed by systemd alongside the
+    // daemon. `kill_on_drop` makes the timeout MEAN something: dropping
+    // this future — timeout, checker shutdown, daemon exit — kills the
+    // child.
+    let fut = async {
         use std::process::Stdio;
-        let mut child = Command::new(&birdc)
-            .args(&args)
+        let mut child = tokio::process::Command::new(birdc)
+            .args(args)
             .stdin(Stdio::null())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
+            .kill_on_drop(true)
             .spawn()
             .map_err(|e| format!("spawn {}: {e}", birdc.display()))?;
         // SAFETY: `stdout`/`stderr` are Some because we configured
@@ -441,21 +448,21 @@ async fn run_birdc(birdc: &std::path::Path, args: &[&str]) -> Result<String, Str
         let mut stderr = child.stderr.take().expect("piped stderr");
         let mut stdout_buf = Vec::with_capacity(4096);
         let mut stderr_buf = Vec::with_capacity(1024);
-        let stdout_truncated = read_capped(&mut stdout, &mut stdout_buf, BIRDC_OUTPUT_CAP)
+        let stdout_truncated = read_capped_async(&mut stdout, &mut stdout_buf, BIRDC_OUTPUT_CAP)
+            .await
             .map_err(|e| format!("read birdc stdout: {e}"))?;
-        let _ = read_capped(&mut stderr, &mut stderr_buf, BIRDC_OUTPUT_CAP);
-        let status = child.wait().map_err(|e| format!("birdc wait: {e}"))?;
-        Ok(BirdcOutput {
+        let _ = read_capped_async(&mut stderr, &mut stderr_buf, BIRDC_OUTPUT_CAP).await;
+        let status = child.wait().await.map_err(|e| format!("birdc wait: {e}"))?;
+        Ok::<BirdcOutput, String>(BirdcOutput {
             status,
             stdout: stdout_buf,
             stderr: stderr_buf,
             stdout_truncated,
         })
-    });
-    let result = tokio::time::timeout(BIRDC_TIMEOUT, join)
+    };
+    let result = tokio::time::timeout(BIRDC_TIMEOUT, fut)
         .await
-        .map_err(|_| format!("birdc {args_display} exceeded {BIRDC_TIMEOUT:?}"))?
-        .map_err(|e| format!("birdc task join: {e}"))??;
+        .map_err(|_| format!("birdc {args_display} exceeded {BIRDC_TIMEOUT:?} (child killed)"))??;
     if !result.status.success() {
         return Err(format!(
             "birdc exit {}: stderr={}",
@@ -483,14 +490,20 @@ struct BirdcOutput {
 /// Read from `r` into `buf` up to `cap` bytes. Returns true when the
 /// reader had more data than the cap (the caller surfaces this as a
 /// hard error rather than parsing a runaway stream).
-fn read_capped<R: std::io::Read>(
+///
+/// Async twin of the original sync helper (replaced when `run_birdc`
+/// moved to `tokio::process` so a timed-out child gets killed instead
+/// of orphaned). Semantics preserved, including draining past the cap
+/// so the child's write end never blocks on a full pipe buffer.
+async fn read_capped_async<R: tokio::io::AsyncRead + Unpin>(
     r: &mut R,
     buf: &mut Vec<u8>,
     cap: usize,
 ) -> std::io::Result<bool> {
+    use tokio::io::AsyncReadExt;
     let mut chunk = [0u8; 4096];
     loop {
-        let n = match r.read(&mut chunk) {
+        let n = match r.read(&mut chunk).await {
             Ok(0) => return Ok(false),
             Ok(n) => n,
             Err(ref e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
@@ -502,7 +515,7 @@ fn read_capped<R: std::io::Read>(
             // Drain the rest of the reader so the child's write end
             // doesn't block on a full pipe buffer once we return.
             let mut sink = [0u8; 4096];
-            while r.read(&mut sink).unwrap_or(0) > 0 {}
+            while r.read(&mut sink).await.unwrap_or(0) > 0 {}
             return Ok(true);
         }
         buf.extend_from_slice(&chunk[..n]);

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -73,6 +73,8 @@ pub struct AttachPaths {
     pub sys: SysPaths,
     /// `/sys/devices/system/cpu`, for the worker placement.
     pub sysfs_cpu: PathBuf,
+    /// `/proc/irq`, for the NIC-IRQ/worker-core overlap check.
+    pub proc_irq: PathBuf,
     pub api_socket: PathBuf,
     pub startup_conf: PathBuf,
 }
@@ -82,6 +84,7 @@ impl AttachPaths {
         Self {
             sys: SysPaths::live(state_dir, hugepage_bytes),
             sysfs_cpu: PathBuf::from(cores::SYSFS_CPU),
+            proc_irq: PathBuf::from("/proc/irq"),
             api_socket: PathBuf::from(API_SOCKET),
             startup_conf: PathBuf::from(STARTUP_CONF),
         }
@@ -264,6 +267,44 @@ pub fn bring_up(
     let workers = cfg.total_workers();
     let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
     let core_map = cores::derive_from_sysfs(&paths.sysfs_cpu, workers)?;
+
+    // NIC queue IRQs must not fire on the cores VPP is about to burn.
+    // This used to be an advice line in the attach log ("move PF IRQ
+    // affinity off the worker cores") — printed and unenforced on the
+    // first primary attach (2026-08-13), where six poll-mode workers
+    // landed on CPUs carrying production rx-queue IRQs: load ~10,
+    // management ssh dropped, birdc past its budget, and VPP itself
+    // starved into a supervisor restart loop. Still pure/read-only —
+    // a refused config must cost no sysfs writes.
+    let member_ifaces: Vec<String> = cfg.ports.iter().map(|(i, _, _)| i.clone()).collect();
+    let mut vpp_cores = vec![core_map.main];
+    vpp_cores.extend(&core_map.workers);
+    let conflicts = cores::nic_irq_conflicts(
+        &paths.sys.sysfs_net,
+        &paths.proc_irq,
+        &member_ifaces,
+        &vpp_cores,
+    )?;
+    if !conflicts.is_empty() {
+        let sample: Vec<String> = conflicts
+            .iter()
+            .take(8)
+            .map(|c| format!("{} irq {} -> cpu {:?}", c.iface, c.irq, c.cpus))
+            .collect();
+        return Err(format!(
+            "{} NIC queue IRQ(s) currently fire on the cores derived for VPP (main {}, \
+             workers {:?}): {}{}. Six hot pollers sharing CPUs with production rx-queue \
+             IRQs is how the first primary attach starved the box into a restart loop. \
+             Move these IRQs off the VPP cores first — for each: \
+             `echo <cpu-list outside the VPP cores> > /proc/irq/<N>/smp_affinity_list` — \
+             then re-attach (docs/runbooks/vpp-offload.md, \"IRQ affinity before attach\")",
+            conflicts.len(),
+            core_map.main,
+            core_map.workers,
+            sample.join(", "),
+            if conflicts.len() > 8 { ", ..." } else { "" },
+        ));
+    }
 
     let hugepage_bytes = paths.sys.hugepage_bytes;
     if hugepage_bytes == 0 {

--- a/crates/modules/vpp-offload/src/cores.rs
+++ b/crates/modules/vpp-offload/src/cores.rs
@@ -668,9 +668,156 @@ mod affinity_tests {
     }
 }
 
+/// A NIC queue interrupt that currently fires on a CPU VPP is about to
+/// occupy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IrqConflict {
+    pub iface: String,
+    pub irq: u32,
+    /// The overlapping CPUs — the intersection of the IRQ's effective
+    /// affinity with VPP's derived cores.
+    pub cpus: Vec<u16>,
+}
+
+/// Every NIC queue IRQ of `ifaces` whose *effective* affinity lands on
+/// one of `vpp_cores`.
+///
+/// This is the module-doc's "operator action" (move the PF IRQs off the
+/// derived worker set) turned into a checkable precondition. The first
+/// primary attach (2026-08-13) ran without it: NIC queue IRQs were
+/// pinned one-per-core across all 18 CPUs, six poll-mode workers landed
+/// on seven of them, and production softirq fought the pollers — load
+/// 10, management ssh dropped, birdc past its budget, and VPP itself
+/// starved into a supervisor restart loop. The attach log's advice line
+/// was printed and nothing enforced it.
+///
+/// `effective_affinity_list` rather than `smp_affinity_list`, because
+/// the question is where the IRQ **fires today**, not where it is
+/// permitted to fire: a 0-17 wildcard mask still delivers to exactly
+/// one CPU, and that CPU either is or is not about to become a hot
+/// poller. Falls back to `smp_affinity_list` on kernels that don't
+/// expose the effective file.
+///
+/// A port without an `msi_irqs` directory contributes nothing — that is
+/// the fixture-sysfs case and any non-MSI device, where there is no
+/// queue IRQ to conflict with. Unreadable affinity files skip the one
+/// IRQ (it may have been freed between the listing and the read);
+/// unreadable directories fail loudly.
+pub fn nic_irq_conflicts(
+    sysfs_net: &std::path::Path,
+    proc_irq: &std::path::Path,
+    ifaces: &[String],
+    vpp_cores: &[u16],
+) -> Result<Vec<IrqConflict>, String> {
+    let mut conflicts = Vec::new();
+    for iface in ifaces {
+        let dir = sysfs_net.join(iface).join("device").join("msi_irqs");
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("read {}: {e}", dir.display())),
+        };
+        let mut irqs: Vec<u32> = entries
+            .filter_map(|e| e.ok())
+            .filter_map(|e| e.file_name().to_str().and_then(|s| s.parse().ok()))
+            .collect();
+        irqs.sort_unstable();
+        for irq in irqs {
+            let eff = proc_irq
+                .join(irq.to_string())
+                .join("effective_affinity_list");
+            let raw = match std::fs::read_to_string(&eff) {
+                Ok(s) => s,
+                Err(_) => {
+                    let smp = proc_irq.join(irq.to_string()).join("smp_affinity_list");
+                    match std::fs::read_to_string(&smp) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    }
+                }
+            };
+            let cpus = match parse_cpu_list(raw.trim()) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+            let overlap: Vec<u16> = cpus.into_iter().filter(|c| vpp_cores.contains(c)).collect();
+            if !overlap.is_empty() {
+                conflicts.push(IrqConflict {
+                    iface: iface.clone(),
+                    irq,
+                    cpus: overlap,
+                });
+            }
+        }
+    }
+    Ok(conflicts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Fixture for the IRQ-overlap check: a sysfs-net with msi_irqs
+    /// entries and a proc-irq with affinity files, in a throwaway dir.
+    fn irq_fixture(tag: &str, irqs: &[(u32, &str)]) -> (std::path::PathBuf, std::path::PathBuf) {
+        let mut base = std::env::temp_dir();
+        base.push(format!("pf-irq-{tag}-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let net = base.join("net");
+        let proc_irq = base.join("proc_irq");
+        let msi = net.join("eth9").join("device").join("msi_irqs");
+        std::fs::create_dir_all(&msi).unwrap();
+        for (irq, aff) in irqs {
+            std::fs::write(msi.join(irq.to_string()), "").unwrap();
+            let d = proc_irq.join(irq.to_string());
+            std::fs::create_dir_all(&d).unwrap();
+            std::fs::write(d.join("effective_affinity_list"), format!("{aff}\n")).unwrap();
+        }
+        (net, proc_irq)
+    }
+
+    /// The incident shape (primary, 2026-08-13): queue IRQs pinned
+    /// one-per-core, some landing exactly on the derived VPP cores.
+    /// Those — and only those — are conflicts.
+    #[test]
+    fn irq_on_a_vpp_core_is_a_conflict_and_others_are_not() {
+        let (net, proc_irq) = irq_fixture("overlap", &[(270, "11"), (261, "2"), (275, "16")]);
+        let got = nic_irq_conflicts(&net, &proc_irq, &["eth9".into()], &[10, 11, 16]).unwrap();
+        assert_eq!(
+            got,
+            vec![
+                IrqConflict {
+                    iface: "eth9".into(),
+                    irq: 270,
+                    cpus: vec![11]
+                },
+                IrqConflict {
+                    iface: "eth9".into(),
+                    irq: 275,
+                    cpus: vec![16]
+                },
+            ]
+        );
+    }
+
+    /// A wildcard mask whose EFFECTIVE affinity is off the VPP cores is
+    /// not a conflict — the check asks where the IRQ fires, not where
+    /// it is permitted to.
+    #[test]
+    fn effective_affinity_decides_not_the_permitted_mask() {
+        let (net, proc_irq) = irq_fixture("effective", &[(300, "0")]);
+        let got = nic_irq_conflicts(&net, &proc_irq, &["eth9".into()], &[10, 11]).unwrap();
+        assert!(got.is_empty(), "{got:?}");
+    }
+
+    /// A port with no msi_irqs directory (fixture sysfs, non-MSI
+    /// device) contributes nothing rather than failing the attach.
+    #[test]
+    fn a_port_without_msi_irqs_is_skipped() {
+        let (net, proc_irq) = irq_fixture("absent", &[]);
+        let got = nic_irq_conflicts(&net, &proc_irq, &["eth-nonexistent".into()], &[1, 2]).unwrap();
+        assert!(got.is_empty());
+    }
 
     /// The reference fleet: 18 cores, `isolcpus=12` owned by
     /// unifi-core, four member ports at one worker each.

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -607,7 +607,27 @@ impl Driver {
             }
             let mut next = Vec::new();
             for e in queue.drain(..) {
+                let prior = self.sup.state();
                 let actions = self.sup.on(e.clone());
+                // A kill order names its cause, in the journal, at the
+                // moment it is given. The supervisor SIGTERMed VPP eight
+                // times during the first primary attach (2026-08-13) and
+                // the journal carried only VPP's "received SIGTERM" —
+                // the daemon side said nothing, so the loop had to be
+                // diagnosed from process lifetimes. The event here IS
+                // the reason; pairing it with the transition makes every
+                // teardown self-explaining.
+                if actions
+                    .iter()
+                    .any(|a| matches!(a, crate::supervisor::Action::Kill))
+                {
+                    tracing::warn!(
+                        event = ?e,
+                        from_state = ?prior,
+                        to_state = ?self.sup.state(),
+                        "supervisor ordered VPP teardown — the event is the cause"
+                    );
+                }
                 applied.push(e);
                 // Re-arm from the supervisor's own view after EVERY
                 // transition, including ones with no budget — arming

--- a/crates/modules/vpp-offload/src/executor.rs
+++ b/crates/modules/vpp-offload/src/executor.rs
@@ -288,6 +288,16 @@ pub fn execute(actions: &[Action], fx: &mut dyn Effects) -> Outcome {
             }
         }
     }
+    // Every failure goes to the JOURNAL, not only to the status
+    // snapshot. `last_failures` carries these on `packetframe status`,
+    // but a snapshot dies with the daemon — the first primary attach
+    // (2026-08-13) restart-looped through eight teardowns whose reasons
+    // existed only in status rows nobody captured, and the post-mortem
+    // had to be reconstructed from the VPP side of the conversation.
+    // The journal is the record that survives.
+    for (action, why) in &out.failures {
+        tracing::warn!(action = ?action, error = %why, "supervised action failed");
+    }
     out
 }
 

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1157,16 +1157,17 @@ impl Module for VppOffloadModule {
 /// non-required: feasibility output informs, attach enforces.
 pub fn run_feasibility_probes(
     ports: &[String],
+    workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
 ) -> Vec<Capability> {
     #[cfg(target_os = "linux")]
     {
-        probe_linux::run(ports, vpp_binary, allowlist)
+        probe_linux::run(ports, workers, vpp_binary, allowlist)
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (ports, vpp_binary, allowlist);
+        let _ = (ports, workers, vpp_binary, allowlist);
         Vec::new()
     }
 }

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -13,13 +13,15 @@ use packetframe_common::probe::Capability;
 
 pub(crate) fn run(
     ports: &[String],
+    workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
 ) -> Vec<Capability> {
-    let mut caps = Vec::with_capacity(4 + ports.len());
+    let mut caps = Vec::with_capacity(5 + ports.len());
     caps.push(probe_iommu());
     caps.push(probe_vfio());
     caps.push(probe_hugepages());
+    caps.push(probe_irq_affinity(ports, workers));
     // Probe the binary the module will ACTUALLY exec. Probing the
     // defaults while the config names another path would report a pass
     // for an executable we never run (or a failure for one that
@@ -31,6 +33,62 @@ pub(crate) fn run(
     }
     caps.push(probe_steering_budget(ports, allowlist));
     caps
+}
+
+/// Do any NIC queue IRQs currently fire on the cores VPP would burn?
+///
+/// The probe that was missing before the first primary attach
+/// (2026-08-13): feasibility passed, and then six poll-mode workers
+/// landed on CPUs carrying production rx-queue IRQs — the exact overlap
+/// this reads off `/proc/irq` in seconds. Attach enforces the same
+/// check (`cores::nic_irq_conflicts`); this surfaces it before a
+/// maintenance window instead of during one.
+fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
+    use std::path::Path;
+    let name = "vpp.irq-affinity";
+    let map = match crate::cores::derive_from_sysfs(Path::new(crate::cores::SYSFS_CPU), workers) {
+        Ok(m) => m,
+        Err(e) => return Capability::unknown(name, format!("derive core map: {e}"), false),
+    };
+    let mut vpp_cores = vec![map.main];
+    vpp_cores.extend(&map.workers);
+    match crate::cores::nic_irq_conflicts(
+        Path::new("/sys/class/net"),
+        Path::new("/proc/irq"),
+        ports,
+        &vpp_cores,
+    ) {
+        Ok(c) if c.is_empty() => Capability::pass(
+            name,
+            format!(
+                "no NIC queue IRQ fires on the derived VPP cores (main {}, workers {:?})",
+                map.main, map.workers
+            ),
+            false,
+        ),
+        Ok(c) => {
+            let sample: Vec<String> = c
+                .iter()
+                .take(8)
+                .map(|x| format!("{} irq {} -> cpu {:?}", x.iface, x.irq, x.cpus))
+                .collect();
+            Capability::fail(
+                name,
+                format!(
+                    "{} NIC queue IRQ(s) fire on the derived VPP cores (main {}, workers \
+                     {:?}): {}{} — attach will refuse; move them first: `echo <cpu-list \
+                     outside the VPP cores> > /proc/irq/<N>/smp_affinity_list`",
+                    c.len(),
+                    map.main,
+                    map.workers,
+                    sample.join(", "),
+                    if c.len() > 8 { ", ..." } else { "" },
+                ),
+                false,
+            )
+        }
+        Err(e) => Capability::unknown(name, e, false),
+    }
 }
 
 /// Can the configured allowlist actually be steered?

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -142,6 +142,11 @@ impl Host {
                     state_dir: base.join("state"),
                 },
                 sysfs_cpu: cpu,
+                // No entries: the fixture's ports have no msi_irqs
+                // directory either, so the IRQ-overlap check has
+                // nothing to inspect and passes — tests that WANT a
+                // conflict populate both sides (cores.rs unit tests).
+                proc_irq: base.join("proc_irq"),
                 api_socket,
                 startup_conf: base.join("startup.conf"),
             },
@@ -389,6 +394,65 @@ fn a_config_that_cannot_work_touches_nothing() {
     assert!(
         !host.paths.startup_conf.exists(),
         "a refused attach rendered a startup.conf"
+    );
+}
+
+/// The incident gate (primary, 2026-08-13): a NIC queue IRQ whose
+/// effective affinity lands on a derived VPP core refuses the attach —
+/// six hot pollers sharing CPUs with production rx-queue IRQs starved
+/// the box AND the VPP into a supervisor restart loop, and the only
+/// guard was an advice line in the attach log. Refusal happens in the
+/// pure phase: nothing may have been acquired.
+#[test]
+fn an_irq_on_a_vpp_core_refuses_the_attach() {
+    let fake = fake_vpp::Fake::start("bringup-irq");
+    let host = Host::new("irq", &[("eth4", "0002:07:00.0")], fake.path.clone());
+
+    // The fixture host: 18 online, cpu12 isolated ⇒ one worker lands
+    // on 17 (main on 16). Pin a queue IRQ of the member port there.
+    let msi = host
+        .paths
+        .sys
+        .sysfs_net
+        .join("eth4")
+        .join("device")
+        .join("msi_irqs");
+    fs::create_dir_all(&msi).unwrap();
+    fs::write(msi.join("270"), "").unwrap();
+    let d = host.paths.proc_irq.join("270");
+    fs::create_dir_all(&d).unwrap();
+    fs::write(d.join("effective_affinity_list"), "17\n").unwrap();
+
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+    let e = bring_up(
+        &cfg,
+        &host.paths,
+        Box::new(Mirror),
+        &ALLOW,
+        None,
+        None,
+        &McamBudget::default(),
+    )
+    .err()
+    .expect("must fail");
+    assert!(e.contains("NIC queue IRQ"), "{e}");
+    assert!(e.contains("irq 270"), "the refusal must name the IRQ: {e}");
+
+    // Pure-phase refusal: no VF, no reservation, no record.
+    assert!(host.state().is_none(), "a refused attach left a state file");
+    assert_eq!(
+        fs::read_to_string(
+            host.paths
+                .sys
+                .sysfs_net
+                .join("eth4")
+                .join("device")
+                .join("sriov_numvfs")
+        )
+        .unwrap()
+        .trim(),
+        "0",
+        "a refused attach created a VF"
     );
 }
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -56,6 +56,7 @@ running badly.
 - [Triage by symptom](#triage-by-symptom)
 - [Numbers: measured vs published-on-faith](#numbers-measured-vs-published-on-faith)
 - [Install and upgrade on the router](#install-and-upgrade-on-the-router)
+- [IRQ affinity before attach](#irq-affinity-before-attach)
 - [Constraints worth knowing before you debug](#constraints-worth-knowing-before-you-debug)
 
 ## Architecture at a glance
@@ -946,14 +947,29 @@ anything.
 
 ### The offload restarts repeatedly
 
-`packetframe status` carries the reason on the failing subsystem, and it
-is **sticky** — retained across the empty backoff ticks that follow a
-failure, so a slow poll cannot miss it. Read it before touching
-anything; the counter of failures is not the reason.
+**Two places carry the reason; read both.** `packetframe status` holds
+it on the **`last-tick`** row — sticky, retained across the empty
+backoff ticks that follow a failure, so a slow poll cannot miss it. Do
+not grep status for only the subsystem names you expect: the 2026-08-13
+primary incident was diagnosed blind because the status reads filtered
+out exactly this row, and the reason died with the daemon. The
+**journal** now carries it permanently: every teardown logs
+`supervisor ordered VPP teardown` (WARN, with the triggering event and
+the state transition) and every failed step logs
+`supervised action failed` (WARN, with the action and its error) —
+`journalctl -u packetframe | grep -E "teardown|action failed"`
+reconstructs a loop after the fact. The counter of failures is not the
+reason.
 
 If the reason mentions a CRC or version mismatch, supervision has
 *ended* rather than looping: the binary API is permanently incompatible
 and no retry can fix it. The installed VPP is not the pinned one.
+
+If the box itself is degraded while the loop runs — climbing load,
+sluggish ssh, `birdc` timeouts in the fast-path integrity row — check
+NIC queue IRQ affinity against the VPP cores first (see
+[IRQ affinity before attach](#irq-affinity-before-attach)); on builds
+carrying the check, attach refuses this shape before it can start.
 
 ### A steer or unsteer that "cannot be confirmed"
 
@@ -1450,6 +1466,40 @@ adopting one is a deliberate two-repo sequence, and whether it needs a
 new packetframe release is answered by the `generated.rs` diff during
 the re-vendor. The full compatibility model and bump procedure:
 `crates/modules/vpp-offload/vpp-api/README.md`.
+
+## IRQ affinity before attach
+
+VPP workers are poll-mode: each one owns its CPU at 100% duty cycle
+from the moment it spawns. On the reference NIC every CPU carries an
+rx-queue IRQ (18 cores = 18 queues, no idle silicon), so without
+operator action some of those IRQs fire on the cores the module derives
+for VPP — and production softirq then fights hot pollers for the same
+CPUs. The first primary attach (2026-08-13) ran exactly that
+experiment, involuntarily: load ~10, management ssh dropped, `birdc`
+past its 10 s budget, and VPP itself starved into a supervisor restart
+loop. Traffic stayed on the eBPF tier throughout — the fallback design
+held — but the box was degraded until the daemon was stopped.
+
+So the overlap is a **checked precondition**: `packetframe feasibility`
+reports it (`vpp.irq-affinity`, listing each conflicting IRQ and the
+derived cores), and attach **refuses** while any member port's queue
+IRQ has its *effective* affinity on a VPP core. Effective, not
+permitted: a `0-17` wildcard mask still delivers to exactly one CPU,
+and that CPU either is or is not about to become a hot poller.
+
+Remediation, before the maintenance window:
+
+```bash
+# Which cores VPP will take: run feasibility, read vpp.irq-affinity —
+# it names main + workers. Then, for each conflicting IRQ it lists:
+echo <cpu-list outside the VPP cores> > /proc/irq/<N>/smp_affinity_list
+```
+
+Re-run feasibility until `vpp.irq-affinity` passes; then attach. The
+affinity write does not persist across reboot — a box that reboots
+into a VPP config re-runs the refusal, which is the reminder. (udapi
+provision cycles may also rewrite affinities; if attach starts refusing
+on a box that used to pass, that is the first place to look.)
 
 ## Constraints worth knowing before you debug
 


### PR DESCRIPTION
## The incident (2026-08-13, first rung-0 attempt on the primary)

New build, six ports member, all `steer off`. Fast-path came up healthy; vpp-offload entered a VPP restart loop — **8 supervisor-initiated SIGTERMs in ~5 minutes**, box load ~10, the operator's ssh session dropped, `birdc show route count` blew its 10 s budget. The two-tier premise held: fast-path forwarded throughout, steering was never armed, and recovery was `systemctl stop` → restore config → `detach --all`. Confirmed environmental fact (`/proc/irq` readout): NIC queue IRQs are pinned one-per-core across **all 18 CPUs**, including the seven cores derived for VPP's main + six workers.

## Three fixes

**1. Supervision decisions reach the journal.** Eight kills, and the daemon logged no reason for any — the actionable cause lived only in status's sticky `last-tick` row, which died with the daemon (and which the incident's status greps happened to filter out). The driver now WARNs every teardown order with the triggering event + state transition; the executor WARNs every failed action with its error. `journalctl -u packetframe | grep -E "teardown|action failed"` reconstructs a loop after the fact.

**2. A timed-out birdc is killed, not orphaned.** `run_birdc` was `std::process` inside `spawn_blocking` with the timeout on the JoinHandle — a blocking task can't be cancelled, so timeout abandoned both the parked thread and the child. systemd SIGKILLed exactly that orphan (plus the daemon) at stop-sigterm timeout during the incident. Now `tokio::process` + `kill_on_drop(true)`: timeout, checker shutdown, and daemon exit all kill the child. Workspace tokio gains the `process` feature; the lean-features comment says why it earned its place. `read_capped` becomes its async twin, semantics preserved (including draining past the cap).

**3. IRQ/worker-core overlap is a checked precondition.** The attach log said *"move PF IRQ affinity off the worker cores"* — printed, unenforced. Now `cores::nic_irq_conflicts` reads each member port's `msi_irqs` against `/proc/irq/*/effective_affinity_list` (**where the IRQ fires, not where it's permitted to** — a 0-17 wildcard still delivers to one CPU), attach **refuses** on any hit naming each IRQ + the remediation, and feasibility grows a `vpp.irq-affinity` probe running the identical check so the next pre-window read catches it days early. Ports without `msi_irqs` contribute nothing (fixture sysfs, non-MSI devices).

## Runbook

New "IRQ affinity before attach" section (the refusal points at it); the restart-loop triage entry now names the `last-tick` row explicitly and the new journal lines — the incident was diagnosed blind partly because the status greps excluded exactly the row built to answer "why".

## Deliberately not in this PR

The ~6 s kill cadence has two live candidate causes (IRQ-contention starvation vs a deterministic `AttachDevices`/`StartResync` failure — both startup budgets are 60/120 s, so no deadline fired). The logging above is what the **shadow repro** (6-worker bring-up, six member ports incl. carrier-less ones) needs to decide it. No second primary attempt until that run answers.

Tests: 3 unit tests for the conflict function (overlap / effective-vs-permitted / absent-msi_irqs), 1 bringup test asserting the refusal is pure-phase (no VF, no state file), full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)