### PR TITLE
fix(vpp-offload): active resync progress extends the phase deadline — a timeout cannot make bird dump faster

### DIFF
--- a/crates/modules/vpp-offload/src/driver.rs
+++ b/crates/modules/vpp-offload/src/driver.rs
@@ -352,7 +352,33 @@ impl Driver {
                     // rather than assumed after issuing StartResync.
                     Ok(Drain::Idle) if resyncing => events.push(Event::SyncComplete),
                     Ok(Drain::Idle) => drain_proved_idle = true,
-                    Ok(Drain::More) => more_to_drain = true,
+                    // ACTIVE PROGRESS extends the deadline too, when it
+                    // happens during a resync. The phase budget exists
+                    // to catch a STALLED convergence, and `More` is
+                    // proof of the opposite: this tick pulled changes
+                    // and pushed them into VPP. Left unextended, the
+                    // budget races the FEED — the fresh trickle-resync
+                    // (#180) converges behind bird's multi-minute dump
+                    // by design, and w10 on the primary (2026-08-13)
+                    // spent its first two minutes returning `More` on
+                    // every tick (the dump outran the drain, so `Idle`
+                    // never came and the fresh hold never got to say
+                    // "deliberately waiting") until `PhaseTimedOut`
+                    // tore down a healthy, actively converging VPP at
+                    // ~117 s. The respawn survived only by accident:
+                    // it began from a mostly-loaded mirror and won the
+                    // race to `Idle`. A deadline cannot make bird dump
+                    // faster. What this does NOT weaken: a dead
+                    // transport takes the `Err` arms below, a silent
+                    // VPP is the wedge detector's measured job, and a
+                    // drain that stops moving stops extending — the
+                    // budget then runs out exactly as designed.
+                    Ok(Drain::More) => {
+                        if resyncing {
+                            self.sched.extend_phase(now, self.sup.phase());
+                        }
+                        more_to_drain = true;
+                    }
                     // Deliberate waiting, not progress and not
                     // completion. The phase deadline is pushed forward
                     // on every deferred tick so `CONVERGENCE_BUDGET`
@@ -827,6 +853,75 @@ mod tests {
     }
 
     // ---- The drain is incremental ----
+
+    /// Active progress must extend the phase deadline: the budget
+    /// exists to catch a STALLED convergence, and `Drain::More` is
+    /// proof of the opposite. w10 on the primary (2026-08-13) spent
+    /// the first two minutes of its fresh trickle-resync returning
+    /// `More` on every tick -- bird's dump outran the drain, `Idle`
+    /// never came, and the fresh hold never got a chance to extend --
+    /// so `PhaseTimedOut` tore down a healthy, actively converging
+    /// VPP at ~117 s. The respawn passed the window only by accident:
+    /// it restarted from a mostly-loaded mirror and won the race to
+    /// `Idle`. A deadline cannot make bird dump faster.
+    ///
+    /// The second half is the control: once progress stops
+    /// (`Verifying`, where the drain is excluded and this fake never
+    /// delivers a verdict), the same deadline still fires. Extending
+    /// on progress must not have disarmed the budget.
+    #[test]
+    fn a_resync_making_progress_outlives_the_budget_but_a_stall_does_not() {
+        use crate::supervisor::CONVERGENCE_BUDGET;
+
+        let t0 = Instant::now();
+        let mut d = Driver::new();
+        let mut fx = Fx::default();
+        let mut w = World {
+            api: true,
+            // `More` on every tick: the feed outruns the drain, which
+            // is what the front of a full-table dump looks like.
+            batches: usize::MAX,
+            ..Default::default()
+        };
+
+        d.inject(t0, Event::StartRequested, &mut fx);
+        let t = d.tick(t0, &mut w, &mut fx);
+        assert!(t.events.contains(&Event::ApiUp));
+        assert_eq!(d.state(), State::Syncing);
+
+        // Three budgets of wall clock, every tick progressing.
+        let step = Duration::from_secs(2);
+        let mut now = t0;
+        for _ in 0..(3 * CONVERGENCE_BUDGET.as_secs() / 2) {
+            now += step;
+            let t = d.tick(now, &mut w, &mut fx);
+            assert!(
+                !t.events.contains(&Event::PhaseTimedOut),
+                "a drain reporting More is progress, not a stall: {:?}",
+                t.events
+            );
+            assert_eq!(d.state(), State::Syncing);
+        }
+
+        // The dump ends; the drain empties; verify begins.
+        w.batches = 2;
+        now += step;
+        d.tick(now, &mut w, &mut fx);
+        now += step;
+        let t = d.tick(now, &mut w, &mut fx);
+        assert!(t.events.contains(&Event::SyncComplete), "{:?}", t.events);
+        assert_eq!(d.state(), State::Verifying);
+
+        // Control: no verdict arrives and nothing extends -- the
+        // budget must still fire.
+        now += CONVERGENCE_BUDGET + Duration::from_secs(1);
+        let t = d.tick(now, &mut w, &mut fx);
+        assert!(
+            t.events.contains(&Event::PhaseTimedOut),
+            "the deadline must survive the extensions: {:?}",
+            t.events
+        );
+    }
 
     /// The reason `drain_batch` is bounded. A blocking full-table drain
     /// would hold the loop for the entire convergence budget, sending no


### PR DESCRIPTION
## The last blemish in w10

The six-port rung-0 window passed — `verify PASS: 64/64 probes, unresolvable=0`, MCAM entries enabled in every snapshot, 600 s clean, the first steer-permitted state the primary has ever reached — but the pf.log showed VPP attached **twice**: the first life died at ~117 s to `PhaseTimedOut from_state=Syncing` while **actively converging**.

Mechanism: at the front of bird's dump the feed outruns the drain, so `drain_batch` returns `More` on every tick. The driver extends the phase deadline on `AwaitingSource` (deliberate waiting) but not on `More` (active progress) — so `Idle` never came, the #180 fresh hold never got a tick to extend, and `CONVERGENCE_BUDGET` (120 s) killed a healthy VPP mid-dump. The respawn passed the window only by accident: it restarted from a mostly-loaded mirror, bulk-drained to `Idle` ahead of the budget, and handed over to the hold. w9 (eth4-only) never hit this because unresolvable routes drain instantly.

Unfixed, every six-port **fresh attach** on the primary tears down one healthy VPP ~2 minutes in — a guaranteed restart (and an extra `oct_port_start`/kick cycle on the shared LMAC) at the exact center of the bring-up path. Same defect family as #180 and #181's escalation rule, arriving through the clock: a deadline cannot make bird dump faster.

## The fix

One arm in the driver: `Ok(Drain::More)` during a resync extends the phase deadline exactly as `AwaitingSource` does. The budget still catches everything it exists for:

- a **stall** stops producing `More`, extensions stop, and the clock runs out — the new test's control half proves the deadline survives the extensions and still fires in `Verifying`;
- a **dead transport** takes the `Err` arm to `ConvergenceFailed` immediately;
- a **silently wedged VPP** is the wedge detector's measured job (`More` cannot be produced without acknowledged sends).

`PhaseKind::Convergence` spans resync **plus** verify, so each progressing tick re-arms the full budget for the verify that follows — which is the sizing the budget was measured for (a bounded readback pass, not a race against the feed).

## Test

`a_resync_making_progress_outlives_the_budget_but_a_stall_does_not` (driver): three budgets of wall clock with `More` on every tick — no `PhaseTimedOut`, state pinned in `Syncing`; then the drain empties, `SyncComplete` → `Verifying`, no verdict ever arrives, and the same deadline fires. Host `make lint` + `make test` green (832 tests, 35 suites).

## After merge

The next fresh six-port window should show **one** VPP pid for its whole life: attach → six kicks → hold through the dump (`More` and `AwaitingSource` both extending) → one `verify PASS` → Ready. That plus a rung-0 soak is the last prerequisite before the eth4 `src` canary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)