### PR TITLE
feat(fast-path): export softnet time_squeeze — the early warning for silent generic-XDP TX drops (w12–w19 findings)

### DIFF
--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -111,6 +111,15 @@ fn write_once(
     // handles that by emitting zeros + a `mode=\"kernel-fib\"` one-hot.
     let fib = packetframe_fast_path::fib_status_from_pin(bpffs_root);
     body.push_str(&packetframe_fast_path::metrics::render_fib_gauges(&fib));
+    // Host softirq pressure. `time_squeeze` is the one early signal
+    // for the silent generic-XDP TX drop mechanism (2026-08-13,
+    // w12–w19), which no packetframe counter, qdisc stat, or tcpdump
+    // can see. Best-effort: a read/parse failure loses this block for
+    // one tick, never the file.
+    match packetframe_fast_path::softnet::from_proc() {
+        Ok(t) => body.push_str(&packetframe_fast_path::metrics::render_softnet(&t)),
+        Err(e) => tracing::debug!(error = %e, "softnet_stat unavailable this tick"),
+    }
     // Whatever the loader last sampled from the modules. Appended rather
     // than merged: each module namespaces its own gauges
     // (`packetframe_vpp_*`), so there is nothing to reconcile — and a

--- a/crates/modules/fast-path/bpf/src/finalize.rs
+++ b/crates/modules/fast-path/bpf/src/finalize.rs
@@ -124,6 +124,9 @@ pub fn finalize(ctx: XdpContext) -> u32 {
 
     match REDIRECT_DEVMAP.redirect(egress_ifindex, 0) {
         Ok(_) => {
+            // Acceptance, not delivery: on the generic-XDP path the
+            // kernel can still drop this frame in generic_xdp_tx()
+            // with no counter (< 5.18). See StatIdx::FwdOk's doc.
             bump(stats, StatIdx::FwdOk);
             xdp_action::XDP_REDIRECT
         }

--- a/crates/modules/fast-path/bpf/src/maps.rs
+++ b/crates/modules/fast-path/bpf/src/maps.rs
@@ -60,6 +60,16 @@ pub enum StatIdx {
     MatchedSrcOnly = 3,
     MatchedDstOnly = 4,
     MatchedBoth = 5,
+    /// Redirects the kernel ACCEPTED — not packets delivered to the
+    /// wire. Under generic XDP the frame still has to survive
+    /// `generic_xdp_tx()`, which silently drops it if the egress TX
+    /// queue is stopped (ring full): no counter on kernels < 5.18, no
+    /// qdisc, no tcpdump. Measured 6–8% of forwarded traffic lost
+    /// with this climbing normally (2026-08-13 w17, EFG under CPU
+    /// squeeze). The tc datapath does not share the caveat — its
+    /// redirect egresses through `dev_queue_xmit`, so qdisc stats see
+    /// its drops. Triage: docs/runbooks/generic-mode-performance.md,
+    /// "Silent TX drops under generic XDP".
     FwdOk = 6,
     FwdDryRun = 7,
     PassFragment = 8,

--- a/crates/modules/fast-path/src/lib.rs
+++ b/crates/modules/fast-path/src/lib.rs
@@ -20,6 +20,7 @@ pub mod fib;
 pub mod metrics;
 pub mod pin;
 pub mod registry;
+pub mod softnet;
 pub mod tc_links;
 
 #[cfg(target_os = "linux")]

--- a/crates/modules/fast-path/src/metrics.rs
+++ b/crates/modules/fast-path/src/metrics.rs
@@ -132,6 +132,43 @@ pub fn render_textfile(stats: &[u64], uptime_seconds: u64) -> String {
     out
 }
 
+/// Render host softirq-pressure counters from `/proc/net/softnet_stat`.
+///
+/// These are host-kernel counters, not packetframe's — exported here
+/// because `time_squeeze` is the only signal that moves in step with
+/// the silent generic-XDP TX drop mechanism (2026-08-13, w12–w19):
+/// the drop itself has no counter anywhere on a 5.15 kernel and is
+/// invisible to tcpdump and qdisc stats, so the early warning has to
+/// ride in the same scrape as `fwd_ok`. Keeping the `module` label
+/// matches every other series in the textfile; the HELP line carries
+/// the host-wide caveat.
+pub fn render_softnet(t: &crate::softnet::SoftnetTotals) -> String {
+    let mut out = String::with_capacity(1024);
+    let rows: [(&str, &str, u64); 3] = [
+        (
+            "packetframe_softnet_processed_total",
+            "softirq-processed packets summed across all CPUs (host-wide, /proc/net/softnet_stat)",
+            t.processed,
+        ),
+        (
+            "packetframe_softnet_dropped_total",
+            "softnet backlog drops summed across all CPUs (host-wide, /proc/net/softnet_stat)",
+            t.dropped,
+        ),
+        (
+            "packetframe_softnet_time_squeeze_total",
+            "NAPI polls truncated by netdev_budget/budget_usecs, summed across all CPUs; a rising rate under generic XDP is the early warning for silent TX drops (docs/runbooks/generic-mode-performance.md)",
+            t.time_squeeze,
+        ),
+    ];
+    for (metric, help, value) in rows {
+        let _ = writeln!(out, "# HELP {metric} {help}");
+        let _ = writeln!(out, "# TYPE {metric} counter");
+        let _ = writeln!(out, "{metric}{{module=\"fast-path\"}} {value}");
+    }
+    out
+}
+
 /// Render custom-FIB occupancy metrics as Prometheus gauges
 /// (Option F, Phase 3.8).
 ///
@@ -293,6 +330,26 @@ mod tests {
         let type_lines = body.lines().filter(|l| l.starts_with("# TYPE")).count();
         // COUNTER_NAMES.len() counters + 1 uptime gauge.
         assert_eq!(type_lines, COUNTER_NAMES.len() + 1);
+    }
+
+    #[test]
+    fn softnet_counters_render_all_three_with_headers() {
+        let t = crate::softnet::SoftnetTotals {
+            processed: 100,
+            dropped: 2,
+            time_squeeze: 46,
+            cpus: 18,
+        };
+        let body = render_softnet(&t);
+        assert!(body.contains("packetframe_softnet_processed_total{module=\"fast-path\"} 100"));
+        assert!(body.contains("packetframe_softnet_dropped_total{module=\"fast-path\"} 2"));
+        assert!(body.contains("packetframe_softnet_time_squeeze_total{module=\"fast-path\"} 46"));
+        assert_eq!(
+            body.lines()
+                .filter(|l| l.starts_with("# TYPE") && l.ends_with("counter"))
+                .count(),
+            3
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/crates/modules/fast-path/src/softnet.rs
+++ b/crates/modules/fast-path/src/softnet.rs
@@ -1,0 +1,118 @@
+//! `/proc/net/softnet_stat` totals — the early warning for silent
+//! generic-XDP TX drops.
+//!
+//! Found the hard way (2026-08-13, w12–w19 on the reference EFG):
+//! under CPU pressure the kernel truncates NAPI polls
+//! (`time_squeeze`), TX-completion reaping falls behind, the egress
+//! ring fills, and `generic_xdp_tx()` drops redirected frames on a
+//! stopped queue — with **no counter anywhere on a 5.15 kernel**
+//! (per-device core-stats accounting for that path arrived in 5.18),
+//! no qdisc visibility, and no tcpdump visibility in either
+//! direction. `fwd_ok` keeps climbing because it counts redirect
+//! *acceptance*, not delivery. The one kernel signal that moves in
+//! step with the condition is `time_squeeze`, so the metrics exporter
+//! ships it. Mechanism and triage:
+//! `docs/runbooks/generic-mode-performance.md`, "Silent TX drops
+//! under generic XDP".
+//!
+//! The parser is pure so it unit-tests on any host; only the `/proc`
+//! read is Linux-gated.
+
+/// Sums of the first three `/proc/net/softnet_stat` columns across
+/// every CPU line. The columns have been stable since long before
+/// 5.15: `processed`, `dropped`, `time_squeeze`, all cumulative
+/// since boot, all hex.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct SoftnetTotals {
+    pub processed: u64,
+    pub dropped: u64,
+    pub time_squeeze: u64,
+    /// Lines summed = online CPUs. Not exported; kept so a parse of
+    /// the wrong file (0 lines) can't masquerade as a quiet host.
+    pub cpus: usize,
+}
+
+/// Parse the full text of `/proc/net/softnet_stat`.
+///
+/// This is a system-boundary read, so it validates: any line that
+/// does not start with three hex fields fails the whole parse rather
+/// than contributing a partial sum — a sum over half the CPUs would
+/// read as a counter going backwards after the format hiccup clears.
+pub fn parse(text: &str) -> Result<SoftnetTotals, String> {
+    let mut totals = SoftnetTotals::default();
+    for (n, line) in text.lines().enumerate() {
+        let mut fields = line.split_whitespace();
+        let mut col = |name: &str| -> Result<u64, String> {
+            let f = fields
+                .next()
+                .ok_or_else(|| format!("line {}: missing column {name}", n + 1))?;
+            u64::from_str_radix(f, 16)
+                .map_err(|e| format!("line {}: column {name} not hex ({e}): {f:?}", n + 1))
+        };
+        totals.processed = totals.processed.wrapping_add(col("processed")?);
+        totals.dropped = totals.dropped.wrapping_add(col("dropped")?);
+        totals.time_squeeze = totals.time_squeeze.wrapping_add(col("time_squeeze")?);
+        totals.cpus += 1;
+    }
+    if totals.cpus == 0 {
+        return Err("empty softnet_stat".into());
+    }
+    Ok(totals)
+}
+
+/// Read and parse `/proc/net/softnet_stat`.
+#[cfg(target_os = "linux")]
+pub fn from_proc() -> Result<SoftnetTotals, String> {
+    let text = std::fs::read_to_string("/proc/net/softnet_stat")
+        .map_err(|e| format!("read /proc/net/softnet_stat: {e}"))?;
+    parse(&text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verbatim shape of a 5.15 softnet_stat (13 columns; the last is
+    // the CPU index). Two CPUs, one with squeeze.
+    const SAMPLE_5_15: &str = "\
+00358f37 00000000 000049e0 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
+0000000a 00000002 00000001 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000001
+";
+
+    #[test]
+    fn sums_across_cpu_lines() {
+        let t = parse(SAMPLE_5_15).unwrap();
+        assert_eq!(t.processed, 0x0035_8f37 + 0xa);
+        assert_eq!(t.dropped, 2);
+        assert_eq!(t.time_squeeze, 0x49e0 + 1);
+        assert_eq!(t.cpus, 2);
+    }
+
+    #[test]
+    fn short_columns_are_tolerated_beyond_the_first_three() {
+        // Very old kernels print fewer trailing columns; only the
+        // first three matter and only they are required.
+        let t = parse("00000001 00000000 00000003\n").unwrap();
+        assert_eq!(t.processed, 1);
+        assert_eq!(t.time_squeeze, 3);
+        assert_eq!(t.cpus, 1);
+    }
+
+    #[test]
+    fn a_malformed_line_fails_the_whole_parse() {
+        let bad = "00000001 00000000 00000003\nnot hex at all\n";
+        let err = parse(bad).unwrap_err();
+        assert!(err.contains("line 2"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn a_truncated_line_fails_rather_than_partially_summing() {
+        let err = parse("00000001 00000000\n").unwrap_err();
+        assert!(err.contains("time_squeeze"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn empty_input_is_an_error_not_a_quiet_host() {
+        assert!(parse("").is_err());
+    }
+}

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -66,7 +66,9 @@ Indicators that the custom-FIB path is working:
   to it (misses indicate prefixes that arrived in XDP before bird
   announced them, or prefixes in the allowlist that bird doesn't cover).
 - `fwd_ok` climbs (the shared success counter; custom and kernel FIB
-  both increment it on redirect).
+  both increment it on redirect **acceptance** — under generic XDP the
+  kernel can still drop the frame silently after the count; see
+  `generic-mode-performance.md`, "Silent TX drops under generic XDP").
 - `pass_no_neigh` stays below ~0.01% of matched traffic after the
   first few seconds (first-packet ARP is expected; sustained-high
   means a nexthop is genuinely unreachable or the neighbor resolver

--- a/docs/runbooks/generic-mode-performance.md
+++ b/docs/runbooks/generic-mode-performance.md
@@ -431,13 +431,87 @@ over the live pins.
 ### Counters that matter (`packetframe status`)
 
 - `rx_total` vs `fwd_ok`: your fast-path hit rate; the difference is traffic paying
-  full kernel-stack cost.
+  full kernel-stack cost. **Caveat:** `fwd_ok` counts redirects the kernel
+  *accepted*, not packets delivered — under generic XDP a frame can still die
+  silently after the count (see "Silent TX drops under generic XDP" below).
 - `pass_not_in_devmap`, `err_tail_call`: should be 0; non-zero means matched
   traffic silently falling back to the slow path.
 - `custom_fib_miss`: destinations the BGP feed doesn't cover (consider
   `fallback-default`).
 - `nexthop_seq_retry`, `custom_fib_no_neigh`: sustained growth means nexthop churn
   or unresolved neighbors, each such packet takes the slow path.
+
+## Silent TX drops under generic XDP (kernel < 5.18)
+
+The single hardest-to-see failure mode of this datapath, root-caused on the
+reference EFG across seven instrumented windows (2026-08-13, w12–w19, under
+VPP-coexistence CPU pressure): **generic XDP can drop forwarded packets with
+no counter, no qdisc stat, and no tcpdump visibility, while `fwd_ok` climbs
+normally.** If users report loss *through* the box and every surface you know
+how to read is clean, read this section before distrusting the reports.
+
+### The mechanism
+
+1. Something eats CPU on the cores that carry NIC softirqs (in the measured
+   case: VPP poll-mode workers; any sustained load works).
+2. The kernel starts truncating NAPI polls — `time_squeeze` in
+   `/proc/net/softnet_stat` rises (measured: 7/s baseline → 46/s during
+   loss).
+3. Truncated polls reap TX completions late, so the egress port's TX ring
+   fills faster than it drains.
+4. `generic_xdp_tx()` finds the TX queue stopped and **frees the frame
+   silently**. Kernels before 5.18 count this nowhere (5.18 added per-device
+   core-stats, where it appears as `tx_dropped` in `ip -s link`); 5.15
+   vendor kernels have nothing.
+
+`fwd_ok` is incremented when `bpf_redirect_map` *accepts* the frame — step 4
+happens after the count. The tc datapath is exempt: its redirect egresses
+through `dev_queue_xmit`, so the qdisc sees (and counts) its drops.
+
+### Why your instruments are blind
+
+- **tcpdump cannot see XDP-forwarded traffic in either direction.** On RX,
+  `do_xdp_generic` runs before packet taps; on TX, `generic_xdp_tx` calls
+  `netdev_start_xmit` directly, bypassing `dev_queue_xmit` — no taps, no
+  qdisc. A capture on the egress port during full-rate XDP forwarding shows
+  only kernel-path stragglers, and a *quiet* capture proves nothing.
+- **Qdisc counters are blind for the same reason** — do not use
+  `tc -s qdisc` deltas as evidence about XDP-forwarded volume.
+- **NIC counters look clean** because the frame is freed before it reaches
+  the driver.
+
+### Diagnosis
+
+1. **Watch `packetframe_softnet_time_squeeze_total`** (exported since this
+   finding) or by hand:
+   `awk '{s+=strtonum("0x"$3)} END {print s}' /proc/net/softnet_stat` — take
+   a delta over 10 s. A rising rate that correlates with reported loss is
+   the fingerprint.
+2. **Localize with mtr from outside**: the hop that answers with
+   kernel-generated TTL-exceeded (the box itself) stays clean while the next
+   hop (traffic forwarded *through* the box) shows loss — the drop is in the
+   forwarding path, not the wire or the far side.
+3. **Confirm by intervention** (there is no tracepoint on a vendor kernel
+   with no tracefs): grow the egress TX ring, e.g.
+   `ethtool -G ethX tx 32768`. If loss stops, the mechanism is confirmed —
+   **then put the ring back.** Measured: 8% loss → 0% at 32k, but average
+   RTT went to ~678 ms (classic bufferbloat). The ring is a diagnostic, not
+   a fix.
+
+### What actually fixes it
+
+Kernel knobs only choose where the CPU deficit surfaces — all three were
+measured on the EFG: stock settings → silent drops; big TX ring → ring
+bufferbloat; `netdev_budget`×4 (`budget_usecs` 80 ms) → `time_squeeze` goes
+to zero and loss mostly stops, but single NAPI rounds hog CPUs for up to
+80 ms and local-segment RTT bloats instead. The durable fixes remove the
+deficit:
+
+- **Remove the competing CPU load** (in the vpp-offload case: fewer staging
+  cores — see that runbook's coexistence section).
+- **Move traffic off generic XDP** — steer it into a hardware path
+  (vpp-offload's MCAM steering), or native XDP where the driver supports it
+  (not on this fleet's vendor kernel).
 
 ## Platform taxes on UniFi OS
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -274,6 +274,13 @@ at least an hour, and through a udapi provision cycle if one is due.
 Nothing is diverted in this state: VPP is up, its FIB is synced and
 verified, and every packet is still on the XDP path.
 
+**Schedule this rung off-peak.** Rung 0 is the maximum-cost state: all
+of VPP's poll-mode CPU tax with zero forwarding benefit, and at traffic
+peak that tax has caused real user-visible loss on the kernel path (see
+the coexistence-squeeze section). Plan the rung-0 soak and the first
+steer inside one quiet window rather than soaking unsteered through a
+peak.
+
 **Rung 1 — one port.** Flip the least important port to `steer on`,
 SIGHUP, and confirm:
 
@@ -300,6 +307,13 @@ Then watch actual traffic, not counters: PMTUD in particular. A DF
 packet larger than the MTU through a steered path must come back as a
 correctly-sourced frag-needed. A silent PMTUD blackhole is a week of
 customer debugging.
+
+A successful steer also has a host-side signature worth confirming:
+the steered flows leave generic XDP, so the rate of
+`packetframe_softnet_time_squeeze_total` should fall (or at worst
+hold) as traffic moves — it must never rise on a steer. VPP's own
+interface counters (`show interface` via the CLI socket) turning over
+at line rate on the member VF is the positive half of the same check.
 
 **Rung 2..N — one port at a time**, with a soak between each. There is
 no prize for going faster; the failure you are looking for is the one
@@ -1088,6 +1102,9 @@ Be precise about this when reasoning about an incident.
 | Fresh six-port attach on the PRIMARY, behind bird's live dump | **~5 min in `Syncing` (held), then one verify** | 2026-08-13, w9 + w10: the #180 hold engaged at have≈23k and released at have≈1,055k; w10 verified PASS 64/64 on the release. This is the number to expect on every primary fresh attach — the 40.32 s row above is a resync from an already-loaded mirror, a different situation. |
 | Load while VPP runs, six workers | **~+7 load permanent** (poll mode), ~22 total during convergence vs ~6 baseline | 2026-08-13 w10. See the load note below. |
 | `reconfigure` (lever move) | **0.215 s** | 2026-08-11, exit 0, writes `OK <ns>` to `last-reconfigure.timestamp`. |
+| Coexistence squeeze, unsteered at evening peak | `time_squeeze` 7/s → 46/s; **6–8% loss** through the box; every counter clean | 2026-08-13 w13/w17, six workers, steering off. See the coexistence-squeeze section. |
+| TX-ring intervention (eth3 4096 → 32768) | loss 0/500 — but avg RTT **678 ms** (bufferbloat) | 2026-08-13 w18. Proof of the silent-drop mechanism, **not a fix**; ring restored. |
+| `netdev_budget` ×4 (300→1200, usecs 20000→80000) | `time_squeeze` → 0; loss 1%; local-segment RTT >100 ms on 22% of pings | 2026-08-13 w19. The deficit moved into 80 ms softirq rounds; settings restored. |
 | Idle draw with VPP polling one worker | 33.56 W, 38/49/42 °C, fan 3780 RPM | 2026-08-11 shadow, chassis total — NOT a VPP attribution, no VPP-off baseline was taken. |
 
 **Published but never measured:**
@@ -1139,6 +1156,50 @@ IRQs moved off them pre-attach), and w10's own counters showed the
 eBPF tier matching and forwarding normally throughout
 (`matched_v4` ≈ `rx_total`, `fwd_ok` climbing). Whether ~7 hot cores
 buy enough forwarding is exactly what the steering canary measures.
+
+Do not stop reading at "the counters are fine", though — the next
+section is about exactly the loss those counters cannot see.
+
+### Loss and latency through the box while VPP runs unsteered — the coexistence squeeze
+
+Root-caused 2026-08-13 (w12–w19) after three windows of "every counter
+is clean but users see loss". Symptom set, at traffic peak, with VPP
+attached and **steering off**:
+
+- packet loss (measured 6–8%) and multi-hundred-ms latency for traffic
+  forwarded *through* the box, reported from outside;
+- load average far above the ~+7 poll-mode floor;
+- every packetframe counter normal, `fwd_ok` climbing, VPP counters
+  near zero, NIC error counters zero.
+
+The mechanism is **not VPP malfunctioning — it is VPP's poll cores
+starving the kernel path that still carries 100% of the traffic.** At
+the staging rung nothing is steered, so all forwarding is generic XDP
+on the CPUs that remain; the squeeze truncates NAPI polls, the egress
+TX ring fills, and `generic_xdp_tx` drops frames **silently** — no
+counter on this 5.15 kernel, invisible to tcpdump and qdisc stats by
+construction, and counted as success by `fwd_ok` (which increments at
+redirect *acceptance*). Full mechanism, diagnosis steps, and why every
+instrument is blind: `docs/runbooks/generic-mode-performance.md`,
+"Silent TX drops under generic XDP".
+
+What to do about it, in order:
+
+1. **Recognize it**: watch `packetframe_softnet_time_squeeze_total`
+   (exported since this finding). Baseline on the reference EFG is
+   ~7/s; the loss windows ran ~46/s.
+2. **Do not reach for kernel knobs as a fix.** All three were
+   measured; each just relocates the deficit (drops → ring bufferbloat
+   → 80 ms softirq rounds). They are diagnostics.
+3. **Shorten the unsteered window.** The staging state is
+   maximum-cost-zero-benefit by design — all of VPP's CPU tax, none of
+   its forwarding. Schedule attaches and soaks off-peak, and treat
+   time-at-rung-0 as a cost to budget, not a neutral holding state.
+4. **The durable fixes** are fewer VPP cores while unsteered (design
+   change, tracked) and climbing to the steered rungs — steering moves
+   allowlisted traffic onto VPP's hardware path *and* removes its XDP
+   cost from the squeezed CPUs, which is the intended end state, not a
+   workaround.
 
 ### A planned restart looks Degraded for 40-80 seconds. Do not page on it.
 


### PR DESCRIPTION
## What

Lands the durable engineering from the w12–w19 loss investigation on the primary (2026-08-13):

1. **`packetframe_softnet_{processed,dropped,time_squeeze}_total`** — new counters in the Prometheus textfile, read from `/proc/net/softnet_stat` each tick. `time_squeeze` is the only kernel signal that moves in step with the silent generic-XDP TX drop mechanism (measured 7/s baseline → 46/s during 6–8% loss). Pure parser (host-tested, validates at the boundary — a malformed line fails the whole parse rather than producing a sum that goes backwards); only the `/proc` read is Linux-gated; best-effort in the exporter so a failure loses the block for one tick, never the file.
2. **`fwd_ok` semantics corrected everywhere it was described**: it counts redirect *acceptance*, not delivery. Under generic XDP the frame can still die in `generic_xdp_tx()` on a stopped TX queue with no counter (<5.18), no qdisc stat, and no tcpdump visibility. Doc comments on `StatIdx::FwdOk` + the increment site, plus the three runbook passages that called it a success counter. The tc datapath is exempt (egresses via `dev_queue_xmit`) and the docs say so.
3. **Runbook sections**:
   - `generic-mode-performance.md` gains the canonical "Silent TX drops under generic XDP (kernel < 5.18)" section — mechanism, why tcpdump/qdisc/NIC counters are all structurally blind, the mtr hop-discrimination and confirmation-by-intervention diagnosis, and why the TX-ring and `netdev_budget` knobs are diagnostics that relocate the deficit (both measured: 32k ring → 0% loss but 678 ms RTT; budget ×4 → squeeze 0 but 80 ms softirq rounds bloating the local segment).
   - `vpp-offload.md` gains the coexistence-squeeze triage section (loss through the box while VPP runs unsteered, every counter clean) and three measured-numbers rows for w13/w17/w18/w19.

## Why

Three windows ran with "every counter is clean" while users saw 6–8% loss — because every surface we had was blind to the failing step by construction. This PR makes the condition observable (the gauge), stops the counters from lying by omission (the docs), and writes down the diagnosis so the next operator doesn't spend seven windows rediscovering it.

## Testing

- `make lint` + `make test` green on host (softnet parser/renderer are un-gated and unit-tested; 5 parser tests + renderer test).
- Exporter wiring is Linux-gated — the cross-build matrix and qemu jobs are the real check.
- The mechanism itself was hardware-confirmed by intervention on the EFG (w18: ring 4096→32768 took loss from 8% to 0%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)