### PR TITLE
fix(vpp-offload): refuse a kernel-owned loopback-address (w22's second finding)

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -370,9 +370,17 @@ module fast-path
 #                                 # 2026-08-07 with 1,053,960 routes verified,
 #                                 # forwarding zero). It is also what sources
 #                                 # ICMP, so PMTUD's frag-needed is only
-#                                 # correct if this is an address the far end
-#                                 # can route back to — pick one this router
-#                                 # owns, not a placeholder.
+#                                 # correct if the far end can route back to
+#                                 # it. Pick an address that is ANNOUNCED BUT
+#                                 # UNASSIGNED: inside a prefix this router
+#                                 # originates, held by nothing else, outside
+#                                 # any DHCP pool. NOT the gateway or any live
+#                                 # kernel address — VPP answers ARP for this
+#                                 # address, and sharing a live one starts a
+#                                 # responder war over it (measured on the
+#                                 # primary 2026-08-14, w22: VPP fought the
+#                                 # kernel for the gateway IP). Attach refuses
+#                                 # a kernel-owned address for this reason.
 #   port eth0 cores 1 steer off   # a member because the fast-path attaches
 #   port eth2 cores 1 steer off   # it — NOT because BGP best-paths egress
 #   port eth3 cores 1 steer off   # here. The measured table egresses via

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -152,6 +152,83 @@ fn port_macs(sysfs_net: &Path, iface: &str) -> Result<([u8; 6], Vec<[u8; 6]>), S
     Ok((own, vec![bridge]))
 }
 
+/// Refuse a `loopback-address` the kernel already holds.
+///
+/// VPP's arp node answers requests targeting its loopback's address,
+/// sourcing the member VF's MAC. If that address is a LIVE kernel
+/// address — the gateway, in the reference incident — two responders
+/// fight over it and hosts learn whichever answered last. Measured on
+/// the primary (w22, 2026-08-14): loop0 held 23.191.200.1, the
+/// br1337 gateway, and VPP sent 105 ARP replies in 27 minutes against
+/// the kernel's. The address VPP needs is *announced but unassigned*:
+/// routable from outside (ICMP sourcing, PMTUD) with no other claimant
+/// (no ARP war, no steered traffic terminating inside VPP).
+///
+/// The decision is split from the `getifaddrs` read so the refusal
+/// text and the match are testable without owning the host's
+/// interfaces.
+fn loopback_collision(
+    loopback: std::net::Ipv4Addr,
+    owned: &[(String, std::net::Ipv4Addr)],
+) -> Option<String> {
+    owned
+        .iter()
+        .find(|(_, a)| *a == loopback)
+        .map(|(ifname, _)| {
+            format!(
+                "`loopback-address {loopback}/32` is an address the kernel already holds (on \
+             {ifname}). VPP answers ARP for its loopback's address, so sharing a live \
+             kernel address starts a responder war over it — hosts learn whichever MAC \
+             answered last (measured on the primary 2026-08-14, w22: 105 competing \
+             replies for the gateway). Pick an announced-but-unassigned host address in \
+             the same prefix instead, outside any DHCP pool"
+            )
+        })
+}
+
+/// Every IPv4 address the kernel currently holds, with the interface
+/// that holds it (for the refusal message).
+///
+/// Degrades OPEN on a `getifaddrs` failure: an empty list skips the
+/// collision check rather than refusing every attach — a guard against
+/// one specific misconfiguration must not become a new way for a
+/// healthy box to fail to start.
+fn kernel_v4_addrs() -> Vec<(String, std::net::Ipv4Addr)> {
+    let mut out = Vec::new();
+    let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
+    // SAFETY: getifaddrs allocates the list; freed below on every path
+    // that saw a zero return.
+    if unsafe { libc::getifaddrs(&mut ifap) } != 0 {
+        return out;
+    }
+    let mut cur = ifap;
+    while !cur.is_null() {
+        // SAFETY: walking the list getifaddrs returned, until null.
+        let ifa = unsafe { &*cur };
+        if !ifa.ifa_addr.is_null() {
+            // SAFETY: ifa_addr is non-null and points at a sockaddr for
+            // this entry; only read further when the family says INET.
+            let family = unsafe { i32::from((*ifa.ifa_addr).sa_family) };
+            if family == libc::AF_INET {
+                // SAFETY: AF_INET guarantees sockaddr_in layout.
+                let raw = unsafe {
+                    (*(ifa.ifa_addr as *const libc::sockaddr_in))
+                        .sin_addr
+                        .s_addr
+                };
+                let name = unsafe { std::ffi::CStr::from_ptr(ifa.ifa_name) }
+                    .to_string_lossy()
+                    .into_owned();
+                out.push((name, std::net::Ipv4Addr::from(u32::from_be(raw))));
+            }
+        }
+        cur = ifa.ifa_next;
+    }
+    // SAFETY: the list came from a successful getifaddrs.
+    unsafe { libc::freeifaddrs(ifap) };
+    out
+}
+
 fn hex_mac(m: &[u8; 6]) -> String {
     format!(
         "{:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
@@ -429,6 +506,9 @@ pub fn bring_up(
                 .into(),
         );
     };
+    if let Some(err) = loopback_collision(loopback.addr, &kernel_v4_addrs()) {
+        return Err(err);
+    }
 
     let (state, acquired) = acquire::acquire(&paths.sys, &ports, pages, cfg.expected_routes)?;
 
@@ -943,6 +1023,41 @@ fn finish(
 /// ran on every deployment, including the ones that set it off precisely
 /// because their `birdc` answers for the wrong bird. Found on the shadow,
 /// where `off` was set and the steer was refused anyway.
+#[cfg(test)]
+mod loopback_collision_tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn a_kernel_owned_address_is_refused_naming_the_interface() {
+        let owned = vec![
+            ("lo".to_string(), Ipv4Addr::new(127, 0, 0, 1)),
+            ("br1337".to_string(), Ipv4Addr::new(23, 191, 200, 1)),
+        ];
+        let err = loopback_collision(Ipv4Addr::new(23, 191, 200, 1), &owned)
+            .expect("the w22 config must be refused");
+        assert!(err.contains("br1337"), "{err}");
+        assert!(err.contains("responder war"), "{err}");
+    }
+
+    #[test]
+    fn an_unassigned_address_in_the_same_prefix_passes() {
+        let owned = vec![("br1337".to_string(), Ipv4Addr::new(23, 191, 200, 1))];
+        assert!(loopback_collision(Ipv4Addr::new(23, 191, 200, 254), &owned).is_none());
+    }
+
+    /// Every host has 127.0.0.1, so this smoke-tests the real
+    /// `getifaddrs` read on whatever runs the suite.
+    #[test]
+    fn the_kernel_address_read_sees_the_loopback() {
+        let owned = kernel_v4_addrs();
+        assert!(
+            owned.iter().any(|(_, a)| *a == Ipv4Addr::new(127, 0, 0, 1)),
+            "getifaddrs returned {owned:?}"
+        );
+    }
+}
+
 #[cfg(test)]
 mod port_mac_tests {
     use super::*;

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -893,6 +893,23 @@ still running (`pgrep -a vpp`) and whether MCAM still points at its VF
 forwarded by an unsupervised process — restart packetframe, which will
 **adopt** it rather than restarting it.
 
+### Hosts flap between two MACs for the gateway, or duplicate-address warnings appear
+
+VPP's arp node answers requests targeting its loopback's address,
+sourcing the member VF's MAC. If `loopback-address` is a **live kernel
+address** — the gateway being the worst case — VPP and the kernel both
+answer, hosts learn whichever replied last, and traffic oscillates
+between two delivery paths. Measured on the primary (2026-08-14, w22):
+loop0 held the br1337 gateway and VPP sent 105 competing replies in
+27 minutes.
+
+Attach now refuses a kernel-owned `loopback-address` outright. The fix
+is one line: point it at an announced-but-unassigned host address in
+the same prefix (outside any DHCP pool), then restart into it —
+`loopback-address` is restart-only. Nothing else changes: ICMP/PMTUD
+sourcing works from any routable address, and members unnumber to it
+identically.
+
 ### Steered traffic reaches VPP and vanishes — `punt` climbing, no `ip4`, no tx
 
 ```bash


### PR DESCRIPTION
## Why

w22's error counters held a second defect behind the MAC capture: `ARP replies sent: 105`. VPP answers ARP for its loopback's address, and `loopback-address` was set to **23.191.200.1 — the live br1337 gateway** — so VPP and the kernel fought over the gateway's ARP for the whole window, sourcing different MACs. Root cause of the root cause: our own `example.conf` said *"pick one this router owns"*, which is exactly wrong. The address must be **announced but unassigned** — routable (ICMP/PMTUD sourcing) with no other claimant.

## What

- **Attach-time refusal** when `loopback-address` matches any IPv4 address the kernel holds, naming the interface that holds it and the w22 evidence. Runs in the pure phase (costs no VF, no hugepages). Degrades open if `getifaddrs` itself fails — the guard must not become a new startup failure mode.
- **`example.conf` guidance corrected** (announced-but-unassigned, outside DHCP pools, never the gateway) and a **runbook triage entry** for the symptom (hosts flapping between two MACs for the gateway).
- Tests: refusal message + pass-case units, plus a live `getifaddrs` smoke (127.0.0.1 must appear) that runs on every host in CI.

## Context

This is the code half of the operational change already agreed for the reference box (loop0 moves to 23.191.200.254). The guard makes that knowledge enforced rather than tribal, fleet-wide. w23 runs on this build.

## Testing

`make lint` green; vpp-offload suites green (580+ tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)