### PR TITLE
fix(vpp-offload): assert the promisc vote on member VFs — VPP's default blacked out the bridge

### DIFF
--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -27,7 +27,8 @@ use crate::vpp_api::generated::{
     DevCreatePortIf, DevCreatePortIfReply, Prefix, SwInterfaceAddDelAddress,
     SwInterfaceAddDelAddressReply, SwInterfaceDetails, SwInterfaceDump, SwInterfaceSetFlags,
     SwInterfaceSetFlagsReply, SwInterfaceSetMacAddress, SwInterfaceSetMacAddressReply,
-    SwInterfaceSetUnnumbered, SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
+    SwInterfaceSetPromisc, SwInterfaceSetPromiscReply, SwInterfaceSetUnnumbered,
+    SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -280,6 +281,7 @@ pub fn attach_ports(
                 // that silently reverted would punt every steered frame
                 // while every counter stayed healthy.
                 set_mac(t, p, idx, p.pf_mac)?;
+                set_promisc_on(t, p, idx)?;
                 set_unnumbered(t, p, idx, loop_idx)?;
                 out.push(AttachedPort {
                     port: p.port.clone(),
@@ -330,6 +332,7 @@ pub fn attach_ports(
         // resolve routes onto while every packet dies at
         // `ip4-not-enabled`.
         set_mac(t, p, sw_if_index, p.pf_mac)?;
+        set_promisc_on(t, p, sw_if_index)?;
         set_unnumbered(t, p, sw_if_index, loop_idx)?;
         out.push(AttachedPort {
             port: p.port.clone(),
@@ -688,6 +691,48 @@ fn set_unnumbered(
     if reply.retval != 0 {
         return Err(AttachError::Refused {
             step: "sw_interface_set_unnumbered",
+            port: p.port.clone(),
+            retval: reply.retval,
+            detail: String::new(),
+        });
+    }
+    Ok(())
+}
+
+/// Promiscuous mode on the member VF — a shared-LMAC VOTE, not a local
+/// flag, and the fix for the primary bridge-blackout (2026-08-14).
+///
+/// On this hardware the rvu AF keeps per-function rx-mode state and
+/// re-evaluates the channel's default MCAM entries — the AF-installed
+/// promisc + multicast catch-alls that forward to the KERNEL PF — on
+/// every rx-mode event from ANY function sharing the LMAC. VPP's octeon
+/// driver asserts promisc=off at port start (its default), which
+/// disabled those entries channel-wide: the bridge-member PF went deaf
+/// to every frame not addressed to its exact unicast MAC, service
+/// delivery died below the kernel (rx_drops flat — frames never reached
+/// the PF), and the kernel's own IFF_PROMISC flag stayed set the whole
+/// time, so nothing host-side looked wrong. Measured directly: NPC MCAM
+/// entries 2004/2005 on channel 0x800 flipped enabled yes->no at VPP
+/// interface-up; an rx-mode kick from the kernel side re-enabled them,
+/// and the next AF re-evaluation (bridge mcast churn arrives every few
+/// seconds) disabled them again — a war, not a fix.
+///
+/// Setting the VPP port promiscuous flips the VF's STORED vote, so
+/// every future re-evaluation — whoever triggers it — lands on
+/// enabled. The entries forward to the PF, not to us, so this does not
+/// divert bridge traffic into VPP; it stops VPP's default from
+/// un-forwarding it. Asserted on both the fresh and reuse paths for
+/// the same reason the MAC is: this is the reconcile point.
+fn set_promisc_on(t: &mut Transport, p: &PortAttach, sw_if_index: u32) -> Result<(), AttachError> {
+    let reply =
+        t.request::<SwInterfaceSetPromisc, SwInterfaceSetPromiscReply>(SwInterfaceSetPromisc {
+            context: 0,
+            sw_if_index,
+            promisc_on: true,
+        })?;
+    if reply.retval != 0 {
+        return Err(AttachError::Refused {
+            step: "sw_interface_set_promisc",
             port: p.port.clone(),
             retval: reply.retval,
             detail: String::new(),

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -39,6 +39,8 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "sw_interface_set_flags_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_set_mac_address", crc: "0xc536e7eb", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "sw_interface_set_mac_address_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "sw_interface_set_promisc", crc: "0xd40860d4", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "sw_interface_set_promisc_reply", crc: "0xe8d4e804", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "create_loopback", crc: "0x42bb5d22", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "create_loopback_reply", crc: "0x5383d31f", context_offset: 2, client_index_prefix: false },
     MessageMeta { name: "sw_interface_add_del_address", crc: "0x5463d73b", context_offset: 6, client_index_prefix: true },
@@ -1233,6 +1235,79 @@ impl Decode for SwInterfaceSetMacAddressReply {
 
 impl Message for SwInterfaceSetMacAddressReply {
     const NAME: &'static str = "sw_interface_set_mac_address_reply";
+    const CRC: &'static str = "0xe8d4e804";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_promisc` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetPromisc {
+    pub context: u32,
+    pub sw_if_index: u32,
+    pub promisc_on: bool,
+}
+
+impl Encode for SwInterfaceSetPromisc {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.sw_if_index).to_be_bytes());
+        buf.push(if self.promisc_on { 1u8 } else { 0u8 });
+    }
+}
+
+impl Decode for SwInterfaceSetPromisc {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let sw_if_index = d.u32()?;
+        let promisc_on = d.bool()?;
+        Ok(Self {
+            context,
+            sw_if_index,
+            promisc_on,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetPromisc {
+    const NAME: &'static str = "sw_interface_set_promisc";
+    const CRC: &'static str = "0xd40860d4";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `sw_interface_set_promisc_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SwInterfaceSetPromiscReply {
+    pub context: u32,
+    pub retval: i32,
+}
+
+impl Encode for SwInterfaceSetPromiscReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+    }
+}
+
+impl Decode for SwInterfaceSetPromiscReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        Ok(Self {
+            context,
+            retval,
+        })
+    }
+}
+
+impl Message for SwInterfaceSetPromiscReply {
+    const NAME: &'static str = "sw_interface_set_promisc_reply";
     const CRC: &'static str = "0xe8d4e804";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -35,8 +35,8 @@ use packetframe_vpp_offload::vpp_api::generated::{
     IpNeighborDetails, IpNeighborDump, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails,
     IpRouteLookupReply, MessageTableEntry, Prefix, SockclntCreateReply,
     SwInterfaceAddDelAddressReply, SwInterfaceDetails, SwInterfaceSetFlagsReply,
-    SwInterfaceSetMacAddressReply, SwInterfaceSetUnnumberedReply, ADDRESS_IP4,
-    FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
+    SwInterfaceSetMacAddressReply, SwInterfaceSetPromiscReply, SwInterfaceSetUnnumberedReply,
+    ADDRESS_IP4, FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL, MESSAGE_META,
 };
 
 /// The index the fake's `dev_create_port_if` hands out. Routes must
@@ -314,6 +314,14 @@ fn serve(
             "sw_interface_set_flags" => {
                 out = reply_head("sw_interface_set_flags_reply");
                 SwInterfaceSetFlagsReply {
+                    context: ctx,
+                    retval: 0,
+                }
+                .encode(&mut out);
+            }
+            "sw_interface_set_promisc" => {
+                out = reply_head("sw_interface_set_promisc_reply");
+                SwInterfaceSetPromiscReply {
                     context: ctx,
                     retval: 0,
                 }

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -37,7 +37,7 @@ use packetframe_vpp_offload::vpp_api::generated::{
     ControlPingReply, CreateLoopbackReply, DevAttachReply, DevCreatePortIfReply, FibPath, IpRoute,
     IpRouteLookupReply, MessageTableEntry, SockclntCreateReply, SwInterfaceAddDelAddressReply,
     SwInterfaceDetails, SwInterfaceSetFlagsReply, SwInterfaceSetMacAddressReply,
-    SwInterfaceSetUnnumberedReply, MESSAGE_META,
+    SwInterfaceSetPromiscReply, SwInterfaceSetUnnumberedReply, MESSAGE_META,
 };
 use packetframe_vpp_offload::vpp_api::Transport;
 
@@ -312,6 +312,14 @@ impl Fake {
                     "sw_interface_set_flags" => {
                         out = reply_head("sw_interface_set_flags_reply");
                         SwInterfaceSetFlagsReply {
+                            context: ctx,
+                            retval: 0,
+                        }
+                        .encode(&mut out);
+                    }
+                    "sw_interface_set_promisc" => {
+                        out = reply_head("sw_interface_set_promisc_reply");
+                        SwInterfaceSetPromiscReply {
                             context: ctx,
                             retval: 0,
                         }
@@ -657,6 +665,13 @@ fn attach_sends_every_message_a_forwarding_port_needs_in_order() {
             "sw_interface_set_mac_address".to_string(),
             "sw_interface_dump".to_string(),
             "control_ping".to_string(),
+            // The promisc VOTE, after the MAC and before the port is
+            // announced. On this hardware promisc is shared-LMAC state
+            // the AF re-evaluates from every function's stored vote;
+            // VPP's own default (off) disabled the kernel PF's bridge
+            // entries and blacked out service delivery (primary,
+            // 2026-08-14). Missing this call is that outage.
+            "sw_interface_set_promisc".to_string(),
             "sw_interface_set_unnumbered".to_string(),
         ]
     );
@@ -790,6 +805,13 @@ fn a_recorded_interface_is_reused_not_re_attached() {
     // this is the reconcile point.
     assert!(
         seen.contains(&"sw_interface_set_flags".to_string()),
+        "{seen:?}"
+    );
+    // And so is the promisc vote — an adopted VPP re-applies its port
+    // config on our schedule too, and the vote is what keeps the AF
+    // re-evaluations landing enabled (primary blackout, 2026-08-14).
+    assert!(
+        seen.contains(&"sw_interface_set_promisc".to_string()),
         "{seen:?}"
     );
 }

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -83,6 +83,20 @@ const MESSAGES: &[&str] = &[
     //   rejection at /32).
     "sw_interface_set_mac_address",
     "sw_interface_set_mac_address_reply",
+    //   Promiscuous mode is a shared-LMAC VOTE on this hardware, not a
+    //   local flag. The rvu AF keeps per-function rx-mode state and
+    //   re-evaluates the channel's default MCAM entries (promisc +
+    //   multicast, AF-installed, forwarding to the kernel PF) on every
+    //   rx-mode event from ANY function on the LMAC. VPP's octeon
+    //   driver asserts promisc=off at port start by default, which
+    //   disabled those entries and made the bridge-member PF deaf to
+    //   all service traffic — measured on the primary 2026-08-14,
+    //   MCAM entries 2004/2005 flipping enabled:yes->no, recovered by
+    //   an rx-mode kick and re-broken within seconds by the next
+    //   re-evaluation. Setting the VPP port promiscuous flips the
+    //   stored vote, so every future re-evaluation lands enabled.
+    "sw_interface_set_promisc",
+    "sw_interface_set_promisc_reply",
     "create_loopback",
     "create_loopback_reply",
     "sw_interface_add_del_address",


### PR DESCRIPTION
## Root cause of the primary rung-0 outage (windows 2/3, 2026-08-14), read from the hardware table

On rvu, **promiscuous mode is shared-LMAC state**. The AF installs channel-default MCAM entries (promisc + multicast catch-alls → the **kernel PF**) and re-evaluates them from every function's stored rx-mode vote, on every rx-mode event from *any* function on the LMAC. VPP's octeon driver asserts `promisc=off` at port start — so attaching a VF on eth4 (the agg uplink, a promisc bridge member) disabled the PF's entries channel-wide. The bridge went deaf *below* the kernel: `rx_drops` flat (frames never reached the PF), `IFF_PROMISC` still set, every host-side surface green, service prefix dark.

Evidence chain, all instrumented with auto-rollback watchdogs (~50 s bounded exposure per run):
- NPC MCAM entries **2004/2005** (channel 0x800) flip `enabled: yes→no` at VPP interface-up — captured in before/after debugfs dumps
- eth1-only attach: harmless (L3 port lives on its unicast entry) — same entries disabled there too, latently
- eth4-only attach: `.7` dead at +29 s, three reproductions
- kernel-side rx-mode kick: recovers within ~1 s, re-broken by the next AF re-evaluation in 4–19 s (bridge mcast churn), five cycles — a war, not a fix

## The fix

Flip the VF's **stored vote**: `sw_interface_set_promisc(on)` after the MAC set, on both fresh and reuse/adopt paths (the reconcile point, same reasoning as the MAC re-assert). Every future AF re-evaluation lands enabled regardless of trigger. The channel entries forward to the PF, not the VF — this diverts nothing into VPP; it stops VPP's default from un-forwarding the bridge.

Message was already vendored; whitelist +2 (38 messages), both fakes answer it, sequence test pins the call by position and name.

## Validation

Host suite green (35 suites). **Hardware validation owed before merge is trusted**: the same eth4-only watchdogged window that failed at +29 s three times tonight must run clean for 240 s on this build. The harness for it already exists on the primary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)