### PR TITLE
fix(vpp-offload): a dark member is not a wrong FIB — degrade + refuse steering, never restart

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -388,6 +388,25 @@ module fast-path
 #                                 # restart, and reconfigure says so.
 #   hugepages 10                  # >= derived minimum (checked at startup)
 #   # vpp-binary /usr/bin/vpp
+#   # steer-direction both        # default. Which packet side the MCAM
+#                                 # rules match, per allowlisted prefix.
+#                                 # `both` = src AND dst rules (2 slots per
+#                                 # v4 prefix): right for pure transit,
+#                                 # where VPP can forward either direction
+#                                 # of a flow. `src` = outbound only (1
+#                                 # slot per prefix): the service-edge
+#                                 # shape — traffic FROM the service
+#                                 # prefix rides VPP's full-table best
+#                                 # path, while traffic TO it stays on the
+#                                 # eBPF tier, whose FDB-pin handles local
+#                                 # delivery to bridge-attached hosts that
+#                                 # VPP has no path to. dst-steering a
+#                                 # service prefix would divert inbound
+#                                 # flows into a FIB that cannot deliver
+#                                 # them. Hot-reloadable: the target is
+#                                 # rebuilt on every reconfigure and steer
+#                                 # is a reconcile, so a change (including
+#                                 # the rollback) applies as a delta.
 #   # require-table-complete on   # default. A first steer waits until the
 #                                 # route mirror is confirmed converged
 #                                 # against bird, because bird's initial

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -8,7 +8,7 @@ use crate::scrub::scrub_for_terminal;
 use std::path::Path;
 
 use packetframe_common::{
-    config::{Config, ModuleDirective},
+    config::{Config, ModuleDirective, VppSteerDirection},
     fib::IpPrefix,
     probe::{run_iface_probes, run_probes, Capability, CapabilityStatus, FeasibilityReport},
 };
@@ -71,6 +71,21 @@ pub fn vpp_workers_from_config(config: &Config) -> u32 {
     workers
 }
 
+/// The configured steer direction, defaulting like the module does.
+pub fn vpp_steer_direction_from_config(config: &Config) -> VppSteerDirection {
+    for m in &config.modules {
+        if m.name != "vpp-offload" {
+            continue;
+        }
+        for d in &m.directives {
+            if let ModuleDirective::VppSteerDirection(dir) = d {
+                return *dir;
+            }
+        }
+    }
+    VppSteerDirection::default()
+}
+
 /// The fast-path allowlist, as the steering probe needs it.
 ///
 /// It comes from the **fast-path** section, not vpp-offload's: steered
@@ -114,12 +129,19 @@ pub fn vpp_binary_from_config(config: &Config) -> Option<String> {
         })
 }
 
+/// The vpp-offload facts the probes need, grouped so the parameter
+/// list stops growing by one per directive (clippy agrees at eight).
+pub struct VppProbeInputs<'a> {
+    pub ports: &'a [String],
+    pub workers: u32,
+    pub binary: Option<&'a str>,
+    pub steer_direction: VppSteerDirection,
+}
+
 pub fn probe_and_render(
     bpffs_root: &Path,
     attach_ifaces: &[String],
-    vpp_ports: &[String],
-    vpp_workers: u32,
-    vpp_binary: Option<&str>,
+    vpp: &VppProbeInputs<'_>,
     allowlist: &[IpPrefix],
     human: bool,
 ) -> Rendered {
@@ -145,18 +167,19 @@ pub fn probe_and_render(
     // module. Non-required like the perf probes — feasibility informs,
     // the module's attach enforces.
     #[cfg(feature = "vpp-offload")]
-    if !vpp_ports.is_empty() {
+    if !vpp.ports.is_empty() {
         for cap in packetframe_vpp_offload::run_feasibility_probes(
-            vpp_ports,
-            vpp_workers,
-            vpp_binary,
+            vpp.ports,
+            vpp.workers,
+            vpp.binary,
             allowlist,
+            vpp.steer_direction,
         ) {
             report.capabilities.push(cap);
         }
     }
     #[cfg(not(feature = "vpp-offload"))]
-    let _ = (vpp_ports, vpp_workers, vpp_binary, allowlist);
+    let _ = (vpp, allowlist);
     // `passed` needs recomputing after the iface probes; the trial
     // attach caps are non-required (a native-XDP failure shouldn't
     // abort startup), but we preserve the existing `passed` logic.

--- a/crates/cli/src/logging.rs
+++ b/crates/cli/src/logging.rs
@@ -40,9 +40,28 @@ use tracing_subscriber::{reload, EnvFilter, Registry};
 /// takes the whole filter with it — see the module docs on precedence.
 const BGPKIT_NLRI_NOISE: &str = "bgpkit_parser::parser::bgp::messages=error";
 
+/// Second upstream noise source, same treatment. `netlink_proto` emits
+/// `WARN netlink socket buffer full` once per dropped datagram on
+/// ENOBUFS — unbounded and identical: the shadow repro (2026-08-13)
+/// logged 25 copies in a quarter second while six ports came up under
+/// VPP churn. The event it describes is survivable by design: the
+/// neighbour resolver seeds from dumps and the kernel's own ARP
+/// lifecycle re-announces entries as they churn REACHABLE/STALE, so a
+/// dropped notification heals; the resolver's periodic stats line is
+/// the ongoing health signal. One copy would be worth keeping — a copy
+/// per datagram buries the WARNs that matter, which during that repro
+/// included the teardown reasons this build exists to surface.
+///
+/// Re-enable when debugging netlink loss:
+/// `RUST_LOG=info,netlink_proto=warn`.
+const NETLINK_ENOBUFS_NOISE: &str = "netlink_proto=error";
+
 /// The filter spec for a config-supplied level.
 fn spec_for(level: LogLevel) -> String {
-    format!("{},{BGPKIT_NLRI_NOISE}", level.as_str())
+    format!(
+        "{},{BGPKIT_NLRI_NOISE},{NETLINK_ENOBUFS_NOISE}",
+        level.as_str()
+    )
 }
 
 /// Where the live filter came from, which decides whether the config

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -352,52 +352,59 @@ fn main() -> ExitCode {
 }
 
 fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
-    let (bpffs_root, attach_ifaces, vpp_ports, vpp_workers, vpp_binary, allowlist) = match &config {
-        Some(path) => match Config::from_file(path) {
-            Ok(c) => {
-                if let Err(e) = c.validate_interfaces() {
-                    eprintln!("config interface check failed: {e}");
+    let (bpffs_root, attach_ifaces, vpp_ports, vpp_workers, vpp_binary, allowlist, vpp_dir) =
+        match &config {
+            Some(path) => match Config::from_file(path) {
+                Ok(c) => {
+                    if let Err(e) = c.validate_interfaces() {
+                        eprintln!("config interface check failed: {e}");
+                        return ExitCode::from(EXIT_STARTUP_ERROR);
+                    }
+                    if let Err(e) = c.validate_vpp_offload() {
+                        eprintln!("vpp-offload config check failed: {e}");
+                        return ExitCode::from(EXIT_STARTUP_ERROR);
+                    }
+                    let ifaces = feasibility::attach_ifaces_from_config(&c);
+                    let vpp_ports = feasibility::vpp_ports_from_config(&c);
+                    let vpp_workers = feasibility::vpp_workers_from_config(&c);
+                    let vpp_binary = feasibility::vpp_binary_from_config(&c);
+                    let allowlist = feasibility::allowlist_from_config(&c);
+                    let vpp_dir = feasibility::vpp_steer_direction_from_config(&c);
+                    (
+                        c.global.bpffs_root,
+                        ifaces,
+                        vpp_ports,
+                        vpp_workers,
+                        vpp_binary,
+                        allowlist,
+                        vpp_dir,
+                    )
+                }
+                Err(e) => {
+                    eprintln!("config parse error: {e}");
                     return ExitCode::from(EXIT_STARTUP_ERROR);
                 }
-                if let Err(e) = c.validate_vpp_offload() {
-                    eprintln!("vpp-offload config check failed: {e}");
-                    return ExitCode::from(EXIT_STARTUP_ERROR);
-                }
-                let ifaces = feasibility::attach_ifaces_from_config(&c);
-                let vpp_ports = feasibility::vpp_ports_from_config(&c);
-                let vpp_workers = feasibility::vpp_workers_from_config(&c);
-                let vpp_binary = feasibility::vpp_binary_from_config(&c);
-                let allowlist = feasibility::allowlist_from_config(&c);
-                (
-                    c.global.bpffs_root,
-                    ifaces,
-                    vpp_ports,
-                    vpp_workers,
-                    vpp_binary,
-                    allowlist,
-                )
-            }
-            Err(e) => {
-                eprintln!("config parse error: {e}");
-                return ExitCode::from(EXIT_STARTUP_ERROR);
-            }
-        },
-        None => (
-            std::path::PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
-            Vec::new(),
-            Vec::new(),
-            0,
-            None,
-            Vec::new(),
-        ),
-    };
+            },
+            None => (
+                std::path::PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
+                Vec::new(),
+                Vec::new(),
+                0,
+                None,
+                Vec::new(),
+                Default::default(),
+            ),
+        };
 
     let report = feasibility::probe_and_render(
         &bpffs_root,
         &attach_ifaces,
-        &vpp_ports,
-        vpp_workers,
-        vpp_binary.as_deref(),
+        &feasibility::VppProbeInputs {
+            ports: &vpp_ports,
+            workers: vpp_workers,
+            binary: vpp_binary.as_deref(),
+            steer_direction: vpp_dir,
+        },
         &allowlist,
         human,
     );

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -201,6 +201,24 @@ pub enum ModuleDirective {
     /// compare against — the shadow has no bird of its own — and it
     /// means the operator owns the completeness judgement instead.
     VppRequireTableComplete(bool),
+    /// `steer-direction src|dst|both` — which side of the packet the
+    /// MCAM rules match, per allowlisted prefix.
+    ///
+    /// Default `both`, which is right for pure-transit deployments
+    /// where VPP can forward either direction of a flow. `src` is for
+    /// service-edge deployments: outbound traffic (src ∈ the service
+    /// prefix) rides VPP's full-table best path, while inbound
+    /// (dst ∈ prefix) stays on the eBPF tier — because inbound
+    /// terminates on bridge-attached hosts VPP has no path to (local
+    /// delivery is the fast-path FDB-pin's job), and dst-steering it
+    /// would blackhole every service flow. The split-tier flow halves
+    /// are safe under the stateless-transit invariant that steering
+    /// already requires — no different from ECMP asymmetry.
+    ///
+    /// Hot-reloadable: the steering target is rebuilt from config on
+    /// every `packetframe reconfigure`, and `steer` is a reconcile, so
+    /// a direction change installs/removes exactly the delta.
+    VppSteerDirection(VppSteerDirection),
     AllowPrefix4(Ipv4Prefix),
     AllowPrefix6(Ipv6Prefix),
     /// Connected/local prefix the operator wants packetframe to
@@ -621,6 +639,41 @@ pub enum DriverWorkaround {
     /// `Off` disables it entirely (correct once the kernel ships the
     /// upstream commit 04f647c8e456 fix).
     RvuNicpfHeadShift(ToggleAutoOnOff),
+}
+
+/// Which side of the packet MCAM steering rules match. See
+/// [`ModuleDirective::VppSteerDirection`] for the deployment reasoning.
+#[derive(Debug, Clone, Copy, Default, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum VppSteerDirection {
+    Src,
+    Dst,
+    #[default]
+    Both,
+}
+
+impl FromStr for VppSteerDirection {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s {
+            "src" => Ok(Self::Src),
+            "dst" => Ok(Self::Dst),
+            "both" => Ok(Self::Both),
+            other => Err(format!(
+                "steer-direction expects src|dst|both, got `{other}`"
+            )),
+        }
+    }
+}
+
+impl std::fmt::Display for VppSteerDirection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Src => "src",
+            Self::Dst => "dst",
+            Self::Both => "both",
+        })
+    }
 }
 
 /// Tri-state on/off/auto toggle used by driver workarounds.
@@ -1990,6 +2043,10 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 _ => Err("require-table-complete expects on|off".to_string()),
             })
         }
+        "steer-direction" => parse_single_arg(line, rest, "steer-direction", |t| {
+            let d: VppSteerDirection = t.parse()?;
+            Ok(ModuleDirective::VppSteerDirection(d))
+        }),
         "hugepages" => parse_single_arg(line, rest, "hugepages", |t| {
             let n: u32 = t
                 .parse()
@@ -3030,6 +3087,29 @@ module fast-path
         // Naming an authority resolves it too.
         let ok2 = base.replace("integrity-authority none\n", "integrity-authority birdc\n");
         Config::parse(&ok2).unwrap().validate_vpp_offload().unwrap();
+    }
+
+    /// `steer-direction` parses its three values and rejects anything
+    /// else by name — a typo'd direction silently defaulting to `both`
+    /// would double the MCAM cost AND divert the inbound direction on
+    /// a service edge, which is the misconfiguration the directive
+    /// exists to prevent.
+    #[test]
+    fn steer_direction_parses_and_rejects() {
+        for (txt, want) in [
+            ("src", VppSteerDirection::Src),
+            ("dst", VppSteerDirection::Dst),
+            ("both", VppSteerDirection::Both),
+        ] {
+            let s = format!("module vpp-offload\n  steer-direction {txt}\n");
+            let c = Config::parse(&s).unwrap();
+            match &c.modules[0].directives[0] {
+                ModuleDirective::VppSteerDirection(d) => assert_eq!(*d, want),
+                other => panic!("expected VppSteerDirection, got {other:?}"),
+            }
+        }
+        let e = Config::parse("module vpp-offload\n  steer-direction inbound\n").unwrap_err();
+        assert!(format!("{e}").contains("expects src|dst|both"), "{e}");
     }
 
     #[test]

--- a/crates/modules/fast-path/src/fib/programmer.rs
+++ b/crates/modules/fast-path/src/fib/programmer.rs
@@ -1793,7 +1793,40 @@ impl FibProgrammer {
         // case free of an allocation on the route-install path.
         if let Some(sink) = self.route_sink.as_deref() {
             if let Some(rec) = self.lookup_mirror(&prefix) {
-                sink.route_resolved(prefix, &rec.nexthop_ips);
+                // Local-ARP /32s stay OFF the second tier. They
+                // describe LOCAL delivery — hosts behind the switch0
+                // bridges — which VPP deliberately does not do (no
+                // VLAN subifs; this tier's FDB-pin owns that path).
+                // Announcing them hands the sink routes whose nexthop
+                // device is a bridge: permanently `unresolvable`,
+                // which fails every readback verify — on exactly the
+                // boxes that use `local-prefix`. The shadow has none,
+                // so no shadow run could ever have caught it; found by
+                // tracing the primary's config (2026-08-14) before the
+                // second attach window rather than during it.
+                //
+                // Filtered here, at the single announce site, because
+                // this is also the only writer of the feed's mirror
+                // copy — so the resync diff inherits the same
+                // exclusion and the two paths cannot disagree.
+                let local_only = !rec.advertisements.is_empty()
+                    && rec
+                        .advertisements
+                        .keys()
+                        .all(|(p, _)| p.as_local_arp_ifindex().is_some());
+                if local_only {
+                    // A withdrawal, not silence. In the ordinary case
+                    // (a record that was local-ARP from birth) this is
+                    // a cheap no-op — the feed queues withdrawals for
+                    // prefixes it never saw, by design. But a record
+                    // whose BGP owners left while a local-ARP one
+                    // remained has been ANNOUNCED before, and going
+                    // quiet here would leave the second tier holding
+                    // its last BGP-era state forever.
+                    sink.route_withdrawn(prefix);
+                } else {
+                    sink.route_resolved(prefix, &rec.nexthop_ips);
+                }
             }
         }
         Ok(())

--- a/crates/modules/fast-path/tests/fib_programmer_integration.rs
+++ b/crates/modules/fast-path/tests/fib_programmer_integration.rs
@@ -1666,6 +1666,80 @@ fn the_sink_is_told_the_resolved_union_not_the_advertisements() {
     );
 }
 
+/// Local-ARP routes never reach the second tier as installs.
+///
+/// They describe LOCAL delivery — hosts behind the switch0 bridges —
+/// which VPP deliberately does not do (no VLAN subifs; this tier's
+/// FDB-pin owns that path). Announced, they would sit in the sink as
+/// routes whose nexthop device is a bridge: permanently unresolvable,
+/// failing every readback verify on exactly the boxes that use
+/// `local-prefix`. The shadow has none, so only this test and the
+/// primary can catch a regression.
+#[test]
+#[ignore = "needs CAP_BPF + bpffs; run via sudo -E cargo test -- --ignored"]
+fn local_arp_routes_do_not_reach_the_sink_as_installs() {
+    let (h, sink) = ProgrammerHarness::with_sink();
+    let local = IpPrefix::V4 {
+        addr: [23, 191, 200, 50],
+        prefix_len: 32,
+    };
+    let transit = IpPrefix::V4 {
+        addr: [203, 0, 113, 0],
+        prefix_len: 24,
+    };
+    let host = IpAddr::V4(Ipv4Addr::new(23, 191, 200, 50));
+    let nh = IpAddr::V4(Ipv4Addr::new(10, 0, 0, 1));
+
+    h.run(async {
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: PeerId::local_arp(33),
+                prefix: local,
+                nexthops: vec![host],
+                path_id: None,
+                local_pref: None,
+            })
+            .await
+            .expect("apply local-arp Add");
+        h.handle
+            .apply_route_event(RouteEvent::Add {
+                peer_id: PeerId(0x2222),
+                prefix: transit,
+                nexthops: vec![nh],
+                path_id: None,
+                local_pref: Some(100),
+            })
+            .await
+            .expect("apply BGP Add");
+    });
+
+    let calls = sink.calls();
+    assert!(
+        !calls
+            .iter()
+            .any(|c| matches!(c, SinkCall::Resolved(p, _) if *p == local)),
+        "a local-arp /32 must never be announced as installable: {calls:?}"
+    );
+    assert!(
+        calls
+            .iter()
+            .any(|c| matches!(c, SinkCall::Resolved(p, _) if *p == transit)),
+        "the filter must not eat ordinary BGP routes: {calls:?}"
+    );
+    // The local-only commit announces as a WITHDRAWAL rather than
+    // going quiet — transition safety: a record whose BGP owners left
+    // while a local-ARP one remained has been announced before, and
+    // silence would leave the second tier holding its last BGP-era
+    // state forever. For a from-birth local record it is a designed
+    // no-op at the feed.
+    assert!(
+        calls
+            .iter()
+            .any(|c| matches!(c, SinkCall::Withdrawn(p) if *p == local)),
+        "the local-only commit must withdraw, not go quiet: {calls:?}"
+    );
+}
+
 /// A withdrawal reaches the sink, and by the same path for every way a
 /// prefix can stop forwarding.
 ///

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -234,7 +234,7 @@ pub fn bring_up(
                 allowlist.len() - steerable
             ));
         }
-        RuleSet::plan(allowlist, budget.clone())?
+        RuleSet::plan(allowlist, budget.clone(), cfg.steer_direction)?
     } else {
         RuleSet::default()
     };
@@ -880,6 +880,7 @@ mod completeness_gate_tests {
             expected_routes: 1_600_000,
             hugepages: None,
             require_table_complete: require,
+            steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
                 prefix_len: 32,

--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -367,7 +367,19 @@ impl Driver {
                     // Failing mid-resync is a convergence failure: the
                     // table is known-incomplete and nothing is forwarding
                     // through it yet.
-                    Err(_) if resyncing => {
+                    //
+                    // Logged HERE because this event produces no failed
+                    // action for the executor to log — the shadow repro
+                    // (2026-08-13) had three teardowns driven from this
+                    // path and the journal named the kill without its
+                    // cause, which is exactly the blindness the
+                    // teardown logging was added to end.
+                    Err(e) if resyncing => {
+                        tracing::warn!(
+                            error = %e,
+                            "resync drain failed; convergence failure — the supervisor \
+                             will tear down and retry"
+                        );
                         self.reconnect_wanted = true;
                         events.push(Event::ConvergenceFailed);
                     }

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -309,19 +309,31 @@ impl Verdict {
     /// `VerifyFailed` — the restart-worthy verdict — fires only when
     /// the FIB itself is wrong ([`VerifyOutcome::fib_correct`]): a
     /// fresh resync rebuilds a wrong FIB, so teardown is a remedy.
-    /// Dark member interfaces route through `VerifyIncomplete` instead:
-    /// same destination as a withheld table — reach `Ready`, do NOT
-    /// steer, keep the want — because a restart cannot plug in a
-    /// cable. Mapping them to `VerifyFailed` turned three uncabled
-    /// shadow ports into an infinite kill-respawn loop over a flawless
-    /// FIB (repro 2026-08-13). The steer path re-checks link state
-    /// fresh at steer time, so recovery is the existing retry loop
-    /// noticing the cable came back, not a verify verdict going stale
-    /// in either direction.
+    /// Dark member interfaces that CARRY ROUTES route through
+    /// `VerifyIncomplete` instead: same destination as a withheld
+    /// table — reach `Ready`, do NOT steer, keep the want — because a
+    /// restart cannot plug in a cable. Mapping them to `VerifyFailed`
+    /// turned three uncabled shadow ports into an infinite
+    /// kill-respawn loop over a flawless FIB (repro 2026-08-13).
+    ///
+    /// A dark member that is IDLE — no installed route can egress it,
+    /// which is the normal state of a dark port, since the BGP session
+    /// that would produce its routes died with the link — blocks
+    /// nothing: it shows in the summary and the ports row, and the
+    /// verdict is whatever the rest of the outcome earns. Refusing to
+    /// steer five live ports over one uncabled one would hold the
+    /// whole offload hostage to a port that poses no risk (the
+    /// primary's eth5 is the motivating case).
+    ///
+    /// The steer path re-checks link state AND usage fresh at steer
+    /// time, so recovery is the existing retry loop noticing the cable
+    /// came back, not a verify verdict going stale in either
+    /// direction.
     pub fn event(&self) -> crate::supervisor::Event {
+        let blocking_dark = self.outcome.dead_interfaces.iter().any(|d| d.in_use);
         if !self.outcome.fib_correct() {
             crate::supervisor::Event::VerifyFailed
-        } else if self.may_steer && self.outcome.dead_interfaces.is_empty() {
+        } else if self.may_steer && !blocking_dark {
             crate::supervisor::Event::VerifyPassed
         } else {
             crate::supervisor::Event::VerifyIncomplete
@@ -1449,8 +1461,16 @@ impl ConvergenceEngine {
         self.verify_seed = next_seed(self.verify_seed);
         let seed = self.verify_seed;
 
+        let active = self.active_egress_indices();
         let t = self.transport.as_mut().expect("checked just above");
-        match verify(t, &self.ledger, &self.port_index, DEFAULT_SAMPLE, seed) {
+        match verify(
+            t,
+            &self.ledger,
+            &self.port_index,
+            &active,
+            DEFAULT_SAMPLE,
+            seed,
+        ) {
             Ok(outcome) => {
                 self.last_verify = Some(outcome.clone());
                 self.phase = None;
@@ -1480,11 +1500,26 @@ impl ConvergenceEngine {
         if let Some(dead) = &self.test_dead_members {
             return Ok(dead.clone());
         }
+        let active = self.active_egress_indices();
         let Some(t) = self.transport.as_mut() else {
             return Err(EngineError::NotConnected);
         };
-        crate::verify::dead_interface_scan(t, &self.port_index.indices())
+        crate::verify::dead_interface_scan(t, &self.port_index.indices(), &active)
             .map_err(EngineError::Transport)
+    }
+
+    /// Interfaces at least one static neighbour lives on — the set of
+    /// egresses the FIB can actually choose, since every route the sink
+    /// installs resolves through a neighbour it installed. Unacked
+    /// neighbours count too: "VPP might hold an adjacency here" is
+    /// enough to treat the interface as in use, in the direction that
+    /// over-blocks rather than under-blocks a steer.
+    fn active_egress_indices(&self) -> std::collections::HashSet<u32> {
+        self.neighbours_installed
+            .keys()
+            .map(|(idx, _)| *idx)
+            .chain(self.neighbours_unacked.iter().map(|(idx, _)| *idx))
+            .collect()
     }
 
     /// Abandon whatever convergence step is in flight.
@@ -1995,6 +2030,7 @@ mod tests {
         e.last_verify = Some(VerifyOutcome {
             sampled: 64,
             dead_interfaces: vec![crate::verify::DeadInterface {
+                in_use: true,
                 sw_if_index: 3,
                 name: "octeon0/0".into(),
                 admin_up: true,
@@ -2082,6 +2118,7 @@ mod tests {
                     name: "octeon0/0".into(),
                     admin_up: true,
                     link_up: false,
+                    in_use: true,
                 }],
                 ..Default::default()
             },
@@ -2090,12 +2127,45 @@ mod tests {
         assert!(dark.outcome.fib_correct(), "the FIB itself is flawless");
         assert!(
             !dark.outcome.passed(),
-            "but a dark member must still block a steering pass"
+            "but an in-use dark member must still block a steering pass"
         );
         assert_eq!(
             dark.event(),
             Event::VerifyIncomplete,
-            "dark members must not restart-loop a healthy VPP"
+            "in-use dark members must not restart-loop a healthy VPP"
+        );
+
+        // An IDLE dark member — no route can egress it — blocks
+        // nothing: the whole offload must not be held hostage to an
+        // uncabled port with no routes (the primary's eth5).
+        let idle_dark = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 64,
+                dead_interfaces: vec![DeadInterface {
+                    sw_if_index: 5,
+                    name: "octeon5/0".into(),
+                    admin_up: true,
+                    link_up: false,
+                    in_use: false,
+                }],
+                ..Default::default()
+            },
+            may_steer: true,
+        };
+        assert!(
+            idle_dark.outcome.passed(),
+            "{}",
+            idle_dark.outcome.summary()
+        );
+        assert_eq!(
+            idle_dark.event(),
+            Event::VerifyPassed,
+            "an idle dark member must not block the offload"
+        );
+        assert!(
+            idle_dark.outcome.summary().contains("idle"),
+            "but it must still be visible: {}",
+            idle_dark.outcome.summary()
         );
 
         // Both at once: a wrong FIB wins — teardown IS the remedy for
@@ -2108,6 +2178,7 @@ mod tests {
                     name: "octeon0/0".into(),
                     admin_up: true,
                     link_up: false,
+                    in_use: true,
                 }],
                 ..Default::default()
             },

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -305,10 +305,23 @@ impl Verdict {
     /// The supervisor event this verdict implies. Keeps the mapping in
     /// one place so a caller cannot pick `VerifyPassed` for an
     /// incomplete table.
+    ///
+    /// `VerifyFailed` — the restart-worthy verdict — fires only when
+    /// the FIB itself is wrong ([`VerifyOutcome::fib_correct`]): a
+    /// fresh resync rebuilds a wrong FIB, so teardown is a remedy.
+    /// Dark member interfaces route through `VerifyIncomplete` instead:
+    /// same destination as a withheld table — reach `Ready`, do NOT
+    /// steer, keep the want — because a restart cannot plug in a
+    /// cable. Mapping them to `VerifyFailed` turned three uncabled
+    /// shadow ports into an infinite kill-respawn loop over a flawless
+    /// FIB (repro 2026-08-13). The steer path re-checks link state
+    /// fresh at steer time, so recovery is the existing retry loop
+    /// noticing the cable came back, not a verify verdict going stale
+    /// in either direction.
     pub fn event(&self) -> crate::supervisor::Event {
-        if !self.outcome.passed() {
+        if !self.outcome.fib_correct() {
             crate::supervisor::Event::VerifyFailed
-        } else if self.may_steer {
+        } else if self.may_steer && self.outcome.dead_interfaces.is_empty() {
             crate::supervisor::Event::VerifyPassed
         } else {
             crate::supervisor::Event::VerifyIncomplete
@@ -442,6 +455,12 @@ pub struct ConvergenceEngine {
 
     phase: Option<Phase>,
     last_verify: Option<VerifyOutcome>,
+    /// Unit-test seam for [`Self::dead_members`]: the real scan needs a
+    /// live transport, which in-crate unit tests of the steer gate do
+    /// not have (the fake VPP lives in the integration-test crate).
+    /// `None` — the only production value — means "run the real scan".
+    #[cfg(test)]
+    pub(crate) test_dead_members: Option<Vec<crate::verify::DeadInterface>>,
     /// The last handshake failure, and whether it can ever succeed.
     ///
     /// `api_ready` returns a bool, which collapses "VPP has not opened
@@ -493,6 +512,8 @@ impl ConvergenceEngine {
             api_incompatible: false,
             phase: None,
             last_verify: None,
+            #[cfg(test)]
+            test_dead_members: None,
             verify_seed: 0,
         }
     }
@@ -1450,6 +1471,22 @@ impl ConvergenceEngine {
         }
     }
 
+    /// Every owned member interface that cannot forward right now,
+    /// from a fresh `sw_interface_dump`. The steer gate's read — see
+    /// [`crate::verify::dead_interface_scan`] for why it must be fresh
+    /// rather than the last verify's recorded outcome.
+    pub fn dead_members(&mut self) -> Result<Vec<crate::verify::DeadInterface>, EngineError> {
+        #[cfg(test)]
+        if let Some(dead) = &self.test_dead_members {
+            return Ok(dead.clone());
+        }
+        let Some(t) = self.transport.as_mut() else {
+            return Err(EngineError::NotConnected);
+        };
+        crate::verify::dead_interface_scan(t, &self.port_index.indices())
+            .map_err(EngineError::Transport)
+    }
+
     /// Abandon whatever convergence step is in flight.
     ///
     /// Only clears the engine's own view. The pending map is left
@@ -2023,6 +2060,60 @@ mod tests {
         };
         assert!(!wrong.outcome.passed());
         assert_eq!(wrong.event(), Event::VerifyFailed);
+    }
+
+    /// A dark member interface is not a wrong FIB, and must not reach
+    /// the restart-worthy verdict — a restart cannot plug in a cable.
+    /// Three uncabled shadow ports turned exactly this mapping into an
+    /// infinite kill-respawn loop over a flawless FIB (repro
+    /// 2026-08-13). It rides the `VerifyIncomplete` arm instead: reach
+    /// `Ready`, keep the want, do not steer — the steer path re-checks
+    /// link state fresh at steer time.
+    #[test]
+    fn a_dark_member_is_incomplete_not_failed() {
+        use crate::supervisor::Event;
+        use crate::verify::DeadInterface;
+
+        let dark = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 64,
+                dead_interfaces: vec![DeadInterface {
+                    sw_if_index: 2,
+                    name: "octeon0/0".into(),
+                    admin_up: true,
+                    link_up: false,
+                }],
+                ..Default::default()
+            },
+            may_steer: true,
+        };
+        assert!(dark.outcome.fib_correct(), "the FIB itself is flawless");
+        assert!(
+            !dark.outcome.passed(),
+            "but a dark member must still block a steering pass"
+        );
+        assert_eq!(
+            dark.event(),
+            Event::VerifyIncomplete,
+            "dark members must not restart-loop a healthy VPP"
+        );
+
+        // Both at once: a wrong FIB wins — teardown IS the remedy for
+        // that half, whatever the cabling looks like.
+        let dark_and_wrong = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 0,
+                dead_interfaces: vec![DeadInterface {
+                    sw_if_index: 2,
+                    name: "octeon0/0".into(),
+                    admin_up: true,
+                    link_up: false,
+                }],
+                ..Default::default()
+            },
+            may_steer: false,
+        };
+        assert_eq!(dark_and_wrong.event(), Event::VerifyFailed);
     }
 
     /// Leftovers from an aborted resync live only in the pending map —

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -108,6 +108,11 @@ pub struct VppOffloadConfig {
     /// check and forwards nothing, which is the failure this whole
     /// module is built to make impossible.
     pub loopback_address: Option<packetframe_common::config::Ipv4Prefix>,
+    /// Which packet side the MCAM rules match. Hot-reloadable: the
+    /// steering target is rebuilt from config on every reconfigure and
+    /// `steer` is a reconcile, so a change installs/removes exactly
+    /// the delta — including the rollback direction.
+    pub steer_direction: packetframe_common::config::VppSteerDirection,
 }
 
 /// Default sizing input when `expected-routes` is absent.
@@ -142,6 +147,7 @@ impl VppOffloadConfig {
                 ModuleDirective::VppHugepages(n) => out.hugepages = Some(*n),
                 ModuleDirective::VppRequireTableComplete(v) => out.require_table_complete = *v,
                 ModuleDirective::VppLoopbackAddress(p) => out.loopback_address = Some(*p),
+                ModuleDirective::VppSteerDirection(d) => out.steer_direction = *d,
                 _ => {}
             }
         }
@@ -517,7 +523,7 @@ fn steering_target(
         });
     }
     let budget = steer::McamBudget::for_ifaces(ports.iter().map(|(iface, _)| iface.as_str()))?;
-    let plan = steer::RuleSet::plan(allowlist, budget)?;
+    let plan = steer::RuleSet::plan(allowlist, budget, cfg.steer_direction)?;
     // `steer on` with nothing steerable is refused for the same reason
     // `bring_up` refuses it: steering would divert nothing while every
     // surface reported it on.
@@ -1160,14 +1166,15 @@ pub fn run_feasibility_probes(
     workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
+    direction: packetframe_common::config::VppSteerDirection,
 ) -> Vec<Capability> {
     #[cfg(target_os = "linux")]
     {
-        probe_linux::run(ports, workers, vpp_binary, allowlist)
+        probe_linux::run(ports, workers, vpp_binary, allowlist, direction)
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (ports, workers, vpp_binary, allowlist);
+        let _ = (ports, workers, vpp_binary, allowlist, direction);
         Vec::new()
     }
 }
@@ -1539,6 +1546,7 @@ mod tests {
             expected_routes: routes,
             hugepages: None,
             require_table_complete: true,
+            steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
                 prefix_len: 32,

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -1668,6 +1668,7 @@ impl crate::runtime::Steering for NtupleSteering {
 mod tests {
     use super::*;
     use crate::steer::{McamBudget, RuleSet};
+    use packetframe_common::config::VppSteerDirection;
     use packetframe_common::fib::IpPrefix;
     use std::net::Ipv4Addr;
 
@@ -1834,6 +1835,7 @@ mod tests {
                 },
             ],
             small,
+            VppSteerDirection::Both,
         )
         .expect_err("six rules cannot fit four slots");
         assert!(e.contains("only 4 slot(s) are free"), "{e}");
@@ -2084,7 +2086,7 @@ mod tests {
             addr: [198, 18, 0, 0],
             prefix_len: 24,
         }];
-        let fresh_plan = RuleSet::plan(&allow, budget).expect("fits");
+        let fresh_plan = RuleSet::plan(&allow, budget, VppSteerDirection::Both).expect("fits");
         for r in &fresh_plan.rules {
             assert!(
                 !inherited.iter().any(|(_, l)| *l == r.location),
@@ -3056,7 +3058,8 @@ mod tests {
             addr: [23, 191, 200, 0],
             prefix_len: 24,
         }];
-        let plan = RuleSet::plan(&allow, McamBudget::default()).expect("fits");
+        let plan =
+            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits");
         let mut s = steering(vec![("eth0".into(), 0)], plan);
         assert!(
             s.installed().is_empty(),
@@ -3105,7 +3108,7 @@ mod tests {
                 prefix_len: 24,
             })
             .collect();
-        RuleSet::plan(&allow, McamBudget::default()).expect("fits")
+        RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits")
     }
 
     /// The happy path, which had never executed anywhere.

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -16,6 +16,7 @@ pub(crate) fn run(
     workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
+    direction: packetframe_common::config::VppSteerDirection,
 ) -> Vec<Capability> {
     let mut caps = Vec::with_capacity(5 + ports.len());
     caps.push(probe_iommu());
@@ -31,7 +32,7 @@ pub(crate) fn run(
     for iface in ports {
         caps.push(probe_sriov(iface));
     }
-    caps.push(probe_steering_budget(ports, allowlist));
+    caps.push(probe_steering_budget(ports, allowlist, direction));
     caps
 }
 
@@ -115,6 +116,7 @@ fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
 fn probe_steering_budget(
     ports: &[String],
     allowlist: &[packetframe_common::fib::IpPrefix],
+    direction: packetframe_common::config::VppSteerDirection,
 ) -> Capability {
     use crate::steer::{McamBudget, RuleSet};
 
@@ -123,7 +125,7 @@ fn probe_steering_budget(
         Err(e) => return Capability::fail("vpp.steering.budget", e, false),
     };
     let free = budget.free.len();
-    match RuleSet::plan(allowlist, budget) {
+    match RuleSet::plan(allowlist, budget, direction) {
         // Nothing to steer is a FAIL however it arose. The two ways there
         // read very differently to an operator, so they are named
         // separately — but neither may pass: a port that steers nothing
@@ -329,7 +331,7 @@ mod steering_probe_tests {
         // No ports: `for_ifaces` asks no NIC and yields the fallback
         // budget, so these stay tests of the ALLOWLIST logic — which is
         // what they were always about — on a host that has no rvu NIC.
-        let empty = probe_steering_budget(&[], &[]);
+        let empty = probe_steering_budget(&[], &[], Default::default());
         assert_eq!(empty.status, CapabilityStatus::Fail, "{empty:?}");
         assert!(
             empty.detail.contains("allowlist is empty"),
@@ -343,6 +345,7 @@ mod steering_probe_tests {
                 addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
                 prefix_len: 32,
             }],
+            Default::default(),
         );
         assert_eq!(v6_only.status, CapabilityStatus::Fail, "{v6_only:?}");
         assert!(
@@ -353,7 +356,7 @@ mod steering_probe_tests {
 
         // A steerable prefix passes, so the failures above are about
         // having nothing to steer rather than the probe always failing.
-        let ok = probe_steering_budget(&[], &[v4(0, 24)]);
+        let ok = probe_steering_budget(&[], &[v4(0, 24)], Default::default());
         assert_eq!(ok.status, CapabilityStatus::Pass, "{ok:?}");
     }
 }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -2309,25 +2309,45 @@ impl Effects for EffectsView {
         // interfaces dump is not a state to divert traffic into.
         if c.steer_diverts_traffic() {
             match c.engine.dead_members() {
-                Ok(dead) if dead.is_empty() => {}
                 Ok(dead) => {
-                    let names: Vec<String> = dead
-                        .iter()
-                        .map(|d| {
-                            format!("{} (admin_up={} link_up={})", d.name, d.admin_up, d.link_up)
-                        })
-                        .collect();
-                    return Err(format!(
-                        "refusing to steer: {} member interface(s) cannot forward: {}. \
-                         Every member is a possible egress (membership is all-or-nothing \
-                         across the forwarding domain), so a steered packet whose best \
-                         path exits a dark port is dropped, not failed over. Restore \
-                         link/admin on the port(s); the steer retries on its own at most \
-                         every {}s, or `packetframe reconfigure` asks immediately",
-                        names.len(),
-                        names.join(", "),
-                        crate::driver::STEER_RETRY_EVERY.as_secs()
-                    ));
+                    // Only dark members that CARRY ROUTES block: a
+                    // steered packet can only die on an egress some
+                    // route names, and a dark port mostly has none —
+                    // its BGP session died with the link. An idle dark
+                    // port (the primary's uncabled eth5) degrades the
+                    // report and holds nothing hostage.
+                    let blocking: Vec<&crate::verify::DeadInterface> =
+                        dead.iter().filter(|d| d.in_use).collect();
+                    if !blocking.is_empty() {
+                        let names: Vec<String> = blocking
+                            .iter()
+                            .map(|d| {
+                                format!(
+                                    "{} (admin_up={} link_up={})",
+                                    d.name, d.admin_up, d.link_up
+                                )
+                            })
+                            .collect();
+                        let idle = dead.len() - blocking.len();
+                        return Err(format!(
+                            "refusing to steer: {} member interface(s) carry routes but \
+                             cannot forward: {}. A steered packet whose best path exits \
+                             a dark port is dropped, not failed over. Restore link/admin \
+                             on the port(s); the steer retries on its own at most every \
+                             {}s, or `packetframe reconfigure` asks immediately{}",
+                            names.len(),
+                            names.join(", "),
+                            crate::driver::STEER_RETRY_EVERY.as_secs(),
+                            if idle > 0 {
+                                format!(
+                                    " ({idle} further dark member(s) carry no routes \
+                                     and do not block)"
+                                )
+                            } else {
+                                String::new()
+                            }
+                        ));
+                    }
                 }
                 Err(e) => {
                     return Err(format!(
@@ -3849,8 +3869,10 @@ mod tests {
             assert!(e.contains("link state could not be read"), "{e}");
         }
 
-        // A dark member: refusal that names the port and the way back.
+        // An IN-USE dark member: refusal that names the port and the
+        // way back.
         rt.core.borrow_mut().engine.test_dead_members = Some(vec![crate::verify::DeadInterface {
+            in_use: true,
             sw_if_index: 2,
             name: "octeon0/0".into(),
             admin_up: true,
@@ -3880,6 +3902,41 @@ mod tests {
         }
     }
 
+    /// An IDLE dark member — no installed route can egress it — must
+    /// not block a steer: holding five live ports hostage to one
+    /// uncabled one is the refusal this refinement removes (the
+    /// primary's eth5 is the motivating case). The dark port is still
+    /// reported — verify's summary and the ports row carry it — it
+    /// just decides nothing.
+    #[test]
+    fn an_idle_dark_member_does_not_block_a_steer() {
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024)], true)),
+            configured: 1,
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        rt.core.borrow_mut().engine.test_dead_members = Some(vec![crate::verify::DeadInterface {
+            in_use: false,
+            sw_if_index: 5,
+            name: "octeon5/0".into(),
+            admin_up: true,
+            link_up: false,
+        }]);
+        let (_, mut fx) = rt.views();
+        fx.steer()
+            .expect("an idle dark member must not hold the offload hostage");
+        assert_eq!(rt.core.borrow().steering.installed().len(), 1);
+    }
+
     /// The empty-target exemption for the link gate specifically: a
     /// reconcile that only removes rules must proceed with members
     /// dark — it is the rollback direction, and refusing it would trap
@@ -3904,6 +3961,7 @@ mod tests {
         // Members dark AND unreadable-by-default would both refuse a
         // diverting steer; neither may block the removal direction.
         rt.core.borrow_mut().engine.test_dead_members = Some(vec![crate::verify::DeadInterface {
+            in_use: true,
             sw_if_index: 2,
             name: "octeon0/0".into(),
             admin_up: true,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -2290,6 +2290,54 @@ impl Effects for EffectsView {
                 ));
             }
         }
+        // The link gate, same chokepoint, same shape, FRESH read. The
+        // verify verdict deliberately routes dark members through
+        // `VerifyIncomplete` (a restart cannot plug in a cable — shadow
+        // repro 2026-08-13), which means nothing upstream of this point
+        // has refused them; a steer is the moment traffic would start
+        // dying on the dark port, so the check runs here, against what
+        // the interfaces report NOW rather than what the last verify
+        // recorded. Recovery is free: a refusal is `SteerFailed`, the
+        // want stays set, and the retry that runs after the cable comes
+        // back passes this gate. Same empty-target exception as the
+        // completeness gate, for the same reason: a reconcile that only
+        // removes rules diverts nothing.
+        //
+        // "Cannot read link state" refuses too. Steering is the one
+        // operation where "probably fine" and "verified fine" differ by
+        // a blackhole, and the transport being unable to answer an
+        // interfaces dump is not a state to divert traffic into.
+        if c.steer_diverts_traffic() {
+            match c.engine.dead_members() {
+                Ok(dead) if dead.is_empty() => {}
+                Ok(dead) => {
+                    let names: Vec<String> = dead
+                        .iter()
+                        .map(|d| {
+                            format!("{} (admin_up={} link_up={})", d.name, d.admin_up, d.link_up)
+                        })
+                        .collect();
+                    return Err(format!(
+                        "refusing to steer: {} member interface(s) cannot forward: {}. \
+                         Every member is a possible egress (membership is all-or-nothing \
+                         across the forwarding domain), so a steered packet whose best \
+                         path exits a dark port is dropped, not failed over. Restore \
+                         link/admin on the port(s); the steer retries on its own at most \
+                         every {}s, or `packetframe reconfigure` asks immediately",
+                        names.len(),
+                        names.join(", "),
+                        crate::driver::STEER_RETRY_EVERY.as_secs()
+                    ));
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "refusing to steer: member link state could not be read from VPP \
+                         ({e}); cannot confirm every egress can forward, and a steered \
+                         miss is dropped rather than falling back"
+                    ));
+                }
+            }
+        }
         let outcome = c.steering.steer();
         c.record_steering();
         outcome
@@ -3552,6 +3600,9 @@ mod tests {
         );
         let handle = std::sync::Arc::new(TableCompleteness::new());
         rt.require_table_complete(handle.clone());
+        // This test exercises the COMPLETENESS gate; give the link gate
+        // a clean answer so the refusals below are the verdict's.
+        rt.core.borrow_mut().engine.test_dead_members = Some(Vec::new());
 
         let (_, mut fx) = rt.views();
         // Nothing published yet: unknown is not permission.
@@ -3756,7 +3807,110 @@ mod tests {
             "/usr/bin/vpp",
             "/tmp/startup.conf",
         );
+        // Completeness gate under test; link gate answered clean.
+        rt.core.borrow_mut().engine.test_dead_members = Some(Vec::new());
         let (_, mut fx) = rt.views();
         fx.steer().expect("no gate configured, no gate applied");
+    }
+
+    /// The link gate: a dark member refuses a diverting steer, an
+    /// unreadable link state refuses too, and an empty target is
+    /// exempt — its only job is removal.
+    ///
+    /// This is the second half of the dark-member fix (shadow repro
+    /// 2026-08-13): the verify verdict deliberately stops restarting
+    /// over dark members, so the steer gate is where traffic is
+    /// actually protected from them — with a FRESH read, which is what
+    /// lets the existing retry loop recover on its own once the cable
+    /// comes back.
+    #[test]
+    fn a_dark_member_refuses_a_diverting_steer_and_an_empty_target_is_exempt() {
+        let steering = LedgerSteering {
+            next: Some((vec![("eth4".into(), 1024)], true)),
+            configured: 1,
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+
+        // Unreadable link state (no transport, no test override):
+        // refusal, because "probably fine" and "verified fine" differ
+        // by a blackhole here.
+        {
+            let (_, mut fx) = rt.views();
+            let e = fx.steer().expect_err("unknown link state must refuse");
+            assert!(e.contains("link state could not be read"), "{e}");
+        }
+
+        // A dark member: refusal that names the port and the way back.
+        rt.core.borrow_mut().engine.test_dead_members = Some(vec![crate::verify::DeadInterface {
+            sw_if_index: 2,
+            name: "octeon0/0".into(),
+            admin_up: true,
+            link_up: false,
+        }]);
+        {
+            let (_, mut fx) = rt.views();
+            let e = fx.steer().expect_err("a dark member must refuse");
+            assert!(e.contains("octeon0/0"), "the port must be named: {e}");
+            assert!(
+                e.contains("link_up=false"),
+                "and its state, so the operator fixes the right thing: {e}"
+            );
+            assert!(
+                rt.core.borrow().steering.installed().is_empty(),
+                "a refused steer must not have touched the NIC"
+            );
+        }
+
+        // Link restored: the same call now goes through — the recovery
+        // path the retry loop drives after a cable comes back.
+        rt.core.borrow_mut().engine.test_dead_members = Some(Vec::new());
+        {
+            let (_, mut fx) = rt.views();
+            fx.steer().expect("clean links steer");
+            assert_eq!(rt.core.borrow().steering.installed().len(), 1);
+        }
+    }
+
+    /// The empty-target exemption for the link gate specifically: a
+    /// reconcile that only removes rules must proceed with members
+    /// dark — it is the rollback direction, and refusing it would trap
+    /// traffic ON the dark dataplane.
+    #[test]
+    fn an_empty_target_unsteers_despite_dark_members() {
+        let steering = LedgerSteering {
+            // Empty target: nothing to install, removal only.
+            next: Some((Vec::new(), true)),
+            configured: 0,
+            ..Default::default()
+        };
+        let rt = Runtime::new(
+            engine(),
+            Box::new(EmptySource),
+            Box::new(steering),
+            Box::new(NullStore),
+            Box::new(NoResources),
+            "/usr/bin/vpp",
+            "/tmp/startup.conf",
+        );
+        // Members dark AND unreadable-by-default would both refuse a
+        // diverting steer; neither may block the removal direction.
+        rt.core.borrow_mut().engine.test_dead_members = Some(vec![crate::verify::DeadInterface {
+            sw_if_index: 2,
+            name: "octeon0/0".into(),
+            admin_up: true,
+            link_up: false,
+        }]);
+        let (_, mut fx) = rt.views();
+        fx.steer()
+            .expect("an empty target diverts nothing and must not be link-gated");
     }
 }

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -56,6 +56,7 @@
 
 use std::net::Ipv4Addr;
 
+use packetframe_common::config::VppSteerDirection;
 use packetframe_common::fib::IpPrefix;
 
 /// One steering rule, before it becomes bytes.
@@ -174,8 +175,23 @@ impl Default for McamBudget {
     }
 }
 
-/// Source and destination — see [`RuleSet::plan`] for why both.
-const RULES_PER_PREFIX: usize = 2;
+/// The sides a configured [`VppSteerDirection`] matches.
+///
+/// `both` is right for pure-transit deployments where VPP can forward
+/// either direction of a flow. `src` is the service-edge shape:
+/// outbound (src in the service prefix) rides VPP full-table best
+/// path while inbound stays on the eBPF tier, whose FDB-pin owns
+/// local delivery — dst-steering inbound service traffic would divert
+/// it into a FIB with no path to the bridge-attached hosts it
+/// terminates on. Split-tier flow halves are safe under the
+/// stateless-transit invariant steering already requires.
+pub fn sides_for(direction: VppSteerDirection) -> &'static [Side] {
+    match direction {
+        VppSteerDirection::Src => &[Side::Src],
+        VppSteerDirection::Dst => &[Side::Dst],
+        VppSteerDirection::Both => &[Side::Src, Side::Dst],
+    }
+}
 
 /// How many prefixes in `allowlist` this NIC could steer at all.
 ///
@@ -194,20 +210,20 @@ pub fn steerable_count(allowlist: &[IpPrefix]) -> usize {
 }
 
 impl RuleSet {
-    /// Decide the rules for one port.
-    ///
-    /// Two per v4 prefix, source and destination, because the allowlist
-    /// names *networks we forward for* and traffic to them and from them
-    /// are both ours. Steering only one direction would send a flow's
-    /// two halves down different tiers, which is precisely the
-    /// asymmetric-path case that breaks PMTUD and anything stateful
-    /// downstream.
+    /// Decide the rules for one port: one per v4 prefix per configured
+    /// side (see [`sides_for`] for what each direction means and when
+    /// it is right).
     ///
     /// Fails rather than truncates when the budget cannot hold them all:
     /// a partially steered port forwards some allowlisted traffic
     /// through VPP and the rest through the kernel, which is a policy
     /// nobody chose.
-    pub fn plan(allowlist: &[IpPrefix], budget: McamBudget) -> Result<Self, String> {
+    pub fn plan(
+        allowlist: &[IpPrefix],
+        budget: McamBudget,
+        direction: VppSteerDirection,
+    ) -> Result<Self, String> {
+        let sides = sides_for(direction);
         // Partition first, then check capacity, then build. The order is
         // what makes the refusal's numbers true: counting as we go can
         // only ever report how far we got, which is the budget size — the
@@ -220,29 +236,29 @@ impl RuleSet {
             })
             .collect();
         let skipped_v6 = (allowlist.len() - steerable.len()) as u32;
-        let needed = steerable.len() * RULES_PER_PREFIX;
+        let needed = steerable.len() * sides.len();
 
         if needed > budget.free.len() {
             return Err(format!(
                 "the allowlist needs {needed} MCAM rule(s) ({} steerable prefix(es) × {} \
-                 directions) but only {} slot(s) are free on this NIC; steering part of the \
-                 allowlist would split it across both forwarding tiers, so none is installed. \
-                 The per-port ntuple table on this hardware holds 16 rules, so at two rules \
-                 per prefix the allowlist can carry at most 8 IPv4 prefixes",
+                 direction(s), `steer-direction {direction}`) but only {} slot(s) are free \
+                 on this NIC; steering part of the allowlist would split it across both \
+                 forwarding tiers, so none is installed. The per-port ntuple table on this \
+                 hardware holds 16 rules",
                 steerable.len(),
-                RULES_PER_PREFIX,
+                sides.len(),
                 budget.free.len()
             ));
         }
 
         let mut rules = Vec::with_capacity(needed);
         for (i, (addr, prefix_len)) in steerable.into_iter().enumerate() {
-            for (j, side) in [Side::Src, Side::Dst].into_iter().enumerate() {
+            for (j, side) in sides.iter().copied().enumerate() {
                 rules.push(SteerRule {
                     prefix: addr,
                     prefix_len,
                     side,
-                    location: budget.free[i * RULES_PER_PREFIX + j],
+                    location: budget.free[i * sides.len() + j],
                 });
             }
         }
@@ -279,7 +295,8 @@ mod tests {
             },
             v4(10, 88, 1, 0, 24),
         ];
-        let set = RuleSet::plan(&allow, McamBudget::default()).expect("fits");
+        let set =
+            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits");
 
         assert_eq!(set.skipped_v6, 1, "the v6 prefix is reported, not hidden");
         assert_eq!(set.rules.len(), 4, "two v4 prefixes, both directions");
@@ -314,7 +331,7 @@ mod tests {
         let budget = McamBudget {
             free: (0..5).rev().collect(),
         };
-        let e = RuleSet::plan(&allow, budget).expect_err("must refuse");
+        let e = RuleSet::plan(&allow, budget, VppSteerDirection::Both).expect_err("must refuse");
 
         assert!(
             e.contains("needs 8 MCAM rule(s)"),
@@ -336,6 +353,7 @@ mod tests {
             McamBudget {
                 free: (0..8).rev().collect(),
             },
+            VppSteerDirection::Both,
         )
         .expect("fits exactly");
         assert_eq!(ok.rules.len(), 8);
@@ -363,11 +381,64 @@ mod tests {
             McamBudget {
                 free: (0..3).rev().collect(),
             },
+            VppSteerDirection::Both,
         )
         .expect_err("must refuse");
         assert!(
             e.contains("needs 4 MCAM rule(s)") && e.contains("2 steerable prefix(es)"),
             "the v6 prefix is not steerable and must not inflate either number: {e}"
+        );
+    }
+
+    /// `steer-direction src` builds exactly one rule per prefix, all
+    /// Src-side, at half the budget cost of `both` — the service-edge
+    /// shape, where inbound stays on the eBPF tier because VPP has no
+    /// path to the bridge-attached hosts it terminates on.
+    #[test]
+    fn src_only_builds_one_rule_per_prefix() {
+        let allow = vec![v4(10, 0, 0, 0, 16), v4(10, 1, 0, 0, 16)];
+        let set =
+            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Src).expect("fits");
+        assert_eq!(set.rules.len(), 2, "{:?}", set.rules);
+        assert!(
+            set.rules.iter().all(|r| r.side == Side::Src),
+            "src-only must never emit a Dst rule: {:?}",
+            set.rules
+        );
+
+        let dst =
+            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Dst).expect("fits");
+        assert!(
+            dst.rules.iter().all(|r| r.side == Side::Dst),
+            "{:?}",
+            dst.rules
+        );
+
+        // Half the rules means twice the prefixes fit: a budget that
+        // refuses 2 prefixes under `both` takes them under `src`.
+        let tight = McamBudget {
+            free: (0..2).rev().collect(),
+        };
+        RuleSet::plan(&allow, tight.clone(), VppSteerDirection::Both)
+            .expect_err("two prefixes x two sides cannot fit two slots");
+        let fits = RuleSet::plan(&allow, tight, VppSteerDirection::Src).expect("fits src-only");
+        assert_eq!(fits.rules.len(), 2);
+    }
+
+    /// The refusal names the configured direction, so an operator
+    /// reading it knows which multiplier produced the number.
+    #[test]
+    fn the_refusal_names_the_direction() {
+        let allow = vec![v4(10, 0, 0, 0, 16), v4(10, 1, 0, 0, 16)];
+        let e = RuleSet::plan(
+            &allow,
+            McamBudget { free: vec![15] },
+            VppSteerDirection::Src,
+        )
+        .expect_err("must refuse");
+        assert!(
+            e.contains("1 direction(s)") && e.contains("steer-direction src"),
+            "{e}"
         );
     }
 
@@ -378,7 +449,8 @@ mod tests {
             addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             prefix_len: 32,
         }];
-        let set = RuleSet::plan(&allow, McamBudget::default()).expect("no rules is not an error");
+        let set = RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both)
+            .expect("no rules is not an error");
         assert!(set.rules.is_empty());
         assert_eq!(
             set.skipped_v6, 1,

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -69,6 +69,16 @@ pub struct DeadInterface {
     pub name: String,
     pub admin_up: bool,
     pub link_up: bool,
+    /// Whether any installed route can actually egress here — the FIB
+    /// holds at least one static neighbour on this interface (counting
+    /// unacked ones, conservatively). This is what separates "a
+    /// blackhole is one steer away" from "a port is dark and nothing
+    /// routes through it": a dark port mostly CANNOT carry routes,
+    /// because the BGP session that would produce them died with the
+    /// link — the primary's uncabled eth5 is the motivating case. Only
+    /// `in_use` dark members block steering; idle ones degrade the
+    /// report and nothing else.
+    pub in_use: bool,
 }
 
 /// Result of one verify pass.
@@ -124,12 +134,14 @@ impl VerifyOutcome {
         self.sampled > 0 && self.mismatches.is_empty() && self.unresolvable == 0
     }
 
-    /// Pass criteria for *steering*: the FIB is correct AND every owned
-    /// interface can forward. The two halves fail differently — see
-    /// [`Self::fib_correct`] — and `Verdict::event` is where the
-    /// difference becomes a supervisor decision.
+    /// Pass criteria for *steering*: the FIB is correct AND every dark
+    /// member is idle — no installed route can egress an interface
+    /// that cannot forward. The halves fail differently — see
+    /// [`Self::fib_correct`] and [`DeadInterface::in_use`] — and
+    /// `Verdict::event` is where the difference becomes a supervisor
+    /// decision.
     pub fn passed(&self) -> bool {
-        self.fib_correct() && self.dead_interfaces.is_empty()
+        self.fib_correct() && !self.dead_interfaces.iter().any(|d| d.in_use)
     }
 
     /// One-line operator summary. Separates the two degraded counts,
@@ -144,7 +156,7 @@ impl VerifyOutcome {
             if self.passed() {
                 "PASS"
             } else if self.fib_correct() {
-                "FIB OK, MEMBER(S) DARK — steering refused, no restart"
+                "FIB OK, IN-USE MEMBER(S) DARK — steering refused, no restart"
             } else {
                 "FAIL"
             },
@@ -158,8 +170,16 @@ impl VerifyOutcome {
         }
         for d in &self.dead_interfaces {
             s.push_str(&format!(
-                ", {} (idx {}) admin_up={} link_up={}",
-                d.name, d.sw_if_index, d.admin_up, d.link_up
+                ", {} (idx {}) admin_up={} link_up={}{}",
+                d.name,
+                d.sw_if_index,
+                d.admin_up,
+                d.link_up,
+                if d.in_use {
+                    " CARRIES ROUTES"
+                } else {
+                    " (idle: no routes egress here; not blocking)"
+                }
             ));
         }
         s
@@ -179,6 +199,7 @@ impl VerifyOutcome {
 pub(crate) fn dead_interface_scan(
     t: &mut Transport,
     owned: &std::collections::HashSet<u32>,
+    active_egress: &std::collections::HashSet<u32>,
 ) -> Result<Vec<DeadInterface>, TransportError> {
     let mut dead = Vec::new();
     let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
@@ -190,6 +211,7 @@ pub(crate) fn dead_interface_scan(
         let (admin_up, link_up) = (iface.admin_up(), iface.link_up());
         if !admin_up || !link_up {
             dead.push(DeadInterface {
+                in_use: active_egress.contains(&iface.sw_if_index),
                 sw_if_index: iface.sw_if_index,
                 name: iface.name,
                 admin_up,
@@ -206,6 +228,7 @@ pub(crate) fn dead_interface_scan(
     for idx in owned.iter().copied() {
         if !seen.contains(&idx) {
             dead.push(DeadInterface {
+                in_use: active_egress.contains(&idx),
                 sw_if_index: idx,
                 name: format!("<absent from VPP, idx {idx}>"),
                 admin_up: false,
@@ -268,6 +291,7 @@ pub fn verify(
     t: &mut Transport,
     ledger: &RouteLedger,
     ports: &PortIndex,
+    active_egress: &std::collections::HashSet<u32>,
     sample_size: usize,
     seed: u64,
 ) -> Result<VerifyOutcome, TransportError> {
@@ -289,7 +313,7 @@ pub fn verify(
     // and we steer into an interface that forwards nothing. The runbook
     // treats link-up as the bring-up pass for exactly this reason;
     // `set_admin_up` only ever asserted the administrative flag.
-    out.dead_interfaces = dead_interface_scan(t, &owned)?;
+    out.dead_interfaces = dead_interface_scan(t, &owned, active_egress)?;
 
     for prefix in probes {
         let reply = t.request::<IpRouteLookup, IpRouteLookupReply>(IpRouteLookup {

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -91,9 +91,11 @@ pub struct VerifyOutcome {
 }
 
 impl VerifyOutcome {
-    /// Pass criteria: at least one route was actually probed, nothing
-    /// sampled disagreed with the ledger, nothing is unresolvable, and
-    /// every owned interface can forward.
+    /// Whether the FIB itself agrees with the ledger: at least one
+    /// route was actually probed, nothing sampled disagreed, and the
+    /// nexthop-device mapping has no holes. This — and only this — is
+    /// the restart-worthy question: a wrong FIB is rebuilt by a fresh
+    /// resync, so teardown is a remedy.
     ///
     /// **`sampled == 0` fails.** An earlier version treated it as a
     /// vacuous pass, and a test asserted that as intended — which was
@@ -108,20 +110,44 @@ impl VerifyOutcome {
     /// mapping is wrong — a misconfiguration, not a capacity condition
     /// — and steering traffic into a FIB with known holes is how a
     /// deploy becomes an outage.
+    ///
+    /// `dead_interfaces` is deliberately NOT here. A member with no
+    /// link makes the dataplane unfit to take traffic — [`Self::passed`]
+    /// still fails on it, and steering still refuses — but the FIB is
+    /// not wrong and a restart cannot plug in a cable. Routing it
+    /// through the restart-worthy verdict turned three uncabled shadow
+    /// ports into an infinite kill-respawn loop (repro 2026-08-13,
+    /// after the first primary attach hid the same shape behind IRQ
+    /// starvation): every cycle rebuilt a flawless FIB, re-observed the
+    /// same dark ports, and died for it.
+    pub fn fib_correct(&self) -> bool {
+        self.sampled > 0 && self.mismatches.is_empty() && self.unresolvable == 0
+    }
+
+    /// Pass criteria for *steering*: the FIB is correct AND every owned
+    /// interface can forward. The two halves fail differently — see
+    /// [`Self::fib_correct`] — and `Verdict::event` is where the
+    /// difference becomes a supervisor decision.
     pub fn passed(&self) -> bool {
-        self.sampled > 0
-            && self.mismatches.is_empty()
-            && self.unresolvable == 0
-            && self.dead_interfaces.is_empty()
+        self.fib_correct() && self.dead_interfaces.is_empty()
     }
 
     /// One-line operator summary. Separates the two degraded counts,
     /// because "mapping is misconfigured" and "table outgrew the box"
-    /// are different pages at 03:00.
+    /// are different pages at 03:00 — and a third label for dark
+    /// members, because "the FIB is wrong" and "a cable is out" are
+    /// too: the first is restart-worthy, the second reads FAIL only if
+    /// you want an operator to bounce a healthy dataplane.
     pub fn summary(&self) -> String {
         let mut s = format!(
             "verify {}: {}/{} probes matched, unresolvable={}, withheld={}",
-            if self.passed() { "PASS" } else { "FAIL" },
+            if self.passed() {
+                "PASS"
+            } else if self.fib_correct() {
+                "FIB OK, MEMBER(S) DARK — steering refused, no restart"
+            } else {
+                "FAIL"
+            },
             self.sampled.saturating_sub(self.mismatches.len()),
             self.sampled,
             self.unresolvable,
@@ -138,6 +164,58 @@ impl VerifyOutcome {
         }
         s
     }
+}
+
+/// Every owned interface that cannot forward right now, from a fresh
+/// `sw_interface_dump`.
+///
+/// Shared between the verify pass and the steer gate — the second
+/// caller is the fix for the dark-member restart loop (shadow repro,
+/// 2026-08-13): verify routes dark members through the no-restart
+/// verdict, so the moment-of-steer check has to be its own, *fresh*
+/// read. Checking a recorded outcome instead would refuse a steer on a
+/// cable that was plugged back in an hour ago, or permit one on a
+/// cable pulled after the last verify.
+pub(crate) fn dead_interface_scan(
+    t: &mut Transport,
+    owned: &std::collections::HashSet<u32>,
+) -> Result<Vec<DeadInterface>, TransportError> {
+    let mut dead = Vec::new();
+    let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
+    for iface in crate::attach::interfaces(t)? {
+        if !owned.contains(&iface.sw_if_index) {
+            continue;
+        }
+        seen.insert(iface.sw_if_index);
+        let (admin_up, link_up) = (iface.admin_up(), iface.link_up());
+        if !admin_up || !link_up {
+            dead.push(DeadInterface {
+                sw_if_index: iface.sw_if_index,
+                name: iface.name,
+                admin_up,
+                link_up,
+            });
+        }
+    }
+    // An owned index that is ABSENT from the dump is not healthy by
+    // omission. Only iterating what the dump returned meant a port that
+    // disappeared after attach was invisible: if the random sample
+    // happened not to select a route through it, every probe matched and
+    // verification passed on a port that could not forward. Report each
+    // missing index as its own failure — nothing about it is up.
+    for idx in owned.iter().copied() {
+        if !seen.contains(&idx) {
+            dead.push(DeadInterface {
+                sw_if_index: idx,
+                name: format!("<absent from VPP, idx {idx}>"),
+                admin_up: false,
+                link_up: false,
+            });
+        }
+    }
+    // Deterministic order so a failing scan reads the same twice.
+    dead.sort_by_key(|d| d.sw_if_index);
+    Ok(dead)
 }
 
 /// Deterministic sampler.
@@ -211,40 +289,7 @@ pub fn verify(
     // and we steer into an interface that forwards nothing. The runbook
     // treats link-up as the bring-up pass for exactly this reason;
     // `set_admin_up` only ever asserted the administrative flag.
-    let mut seen: std::collections::HashSet<u32> = std::collections::HashSet::new();
-    for iface in crate::attach::interfaces(t)? {
-        if !owned.contains(&iface.sw_if_index) {
-            continue;
-        }
-        seen.insert(iface.sw_if_index);
-        let (admin_up, link_up) = (iface.admin_up(), iface.link_up());
-        if !admin_up || !link_up {
-            out.dead_interfaces.push(DeadInterface {
-                sw_if_index: iface.sw_if_index,
-                name: iface.name,
-                admin_up,
-                link_up,
-            });
-        }
-    }
-    // An owned index that is ABSENT from the dump is not healthy by
-    // omission. Only iterating what the dump returned meant a port that
-    // disappeared after attach was invisible: if the random sample
-    // happened not to select a route through it, every probe matched and
-    // verification passed on a port that could not forward. Report each
-    // missing index as its own failure — nothing about it is up.
-    for idx in owned.iter().copied() {
-        if !seen.contains(&idx) {
-            out.dead_interfaces.push(DeadInterface {
-                sw_if_index: idx,
-                name: format!("<absent from VPP, idx {idx}>"),
-                admin_up: false,
-                link_up: false,
-            });
-        }
-    }
-    // Deterministic order so a failing verify reads the same twice.
-    out.dead_interfaces.sort_by_key(|d| d.sw_if_index);
+    out.dead_interfaces = dead_interface_scan(t, &owned)?;
 
     for prefix in probes {
         let reply = t.request::<IpRouteLookup, IpRouteLookupReply>(IpRouteLookup {

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -889,7 +889,7 @@ fn verify_passes_when_every_probe_finds_a_route_on_an_owned_interface() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(200);
 
-    let out = verify(&mut t, &ledger, &ports, 16, 42).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 16, 42).expect("verify");
     assert_eq!(out.sampled, 16);
     assert!(out.mismatches.is_empty(), "{:?}", out.mismatches);
     assert!(out.passed(), "{}", out.summary());
@@ -908,7 +908,7 @@ fn verify_fails_a_path_on_an_interface_we_do_not_own() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(50);
 
-    let out = verify(&mut t, &ledger, &ports, 8, 7).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 8, 7).expect("verify");
     assert!(!out.passed());
     assert_eq!(out.mismatches.len(), 8);
     assert!(
@@ -930,7 +930,7 @@ fn verify_fails_an_absent_route() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(50);
 
-    let out = verify(&mut t, &ledger, &ports, 4, 3).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 4, 3).expect("verify");
     assert!(!out.passed());
     assert!(
         out.mismatches
@@ -951,7 +951,7 @@ fn verify_fails_a_route_with_no_paths() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(50);
 
-    let out = verify(&mut t, &ledger, &ports, 4, 3).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 4, 3).expect("verify");
     assert!(!out.passed());
     assert!(
         out.mismatches
@@ -977,7 +977,7 @@ fn verify_fails_on_unresolvable_even_with_clean_probes() {
     // A route whose nexthops resolve nowhere.
     ledger.classify_resolved(v4(99, 99), 0);
 
-    let out = verify(&mut t, &ledger, &ports, 8, 11).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 8, 11).expect("verify");
     assert!(out.mismatches.is_empty(), "probes were clean");
     assert_eq!(out.unresolvable, 1);
     assert!(!out.passed(), "{}", out.summary());
@@ -998,7 +998,7 @@ fn an_empty_table_fails_rather_than_passing_vacuously() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(0);
 
-    let out = verify(&mut t, &ledger, &ports, 16, 5).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 16, 5).expect("verify");
     assert_eq!(out.sampled, 0);
     assert!(
         out.mismatches.is_empty(),
@@ -1032,7 +1032,9 @@ fn verify_fails_when_an_owned_interface_has_no_carrier() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(50);
 
-    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    // Routes egress idx 7 (the lookup behaviour says so), so the dark
+    // port is IN USE — the case that blocks steering.
+    let out = verify(&mut t, &ledger, &ports, &[7].into_iter().collect(), 8, 4).expect("verify");
     assert!(
         out.mismatches.is_empty(),
         "every route probe looks perfect: {:?}",
@@ -1040,6 +1042,7 @@ fn verify_fails_when_an_owned_interface_has_no_carrier() {
     );
     assert_eq!(out.dead_interfaces.len(), 1);
     assert_eq!(out.dead_interfaces[0].sw_if_index, 7);
+    assert!(out.dead_interfaces[0].in_use);
     assert!(out.dead_interfaces[0].admin_up);
     assert!(!out.dead_interfaces[0].link_up);
     assert!(!out.passed(), "{}", out.summary());
@@ -1064,7 +1067,8 @@ fn verify_fails_when_an_owned_interface_is_absent_from_vpp() {
     let (ledger, mut ports) = ledger_with(50);
     ports.insert("eth2", None, 9);
 
-    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    // The vanished port carries routes too — in use, so blocking.
+    let out = verify(&mut t, &ledger, &ports, &[7, 9].into_iter().collect(), 8, 4).expect("verify");
     assert!(
         out.mismatches.is_empty(),
         "every route probe still looks perfect: {:?}",
@@ -1072,6 +1076,7 @@ fn verify_fails_when_an_owned_interface_is_absent_from_vpp() {
     );
     assert_eq!(out.dead_interfaces.len(), 1, "{:?}", out.dead_interfaces);
     assert_eq!(out.dead_interfaces[0].sw_if_index, 9);
+    assert!(out.dead_interfaces[0].in_use);
     assert!(!out.dead_interfaces[0].admin_up);
     assert!(!out.dead_interfaces[0].link_up);
     assert!(!out.passed(), "{}", out.summary());
@@ -1096,7 +1101,7 @@ fn verify_ignores_link_state_on_interfaces_we_do_not_own() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(50);
 
-    let out = verify(&mut t, &ledger, &ports, 8, 4).expect("verify");
+    let out = verify(&mut t, &ledger, &ports, &Default::default(), 8, 4).expect("verify");
     assert!(out.dead_interfaces.is_empty(), "{:?}", out.dead_interfaces);
     assert!(out.passed(), "{}", out.summary());
 }
@@ -1114,8 +1119,8 @@ fn consecutive_passes_probe_different_routes() {
     let mut t = fake.connect();
     let (ledger, ports) = ledger_with(500);
 
-    let a = verify(&mut t, &ledger, &ports, 32, 1).expect("verify");
-    let b = verify(&mut t, &ledger, &ports, 32, 2).expect("verify");
+    let a = verify(&mut t, &ledger, &ports, &Default::default(), 32, 1).expect("verify");
+    let b = verify(&mut t, &ledger, &ports, &Default::default(), 32, 2).expect("verify");
     assert_eq!(a.sampled, 32);
     assert_eq!(b.sampled, 32);
     // 64 lookups total reached the socket across the two passes.

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -168,6 +168,7 @@ impl Host {
             // against, and none of them steers; the gate is exercised
             // where it lives, in `runtime`.
             require_table_complete: false,
+            steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
                 prefix_len: 32,

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1367,6 +1367,7 @@ fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {
     packetframe_vpp_offload::steer::RuleSet::plan(
         &allow,
         packetframe_vpp_offload::steer::McamBudget::default(),
+        Default::default(),
     )
     .expect("fits")
 }

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1276,6 +1276,33 @@ carrying that traffic; VPP still is.
   A box that adopts while steered under a vetoing authority has no fast
   rollback. Worth knowing before the canary rather than during it.
 
+### A member port with no link — degraded and steer-refused, never a restart
+
+`packetframe status` shows `fib-synced` carrying a verify line like:
+
+```text
+verify FIB OK, MEMBER(S) DARK — steering refused, no restart: 64/64 probes
+matched, unresolvable=0, withheld=0, octeon0/0 (idx 2) admin_up=true link_up=false
+```
+
+Read it as three separate facts. The FIB is **correct** (the probes
+matched). The named member(s) currently **cannot forward** (no link —
+a pulled cable, a dead SFP, a port that was never cabled). And the
+module's response is the designed one: reach `Ready`, keep the steer
+want, **refuse to steer** — every member is a possible egress, so a
+steered packet whose best path exits a dark port is dropped, not
+failed over — and do **not** restart, because a restart cannot plug in
+a cable. (The first build to meet this state restart-looped a VPP with
+a flawless FIB over three uncabled ports, every ~10 s, indefinitely —
+shadow repro 2026-08-13.)
+
+Remedy: restore link (or remove the port from membership — but
+membership is all-or-nothing across the fast-path attach set, so that
+means removing it from `attach` too). Recovery is automatic: the steer
+retry re-reads link state fresh from VPP on every attempt, so once the
+port has link the next retry steers. `packetframe reconfigure` asks
+immediately instead of waiting for the retry interval.
+
 ### A member port needs two things admin-up does not give it
 
 Both were found by tracing a live VPP on 2026-08-07, each hidden behind

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -1276,32 +1276,41 @@ carrying that traffic; VPP still is.
   A box that adopts while steered under a vetoing authority has no fast
   rollback. Worth knowing before the canary rather than during it.
 
-### A member port with no link — degraded and steer-refused, never a restart
+### A member port with no link — reported always, blocking only when routes use it
 
-`packetframe status` shows `fib-synced` carrying a verify line like:
+`packetframe status` shows `fib-synced` carrying a verify line naming
+every dark member, annotated one of two ways:
 
 ```text
-verify FIB OK, MEMBER(S) DARK — steering refused, no restart: 64/64 probes
-matched, unresolvable=0, withheld=0, octeon0/0 (idx 2) admin_up=true link_up=false
+..., octeon5/0 (idx 5) admin_up=true link_up=false (idle: no routes egress here; not blocking)
 ```
 
-Read it as three separate facts. The FIB is **correct** (the probes
-matched). The named member(s) currently **cannot forward** (no link —
-a pulled cable, a dead SFP, a port that was never cabled). And the
-module's response is the designed one: reach `Ready`, keep the steer
-want, **refuse to steer** — every member is a possible egress, so a
-steered packet whose best path exits a dark port is dropped, not
-failed over — and do **not** restart, because a restart cannot plug in
-a cable. (The first build to meet this state restart-looped a VPP with
-a flawless FIB over three uncabled ports, every ~10 s, indefinitely —
-shadow repro 2026-08-13.)
+An **idle** dark member decides nothing. This is the normal state of a
+dark port — the BGP session that would produce its routes died with
+the link, so no installed route can egress it, and a steered packet
+cannot choose an egress no route names. The port shows here and in the
+`ports` row so it gets fixed, but steering proceeds and the offload is
+not held hostage to an uncabled port (the primary's eth5 shipped this
+way).
 
-Remedy: restore link (or remove the port from membership — but
-membership is all-or-nothing across the fast-path attach set, so that
-means removing it from `attach` too). Recovery is automatic: the steer
-retry re-reads link state fresh from VPP on every attempt, so once the
-port has link the next retry steers. `packetframe reconfigure` asks
-immediately instead of waiting for the retry interval.
+```text
+verify FIB OK, IN-USE MEMBER(S) DARK — steering refused, no restart: 64/64
+probes matched, ..., octeon3/0 (idx 5) admin_up=true link_up=false CARRIES ROUTES
+```
+
+A dark member that **carries routes** — static routes pinned to it, or
+a link that died faster than its BGP session withdrew — is the real
+blackhole risk, and the response is the designed one: reach `Ready`,
+keep the steer want, **refuse to steer**, and do **not** restart,
+because a restart cannot plug in a cable. (The first build to meet
+this state restart-looped a VPP with a flawless FIB over three
+uncabled ports, every ~10 s, indefinitely — shadow repro 2026-08-13.)
+
+Remedy: restore link, or remove the routes that egress the dead port.
+Recovery is automatic either way: the steer retry re-reads link state
+AND usage fresh from VPP on every attempt, so the next retry after the
+fix steers. `packetframe reconfigure` asks immediately instead of
+waiting for the retry interval.
 
 ### A member port needs two things admin-up does not give it
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -213,6 +213,18 @@ Traffic moves only when you say so. The module never steers on a first
 attach, and a reconfigure that did not change a `steer` flag will not
 either, so editing an unrelated line cannot divert traffic by accident.
 
+**Choose `steer-direction` before the first rung, not during it.** On a
+service edge — the reference fleet — the right value is `src`: outbound
+traffic (src ∈ the service prefix, arriving from the agg switches)
+rides VPP's full-table best path, and inbound stays on the eBPF tier,
+whose FDB-pin owns delivery to the bridge-attached hosts VPP has no
+path to. The default `both` is for pure transit, and dst-steering a
+service prefix diverts inbound flows into a FIB that cannot deliver
+them — every steered service flow would blackhole with all gauges
+green. The directive is hot-reloadable (the target is a reconcile), so
+getting it wrong is recoverable — but the recovery window is however
+long it takes to notice.
+
 Each rung is a `steer` edit plus a SIGHUP. There is no restart and no
 resync: a restart would cost about 40 seconds with the offload down at
 every step, including the step meant to get traffic off a bad VPP


### PR DESCRIPTION
## The bug (shadow repro 2026-08-13, six member ports, three uncabled)

The first run with #176's teardown logging named it immediately:

```
last-tick: Verify: verify FAIL: 64/64 probes matched, unresolvable=0, withheld=0,
octeon0/0 (idx 2) admin_up=true link_up=false, octeon2/0 ..., octeon3/0 ...
```

A **flawless FIB** failed verification because three members had no link, `VerifyFailed` is the restart-worthy verdict, and a restart cannot plug in a cable → kill-respawn every ~10 s, forever. This is very likely the second half of the primary incident (VPP #2's 107 s life = a full resync reaching verify), layered under the IRQ starvation #176 fixed.

## The fix — the `VerifyIncomplete` lesson, applied again

- **`VerifyOutcome::fib_correct()` / `passed()` split.** `fib_correct` (probes matched, no mapping holes, non-empty sample) is the only restart-worthy question. `Verdict::event()` maps dark-members-only → `VerifyIncomplete`: reach Ready, keep the want, don't steer. `passed()` still fails on dark members — nothing about "fit to take traffic" weakened. Third summary label: `FIB OK, MEMBER(S) DARK — steering refused, no restart`.
- **Traffic protection moves to the steer chokepoint, with a FRESH read.** `Effects::steer` (both operator reconfigure and automatic re-steer pass through it — same rationale as the completeness gate beside it) runs `dead_interface_scan` against what VPP reports *now*: refuses naming each dark port; refuses when link state can't be read at all; **exempts empty targets** (removal-only = the rollback direction; refusing it would trap traffic ON the dark dataplane). Recovery is the existing retry loop noticing the cable came back — no new machinery, no stale state.
- **Drain-error kills name their cause**: the one supervision path #176's logging missed (event pushed with no failed action — 3 of the repro's 4 teardowns) now WARNs with the error.
- **`netlink_proto=error` default filter directive**, same pattern as the bgpkit one: 25 identical WARNs in 250 ms during six-port bring-up bury the lines that matter; the resolver seeds from dumps and ARP lifecycle churn re-announces what a dropped datagram missed. `RUST_LOG` re-enables.

Runbook: new triage entry ("A member port with no link — degraded and steer-refused, never a restart") with the recovery story.

## Tests

Verdict-mapping (dark→Incomplete, dark+wrong→Failed), the three steer-gate arms (dark refuses naming the port, unreadable refuses, restored link steers), empty-target exemption under dark members, summary labels. A `cfg(test)` seam on the engine supplies the scan where unit tests have no transport — the integration crate's fake VPP exercises the real one. 35 suites green, lint clean.

## Validation after merge

Shadow re-run of the same six-port config: expect **Ready, `fib-synced` healthy-degraded with the DARK label, steering refused by name, zero restarts** — then the primary pre-flight checklist gains its carrier-state read alongside `vpp.irq-affinity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)