### PR TITLE
fix(vpp-offload): only a PF rx-mode event revives the LMAC's channel defaults — kick it after every attach

### DIFF
--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -732,6 +732,13 @@ fn finish(
         if let Some(handle) = feed_session {
             runtime.feed_session(handle);
         }
+        // The kernel rx-mode kick — the AllmultiKick doc in `runtime`
+        // carries the w6/w8 evidence. Installed unconditionally on
+        // Linux: every member VF attach needs it, and the real
+        // implementation logs each kick, so its absence from an attach
+        // log is itself the diagnostic.
+        #[cfg(target_os = "linux")]
+        runtime.rx_mode_kick(Box::new(crate::runtime::AllmultiKick));
         let initial = match adopted {
             Some(p) => {
                 // The API handshake MUST happen before the adoption is

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -172,6 +172,108 @@ impl ResourceRelease for NoResources {
     }
 }
 
+/// Re-asserts a member port's KERNEL PF rx-mode after the VPP side of
+/// a device attach settles.
+///
+/// Why this exists (w8, primary, 2026-08-13): bringing the member VF up
+/// disables the AF's channel-default MCAM entries for the whole shared
+/// LMAC (observed as entries 2004/2005 flipping `enabled: no`), which
+/// leaves the kernel PF deaf BELOW the kernel — `rx_drops` frozen,
+/// `IFF_PROMISC` still set, every host surface green — and on a
+/// bridge-member port (the primary's eth4/switch0) that is a full
+/// bridge blackout. The VF-side promisc vote (#178) provably does NOT
+/// re-enable them: w8 ran a single stable VPP — no respawns, zero
+/// `VerifyFailed`, `sw_interface_set_promisc` acknowledged — and the
+/// port froze within a second of device attach anyway. Only a PF-side
+/// rx-mode event makes the AF re-install its defaults, proven
+/// five-for-five by the w6 kick cycles (~1 s recovery each). The
+/// re-breaks that made the kick look non-viable in w6 were the verify
+/// kill-respawn loop #180 removed: each new VPP's port start
+/// re-disabled the entries within its backoff interval.
+///
+/// A trait rather than a direct ioctl so the service tests can record
+/// calls and non-Linux builds never pretend.
+pub trait RxModeKick {
+    /// Force the kernel netdev named `port` to resend its rx-mode to
+    /// the AF. Any rx-mode event does it; the Linux implementation
+    /// toggles `IFF_ALLMULTI`.
+    fn kick(&mut self, port: &str) -> Result<(), String>;
+}
+
+/// No kick installed: tests and harnesses. Deliberately SILENT — the
+/// real implementation logs each kick, so a production attach log
+/// without the kick lines means the wiring did not install
+/// [`AllmultiKick`], visibly, rather than a stub logging success it
+/// never performed.
+#[derive(Debug, Default)]
+pub struct NoKick;
+impl RxModeKick for NoKick {
+    fn kick(&mut self, _port: &str) -> Result<(), String> {
+        Ok(())
+    }
+}
+
+/// The real kick: `IFF_ALLMULTI` on, then back to the flags that were
+/// read, via `SIOCSIFFLAGS` on the kernel netdev. Two rx-mode events,
+/// each forcing the PF driver to resend `NIX_RX_MODE` to the AF; the
+/// entries end enabled and the port's flags end where they started.
+/// Same ioctl shape and musl/glibc cast note as
+/// `ntuple::sys::ethtool_raw`.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Default)]
+pub struct AllmultiKick;
+
+#[cfg(target_os = "linux")]
+impl RxModeKick for AllmultiKick {
+    fn kick(&mut self, port: &str) -> Result<(), String> {
+        fn flags_ioctl(port: &str, set_to: Option<libc::c_short>) -> Result<libc::c_short, String> {
+            let name = port.as_bytes();
+            let mut ifr: libc::ifreq = unsafe { std::mem::zeroed() };
+            if name.len() >= ifr.ifr_name.len() {
+                return Err(format!("interface name `{port}` exceeds IFNAMSIZ"));
+            }
+            for (dst, src) in ifr.ifr_name.iter_mut().zip(name) {
+                *dst = *src as libc::c_char;
+            }
+            let sock = unsafe { libc::socket(libc::AF_INET, libc::SOCK_DGRAM, 0) };
+            if sock < 0 {
+                return Err(std::io::Error::last_os_error().to_string());
+            }
+            let (cmd, verb) = match set_to {
+                Some(f) => {
+                    ifr.ifr_ifru.ifru_flags = f;
+                    (libc::SIOCSIFFLAGS, "SIOCSIFFLAGS")
+                }
+                None => (libc::SIOCGIFFLAGS, "SIOCGIFFLAGS"),
+            };
+            // `ioctl`'s request argument is `c_ulong` on glibc and
+            // `c_int` on musl; without the cast one published target
+            // does not compile, with it the other needs the allow.
+            #[allow(clippy::unnecessary_cast)]
+            let rc = unsafe { libc::ioctl(sock, cmd as _, &mut ifr) };
+            let err = std::io::Error::last_os_error();
+            unsafe { libc::close(sock) };
+            if rc != 0 {
+                return Err(format!("{verb} on {port}: {err}"));
+            }
+            Ok(unsafe { ifr.ifr_ifru.ifru_flags })
+        }
+
+        let original = flags_ioctl(port, None)?;
+        let allmulti = libc::IFF_ALLMULTI as libc::c_short;
+        flags_ioctl(port, Some(original | allmulti))?;
+        // Restore EXACTLY what was read — an operator running with
+        // allmulti deliberately on must get it back.
+        flags_ioctl(port, Some(original))?;
+        tracing::info!(
+            port,
+            "kernel rx-mode re-asserted (allmulti toggle): the AF re-installs its \
+             channel-default MCAM entries for this LMAC"
+        );
+        Ok(())
+    }
+}
+
 /// What one pass of the steering audit established.
 ///
 /// Two facts rather than one, because they are independent: a pass can
@@ -414,6 +516,10 @@ struct Core {
     /// by `start_resync`'s fresh arm when an authority is configured;
     /// cleared by `drain_batch` on release. See [`FreshHold`].
     fresh_hold: Option<FreshHold>,
+    /// The kernel rx-mode kick, run per member port after every device
+    /// attach. [`NoKick`] until the attach wiring installs
+    /// [`AllmultiKick`] on Linux. See [`RxModeKick`] for the incident.
+    rx_kick: Box<dyn RxModeKick>,
     /// When the NIC was last audited against the steering ledger, and
     /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
     last_steer_audit: Option<std::time::Instant>,
@@ -1120,6 +1226,7 @@ impl Runtime {
                 last_drain_error: None,
                 deferred_resync: None,
                 fresh_hold: None,
+                rx_kick: Box::new(NoKick),
                 last_steer_audit: None,
                 steer_missing: 0,
                 steer_stray: 0,
@@ -1175,6 +1282,13 @@ impl Runtime {
     /// leaves behind.
     pub fn feed_session(&self, handle: std::sync::Arc<packetframe_common::fib::FeedSession>) {
         self.core.borrow_mut().feed_session = Some(handle);
+    }
+
+    /// Install the kernel rx-mode kick. The attach wiring installs the
+    /// ioctl-backed [`AllmultiKick`] on Linux; everything else keeps
+    /// [`NoKick`]. See [`RxModeKick`] for why this exists.
+    pub fn rx_mode_kick(&self, k: Box<dyn RxModeKick>) {
+        self.core.borrow_mut().rx_kick = k;
     }
 
     /// Point steering at a new set of ports and rules.
@@ -2485,6 +2599,28 @@ impl Effects for EffectsView {
         // whole-record (see `note_persist`).
         let r = c.store.interfaces_attached(&indices);
         let _ = c.note_persist(r);
+        // The kernel PF's half of the attach: the VF that just came up
+        // disabled the AF's channel-default MCAM entries for the whole
+        // LMAC, and only a PF-side rx-mode event re-enables them — the
+        // VPP-side promisc vote provably does not (w8, 2026-08-13; see
+        // [`RxModeKick`]). Per member port, after EVERY device attach,
+        // so a supervisor respawn re-asserts it on the same path that
+        // re-created the condition. Failure is surfaced, not fatal: a
+        // teardown cannot fix a host-side ioctl, and escalating it is
+        // the #180 defect with a new face — but it IS a possible bridge
+        // blackout, so the warning names the by-hand remedy.
+        for (port, _) in &indices {
+            if let Err(e) = c.rx_kick.kick(port) {
+                tracing::warn!(
+                    port = %port,
+                    error = %e,
+                    "kernel rx-mode kick failed; the AF's channel-default MCAM entries \
+                     for this LMAC may be disabled and the kernel PF deaf below the \
+                     kernel (bridge members go dark). By hand: `ip link set <port> \
+                     allmulti on` then `allmulti off`"
+                );
+            }
+        }
         Ok(())
     }
 

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -3157,3 +3157,91 @@ fn a_backlog_blocks_the_release_and_an_empty_sample_never_tears_down() {
         "and never tears down — a restart cannot conjure routes: {events:?}"
     );
 }
+
+/// The kernel rx-mode kick runs once per member port after the device
+/// attach — the PF-side half of bringing a VF up on a shared LMAC.
+///
+/// w8 (primary, 2026-08-13) is the evidence this encodes: a single
+/// stable VPP — zero `VerifyFailed`, promisc vote acknowledged — and
+/// eth4's `rx_drops` froze within a second of device attach anyway,
+/// with the AF's channel-default entries 2004/2005 `enabled: no` at
+/// tFAIL. Only a PF-side rx-mode event re-installs them (five-for-five
+/// in the w6 kick cycles), so the module must issue that event itself,
+/// on every attach, or the first steer-less membership test blacks out
+/// the bridge again.
+#[test]
+fn the_rx_mode_kick_runs_per_member_after_the_device_attach() {
+    use packetframe_vpp_offload::runtime::RxModeKick;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    struct Recording(Rc<RefCell<Vec<String>>>);
+    impl RxModeKick for Recording {
+        fn kick(&mut self, port: &str) -> Result<(), String> {
+            self.0.borrow_mut().push(port.to_string());
+            Ok(())
+        }
+    }
+
+    let fake = Fake::start("rx-kick");
+    let rt = runtime_for(&fake, 2);
+    let kicks = Rc::new(RefCell::new(Vec::new()));
+    rt.rx_mode_kick(Box::new(Recording(Rc::clone(&kicks))));
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (_, _) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    assert_eq!(
+        kicks.borrow().as_slice(),
+        ["eth4"],
+        "one kick per member port, after the attach, exactly once"
+    );
+}
+
+/// A failed kick degrades and warns; it must NOT fail the attach.
+///
+/// A teardown cannot fix a host-side ioctl — escalating this is the
+/// #180 defect with a new face. The port may be dark below the kernel,
+/// which is why the warning names the by-hand remedy, but the offload
+/// still converges and the operator decides.
+#[test]
+fn a_failed_kick_degrades_without_failing_the_attach() {
+    use packetframe_vpp_offload::runtime::RxModeKick;
+
+    struct Refusing;
+    impl RxModeKick for Refusing {
+        fn kick(&mut self, _port: &str) -> Result<(), String> {
+            Err("SIOCSIFFLAGS on eth4: Operation not permitted".into())
+        }
+    }
+
+    let fake = Fake::start("rx-kick-fail");
+    let rt = runtime_for(&fake, 2);
+    rt.rx_mode_kick(Box::new(Refusing));
+
+    let mut d = Driver::new();
+    let t0 = Instant::now();
+    {
+        let (mut obs, _) = rt.views();
+        use packetframe_vpp_offload::driver::Observe as _;
+        assert!(obs.api_ready());
+    }
+    {
+        let (_, mut fx) = rt.views();
+        d.inject(t0, Event::Adopted { steered: false }, &mut fx);
+    }
+    let (_, events) = run_until(&mut d, &rt, t0, |d| d.state() == State::Ready);
+    assert!(
+        events.contains(&Event::VerifyPassed),
+        "the convergence itself is untouched by a kick failure: {events:?}"
+    );
+}

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -852,6 +852,43 @@ keyword mis-encodes it on the rvu driver, so a rule installed by hand
 with that keyword lands somewhere else. Gate 0a established this by
 inserting both forms and reading back what the NIC stored.
 
+### A bridge-member port goes dark right after attach — hosts behind the bridge unreachable, every status green
+
+The shared-LMAC MCAM disable (found on the primary, w3–w8, 2026-08-13).
+On rvu, the AF's channel-default MCAM entries (the promisc/multicast
+catch-alls that make the KERNEL PF receive; `Installed by: PF0`,
+`Forward to: PF1` in the debugfs dump) cover the whole LMAC, and
+bringing the member VF up under VPP disables them. Fingerprint: the
+port's `ethtool -S <pf> | grep rx_drops` counter **freezes** within a
+second or two of the device attach while `ip link` still shows
+`PROMISC,UP`; hosts behind any bridge that port is a member of become
+unreachable, including from the router itself; nothing in `packetframe
+status`, VPP, or the kernel log complains. Confirm at the hardware
+table: `grep -A12 'mcam entry: <n>' /sys/kernel/debug/octeontx2/npc/mcam_rules`
+— the channel's default entries read `enabled: no`.
+
+The module handles this itself: after every device attach it toggles
+`IFF_ALLMULTI` on each member's kernel netdev (the "rx-mode kick" —
+look for `kernel rx-mode re-asserted` in the attach log), which forces
+the PF driver to resend its rx-mode and the AF to re-install its
+defaults. The VPP-side `sw_interface_set_promisc` the attach also sends
+does NOT re-enable them — only a PF-side event does; that was measured,
+not assumed (w6: five kick cycles, ~1 s recovery each; w8: a stable
+promisc-voting VPP went dark anyway).
+
+If the attach log shows the kick **failing**, or the port went dark
+later without an attach, apply it by hand and confirm the counter moves
+again:
+
+```sh
+ip link set <port> allmulti on && ip link set <port> allmulti off
+ethtool -S <port> | grep rx_drops   # twice, a second apart — must move
+```
+
+A port that re-breaks *without* a VPP restart in between is new
+behaviour beyond this entry: capture the mcam_rules dump before and
+after and treat it as an AF-level finding, not a packetframe one.
+
 ### A steer is refused with "the route mirror holds N of M routes"
 
 The completeness gate. bird's initial dump has not finished, so the


### PR DESCRIPTION
## What w8 proved

The first window where VPP survived its whole life — #180's fresh-resync hold engaged (`holding verify while installs continue have=32408`), **zero `VerifyFailed`, a single pid** — and eth4 still went deaf. The counters bracket the moment exactly: `rx_drops` moving at 08:42:48.1, frozen from 08:42:50.1; VF creation was 08:42:48.4, VPP's device attach ~08:42:49.5. At tFAIL the AF's channel-default MCAM entries 2004/2005 (`Installed by: PF0`, `Forward to: PF1`) read `enabled: no` — under a live, stable VPP whose `sw_interface_set_promisc` had been acknowledged.

That falsifies the remedy half of #178: **the VF-side disable propagates channel-wide, but the VF's promisc-on vote does not re-enable the PF's channel defaults.** Only a PF-side rx-mode event makes the AF re-install them — measured five-for-five in the w6 kick cycles (~1 s recovery each). And the w6 re-breaks that made the kick look non-viable are now fully explained: each one was the next respawn of the #180 kill loop re-running `oct_port_start` inside its backoff interval. With the loop gone, the kick is the production fix, not a workaround.

## The change

- New `RxModeKick` seam on the runtime (same pattern as `ResourceRelease`/`IdentityStore`), called **once per member port after every device attach** — supervisor respawns re-assert it on the same path that re-creates the condition.
- `AllmultiKick` (Linux): `IFF_ALLMULTI` on then back to the exact flags read, via `SIOCSIFFLAGS` — two rx-mode events, PF driver resends `NIX_RX_MODE`, AF re-installs its defaults. Same ioctl shape and musl/glibc cast note as the ntuple path. It logs each kick, so a wiring that failed to install it is visible in the attach log; `NoKick` (tests) is deliberately silent for the same reason.
- A failed kick **warns with the by-hand remedy and does not fail the attach**: a teardown cannot fix a host-side ioctl, and escalating it is the #180 defect with a new face. It is a possible bridge blackout though, so the warning says exactly what to run.
- #178's promisc call stays: it is the belt that keeps the VF's *stored vote* from re-disabling the entries on future AF re-evaluations.
- Runbook: new triage entry — frozen `rx_drops` + all surfaces green + `mcam_rules` `enabled: no`, the kick log line to look for, and the manual toggle.

## Tests

Service level against the fake VPP: `the_rx_mode_kick_runs_per_member_after_the_device_attach` (recording kick, exactly `["eth4"]` once, after attach, through the full convergence) and `a_failed_kick_degrades_without_failing_the_attach` (refusing kick, `VerifyPassed` still reached). Host `make lint` + `make test` green (831 tests, 35 suites); cross-builds compile the Linux-only ioctl arm.

## The remaining hardware question

This is the third mechanism candidate for the same blackout, so stating the falsifiable prediction plainly: on the next eth4-only window, the attach log shows `kernel rx-mode re-asserted` for eth4 within a second of device attach, `.7` recovers (or never drops), e4 `rx_drops` keeps counting, and 2004/2005 read `enabled: yes` in every snapshot for the rest of the window. If the port re-breaks **without** a VPP restart in between, that is a new AF behaviour beyond both #178 and this PR — the runbook entry says to capture the before/after MCAM dumps and treat it as a vendor-level finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)