### PR TITLE
chore(vpp-offload): make the fresh hold visible in status, and land the w9/w10 docs

### DIFF
--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1453,6 +1453,18 @@ impl Runtime {
             resync_deferred: c
                 .deferred_resync
                 .map(|d| (c.source.route_count(), d.floor())),
+            // `want` is the authority's own count so the status row can
+            // say how far along the dump is; 0 until its first report,
+            // which the row words for separately.
+            fresh_hold: c.fresh_hold.as_ref().map(|_| {
+                (
+                    c.source.route_count(),
+                    c.completeness
+                        .as_ref()
+                        .and_then(|h| h.latest_verdict().0)
+                        .map_or(0, |r| r.authority_routes),
+                )
+            }),
             steer_missing: c.steer_missing,
             steer_stray: c.steer_stray,
             steer_audit_error: c.steer_audit_error.clone(),
@@ -1585,6 +1597,10 @@ pub struct RuntimeStatus {
     /// `Some((have, want))` while an adopted resync is deferred for a
     /// still-loading route source. See `Core::deferred_resync`.
     pub resync_deferred: Option<(u64, u64)>,
+    /// `Some((have, want))` while a fresh convergence holds verify for
+    /// the completeness authority. See [`FreshHold`] and the status
+    /// row's doc in `status.rs`.
+    pub fresh_hold: Option<(u64, u64)>,
     /// What the authority can say right now — the deferral health text
     /// depends on it: an attested deployment's below-floor wait
     /// resolves through the authority and telling it to "add bird"

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1083,6 +1083,7 @@ fn run_loop(
             driver.api_health(now),
             fib,
             rs.resync_deferred,
+            rs.fresh_hold,
             rs.authority,
             rs.port_links,
             rs.store_error.clone(),

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -302,6 +302,16 @@ pub struct StatusSnapshot {
     /// FIB is deliberately left forwarding, so this reads as Degraded
     /// with the reason, never as steered-but-broken.
     pub resync_deferred: Option<(u64, u64)>,
+    /// `Some((have, want))` while a FRESH convergence holds verify until
+    /// the completeness authority confirms the table: `have` is the
+    /// mirror's count now, `want` the authority's own count (`0` until
+    /// its first report). Routes install as the source loads — nothing
+    /// is being protected, unlike the adopted deferral — and on a
+    /// full-table feed this holds for the length of bird's dump
+    /// (~5 minutes on the primary, measured twice on 2026-08-13). An
+    /// operator watching `Syncing` for minutes needs the row to say
+    /// that is the designed path. See `runtime`'s `FreshHold`.
+    pub fresh_hold: Option<(u64, u64)>,
     /// See [`crate::runtime::RuntimeStatus::authority`].
     pub authority: crate::runtime::AuthorityPosture,
     pub ports: Vec<PortLink>,
@@ -368,6 +378,7 @@ impl StatusSnapshot {
             api,
             fib,
             None,
+            None,
             // No deferral in this shorthand, so the posture is unread;
             // Absent is the honest default rather than a claim.
             crate::runtime::AuthorityPosture::Absent,
@@ -398,6 +409,7 @@ impl StatusSnapshot {
         api: ApiHealth,
         fib: FibSync,
         resync_deferred: Option<(u64, u64)>,
+        fresh_hold: Option<(u64, u64)>,
         authority: crate::runtime::AuthorityPosture,
         ports: Vec<PortLink>,
         store_error: Option<String>,
@@ -422,6 +434,7 @@ impl StatusSnapshot {
             api,
             fib,
             resync_deferred,
+            fresh_hold,
             authority,
             ports,
             store_error,
@@ -835,6 +848,36 @@ impl StatusSnapshot {
                 HealthState::Unhealthy,
                 Some("traffic steered into an unverified FIB".into()),
             ),
+            // The FRESH counterpart of the deferral arm above, and
+            // AFTER the steered arm deliberately: a fresh hold is never
+            // steered (fresh spawns cannot be), so if the two ever
+            // coexist something upstream broke and the steered alarm is
+            // the one that must win. Unlike the adopted deferral nothing
+            // here is being protected — routes install as they arrive —
+            // so the row answers what an operator watching minutes of
+            // `Syncing` actually needs: this is the designed path, and
+            // here is what releases it (w10, 2026-08-13: ~5 minutes of
+            // hold behind bird's dump on the primary).
+            FibSync::NeverVerified if self.fresh_hold.is_some() => {
+                let (have, want) = self.fresh_hold.expect("checked above");
+                let msg = if want == 0 {
+                    format!(
+                        "fresh convergence: routes install as the source loads (mirror \
+                         holds {have}); verify waits for the completeness authority's \
+                         first report (require-table-complete). On a full-table feed \
+                         this holds for the length of bird's dump — minutes — by design"
+                    )
+                } else {
+                    format!(
+                        "fresh convergence: routes install as the source loads (mirror \
+                         holds {have} of the authority's {want}); verify runs once over \
+                         the complete table when the authority confirms it \
+                         (require-table-complete). On a full-table feed this holds for \
+                         the length of bird's dump — minutes — by design"
+                    )
+                };
+                (HealthState::Degraded, Some(msg))
+            }
             FibSync::NeverVerified => (HealthState::Degraded, Some("not yet verified".into())),
             FibSync::Failed { summary, .. } => (HealthState::Unhealthy, Some(summary.clone())),
             FibSync::Verified { sampled, .. } => {
@@ -2865,6 +2908,71 @@ mod tests {
             FibSync::from_outcome(&good, Duration::ZERO),
             FibSync::Verified { sampled: 64, .. }
         ));
+    }
+
+    /// The fresh hold reads as the designed path, not a fault.
+    ///
+    /// w10 (primary, 2026-08-13): five minutes of `Syncing` while the
+    /// #180 hold waited out bird's dump, with `packetframe status`
+    /// saying only "not yet verified" — the row an operator watches
+    /// during every fresh attach said nothing about WHY, for HOW LONG,
+    /// or that anything was progressing. The next shift babysits this
+    /// exact state; the row must carry the counts and name the release
+    /// condition, at Degraded, without paging.
+    #[test]
+    fn a_fresh_hold_names_the_designed_path_and_its_release() {
+        let led = ledger_with(23_107, 0, 0);
+        let mut snap = snap_of(
+            &ready_supervisor(),
+            &led,
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(200),
+            },
+            FibSync::NeverVerified,
+            ports_up(),
+        );
+        snap.fresh_hold = Some((23_107, 1_054_898));
+
+        let report = snap.report();
+        let fib = report
+            .subsystems
+            .iter()
+            .find(|s| s.name == SUBSYS_FIB)
+            .expect("the fib row always exists");
+        assert_eq!(
+            fib.state,
+            HealthState::Degraded,
+            "designed path, not a page"
+        );
+        let msg = fib.message.as_deref().expect("the hold explains itself");
+        assert!(
+            msg.contains("fresh convergence") && msg.contains("23107"),
+            "the row must say what is happening and how far along: {msg}"
+        );
+        assert!(
+            msg.contains("1054898") && msg.contains("require-table-complete"),
+            "and name the target and the release condition: {msg}"
+        );
+        assert_ne!(
+            report.overall,
+            HealthState::Unhealthy,
+            "a fresh attach converging behind a dump must never page"
+        );
+
+        // Before the authority's first report there is no honest
+        // target; the row must not print "of the authority's 0".
+        snap.fresh_hold = Some((23_107, 0));
+        let msg = snap
+            .report()
+            .subsystems
+            .into_iter()
+            .find(|s| s.name == SUBSYS_FIB)
+            .and_then(|s| s.message)
+            .expect("still explains itself");
+        assert!(
+            msg.contains("first report") && !msg.contains("authority's 0"),
+            "no report yet is its own message, not a zero target: {msg}"
+        );
     }
 
     /// A vetoed deferral must not be described as waiting for quiet.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -198,6 +198,15 @@ vppctl -s /run/packetframe/vpp/api.sock.cli show ip fib summary
 ```
 
 ```bash
+# What is the VF absorbing? While VPP holds a member VF, the kernel
+# PF's `rx_drops` legitimately freezes (w9/w10: the flood the kernel
+# used to receive-and-drop diverts to the VF) — these counters are
+# where it went. Worth reading before the first steer: flood absorbed
+# by poll-mode workers is CPU the canary should account for.
+vppctl -s /run/packetframe/vpp/api.sock.cli show interface
+```
+
+```bash
 # The interfaces VPP created, and their link state.
 vppctl -s /run/packetframe/vpp/api.sock.cli show interface
 ```
@@ -858,14 +867,23 @@ The shared-LMAC MCAM disable (found on the primary, w3–w8, 2026-08-13).
 On rvu, the AF's channel-default MCAM entries (the promisc/multicast
 catch-alls that make the KERNEL PF receive; `Installed by: PF0`,
 `Forward to: PF1` in the debugfs dump) cover the whole LMAC, and
-bringing the member VF up under VPP disables them. Fingerprint: the
-port's `ethtool -S <pf> | grep rx_drops` counter **freezes** within a
-second or two of the device attach while `ip link` still shows
-`PROMISC,UP`; hosts behind any bridge that port is a member of become
-unreachable, including from the router itself; nothing in `packetframe
-status`, VPP, or the kernel log complains. Confirm at the hardware
-table: `grep -A12 'mcam entry: <n>' /sys/kernel/debug/octeontx2/npc/mcam_rules`
+bringing the member VF up under VPP disables them. Fingerprint —
+**both halves required**: hosts behind any bridge that port is a
+member of become unreachable, including from the router itself, while
+every host surface stays green (`ip link` still shows `PROMISC,UP`,
+nothing in `packetframe status`, VPP, or the kernel log complains).
+The authoritative check is the hardware table:
+`grep -A12 'mcam entry: <n>' /sys/kernel/debug/octeontx2/npc/mcam_rules`
 — the channel's default entries read `enabled: no`.
+
+A frozen `ethtool -S <pf> | grep rx_drops` counter is **NOT** the
+fingerprint on its own, and treating it as one will false-alarm every
+healthy window. While VPP holds the member VF, `rx_drops` on the
+kernel PF legitimately stops counting (w9 and w10, both with entries
+enabled and traffic flowing perfectly): the flood the kernel used to
+receive-and-drop diverts to the VF instead. It resumes when VPP
+releases the VF. Deaf is *frozen counter AND unreachable hosts AND*
+`enabled: no` *in the table* — the middle one is what pages.
 
 The module handles this itself: after every device attach it toggles
 `IFF_ALLMULTI` on each member's kernel netdev (the "rx-mode kick" —
@@ -888,6 +906,10 @@ ethtool -S <port> | grep rx_drops   # twice, a second apart — must move
 A port that re-breaks *without* a VPP restart in between is new
 behaviour beyond this entry: capture the mcam_rules dump before and
 after and treat it as an AF-level finding, not a packetframe one.
+
+The complete evidence chain for the vendor report — the asymmetry,
+the reproduction, the w5–w10 forensics index — lives in
+`docs/vendor/rvu-af-channel-default-mcam.md`.
 
 ### A steer is refused with "the route mirror holds N of M routes"
 
@@ -1063,6 +1085,8 @@ Be precise about this when reasoning about an incident.
 | `ip_route_dump` at adoption | **7.04 s** for 1,054,548 routes | 2026-08-11, timed directly rather than inferred from a traffic gap. This is the barrier-sync freeze §the deferral exists to keep away from steered traffic. |
 | Adopted restart, UNSTEERED | ~53 s start→verified | 2026-08-11. Dump at +7 s, deferral held 32.8 s waiting for the mirror, diff+verify after. No traffic impact — nothing was steered. |
 | Cold bring-up (nothing running) | **11.4 s to `healthy`, ≤61 s to full table** | 2026-08-11. Read the caveat: `healthy` at 11.4 s meant **110,724 routes** — 10% of the table, verified clean. See "A verified FIB is not a complete one". |
+| Fresh six-port attach on the PRIMARY, behind bird's live dump | **~5 min in `Syncing` (held), then one verify** | 2026-08-13, w9 + w10: the #180 hold engaged at have≈23k and released at have≈1,055k; w10 verified PASS 64/64 on the release. This is the number to expect on every primary fresh attach — the 40.32 s row above is a resync from an already-loaded mirror, a different situation. |
+| Load while VPP runs, six workers | **~+7 load permanent** (poll mode), ~22 total during convergence vs ~6 baseline | 2026-08-13 w10. See the load note below. |
 | `reconfigure` (lever move) | **0.215 s** | 2026-08-11, exit 0, writes `OK <ns>` to `last-reconfigure.timestamp`. |
 | Idle draw with VPP polling one worker | 33.56 W, 38/49/42 °C, fan 3780 RPM | 2026-08-11 shadow, chassis total — NOT a VPP attribution, no VPP-off baseline was taken. |
 
@@ -1071,6 +1095,50 @@ Be precise about this when reasoning about an incident.
 | number | status |
 |---|---|
 | `detach` across **more than one** VF | UNMEASURED — the single-VF case is measured above at 2.814 s. Nothing has torn down N>1 VFs, and the per-VF cost is unknown. |
+
+### A fresh attach on a full-table box holds in `Syncing` for minutes. That is the fix working.
+
+A FRESH attach (no VPP to adopt) under `require-table-complete on`
+converges *behind* bird's dump: routes install as they arrive, and the
+one readback verify waits until the completeness authority confirms
+the table. On the primary that is **~5 minutes of `Syncing`**,
+measured twice (2026-08-13, w9/w10). The status row says so while it
+holds:
+
+```
+fib-synced   DEGRADED — fresh convergence: routes install as the
+             source loads (mirror holds N of the authority's M) ...
+```
+
+and the log brackets it with `fresh resync is idle but the route
+source has not converged` and `route source converged and drained;
+fresh resync complete — verifying the full table`. Do not restart it,
+and do not page on it — the state before this hold existed was seven
+kill-respawn cycles in 31 s over an empty table (w7), and a restart
+re-enters the same dump from zero.
+
+A verify that ends `INCOMPLETE — steering refused, no restart` is the
+same philosophy after the hold releases: the FIB is not fit to divert
+traffic into (unresolvable routes, or nothing sampled), but nothing a
+teardown fixes is wrong. `FAIL` is reserved for probe mismatches —
+the one verdict a restart genuinely repairs — and only `FAIL`
+tears down.
+
+### Load rises by roughly one core per VPP worker, permanently. That is poll mode, not a fault.
+
+The native octeon driver supports neither interrupt nor adaptive rx
+mode (gate 0b item 9), so every VPP worker is a pure poll loop pinned
+at 100% — load average counts always-runnable threads, so six member
+ports at `cores 1` add ~7 to load (workers + main) for as long as VPP
+runs, forwarding or idle. w10 measured ~22 during convergence against
+a ~6 baseline: ~7 of that is the permanent poll cost, the rest was
+bird's dump plus the daemon feeding two tiers, and it subsides when
+convergence ends. Load average here is not starvation: the worker
+cores are deliberately vacated (daemon threads restricted away, NIC
+IRQs moved off them pre-attach), and w10's own counters showed the
+eBPF tier matching and forwarding normally throughout
+(`matched_v4` ≈ `rx_total`, `fwd_ok` climbing). Whether ~7 hot cores
+buy enough forwarding is exactly what the steering canary measures.
 
 ### A planned restart looks Degraded for 40-80 seconds. Do not page on it.
 

--- a/docs/vendor/rvu-af-channel-default-mcam.md
+++ b/docs/vendor/rvu-af-channel-default-mcam.md
@@ -1,0 +1,101 @@
+# RVU AF: a VF coming up disables the PF's channel-default MCAM entries, and nothing VF-side re-enables them
+
+Finding on Marvell CN96xx (CN9670, EFG gateway), vendor 5.15 kernel,
+`rvu_af`/`rvu_nicpf`/`rvu_nicvf` drivers. Written up for an upstream /
+vendor report; every claim below was measured on hardware between
+2026-08-13 windows w3 and w10, with forensics retained (NPC debugfs
+dumps, timestamped counters, driver logs).
+
+## Summary
+
+When a VF on a shared LMAC is brought up by a userspace dataplane
+(VPP's native octeon driver on a vfio-pci VF), the AF **disables its
+channel-default MCAM entries** for that LMAC — the multicast catch-all
+and promiscuous entries that make the *kernel PF* receive (observed as
+entries 2004/2005 for the channel, `Installed by: PF0`,
+`Forward to: PF1`, flipping `enabled: yes → no`). The kernel PF goes
+deaf below every software surface: `IFF_PROMISC` still set, link up,
+no kernel log, `ethtool -S` `rx_drops` frozen. On a PF that is a
+bridge member, that is a silent L2 blackout of everything behind the
+bridge.
+
+Two asymmetries make this hard to live with:
+
+1. **The disable propagates from VF-side events; no VF-side action
+   re-enables.** Setting promiscuous mode on the VF itself (VPP
+   `sw_interface_set_promisc` → `roc_nix_npc_promisc_ena_dis(nix, 1)`,
+   acknowledged) does **not** re-enable the PF's channel defaults —
+   verified with a single stable VPP holding the promisc setting while
+   the entries stayed disabled and the bridge stayed dark (w8).
+2. **Only a PF-side rx-mode event restores them.** Any rx-mode
+   set on the kernel PF netdev (an `IFF_ALLMULTI` toggle suffices)
+   makes the PF driver resend `NIX_RX_MODE`, after which the AF
+   re-installs/enables its defaults. Measured five-for-five with ~1 s
+   recovery (w6), and confirmed as a durable fix when issued once
+   after the VF settles (w9/w10: 420 s and 600 s windows, entries
+   enabled in every snapshot).
+
+## Reproduction
+
+EFG (CN9670), eth4 = kernel PF, bridge member (switch0), one VF
+(`sriov_numvfs=1`) bound to vfio-pci, VPP v26.06 built with
+`VPP_PLATFORM=octeon9` attaching the VF (`device attach pci/...`,
+interface up). Within ~1 s of the device attach:
+
+- hosts behind the bridge unreachable (including from the router);
+- `ethtool -S eth4 | grep rx_drops` stops advancing;
+- `/sys/kernel/debug/octeontx2/npc/mcam_rules`: the channel's default
+  entries read `enabled: no`.
+
+Recovery: `ip link set eth4 allmulti on; ip link set eth4 allmulti off`
+— reachability returns in ~1 s and the entries read `enabled: yes`.
+
+A control on a non-bridge L3 port (eth1) shows the same table change
+without user-visible impact, which is why this survives on most
+topologies and bites bridge members.
+
+## Why we believe the trigger is the VF's rx-mode state at the AF
+
+VPP's `oct_port_start` asserts `roc_nix_npc_promisc_ena_dis(nix,
+port->promisc)` with `promisc = false` at port start — a VF-side
+rx-mode message to the AF. The AF appears to fold every function's
+stored rx-mode into the LMAC's channel-default entry state on any
+function's rx-mode event, in the disable direction — but the converse
+(VF promisc on) does not restore the PF's entries, so the state is
+asymmetric: a VF can subtract from the channel defaults and cannot add
+them back; only the PF's own `NIX_RX_MODE` refresh can.
+
+This is the same shared-LMAC state family as the CGX flow-control
+refusal (which the AF *refuses* loudly) — but here the interaction is
+silent and the loser is the kernel PF.
+
+## What we ship as the workaround
+
+packetframe (the supervisor that runs VPP on the VF) issues the
+PF-side rx-mode toggle itself after every VF device attach
+(`RxModeKick` in `crates/modules/vpp-offload/src/runtime.rs`, PR
+#181), and keeps the VF's promisc vote asserted (PR #178) so future AF
+re-evaluations land enabled. Operators get the by-hand toggle in
+`docs/runbooks/vpp-offload.md` ("A bridge-member port goes dark right
+after attach").
+
+## Asks
+
+1. Should a VF's rx-mode state be able to disable the PF's
+   channel-default entries at all? If yes, the enable direction should
+   be symmetric.
+2. If the current behaviour is intended, an AF log line (or debugfs
+   event counter) when channel defaults are disabled on behalf of
+   another function would have cut days off diagnosing this — the
+   kernel PF surfaces nothing today.
+
+## Evidence index (retained on the reference router)
+
+- `/root/w5/`, `/root/w6/`: eth4-only bisection + five kick/re-break
+  cycles (re-breaks later explained by a supervisor respawn loop on
+  our side — each respawn re-ran `oct_port_start`; the kick's ~1 s
+  recovery stands).
+- `/root/w8/`: single stable VPP, promisc acknowledged, entries
+  `enabled: no`, `rx_drops` frozen 08:42:48–:50 bracketing the attach.
+- `/root/w9/`, `/root/w10/`: with the PF-side kick after attach,
+  420 s / 600 s windows, entries `enabled: yes` in every snapshot.


### PR DESCRIPTION
The handoff PR: everything the w7–w10 nights taught that was not yet in a PR, so the next shift starts from documents instead of scrollback. Pairs with #182 (independent branches, either merge order works).

## Status: the fresh hold explains itself

w10's status at t90 showed `Syncing` and a fib row saying `not yet verified` — nothing about the five minutes of designed holding the operator was watching. The runtime now surfaces the hold as `(mirror have, authority want)` and the fib row reads:

> `fresh convergence: routes install as the source loads (mirror holds N of the authority's M); verify runs once over the complete table when the authority confirms it (require-table-complete). On a full-table feed this holds for the length of bird's dump — minutes — by design`

with a distinct wording before the authority's first report (no "of the authority's 0"). Degraded, never paging; the arm sits after the steered-unverified alarm so that impossible-by-construction combination would still page. Threaded through `observe_parts` so the service call site is compiler-enforced rather than a field someone remembers to set. Tested at the report level (message contents, severity, overall never Unhealthy).

## Runbook: three corrections/additions from the windows

- **The #181 triage entry's fingerprint was wrong in one detail that will false-alarm next shift**: `rx_drops` freezing is *benign* whenever VPP holds the member VF — w9 and w10 both froze the counter with entries enabled and traffic perfect (the flood the kernel used to receive-and-drop diverts to the VF). Deaf is now the three-part fingerprint: frozen counter **and** unreachable hosts **and** `enabled: no` in the MCAM table.
- **New section: a fresh attach holds in `Syncing` for minutes — that is the fix working**, with the exact status/log lines, the measured ~5 min, why restarting it is the one wrong move (w7's seven kill-respawn cycles), and what `INCOMPLETE` vs `FAIL` verify labels mean.
- **New section + table rows: load rises ~1 core per worker, permanently** — poll mode (gate 0b item 9), w10's measured 22-vs-6 with the counters proving the eBPF tier was unaffected, and why load average is not starvation here.
- Inspection commands gain `vppctl ... show interface` with the note about reading where the diverted flood went before the first steer.

## docs/vendor: the AF finding, report-ready

`docs/vendor/rvu-af-channel-default-mcam.md` — the complete evidence chain for the upstream/vendor report: a VF coming up disables the PF's channel-default MCAM entries LMAC-wide; VF-side promisc cannot re-enable them (single stable VPP, acknowledged setting, entries stayed disabled); only a PF-side rx-mode event restores them (5/5 kicks, ~1 s; durable in 420 s/600 s windows once issued post-attach). Includes the reproduction, the shipped workaround (#178 + #181), two concrete asks, and the forensics index (`/root/w5..w10/`). Referenced from the runbook triage entry.

Host `make lint` + `make test` green (832 tests, 35 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)