### PR TITLE
fix(vpp-offload): dark-idle members must not page, and a failure episode must be able to end

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -599,30 +599,44 @@ impl ConvergenceEngine {
     /// `status::StatusSnapshot::nominal` requires a *passing verify*
     /// independently — so the window is bounded by something that does
     /// not trust this value.
+    ///
+    /// `in_use` is deliberately NOT the verify-time
+    /// [`crate::verify::DeadInterface::in_use`]: verify does not re-run
+    /// in steady state, so that copy ages exactly like the link flags —
+    /// but in the dangerous direction. Routes shifting ONTO a dark
+    /// member after the last verify are what turn "idle, carries
+    /// nothing" into a blackhole, and the neighbour ledger here is the
+    /// engine's own current bookkeeping (the same `active_egress_indices`
+    /// read that feeds the steer gate), so the health surface reads it
+    /// live rather than as a recording.
     pub fn port_links(&self) -> Vec<PortLink> {
         let dead = self
             .last_verify
             .as_ref()
             .map(|v| v.dead_interfaces.as_slice())
             .unwrap_or_default();
+        let active = self.active_egress_indices();
         self.attached
             .iter()
-            .map(
-                |p| match dead.iter().find(|d| d.sw_if_index == p.sw_if_index) {
+            .map(|p| {
+                let in_use = active.contains(&p.sw_if_index);
+                match dead.iter().find(|d| d.sw_if_index == p.sw_if_index) {
                     Some(d) => PortLink {
                         port: p.port.clone(),
                         sw_if_index: p.sw_if_index,
                         admin_up: d.admin_up,
                         link_up: d.link_up,
+                        in_use,
                     },
                     None => PortLink {
                         port: p.port.clone(),
                         sw_if_index: p.sw_if_index,
                         admin_up: true,
                         link_up: true,
+                        in_use,
                     },
-                },
-            )
+                }
+            })
             .collect()
     }
 
@@ -2044,6 +2058,21 @@ mod tests {
         assert!(
             !links[0].link_up,
             "a port verify found dead must not report as forwarding"
+        );
+        // `in_use` is the CURRENT neighbour ledger, not the verify-time
+        // recording — the dead entry above claims in_use and must not be
+        // believed while no neighbour lives on the port. Verify never
+        // re-runs in steady state, so a recording would miss routes
+        // shifting onto a dark member afterwards.
+        assert!(
+            !links[0].in_use,
+            "no neighbour lives on idx 3, so nothing can egress there now"
+        );
+        e.neighbours_installed
+            .insert((3, IpAddr::V4(Ipv4Addr::new(192, 0, 2, 1))), [0; 6]);
+        assert!(
+            e.port_links()[0].in_use,
+            "a neighbour on the port means installed routes can egress it"
         );
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -221,8 +221,17 @@ pub struct Published {
     /// republishing each tick verbatim cleared this within ~50 ms while
     /// the service stayed in the same failed state for seconds — an
     /// operator polling status would essentially always miss it. Cleared
-    /// when the supervisor's consecutive-failure count returns to zero,
-    /// which it does only on a verified-healthy cycle.
+    /// when `crate::status::StatusSnapshot::failure_episode_over`
+    /// observes recovery: a verified-healthy cycle (zero consecutive
+    /// failures in `Ready`/`Steered`, passing verify, answering API)
+    /// with steering matching intent and no live fault retained on its
+    /// own row. Deliberately NOT "when health returns to `Healthy`",
+    /// which this clause used to say and the code used to do: a
+    /// dark-idle member port keeps the module honestly Degraded for as
+    /// long as the cable is out — permanently, on the primary — and
+    /// keying the clear on `Healthy` retained the full failure history
+    /// of a long-recovered storm forever (measured on the shadow,
+    /// 2026-08-14).
     ///
     /// Covers failures from injected events too (a `VerifyPassed` whose
     /// `Steer` was refused, a `VerifyFailed` whose teardown failed);
@@ -820,7 +829,8 @@ fn expire_verdict(
 /// bounded: `MAX_EPISODE_REASONS` distinct entries, deduplicated, because a
 /// long backoff loop would otherwise append the same spawn failure forever
 /// into a `Vec` published on every tick. The episode ends — and the list is
-/// cleared — when health returns to `Healthy`.
+/// cleared — when the published snapshot observes recovery
+/// ([`crate::status::StatusSnapshot::failure_episode_over`]).
 fn remember_failures(into: &mut Vec<String>, new: Vec<String>) {
     for reason in new {
         if into.len() >= MAX_EPISODE_REASONS {
@@ -1035,8 +1045,12 @@ fn run_loop(
         remember_failures(&mut last_failures, fmt_failures(&injected.outcome));
     }
 
-    // Returns the overall health it published, which is what decides
-    // whether a retained failure reason may finally be dropped.
+    // Returns whether the snapshot it published observed the failure
+    // episode to be over, which is what decides whether a retained
+    // failure reason may finally be dropped. The predicate lives on the
+    // snapshot (`failure_episode_over`), beside `nominal()`, so the
+    // surface that reports health and the condition that releases the
+    // reasons cannot drift apart.
     let publish = |driver: &Driver,
                    runtime: &Runtime,
                    last_verify: &Option<crate::verify::VerifyOutcome>,
@@ -1045,7 +1059,7 @@ fn run_loop(
                    teardown_failures: &[String],
                    resources_leaked: bool,
                    last_failures: &[String]|
-     -> packetframe_common::module::HealthState {
+     -> bool {
         let now = Instant::now();
         let rs = runtime.status();
         let fib = match (last_verify, last_verify_at) {
@@ -1082,7 +1096,7 @@ fn run_loop(
             },
         );
         let report = snap.report();
-        let overall = report.overall;
+        let episode_over = snap.failure_episode_over();
         let published = Published {
             report,
             metrics: crate::status::render_metrics(&snap, module),
@@ -1095,7 +1109,7 @@ fn run_loop(
             store_error: rs.store_error,
         };
         *shared.latest.lock().expect("status lock") = Some(published);
-        overall
+        episode_over
     };
 
     // First snapshot before the first tick; the handshake below is
@@ -1227,8 +1241,8 @@ fn run_loop(
         //
         // So it is sticky, and the release condition is an *observation*
         // of recovery: the reason is dropped only once the published
-        // health returns to `Healthy`. A newer failure supersedes an
-        // older one.
+        // snapshot reports the failure episode over. A newer failure
+        // supersedes an older one.
         //
         // The obvious release condition — the supervisor's own
         // consecutive-failure count reaching zero — is WRONG, and
@@ -1236,9 +1250,14 @@ fn run_loop(
         // as a supervisor failure (a failed canary must not cycle a VPP
         // that is forwarding fine), so `failures()` is already zero at
         // the moment the steer is refused, and keying on it wiped the
-        // reason on the very next tick. `Healthy` is the condition that
-        // actually covers every way this module can be unwell, because it
-        // is the same whitelist `nominal()` applies.
+        // reason on the very next tick. The opposite pole — published
+        // health returning to `Healthy` — is wrong the other way, and
+        // was measured being so (shadow, 2026-08-14): a dark-idle member
+        // keeps the module honestly Degraded indefinitely, so a box in
+        // its designed steady state retained the failure history of a
+        // fully-recovered storm forever. The condition that covers both
+        // is `StatusSnapshot::failure_episode_over`, defined beside
+        // `nominal()` and documented clause by clause against it.
         remember_failures(&mut last_failures, failures);
 
         // One call, one rule. See `expire_verdict`.
@@ -1281,7 +1300,7 @@ fn run_loop(
         if shared.stop.load(Ordering::SeqCst) {
             break;
         }
-        let overall = publish(
+        let episode_over = publish(
             &driver,
             &runtime,
             &last_verify,
@@ -1291,7 +1310,7 @@ fn run_loop(
             false,
             &last_failures,
         );
-        if overall == packetframe_common::module::HealthState::Healthy {
+        if episode_over {
             last_failures.clear();
         }
 

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -226,11 +226,29 @@ pub struct PortLink {
     pub sw_if_index: u32,
     pub admin_up: bool,
     pub link_up: bool,
+    /// Whether any installed route can egress here — the engine's
+    /// **current** neighbour bookkeeping, deliberately fresher than the
+    /// verify-time flags above. See [`crate::verify::DeadInterface`] for
+    /// the distinction this carries: a dark member nothing routes
+    /// through deliberately carries nothing (the primary's uncabled eth5
+    /// is permanent, by discipline), while a dark member with routes
+    /// egressing it is a blackhole the moment anything is steered.
+    /// Verify does not re-run in steady state, so keying this to the
+    /// last verify would miss routes shifting ONTO a dark member
+    /// afterwards — the direction that turns green gauges into a
+    /// blackhole.
+    pub in_use: bool,
 }
 
 impl PortLink {
     fn forwards(&self) -> bool {
         self.admin_up && self.link_up
+    }
+
+    /// Cannot forward, yet installed routes egress here: dropping
+    /// traffic if steered, one steer away from dropping it if not.
+    fn blackhole(&self) -> bool {
+        !self.forwards() && self.in_use
     }
 }
 
@@ -417,6 +435,11 @@ impl StatusSnapshot {
         self.ports.iter().filter(|p| !p.forwards()).collect()
     }
 
+    /// Ports that cannot forward AND that installed routes egress.
+    fn blackhole_ports(&self) -> Vec<&PortLink> {
+        self.ports.iter().filter(|p| p.blackhole()).collect()
+    }
+
     /// Whether traffic is diverted into a VPP that cannot forward it
     /// correctly. The worst condition the module can be in, and the
     /// reason `overall` is not simply the max of the subsystems.
@@ -432,11 +455,18 @@ impl StatusSnapshot {
         // report the safeguard as the module's worst fault for as long
         // as bird takes to reload.
         let fib_unverified = !self.fib.verified() && self.resync_deferred.is_none();
+        // BLACKHOLE ports, not dead ones — "under paths that resolve
+        // through it" was this comment's claim all along, and the code
+        // read every dark member as one. On the shadow (2026-08-14) a
+        // steered, verified VPP with five deliberately-idle dark members
+        // paged as the worst state in the system while forwarding
+        // everything correctly; verify itself already draws the line at
+        // `DeadInterface::in_use`.
         self.steered
             && (!self.state.has_process()
                 || matches!(self.api, ApiHealth::Silent { .. })
                 || fib_unverified
-                || !self.dead_ports().is_empty())
+                || !self.blackhole_ports().is_empty())
     }
 
     /// Structured report for `packetframe status`, circuit breakers and
@@ -547,6 +577,13 @@ impl StatusSnapshot {
             // Membership is all-or-nothing, so "no ports" is not a
             // vacuous pass — it means nothing was ever attached.
             && !self.ports.is_empty()
+            // ALL dead ports, idle ones included — deliberately stricter
+            // than `steered_but_broken`, which only counts blackholes. A
+            // dark-idle member is lost redundancy: real degradation, an
+            // honest Degraded, and the ports row says so — `overall`
+            // must not outrank its own subsystems. What a dark-idle
+            // member must NOT do is page (severity, above) or retain
+            // failure history forever ([`Self::failure_episode_over`]).
             && self.dead_ports().is_empty()
             // Steering wanted but absent: a broken rollout, not staging.
             && (self.steered || !self.steer_intended)
@@ -560,6 +597,60 @@ impl StatusSnapshot {
             // from bird's with every update it misses. Nothing restarts
             // over it by design, which is exactly why it must not read as
             // nominal.
+            && self.drain_error.is_none()
+    }
+
+    /// Whether the CURRENT failure episode is over — the release
+    /// condition for the retained failure reasons
+    /// ([`crate::service::Published::last_failures`], the `last-tick`
+    /// row).
+    ///
+    /// NOT [`Self::nominal`], deliberately, though it is nominal's
+    /// clauses minus the conditions that are not failures. Nominal is
+    /// "this module is doing its job with nothing worth a look"; this is
+    /// "the machinery that was failing has been observed working again".
+    /// The difference is the degradations that are designed, and
+    /// possibly permanent: a dark-idle member (the primary's uncabled
+    /// eth5 never comes up, by discipline) and a table withheld at
+    /// capacity keep the module honestly Degraded for as long as they
+    /// hold. The clear used to key on published health returning to
+    /// `Healthy`, and on the shadow (2026-08-14, post-storm) that meant
+    /// `vpp-process` read healthy with zero failures while `last-tick`
+    /// still carried the entire storm history — five dark-idle members
+    /// pinned overall at not-Healthy, so the clear could never fire on
+    /// the very posture the box is designed to hold.
+    ///
+    /// Every clause here is the recovery observation for a class of
+    /// retained reason:
+    /// - `Ready`/`Steered` with zero failures: the supervisor completed
+    ///   a verified-healthy cycle, releasing spawn/attach/teardown
+    ///   reasons. (`failures == 0` alone is NOT sufficient — a refused
+    ///   steer never increments it, which is why the next clause
+    ///   exists.)
+    /// - a passing verify and an answering API: verify summaries and
+    ///   wedge reasons describe a condition that is gone.
+    /// - steering matching intent: a refused steer's reason lives
+    ///   exactly as long as the want it left behind.
+    /// - no blackhole member: an in-use dark port is a live fault even
+    ///   when everything above recovered. Idle dark ports deliberately
+    ///   do not hold the episode open.
+    /// - no store or drain error: both are active failures with their
+    ///   own retained rows, and an episode that "ends" while they
+    ///   persist would drop reasons that may share their cause.
+    ///
+    /// What is deliberately absent: `counts.degraded()`. Withholding is
+    /// the designed response to a table that outgrew the box, not a
+    /// failure, and unresolvable routes cannot coexist with the passing
+    /// verify required above (`fib_correct` fails on them).
+    pub(crate) fn failure_episode_over(&self) -> bool {
+        !self.undead
+            && matches!(self.state, State::Ready | State::Steered)
+            && self.failures == 0
+            && self.fib.verified()
+            && matches!(self.api, ApiHealth::Answering { .. })
+            && (self.steered || !self.steer_intended)
+            && self.blackhole_ports().is_empty()
+            && self.store_error.is_none()
             && self.drain_error.is_none()
     }
 
@@ -1089,21 +1180,56 @@ impl StatusSnapshot {
                 Some(format!("{} member port(s) up", self.ports.len())),
             )
         } else {
-            // Membership is all-or-nothing: a down member port means
-            // every prefix whose best path egresses it is a blackhole
-            // once anything is steered, which is why this is Unhealthy
-            // while steered and Degraded otherwise.
+            // Severity consults BOTH facts about a dead member: whether
+            // it can forward, and whether anything routes through it.
+            // Membership is all-or-nothing, so every possible egress
+            // holds a VF — including ports that deliberately carry
+            // nothing (under `steer-direction src` an idle uplink's VF
+            // is permanently dark; the primary's eth5 is the motivating
+            // case). A dark member is a blackhole only when installed
+            // routes egress it, which is the same line verify draws at
+            // `DeadInterface::in_use`. The first cut escalated on
+            // link-down alone: the shadow steered healthy with five
+            // dark-idle members and read `ports UNHEALTHY` (2026-08-14)
+            // — a page for a box forwarding everything correctly, which
+            // is how alerts get muted.
             let names = dead
                 .iter()
-                .map(|p| format!("{} (admin_up={} link_up={})", p.port, p.admin_up, p.link_up))
+                .map(|p| {
+                    format!(
+                        "{} (admin_up={} link_up={}{})",
+                        p.port,
+                        p.admin_up,
+                        p.link_up,
+                        if p.in_use {
+                            "; ROUTES EGRESS HERE"
+                        } else {
+                            "; idle"
+                        }
+                    )
+                })
                 .collect::<Vec<_>>()
                 .join(", ");
-            let st = if self.steered {
-                HealthState::Unhealthy
-            } else {
-                HealthState::Degraded
+            let (st, tail) = match (dead.iter().any(|p| p.in_use), self.steered) {
+                (true, true) => (
+                    HealthState::Unhealthy,
+                    "installed routes egress a member that cannot forward, and traffic is \
+                     steered — those paths are dropping",
+                ),
+                (true, false) => (
+                    HealthState::Degraded,
+                    "installed routes egress a member that cannot forward; a steer into \
+                     this would blackhole those paths, and verify refuses it while this \
+                     holds",
+                ),
+                (false, _) => (
+                    HealthState::Degraded,
+                    "no installed route egresses them, so they deliberately carry nothing \
+                     and steering is unaffected; link-up plus a steering retry brings one \
+                     back into service",
+                ),
             };
-            (st, Some(format!("down: {names}")))
+            (st, Some(format!("down: {names} — {tail}")))
         };
         SubsystemHealth {
             name: SUBSYS_PORTS.into(),
@@ -1424,15 +1550,31 @@ mod tests {
             sw_if_index: 3,
             admin_up: true,
             link_up: true,
+            in_use: true,
         }]
     }
 
+    /// A dark member nothing routes through — the common shape on this
+    /// fleet (the primary's uncabled eth5, the shadow's five idle
+    /// members under `steer-direction src`).
     fn port_down() -> Vec<PortLink> {
         vec![PortLink {
             port: "eth4".into(),
             sw_if_index: 3,
             admin_up: true,
             link_up: false,
+            in_use: false,
+        }]
+    }
+
+    /// A dark member that installed routes egress: the blackhole shape.
+    fn port_down_in_use() -> Vec<PortLink> {
+        vec![PortLink {
+            port: "eth4".into(),
+            sw_if_index: 3,
+            admin_up: true,
+            link_up: false,
+            in_use: true,
         }]
     }
 
@@ -2494,32 +2636,212 @@ mod tests {
     }
 
     /// A down member port blackholes every prefix whose best path
-    /// egresses it — but only once traffic is steered. Membership is
-    /// all-or-nothing, so this is the difference between an outage and a
-    /// staging problem.
+    /// egresses it — so the escalation to Unhealthy needs BOTH facts:
+    /// routes actually egress it (`in_use`) and traffic is steered.
+    /// Severity ignoring `in_use` is a measured defect, not a
+    /// hypothetical: the shadow steered healthy with five dark-idle
+    /// members (fib-synced verified, zero teardowns) and read `ports
+    /// UNHEALTHY` (2026-08-14) — a page for a box forwarding everything
+    /// correctly. A dark-idle member deliberately carries nothing;
+    /// verify already draws this exact line at `DeadInterface::in_use`.
     #[test]
-    fn a_down_member_port_escalates_only_when_steered() {
-        let steered = snap_of(
+    fn a_down_member_port_escalates_only_when_steered_and_in_use() {
+        let api = || ApiHealth::Answering {
+            silent_for: Duration::ZERO,
+        };
+        // The blackhole: steered, and installed routes egress the dark
+        // member. The one shape that pages.
+        let steered_blackhole = snap_of(
+            &steered_supervisor(),
+            &ledger_with(10, 0, 0),
+            api(),
+            verified(1),
+            port_down_in_use(),
+        );
+        assert_eq!(steered_blackhole.report().overall, HealthState::Unhealthy);
+
+        // Steered with the dark member idle: the shadow's designed
+        // steady state under `steer-direction src`. Degraded at most.
+        let steered_idle = snap_of(
+            &steered_supervisor(),
+            &ledger_with(10, 0, 0),
+            api(),
+            verified(1),
+            port_down(),
+        );
+        let r = steered_idle.report();
+        assert_eq!(
+            r.overall,
+            HealthState::Degraded,
+            "a dark-idle member deliberately carries nothing; steered traffic is unaffected"
+        );
+        let ports = r
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_PORTS)
+            .expect("ports row");
+        assert_eq!(ports.state, HealthState::Degraded);
+        let msg = ports.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains("idle") && msg.contains("steering is unaffected"),
+            "the row must say the dark member carries nothing: {msg}"
+        );
+
+        // Unsteered, either way: a staging problem, not an outage.
+        for ports in [port_down(), port_down_in_use()] {
+            let staged = snap_of(
+                &ready_supervisor(),
+                &ledger_with(10, 0, 0),
+                api(),
+                verified(1),
+                ports,
+            );
+            assert_eq!(staged.report().overall, HealthState::Degraded);
+        }
+
+        // An in-use dark member names the risk even before a steer.
+        let staged_blackhole = snap_of(
+            &ready_supervisor(),
+            &ledger_with(10, 0, 0),
+            api(),
+            verified(1),
+            port_down_in_use(),
+        );
+        let r = staged_blackhole.report();
+        let ports = r
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_PORTS)
+            .expect("ports row");
+        let msg = ports.message.as_deref().unwrap_or_default();
+        assert!(
+            msg.contains("ROUTES EGRESS HERE"),
+            "an in-use dark member must be distinguishable from an idle one: {msg}"
+        );
+    }
+
+    /// The regression behind the stuck `last-tick` row (shadow,
+    /// 2026-08-14): after the L2-loop storm recovered unattended —
+    /// eleven teardowns, then Ready+steered with a verified FIB and
+    /// `failures == 0` — the retained failure reasons never cleared,
+    /// because the release keyed on published health returning to
+    /// `Healthy` and five dark-idle members pin overall at Degraded
+    /// indefinitely. That posture is the box's DESIGNED steady state
+    /// under `steer-direction src`, so "wait for Healthy" meant "never".
+    ///
+    /// The episode predicate must release exactly there, while the
+    /// overall verdict honestly stays Degraded.
+    #[test]
+    fn the_failure_episode_ends_despite_dark_idle_members() {
+        let mut ports = vec![PortLink {
+            port: "eth1".into(),
+            sw_if_index: 1,
+            admin_up: true,
+            link_up: true,
+            in_use: true,
+        }];
+        for (i, name) in ["eth0", "eth2", "eth3", "eth4", "eth5"].iter().enumerate() {
+            ports.push(PortLink {
+                port: (*name).into(),
+                sw_if_index: 2 + i as u32,
+                admin_up: true,
+                link_up: false,
+                in_use: false,
+            });
+        }
+        let s = snap_of(
             &steered_supervisor(),
             &ledger_with(10, 0, 0),
             ApiHealth::Answering {
                 silent_for: Duration::ZERO,
             },
-            verified(1),
-            port_down(),
+            verified(3),
+            ports,
         );
-        assert_eq!(steered.report().overall, HealthState::Unhealthy);
+        // The old release condition, shown never to fire here: the
+        // dark-idle members keep the module honestly Degraded for as
+        // long as the cables are out.
+        assert_eq!(s.report().overall, HealthState::Degraded);
+        assert!(
+            s.failure_episode_over(),
+            "a verified-healthy steered cycle must release retained failure reasons \
+             even though dark-idle members hold overall at Degraded"
+        );
+    }
 
-        let staged = snap_of(
+    /// The other pole, which is why the release was never simply
+    /// `failures() == 0`: a refused steer does not count as a supervisor
+    /// failure (a failed canary must not cycle a forwarding VPP), so the
+    /// count is already zero while the refusal is the live problem. The
+    /// episode stays open until steering matches intent.
+    #[test]
+    fn a_refused_steer_keeps_the_episode_open() {
+        let mut s = snap_of(
             &ready_supervisor(),
             &ledger_with(10, 0, 0),
             ApiHealth::Answering {
                 silent_for: Duration::ZERO,
             },
             verified(1),
-            port_down(),
+            ports_up(),
         );
-        assert_eq!(staged.report().overall, HealthState::Degraded);
+        assert_eq!(s.failures, 0);
+        // Steering wanted but absent — the posture a refused steer
+        // leaves behind.
+        s.steer_intended = true;
+        assert!(!s.steered);
+        assert!(
+            !s.failure_episode_over(),
+            "the refused steer's reason must outlive the tick while the want is unmet"
+        );
+
+        // ...and an in-use dark member is a live fault that holds it
+        // open even with everything else recovered.
+        let mut s = snap_of(
+            &steered_supervisor(),
+            &ledger_with(10, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::ZERO,
+            },
+            verified(1),
+            port_down_in_use(),
+        );
+        assert!(!s.failure_episode_over());
+        // The same shape with the member idle releases.
+        s.ports = port_down();
+        assert!(s.failure_episode_over());
+    }
+
+    /// `failure_episode_over` is `nominal()` minus the non-failure
+    /// degradations, so nominal must always imply it — a snapshot that
+    /// reads Healthy while still retaining failure reasons would mean
+    /// the two whitelists drifted apart.
+    #[test]
+    fn nominal_implies_the_episode_is_over() {
+        for state in STATE_LABELS.map(|(s, _)| s) {
+            for ports in [ports_up(), port_down(), port_down_in_use(), Vec::new()] {
+                for fib in [FibSync::NeverVerified, verified(1)] {
+                    for sup in [steered_supervisor(), ready_supervisor()] {
+                        let mut s = snap_of(
+                            &sup,
+                            &ledger_with(4, 0, 0),
+                            ApiHealth::Answering {
+                                silent_for: Duration::ZERO,
+                            },
+                            fib.clone(),
+                            ports.clone(),
+                        );
+                        s.state = state;
+                        assert!(
+                            !s.nominal() || s.failure_episode_over(),
+                            "nominal but episode not over: state={state:?} fib={fib:?} \
+                             ports={:?}",
+                            s.ports
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// `FibSync` must not re-derive the pass criteria — if it did, the
@@ -3055,7 +3377,7 @@ mod tests {
         // Sweep the lifecycle against both port conditions and a
         // never-verified FIB, which is the shape that regressed.
         for state in STATE_LABELS.map(|(s, _)| s) {
-            for ports in [ports_up(), port_down(), Vec::new()] {
+            for ports in [ports_up(), port_down(), port_down_in_use(), Vec::new()] {
                 for fib in [FibSync::NeverVerified, verified(1)] {
                     for api in [
                         ApiHealth::NoProcess,
@@ -3110,6 +3432,7 @@ mod tests {
                 sw_if_index: 3,
                 admin_up: true,
                 link_up: true,
+                in_use: true,
             }],
         );
         let m = render_metrics(&s, "vpp-offload");
@@ -3143,6 +3466,7 @@ mod tests {
             sw_if_index: 4,
             admin_up: true,
             link_up: false,
+            in_use: false,
         });
         let m = render_metrics(&s, "vpp-offload");
         assert!(m.contains("port=\"eth4\",sw_if_index=\"3\"} 1"), "{m}");

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -181,6 +181,16 @@ pub struct Behaviour {
     /// convergence would delete the connected and local routes VPP needs
     /// to resolve any adjacency at all.
     pub existing_routes: &'static [([u8; 4], u8, u32, bool)],
+    /// Report every member port created after the first as admin-up but
+    /// LINK-DOWN — the dark-idle member shape (the primary's uncabled
+    /// eth5, the shadow's five idle members under `steer-direction src`).
+    ///
+    /// Also makes `dev_create_port_if` hand out sequential indices
+    /// (`ASSIGNED_INDEX`, `ASSIGNED_INDEX + 1`, ...) so a second member
+    /// exists at all; without this flag every create returns
+    /// `ASSIGNED_INDEX` and the dump reports exactly one interface, which
+    /// is what every single-port test depends on.
+    pub dark_extra_ports: bool,
 }
 
 impl Fake {
@@ -281,6 +291,10 @@ fn serve(
     write_frame(sock, &payload);
 
     let mut routes_seen = 0usize;
+    // Ports created on THIS connection, for `dark_extra_ports`. Resets
+    // with the connection, exactly like `macs`: a fresh attach after a
+    // reconnect re-creates its ports and must land on the same indices.
+    let mut ports_created = 0u32;
 
     loop {
         let req = read_frame(sock)?;
@@ -302,10 +316,16 @@ fn serve(
                 .encode(&mut out);
             }
             "dev_create_port_if" => {
+                let idx = if behaviour.dark_extra_ports {
+                    ASSIGNED_INDEX + ports_created
+                } else {
+                    ASSIGNED_INDEX
+                };
+                ports_created += 1;
                 out = reply_head("dev_create_port_if_reply");
                 DevCreatePortIfReply {
                     context: ctx,
-                    sw_if_index: ASSIGNED_INDEX,
+                    sw_if_index: idx,
                     retval: 0,
                     error_string: String::new(),
                 }
@@ -478,6 +498,21 @@ fn serve(
                 }
                 det.encode(&mut d);
                 write_frame(sock, &d);
+                // Every extra created port reports admin-up but
+                // link-down: flags 1 = IF_STATUS_ADMIN_UP alone, the
+                // dark-member shape.
+                if behaviour.dark_extra_ports {
+                    for n in 1..ports_created {
+                        let idx = ASSIGNED_INDEX + n;
+                        let mut d = reply_head("sw_interface_details");
+                        let mut det = details(idx, &format!("octeon{n}/0"), 1, ctx);
+                        if let Some(m) = macs.get(&idx) {
+                            det.l2_address = *m;
+                        }
+                        det.encode(&mut d);
+                        write_frame(sock, &d);
+                    }
+                }
                 continue;
             }
             "sw_interface_set_mac_address" => {

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1864,3 +1864,182 @@ fn a_first_steer_refused_by_the_fib_gate_is_still_remembered() {
         log.lock().unwrap()
     );
 }
+
+/// The shadow's designed steady state, end to end: steered on one
+/// member with the other member dark-and-idle — and a failure episode
+/// behind it that must CLEAR.
+///
+/// Both halves are measured defects from the 2026-08-14 shadow chaos
+/// test, not hypotheticals:
+///
+/// - **Severity ignored `in_use`.** A steered, verified VPP with five
+///   dark-idle members read `ports UNHEALTHY` — the module's worst
+///   verdict for a box forwarding everything correctly. The steer gate
+///   and verify already drew the line at `DeadInterface::in_use`; the
+///   status surface was the one consumer that did not.
+/// - **`last-tick` never cleared.** After the storm recovered
+///   unattended, `vpp-process` read healthy with zero consecutive
+///   failures while `last_failures` still carried the whole storm
+///   history: the release keyed on overall health returning to
+///   `Healthy`, and a dark-idle member pins overall at Degraded for as
+///   long as the cable is out — permanently, on this fleet. The episode
+///   predicate releases on observed recovery instead.
+#[test]
+fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
+    let fake = fake_vpp::Fake::start_behaving(
+        "svc-dark-idle",
+        fake_vpp::Behaviour {
+            dark_extra_ports: true,
+            ..Default::default()
+        },
+    );
+    let sock = fake.path.clone();
+    let log = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let spy = std::sync::Arc::clone(&log);
+    let allow = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let gate = std::sync::Arc::clone(&allow);
+
+    let svc = SupervisionService::start(
+        "vpp-offload",
+        Box::new(move || {
+            let engine = ConvergenceEngine::new(
+                &sock,
+                vec![
+                    PortAttach {
+                        port: "eth4".into(),
+                        pci_addr: "0002:07:00.1".into(),
+                        port_id: 0,
+                        num_rx_queues: 1,
+                        pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+                    },
+                    // The dark member: the fake reports every port after
+                    // the first as admin-up but link-down, and no
+                    // neighbour lives on it, so nothing can egress there.
+                    PortAttach {
+                        port: "eth5".into(),
+                        pci_addr: "0002:07:00.2".into(),
+                        port_id: 0,
+                        num_rx_queues: 1,
+                        pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x02],
+                    },
+                ],
+                vec!["eth4".into(), "eth5".into()],
+                1_000_000,
+                FamilyPolicy::V4Only,
+                packetframe_common::config::Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+                    prefix_len: 32,
+                },
+            );
+            let runtime = Runtime::new(
+                engine,
+                Box::new(Mirror((0..6).map(|i| fake_vpp::v4(0, i)).collect())),
+                Box::new(GatedSteer {
+                    log: spy,
+                    allow: gate,
+                }),
+                Box::new(NullStore),
+                Box::new(NoResources),
+                "/usr/bin/vpp",
+                "/tmp/startup.conf",
+            );
+            {
+                use packetframe_vpp_offload::driver::Observe as _;
+                let (mut obs, _) = runtime.views();
+                assert!(obs.api_ready());
+            }
+            Ok((
+                Driver::new(),
+                runtime,
+                vec![Event::Adopted { steered: false }],
+            ))
+        }),
+    )
+    .expect("service starts");
+
+    // Converges to Ready despite the dark member: verify routes it
+    // through the idle (non-blocking) verdict.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "did not reach Ready; last state {:?}, report {:?}",
+            s.state,
+            s.report
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Seed the failure episode: a lever move whose steer the gate
+    // refuses. The refusal is remembered — `steer_intended` holds, so
+    // the episode is NOT over — and stays remembered until steering
+    // matches intent again.
+    let err = svc
+        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .expect_err("the gate is closed");
+    assert!(err.contains("refusing to steer"), "{err}");
+    let seeded = svc.status().expect("published");
+    assert!(
+        seeded
+            .last_failures
+            .iter()
+            .any(|f| f.contains("refusing to steer")),
+        "the refused steer's reason must be retained: {:?}",
+        seeded.last_failures
+    );
+
+    // Recovery: the operator's retry succeeds and the module steers.
+    allow.store(true, std::sync::atomic::Ordering::SeqCst);
+    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .expect("the lever turns once the gate opens");
+
+    // The regression, both defects at once. The episode reasons must
+    // clear even though the dark-idle member holds overall at Degraded
+    // forever — under the old release ("wait for Healthy") this loop
+    // never terminates — and the steered snapshot must read Degraded,
+    // not Unhealthy, while it does.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let settled = loop {
+        let s = svc.status().expect("published");
+        if s.state == State::Steered && s.last_failures.is_empty() {
+            break s;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the failure episode never cleared: state {:?}, overall {:?}, last_failures \
+             {:?}",
+            s.state,
+            s.report.overall,
+            s.last_failures
+        );
+        std::thread::sleep(Duration::from_millis(20));
+    };
+    assert_eq!(
+        settled.report.overall,
+        HealthState::Degraded,
+        "steered with a dark-idle member is Degraded at most — it deliberately carries \
+         nothing: {:?}",
+        settled.report
+    );
+    let ports = settled
+        .report
+        .subsystems
+        .iter()
+        .find(|x| x.name == "ports")
+        .expect("ports row");
+    assert_eq!(
+        ports.state,
+        HealthState::Degraded,
+        "{:?}",
+        settled.report.subsystems
+    );
+    let msg = ports.message.as_deref().unwrap_or_default();
+    assert!(
+        msg.contains("eth5") && msg.contains("idle") && msg.contains("steering is unaffected"),
+        "the row must name the dark member and say it carries nothing: {msg}"
+    );
+}


### PR DESCRIPTION
Two status-surface defects found during the 2026-08-14 shadow chaos test (six members + `steer-direction src` on the cfa09fb build), with hardware evidence in the ~05:10 UTC shadow status output. One missing distinction sits behind both.

## 1. Ports severity ignored `in_use`

The steer gate (`runtime.rs`), verify's verdict routing (#177), and `DeadInterface` all already distinguish a dark member that **carries routes** (a blackhole) from one **nothing egresses** (deliberately idle — the primary's uncabled eth5, the shadow's five idle members under src-only steering). `PortLink` never carried that bit, so `ports_health()` and `steered_but_broken()` treated every dark member as a blackhole: the shadow, steered healthy with 5/6 members dark-idle and 1,055,301 routes verified, read **`ports UNHEALTHY`** — the module's worst verdict for a box forwarding everything correctly, which is how alerts get muted.

**Fix:**
- `PortLink` gains `in_use`, populated in `engine::port_links()` from the **live** neighbour ledger, deliberately not the verify-time recording: verify never re-runs in steady state, and routes shifting *onto* a dark member is the direction that must escalate without one.
- `ports_health()` pages (UNHEALTHY) only for steered + in-use-dark; dark-idle is Degraded, and the row now says which kind each dead port is (`idle` vs `ROUTES EGRESS HERE`) with the matching remedy tail.
- `steered_but_broken()` counts only blackhole ports — its own comment ("a port whose link is down **under paths that resolve through it**") claimed this all along.
- `nominal()` still requires every member up: a dark member is real lost redundancy, the ports row stays Degraded, and `overall` must never outrank its own subsystems (existing invariant test, now swept over the in-use shape too).

## 2. `last-tick` never cleared after recovery

Root cause found: the doc on `Published::last_failures` said the retained reasons clear "when the supervisor's consecutive-failure count returns to zero" — **stale**; the code actually cleared on published overall health returning to `Healthy` (the count is zero *during* a refused steer, so it was never usable as the key). Both conditions are wrong, in opposite directions. `Healthy` is unreachable on a box with a dark-idle member — Degraded is its **designed steady state**, indefinitely — so after the storm recovered unattended (Ready+steered, verified FIB, `failures == 0`), `last-tick` still carried the entire storm history and always would have.

**Fix:** the release is now `StatusSnapshot::failure_episode_over()` — `nominal()` minus the degradations that are not failures (dark-idle members, withheld-at-capacity), keeping a refused steer open via `steer_intended` and in-use-dark/store/drain faults open as live failures. Defined beside `nominal()` and documented clause-by-clause against it so the two whitelists cannot drift apart; both stale doc sites rewritten to the real contract.

## Tests

- **status.rs**: escalation matrix rewritten (`a_down_member_port_escalates_only_when_steered_and_in_use`); `the_failure_episode_ends_despite_dark_idle_members` (predicate true while overall — the old key — is Degraded); `a_refused_steer_keeps_the_episode_open`; `nominal_implies_the_episode_is_over` sweep.
- **engine.rs**: `port_links` pins `in_use` to the live ledger, not the verify recording.
- **Service level**: the fake VPP gains an opt-in `dark_extra_ports` behaviour (sequential indices, extras report admin-up/link-down; zero change to single-port tests), and `a_dark_idle_member_neither_pages_nor_pins_failure_history` drives the full shadow story end to end: converge with a dark member → gate-refused steer retained → gate opens, steer lands → reasons clear while overall honestly stays Degraded.

Both fixes verified against their own revert: the old severity fails three tests; the old release condition dies with exactly the shadow's symptom — `state Steered, overall Degraded, last_failures` still full at the 10 s deadline.

## For reviewers / operators

- With a permanently dark member the module now rests at **Degraded by design**. The drill-notes alert guidance ("sustained not-healthy ≥ 2 min") should key on **Unhealthy** (or Degraded *transitions*), not on any not-Healthy state.
- `in_use` freshness is a deliberate asymmetry: link flags are verify-time, `in_use` is current. The doc on `port_links()` records why (over-alerting on an unacked neighbour is bounded; under-alerting on a post-verify route shift is a blackhole with green gauges).

Host `make test` + `make lint` green; everything touched is cross-platform vpp-offload code, cross-builds and qemu are CI's to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)