### PR TITLE
fix(vpp-offload): a table bird has not dumped yet is not a wrong FIB — hold, never tear down

### DIFF
--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -306,15 +306,44 @@ impl Verdict {
     /// one place so a caller cannot pick `VerifyPassed` for an
     /// incomplete table.
     ///
-    /// `VerifyFailed` — the restart-worthy verdict — fires only when
-    /// the FIB itself is wrong ([`VerifyOutcome::fib_correct`]): a
-    /// fresh resync rebuilds a wrong FIB, so teardown is a remedy.
-    /// Dark member interfaces that CARRY ROUTES route through
-    /// `VerifyIncomplete` instead: same destination as a withheld
-    /// table — reach `Ready`, do NOT steer, keep the want — because a
-    /// restart cannot plug in a cable. Mapping them to `VerifyFailed`
-    /// turned three uncabled shadow ports into an infinite
-    /// kill-respawn loop over a flawless FIB (repro 2026-08-13).
+    /// `VerifyFailed` — the restart-worthy verdict — fires only on
+    /// **mismatches**: VPP answered a probe and disagreed with the
+    /// ledger. That is the one condition a teardown remedies, because
+    /// a fresh resync rebuilds a wrong FIB. Everything else that fails
+    /// [`VerifyOutcome::fib_correct`] is a condition a restart cannot
+    /// change, and each has produced a kill-respawn loop by riding
+    /// this verdict:
+    ///
+    /// - `sampled == 0` — the source has not delivered the table yet.
+    ///   On a fresh attach the feed connects AFTER the module (bird
+    ///   dials the passive listener), so the first verify can run with
+    ///   the sink legitimately empty. The primary's w7 window
+    ///   (2026-08-13) took SEVEN teardowns in 31 s through this arm —
+    ///   the first before bird's session had even opened — and every
+    ///   respawn re-ran the octeon driver's port start against the
+    ///   shared LMAC, blacking out the switch0 bridge below the
+    ///   kernel. A restart cannot make bird dump faster. (The
+    ///   fresh-resync hold in `runtime.rs` keeps verify from running
+    ///   this early at all when a completeness authority is
+    ///   configured; this arm is the backstop for deployments
+    ///   without one.)
+    /// - `unresolvable > 0` — the nexthop-device mapping has holes: a
+    ///   nexthop egresses a port VPP does not own, or a neighbour has
+    ///   not resolved yet. A restart cannot make eth3 a member. The
+    ///   single-member bisection configs are the standing case: the
+    ///   full table's nexthops egress non-member ports, permanently.
+    /// - Dark member interfaces that CARRY ROUTES — a restart cannot
+    ///   plug in a cable. Three uncabled shadow ports turned exactly
+    ///   this into an infinite kill-respawn loop over a flawless FIB
+    ///   (repro 2026-08-13).
+    ///
+    /// All of those ride `VerifyIncomplete`: reach `Ready`, keep the
+    /// want, do NOT steer. Steering stays refused by the LIVE gates —
+    /// `steer_permitted` re-reads the authority verdict, the source
+    /// backlog and `blocks_first_steer` on every retry, none of which
+    /// consult this verdict's snapshot — so recovery is the retry loop
+    /// noticing conditions changed, not a verdict going stale in
+    /// either direction.
     ///
     /// A dark member that is IDLE — no installed route can egress it,
     /// which is the normal state of a dark port, since the BGP session
@@ -324,16 +353,11 @@ impl Verdict {
     /// steer five live ports over one uncabled one would hold the
     /// whole offload hostage to a port that poses no risk (the
     /// primary's eth5 is the motivating case).
-    ///
-    /// The steer path re-checks link state AND usage fresh at steer
-    /// time, so recovery is the existing retry loop noticing the cable
-    /// came back, not a verify verdict going stale in either
-    /// direction.
     pub fn event(&self) -> crate::supervisor::Event {
         let blocking_dark = self.outcome.dead_interfaces.iter().any(|d| d.in_use);
-        if !self.outcome.fib_correct() {
+        if !self.outcome.mismatches.is_empty() {
             crate::supervisor::Event::VerifyFailed
-        } else if self.may_steer && !blocking_dark {
+        } else if self.outcome.fib_correct() && self.may_steer && !blocking_dark {
             crate::supervisor::Event::VerifyPassed
         } else {
             crate::supervisor::Event::VerifyIncomplete
@@ -2118,13 +2142,70 @@ mod tests {
             "and must not re-steer either"
         );
 
-        // A genuinely wrong FIB still fails, regardless of steerability.
+        // A genuinely wrong FIB still fails, regardless of steerability
+        // — and "wrong" means MISMATCHES: VPP answered a probe and
+        // disagreed. That is the only condition a teardown repairs.
         let wrong = Verdict {
-            outcome: VerifyOutcome::default(),
+            outcome: VerifyOutcome {
+                sampled: 64,
+                mismatches: vec![crate::verify::Mismatch::NoPaths {
+                    prefix: IpPrefix::V4 {
+                        addr: [192, 0, 2, 0],
+                        prefix_len: 24,
+                    },
+                }],
+                ..Default::default()
+            },
             may_steer: true,
         };
         assert!(!wrong.outcome.passed());
         assert_eq!(wrong.event(), Event::VerifyFailed);
+    }
+
+    /// A table the source has not delivered yet is not a wrong FIB,
+    /// and neither is a nexthop-device mapping with holes. Both fail
+    /// `fib_correct` — steering must refuse them — but neither is
+    /// restart-worthy: a teardown cannot make bird dump faster, and it
+    /// cannot make a non-member port a member.
+    ///
+    /// The primary's w7 window (2026-08-13) is the repro for the first
+    /// arm: verify ran ~1 s after spawn, before bird's session opened,
+    /// sampled nothing, and `sampled == 0` rode the restart-worthy
+    /// verdict — seven kill-respawn cycles in 31 s, each one re-running
+    /// the octeon driver's port start against the shared LMAC and
+    /// blacking out the switch0 bridge. The eth4-only bisection config
+    /// is the repro for the second: the full table's nexthops egress
+    /// eth2/eth3, which are not members, so `unresolvable` is
+    /// structurally nonzero and the old mapping could never converge.
+    #[test]
+    fn an_undelivered_or_unmappable_table_holds_rather_than_restarts() {
+        use crate::supervisor::Event;
+
+        let empty = Verdict {
+            outcome: VerifyOutcome::default(),
+            may_steer: false,
+        };
+        assert!(!empty.outcome.fib_correct(), "empty is still not correct");
+        assert_eq!(
+            empty.event(),
+            Event::VerifyIncomplete,
+            "an empty sample must hold, not tear down"
+        );
+
+        let holes = Verdict {
+            outcome: VerifyOutcome {
+                sampled: 64,
+                unresolvable: 3,
+                ..Default::default()
+            },
+            may_steer: false,
+        };
+        assert!(!holes.outcome.fib_correct(), "holes still refuse steering");
+        assert_eq!(
+            holes.event(),
+            Event::VerifyIncomplete,
+            "unresolvable routes must hold, not tear down"
+        );
     }
 
     /// A dark member interface is not a wrong FIB, and must not reach
@@ -2198,10 +2279,20 @@ mod tests {
         );
 
         // Both at once: a wrong FIB wins — teardown IS the remedy for
-        // that half, whatever the cabling looks like.
+        // that half, whatever the cabling looks like. "Wrong" means a
+        // probe mismatch; an empty sample alongside a dark member is
+        // two hold conditions, not a failure (the old `sampled: 0`
+        // fixture here asserted the exact mapping that kill-looped the
+        // primary's w7 window, 2026-08-13).
         let dark_and_wrong = Verdict {
             outcome: VerifyOutcome {
-                sampled: 0,
+                sampled: 64,
+                mismatches: vec![crate::verify::Mismatch::NoPaths {
+                    prefix: IpPrefix::V4 {
+                        addr: [192, 0, 2, 0],
+                        prefix_len: 24,
+                    },
+                }],
                 dead_interfaces: vec![DeadInterface {
                     sw_if_index: 2,
                     name: "octeon0/0".into(),

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -409,6 +409,11 @@ struct Core {
     /// itself freezes VPP's workers (drill (d10), 2026-08-09). See
     /// [`DeferredResync`] for the two stages.
     deferred_resync: Option<DeferredResync>,
+    /// `Some` while a FRESH resync is holding `SyncComplete` back until
+    /// the completeness authority says the source has converged. Armed
+    /// by `start_resync`'s fresh arm when an authority is configured;
+    /// cleared by `drain_batch` on release. See [`FreshHold`].
+    fresh_hold: Option<FreshHold>,
     /// When the NIC was last audited against the steering ledger, and
     /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
     last_steer_audit: Option<std::time::Instant>,
@@ -626,6 +631,39 @@ impl SourceGate {
 enum SteerRequest {
     Settle,
     Revoke,
+}
+
+/// Armed by a FRESH `start_resync` when a completeness authority is
+/// configured (`require-table-complete on`). While armed, an idle
+/// drain during the resync reports [`crate::driver::Drain::AwaitingSource`]
+/// instead of `Idle`, so `SyncComplete` cannot fire — and the single
+/// verify runs over the full table rather than over whatever had
+/// trickled in when the pending map first went momentarily empty.
+///
+/// Why this exists: on a fresh attach the feed connects AFTER the
+/// module (bird dials the passive listener), so the first idle drain
+/// lands ~1 s after spawn with the mirror holding only the local seeds
+/// the tee excludes. Verify then sampled nothing, and the old verdict
+/// mapping tore VPP down for it — seven kill-respawn cycles in 31 s on
+/// the primary (w7, 2026-08-13), the first BEFORE bird's session had
+/// even opened, each respawn re-running the octeon driver's port start
+/// against the shared LMAC and blacking out the switch0 bridge. The
+/// adopted paths already defer behind [`SourceGate`]s for exactly this
+/// reason; this is the fresh path's equivalent, minus the floor
+/// machinery an empty dataplane does not need — installs keep
+/// trickling in while the hold is armed, so convergence overlaps the
+/// dump instead of following it.
+///
+/// Release needs the authority's CURRENT word (`authority_current`,
+/// the same helper the adopted release consults) AND a drained source
+/// backlog — the mirror-vs-bird comparison cannot see updates the feed
+/// still holds (`source_current`'s doc describes that gap). With no
+/// authority configured there is nothing honest to wait for, the hold
+/// is never armed, and `Verdict::event`'s `VerifyIncomplete` arm is
+/// the backstop.
+struct FreshHold {
+    /// One log line per hold, not one per tick.
+    announced: bool,
 }
 
 /// What a deferred adopted reconciliation is waiting for.
@@ -1081,6 +1119,7 @@ impl Runtime {
                 last_store_error: None,
                 last_drain_error: None,
                 deferred_resync: None,
+                fresh_hold: None,
                 last_steer_audit: None,
                 steer_missing: 0,
                 steer_stray: 0,
@@ -2149,6 +2188,8 @@ impl Observe for ObserveView {
             engine,
             source,
             last_drain_error,
+            completeness,
+            fresh_hold,
             ..
         } = &mut *c;
         // `?`-equivalent: a failed neighbour programming must not be
@@ -2172,6 +2213,47 @@ impl Observe for ObserveView {
         // reports a fault that recovered as though it were still
         // happening.
         *last_drain_error = r.as_ref().err().cloned();
+        // The fresh-resync hold: an idle pending map during a fresh
+        // resync is NOT completion while the authority still says the
+        // source is short — it is what "bird has not dumped yet" looks
+        // like from in here, and letting it become `SyncComplete` runs
+        // verify against a table that is not there (see [`FreshHold`]).
+        // `AwaitingSource` extends the phase deadline, exactly as the
+        // adopted deferrals do, so a multi-minute dump cannot time the
+        // convergence out either. Backlog must be drained too: the
+        // authority compares bird against the MIRROR, which the tee has
+        // already updated, so an idle map plus a converged word can
+        // still hide a burst the feed holds (`source_current`'s gap).
+        let mut release_hold = false;
+        if let (Ok(crate::driver::Drain::Idle), Some(hold)) = (&r, fresh_hold.as_mut()) {
+            let have = source.route_count();
+            let released =
+                authority_current(completeness, have) == Some(true) && source.backlog() == 0;
+            if !released {
+                if !hold.announced {
+                    hold.announced = true;
+                    tracing::info!(
+                        have,
+                        "fresh resync is idle but the route source has not converged; \
+                         holding verify while installs continue"
+                    );
+                }
+                let want = completeness
+                    .as_ref()
+                    .and_then(|h| h.latest_verdict().0)
+                    .map_or(0, |rep| rep.authority_routes);
+                return Ok(crate::driver::Drain::AwaitingSource { have, want });
+            }
+            tracing::info!(
+                have,
+                "route source converged and drained; fresh resync complete — verifying \
+                 the full table"
+            );
+            release_hold = true;
+        }
+        if release_hold {
+            *fresh_hold = None;
+        }
         r
     }
 }
@@ -2408,6 +2490,9 @@ impl Effects for EffectsView {
 
     fn start_resync(&mut self) -> Result<(), String> {
         let mut c = self.core.borrow_mut();
+        // Any hold from an earlier attempt is that attempt's state.
+        // The fresh arm below re-arms it when it applies.
+        c.fresh_hold = None;
         // A steered start is necessarily a steered ADOPTION: rules
         // reach the NIC only after a verify, which no fresh spawn has
         // had, and inherited orphan rules are torn down before
@@ -2512,7 +2597,20 @@ impl Effects for EffectsView {
                 })
             }
         };
+        // The fresh arm (deferral: none) trickle-converges by design,
+        // but its VERIFY must wait for the loaded table where anyone
+        // can attest one. See [`FreshHold`] for the incident this
+        // encodes.
+        let fresh = deferral.is_none();
         c.deferred_resync = deferral;
+        if fresh && c.completeness.is_some() {
+            tracing::info!(
+                "fresh resync under a completeness authority: routes install as the \
+                 source loads, and verify waits until the authority confirms the \
+                 table is complete (require-table-complete)"
+            );
+            c.fresh_hold = Some(FreshHold { announced: false });
+        }
         Ok(())
     }
 
@@ -2552,6 +2650,23 @@ impl Effects for EffectsView {
                 // not from inside this Effects call — the same seam
                 // every driver test drives.
                 let event = verdict.event();
+                // Logged HERE, with the outcome's own words: the w7
+                // window (2026-08-13) produced seven teardowns whose
+                // only trace was the supervisor WARN naming the event
+                // — sampled/mismatches/unresolvable were invisible
+                // even with the unit log captured, and the loop was
+                // misread for a hardware fault because of it.
+                match event {
+                    Event::VerifyFailed => tracing::warn!(
+                        outcome = %verdict.outcome.summary(),
+                        "verify found FIB mismatches; teardown and a fresh resync follow"
+                    ),
+                    Event::VerifyIncomplete => tracing::info!(
+                        outcome = %verdict.outcome.summary(),
+                        "verify incomplete; steering stays refused and VPP stays up"
+                    ),
+                    _ => tracing::info!(outcome = %verdict.outcome.summary(), "verify passed"),
+                }
                 c.pending.push(event);
                 Ok(())
             }

--- a/crates/modules/vpp-offload/src/verify.rs
+++ b/crates/modules/vpp-offload/src/verify.rs
@@ -103,9 +103,13 @@ pub struct VerifyOutcome {
 impl VerifyOutcome {
     /// Whether the FIB itself agrees with the ledger: at least one
     /// route was actually probed, nothing sampled disagreed, and the
-    /// nexthop-device mapping has no holes. This — and only this — is
-    /// the restart-worthy question: a wrong FIB is rebuilt by a fresh
-    /// resync, so teardown is a remedy.
+    /// nexthop-device mapping has no holes. This is the *fit to take
+    /// traffic* question, NOT the restart-worthy one — those were the
+    /// same predicate until 2026-08-13, when the primary's w7 window
+    /// showed the difference the hard way. Only `mismatches` is
+    /// restart-worthy (a fresh resync rebuilds a wrong FIB); the other
+    /// two failure modes here are conditions a teardown cannot change,
+    /// and `Verdict::event` routes them to a hold instead.
     ///
     /// **`sampled == 0` fails.** An earlier version treated it as a
     /// vacuous pass, and a test asserted that as intended — which was
@@ -114,7 +118,11 @@ impl VerifyOutcome {
     /// would (re-)steer traffic into a VPP with an empty FIB. That is
     /// the blackhole rule 1 exists to prevent, arrived at through the
     /// gate meant to prevent it. A box with genuinely no routes should
-    /// not be steered either, so failing is right in both readings.
+    /// not be steered either, so failing is right in both readings —
+    /// but failing here means "refuse steering", never "tear down": an
+    /// empty sample is what a fresh attach looks like before bird has
+    /// dumped, and tearing down for it produced seven kill-respawn
+    /// cycles in 31 s on the primary (w7, 2026-08-13).
     ///
     /// `unresolvable > 0` fails because it means the nexthop-device
     /// mapping is wrong — a misconfiguration, not a capacity condition
@@ -146,10 +154,14 @@ impl VerifyOutcome {
 
     /// One-line operator summary. Separates the two degraded counts,
     /// because "mapping is misconfigured" and "table outgrew the box"
-    /// are different pages at 03:00 — and a third label for dark
-    /// members, because "the FIB is wrong" and "a cable is out" are
-    /// too: the first is restart-worthy, the second reads FAIL only if
-    /// you want an operator to bounce a healthy dataplane.
+    /// are different pages at 03:00 — and distinct labels for dark
+    /// members and for a not-yet-deliverable table, because "the FIB
+    /// is wrong" and "a cable is out" and "bird has not dumped yet"
+    /// are three different situations: only the first is
+    /// restart-worthy, and labelling the others FAIL invites an
+    /// operator to bounce a dataplane a bounce cannot fix (the
+    /// supervisor made exactly that mistake until 2026-08-13 — see
+    /// `Verdict::event`).
     pub fn summary(&self) -> String {
         let mut s = format!(
             "verify {}: {}/{} probes matched, unresolvable={}, withheld={}",
@@ -157,8 +169,10 @@ impl VerifyOutcome {
                 "PASS"
             } else if self.fib_correct() {
                 "FIB OK, IN-USE MEMBER(S) DARK — steering refused, no restart"
-            } else {
+            } else if !self.mismatches.is_empty() {
                 "FAIL"
+            } else {
+                "INCOMPLETE — steering refused, no restart"
             },
             self.sampled.saturating_sub(self.mismatches.len()),
             self.sampled,

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -2546,9 +2546,11 @@ fn a_steer_refused_by_completeness_retries_when_the_mirror_catches_up() {
     );
     let handle = std::sync::Arc::new(TableCompleteness::new());
     rt.require_table_complete(handle.clone());
-    // bird's dump is still arriving: five of a thousand.
+    // Converged at bring-up, so the fresh-resync hold releases and the
+    // box reaches `Ready` the honest way (the hold is its own test;
+    // this one is about the seam AT Ready).
     handle.publish(CompletenessReport {
-        authority_routes: 1_000,
+        authority_routes: 5,
         mirror_routes: 5,
         at: std::time::Instant::now(),
     });
@@ -2565,6 +2567,14 @@ fn a_steer_refused_by_completeness_retries_when_the_mirror_catches_up() {
         d.inject(t0, Event::Adopted { steered: false }, &mut fx);
     }
     let (mut now, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+
+    // bird bounces and reloads: its count runs ahead of the mirror,
+    // and the verdict turns incomplete under a box already at Ready.
+    handle.publish(CompletenessReport {
+        authority_routes: 1_000,
+        mirror_routes: 5,
+        at: std::time::Instant::now(),
+    });
 
     // The operator turns the lever. The gate declines it.
     {
@@ -2853,12 +2863,13 @@ fn an_empty_target_is_permitted_over_a_table_with_known_holes() {
         Box::new(EmptyTarget(Vec::new())),
         2,
     );
-    // A condemning verdict on top, because a rollback happens in
-    // exactly this weather and neither gate may hold it.
+    // Converged at bring-up so the fresh-resync hold releases; the
+    // condemning verdict lands AFTER Ready, which is when a rollback
+    // actually happens in this weather.
     let handle = std::sync::Arc::new(packetframe_common::fib::TableCompleteness::new());
     rt.require_table_complete(handle.clone());
     handle.publish(packetframe_common::fib::CompletenessReport {
-        authority_routes: 1_000,
+        authority_routes: 5,
         mirror_routes: 5,
         at: std::time::Instant::now(),
     });
@@ -2884,6 +2895,11 @@ fn an_empty_target_is_permitted_over_a_table_with_known_holes() {
         counts.blocks_first_steer() && counts.withheld > 0,
         "and the FIB gate must really be closed, or this proves nothing: {counts:?}"
     );
+    handle.publish(packetframe_common::fib::CompletenessReport {
+        authority_routes: 1_000,
+        mirror_routes: 5,
+        at: std::time::Instant::now(),
+    });
 
     let (mut obs, _) = rt.views();
     use packetframe_vpp_offload::driver::Observe as _;
@@ -2891,5 +2907,253 @@ fn an_empty_target_is_permitted_over_a_table_with_known_holes() {
         obs.steer_permitted(),
         "a reconcile that only removes must not be held by gates describing a table \
          traffic would be diverted INTO — that is what leaves a rollback unfinished"
+    );
+}
+
+/// The fresh-resync hold, end to end (primary w7, 2026-08-13): a fresh
+/// convergence under `require-table-complete on` whose source has not
+/// loaded yet must SIT in `Syncing` — installs trickling in as the feed
+/// delivers — and verify exactly once, over the full table, after the
+/// authority confirms it. The old behaviour was `SyncComplete` on the
+/// first momentarily-empty drain, ~1 s after spawn and before bird's
+/// session had even opened, then `sampled == 0` riding the
+/// restart-worthy verdict: seven kill-respawn cycles in 31 s, each one
+/// re-running the octeon driver's port start against the shared LMAC
+/// and blacking out the switch0 bridge below the kernel.
+///
+/// Driven through the adopted-an-empty-FIB door because host CI cannot
+/// spawn a real VPP — `adopted == 0` takes the identical fresh arm of
+/// `start_resync` (the harness note on `the_full_loop` test explains
+/// the constraint).
+#[test]
+fn a_fresh_convergence_holds_verify_until_the_authority_confirms_the_table() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+    use packetframe_vpp_offload::engine::SourceChanges;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    /// A live-feed stand-in: the mirror fills over time, and new routes
+    /// reach the engine through `drain_changes`, exactly like the
+    /// production tee.
+    struct LoadingFeed {
+        mirror: Rc<RefCell<Vec<IpPrefix>>>,
+        queued: Rc<RefCell<Vec<IpPrefix>>>,
+    }
+    impl RouteSource for LoadingFeed {
+        fn requeue(&self, changes: SourceChanges) {
+            // Fill-if-absent is moot here: the test never fails a send.
+            self.queued
+                .borrow_mut()
+                .extend(changes.routes.into_iter().map(|(p, _)| p));
+        }
+        fn route_count(&self) -> u64 {
+            self.mirror.borrow().len() as u64
+        }
+        fn change_seq(&self) -> u64 {
+            self.mirror.borrow().len() as u64
+        }
+        fn backlog(&self) -> u64 {
+            self.queued.borrow().len() as u64
+        }
+        fn drain_changes(&self, max: usize) -> SourceChanges {
+            let mut q = self.queued.borrow_mut();
+            let take = q.len().min(max);
+            SourceChanges {
+                routes: q
+                    .drain(..take)
+                    .map(|p| (p, Some(vec![fake_vpp::nh()])))
+                    .collect(),
+                neighbours: Vec::new(),
+            }
+        }
+        fn for_each_route(&self, visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {
+            for p in self.mirror.borrow().iter() {
+                visit(*p, &[fake_vpp::nh()]);
+            }
+        }
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+
+    let fake = Fake::start("fresh-hold");
+    let mirror = Rc::new(RefCell::new(Vec::new()));
+    let queued = Rc::new(RefCell::new(Vec::new()));
+    let rt = runtime_with_source(
+        &fake,
+        Box::new(LoadingFeed {
+            mirror: Rc::clone(&mirror),
+            queued: Rc::clone(&queued),
+        }),
+    );
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+
+    let mut d = Driver::new();
+    let mut now = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(now, Event::Adopted { steered: false }, &mut fx);
+    }
+    assert_eq!(d.state(), State::Syncing);
+
+    // The incident window: the source is empty and the authority has
+    // published nothing. Thirty ticks was ~three teardowns' worth of
+    // wall time on the primary; here the loop must go NOWHERE.
+    let (mut obs, mut fx) = rt.views();
+    for _ in 0..30 {
+        let t = d.tick(now, &mut obs, &mut fx);
+        assert!(
+            !t.events.contains(&Event::SyncComplete),
+            "an empty pending map is not a complete sync while the authority is silent"
+        );
+        for e in rt.take_pending() {
+            assert!(
+                !matches!(e, Event::VerifyFailed),
+                "the exact verdict that kill-looped the primary"
+            );
+            d.inject(now, e, &mut fx);
+        }
+        now += t
+            .sleep
+            .unwrap_or(Duration::from_millis(100))
+            .max(Duration::from_millis(1));
+    }
+    assert_eq!(
+        d.state(),
+        State::Syncing,
+        "holding IS the fix: no verify, no teardown, VPP untouched"
+    );
+    drop((obs, fx));
+
+    // bird's dump lands (through the delta seam, like the live feed)
+    // and the authority confirms it.
+    let table: Vec<IpPrefix> = (0..5).map(|i| fake_vpp::v4(0, i)).collect();
+    mirror.borrow_mut().extend(table.iter().copied());
+    queued.borrow_mut().extend(table.iter().copied());
+    handle.publish(CompletenessReport {
+        authority_routes: 5,
+        mirror_routes: 5,
+        at: Instant::now(),
+    });
+
+    let (_, events) = run_until(&mut d, &rt, now, |d| d.state() == State::Ready);
+    assert!(
+        events.contains(&Event::SyncComplete),
+        "the hold must release once the authority confirms: {events:?}"
+    );
+    assert!(
+        events.contains(&Event::VerifyPassed),
+        "and the one verify runs over the FULL table: {events:?}"
+    );
+    assert!(
+        !events.contains(&Event::VerifyFailed),
+        "no teardown anywhere in the whole convergence: {events:?}"
+    );
+    assert_eq!(rt.status().counts.installed, 5);
+}
+
+/// The two release conditions are AND, and the verdict backstop holds
+/// when the gate cannot: a converged authority word over a feed still
+/// HOLDING changes must not release (the mirror-vs-bird comparison
+/// cannot see them — the #160 gap), and when the release does come with
+/// nothing installed, the empty sample rides `VerifyIncomplete` — reach
+/// `Ready`, refuse steering — never the teardown verdict.
+#[test]
+fn a_backlog_blocks_the_release_and_an_empty_sample_never_tears_down() {
+    use packetframe_common::fib::{CompletenessReport, TableCompleteness};
+    use packetframe_vpp_offload::engine::SourceChanges;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    /// Claims five routes and a converged-looking count, but has never
+    /// handed anything over and still holds a backlog.
+    struct Withholding {
+        backlog: Rc<Cell<u64>>,
+    }
+    impl RouteSource for Withholding {
+        fn requeue(&self, _: SourceChanges) {
+            unreachable!("this source hands nothing over, so nothing can come back")
+        }
+        fn route_count(&self) -> u64 {
+            5
+        }
+        fn change_seq(&self) -> u64 {
+            5
+        }
+        fn backlog(&self) -> u64 {
+            self.backlog.get()
+        }
+        fn for_each_route(&self, _: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(fake_vpp::nh(), "eth4", MAC);
+        }
+    }
+
+    let fake = Fake::start("fresh-hold-backlog");
+    let backlog = Rc::new(Cell::new(4_096u64));
+    let rt = runtime_with_source(
+        &fake,
+        Box::new(Withholding {
+            backlog: Rc::clone(&backlog),
+        }),
+    );
+    let handle = std::sync::Arc::new(TableCompleteness::new());
+    rt.require_table_complete(handle.clone());
+    handle.publish(CompletenessReport {
+        authority_routes: 5,
+        mirror_routes: 5,
+        at: Instant::now(),
+    });
+
+    let mut d = Driver::new();
+    let mut now = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(now, Event::Adopted { steered: false }, &mut fx);
+    }
+
+    // Authority says converged — but the feed still holds a backlog,
+    // and the backlog wins.
+    {
+        let (mut obs, mut fx) = rt.views();
+        for _ in 0..10 {
+            let t = d.tick(now, &mut obs, &mut fx);
+            assert!(
+                !t.events.contains(&Event::SyncComplete),
+                "a converged word cannot vouch for changes the feed has not handed over"
+            );
+            for e in rt.take_pending() {
+                d.inject(now, e, &mut fx);
+            }
+            now += t
+                .sleep
+                .unwrap_or(Duration::from_millis(100))
+                .max(Duration::from_millis(1));
+        }
+        assert_eq!(d.state(), State::Syncing);
+    }
+
+    // Backlog drains; the hold releases — onto a ledger that installed
+    // nothing, which is exactly the shape the verdict backstop covers.
+    backlog.set(0);
+    let (_, events) = run_until(&mut d, &rt, now, |d| d.state() == State::Ready);
+    assert!(
+        events.contains(&Event::VerifyIncomplete),
+        "an empty sample holds: {events:?}"
+    );
+    assert!(
+        !events.contains(&Event::VerifyFailed),
+        "and never tears down — a restart cannot conjure routes: {events:?}"
     );
 }


### PR DESCRIPTION
## What the w7 window actually found

The first eth4-only run on the #178 promisc-vote build died at +31 s like every run before it — but tonight's harness carried a packetframe unit-log tap for the first time, and the log rewrote the story: **the supervisor killed VPP seven times in 31 s**, every teardown `event=VerifyFailed from_state=Verifying`, and the first one landed at 07:04:55.16 — **before bird's session opened at 07:04:56.5**.

The mechanism: on a fresh attach the feed connects *after* the module (bird dials the passive listener), so the engine's pending map goes momentarily empty ~1 s after spawn, `Drain::Idle` becomes `SyncComplete`, and verify runs against a sink the local-ARP tee had correctly left empty. `sampled == 0` fails `fib_correct()` — rightly, for steering — but the verdict mapping sent it to `VerifyFailed`, the teardown verdict. Each respawn re-ran `oct_port_start` against the shared LMAC, so the switch0 bridge stayed dark below the kernel for the whole window (e4 `rx_drops` frozen from 07:04:55.9). MCAM entries 2004/2005 read `enabled: no` in the t30/tFAIL snapshots, but with a VPP living ~1–15 s per cycle those snapshots can't separate the vote failing from the churn — the #178 verdict stays open until VPP can survive its first minute, which is what this PR buys.

Retroactively this also explains the invisible half of the w3–w6 runs (no unit-log tap existed) and fits the w6 kick war's 4–19 s re-break cadence: a backoff-stretching respawn loop re-running port start, not a spontaneous AF re-evaluation.

Worse, the eth4-only bisection config could **never** have converged: the full table's nexthops egress eth2/eth3, which aren't members, so `unresolvable > 0` is structural there — the same eternal loop through a second door.

## The fix — same family as #177, one door over

A restart cannot make bird dump faster, and it cannot make eth3 a member.

1. **`Verdict::event()` split**: `VerifyFailed` fires only on **mismatches** — VPP answered a probe and disagreed, the one condition a fresh resync repairs. `sampled == 0` and `unresolvable > 0` ride `VerifyIncomplete`: reach `Ready`, keep the want, steering refused by the **live** gates (`steer_permitted` re-reads the authority verdict, source backlog and `blocks_first_steer` every retry — none consult the verdict snapshot, so recovery needs no re-verify plumbing). `fib_correct()` itself is unchanged: status still reports the condition, steering still refuses.
2. **Fresh-resync hold**: with `require-table-complete on`, an idle drain during a fresh resync reports `AwaitingSource` — extending the phase deadline exactly as the adopted deferrals do — until `authority_current` says converged **and** the source backlog is drained (the mirror-vs-bird comparison can't see changes the feed still holds — the #160 gap). Installs keep trickling in while it holds, so convergence overlaps bird's dump; the single verify then runs over the full table. The adopted paths already had `SourceGate`s for precisely this reason; the fresh path was the one door left open. No authority configured → no hold (nothing honest to wait for); the verdict split is the backstop.
3. **Verify verdicts log their outcome summary** (`sampled/mismatches/unresolvable/withheld`). The w7 teardowns carried no reason even with the unit log captured, and the loop was misread as a hardware fault for most of a night because of it. The summary also now labels mismatch-free failures `INCOMPLETE — steering refused, no restart` instead of `FAIL`, so an operator isn't invited to bounce a dataplane a bounce cannot fix.

## Tests

- `engine.rs`: the old fixtures literally asserted `sampled: 0` → `VerifyFailed` — the exact mapping that killed the primary — rewritten with mismatches as the wrongness signal; new `an_undelivered_or_unmappable_table_holds_rather_than_restarts`.
- `vpp_runtime.rs` service level, against the fake VPP: `a_fresh_convergence_holds_verify_until_the_authority_confirms_the_table` drives the whole incident — empty source + silent authority → 30 ticks pinned in `Syncing` with zero `SyncComplete`/`VerifyFailed`, then the dump lands through the delta seam, the authority confirms, and the loop releases into one full-table `VerifyPassed`. `a_backlog_blocks_the_release_and_an_empty_sample_never_tears_down` covers the AND of the release conditions and the `VerifyIncomplete` backstop.
- Two existing tests published incomplete reports and expected a fresh convergence to reach Ready anyway — the premise the hold now refuses. Their subjects are at-Ready seams (the #157 steer retry, the empty-target exception), so they now converge under a converged verdict and degrade it afterwards — which is how those states arise in production.

Host `make lint` + `make test` green (829 tests, 35 suites); cross-builds and qemu are CI's to confirm.

## After merge

The eth4-only window gets rerun on this build. Expected shape: attach → **Syncing holds for the length of bird's dump** (minutes, VPP alive and stable — finally giving MCAM 2004/2005 a steady state to be observed in) → verify → `VerifyIncomplete` on the structural unresolvable count → Ready, degraded, zero teardowns. `.7` staying alive through that window is the #178 promisc verdict; this PR is what makes the experiment runnable at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)