### PR TITLE
feat(vpp-offload): kernel exemptions — the w23 residual, and the road to always-on

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -401,6 +401,23 @@ module fast-path
 #                                 # two minutes, zero forwarded, every gauge
 #                                 # green. Untagged/access ports omit it.
 #                                 # Restart-only, like cores.
+#   steer-exempt 23.191.200.1/32  # Destinations that STAY ON THE KERNEL PATH
+#   steer-exempt 10.88.1.1/32     # while steering is on, as higher-priority
+#                                 # MCAM rules delivering to the PF. List every
+#                                 # address that terminates on this router for
+#                                 # a steered VLAN — the gateway IPs above all.
+#                                 # Without them, src-steered traffic TO the
+#                                 # router (monitoring replies, unicast DHCP
+#                                 # renewals, management from the service net)
+#                                 # matches the steer rules and dies in VPP,
+#                                 # which has no local delivery: measured on
+#                                 # the primary (2026-08-14, w23), 110,917
+#                                 # packets blackholed in five steered minutes.
+#                                 # Broadcast (255.255.255.255/32) and
+#                                 # multicast (224.0.0.0/4) exemptions are
+#                                 # BUILT IN and need no directive. Each entry
+#                                 # costs one slot of the 16-per-port MCAM
+#                                 # budget. Hot-reloadable like the allowlist.
 #   expected-routes 1600000       # v4+v6 DFZ + growth; drives memory sizing.
 #                                 # Live table measured ~1.30M (2026-08-02);
 #                                 # DFZ grows ~100k/yr, so this is ~3 years.

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -115,6 +115,25 @@ pub fn allowlist_from_config(config: &Config) -> Vec<IpPrefix> {
     out
 }
 
+/// The `steer-exempt` entries, so the budget probe counts the same
+/// arithmetic attach enforces: diversions + built-ins + exemptions.
+/// A probe that omitted them would pass a config attach refuses,
+/// two slots short.
+pub fn vpp_steer_exempts_from_config(
+    config: &Config,
+) -> Vec<packetframe_common::config::Ipv4Prefix> {
+    config
+        .modules
+        .iter()
+        .filter(|m| m.name == "vpp-offload")
+        .flat_map(|m| &m.directives)
+        .filter_map(|d| match d {
+            ModuleDirective::VppSteerExempt(p) => Some(*p),
+            _ => None,
+        })
+        .collect()
+}
+
 /// The `vpp-binary` override from a `vpp-offload` section, if set, so
 /// feasibility probes the executable the module will actually run.
 pub fn vpp_binary_from_config(config: &Config) -> Option<String> {
@@ -136,6 +155,7 @@ pub struct VppProbeInputs<'a> {
     pub workers: u32,
     pub binary: Option<&'a str>,
     pub steer_direction: VppSteerDirection,
+    pub steer_exempts: &'a [packetframe_common::config::Ipv4Prefix],
 }
 
 pub fn probe_and_render(
@@ -174,6 +194,7 @@ pub fn probe_and_render(
             vpp.binary,
             allowlist,
             vpp.steer_direction,
+            vpp.steer_exempts,
         ) {
             report.capabilities.push(cap);
         }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -352,49 +352,60 @@ fn main() -> ExitCode {
 }
 
 fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
-    let (bpffs_root, attach_ifaces, vpp_ports, vpp_workers, vpp_binary, allowlist, vpp_dir) =
-        match &config {
-            Some(path) => match Config::from_file(path) {
-                Ok(c) => {
-                    if let Err(e) = c.validate_interfaces() {
-                        eprintln!("config interface check failed: {e}");
-                        return ExitCode::from(EXIT_STARTUP_ERROR);
-                    }
-                    if let Err(e) = c.validate_vpp_offload() {
-                        eprintln!("vpp-offload config check failed: {e}");
-                        return ExitCode::from(EXIT_STARTUP_ERROR);
-                    }
-                    let ifaces = feasibility::attach_ifaces_from_config(&c);
-                    let vpp_ports = feasibility::vpp_ports_from_config(&c);
-                    let vpp_workers = feasibility::vpp_workers_from_config(&c);
-                    let vpp_binary = feasibility::vpp_binary_from_config(&c);
-                    let allowlist = feasibility::allowlist_from_config(&c);
-                    let vpp_dir = feasibility::vpp_steer_direction_from_config(&c);
-                    (
-                        c.global.bpffs_root,
-                        ifaces,
-                        vpp_ports,
-                        vpp_workers,
-                        vpp_binary,
-                        allowlist,
-                        vpp_dir,
-                    )
-                }
-                Err(e) => {
-                    eprintln!("config parse error: {e}");
+    let (
+        bpffs_root,
+        attach_ifaces,
+        vpp_ports,
+        vpp_workers,
+        vpp_binary,
+        allowlist,
+        vpp_dir,
+        vpp_exempts,
+    ) = match &config {
+        Some(path) => match Config::from_file(path) {
+            Ok(c) => {
+                if let Err(e) = c.validate_interfaces() {
+                    eprintln!("config interface check failed: {e}");
                     return ExitCode::from(EXIT_STARTUP_ERROR);
                 }
-            },
-            None => (
-                std::path::PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
-                Vec::new(),
-                Vec::new(),
-                0,
-                None,
-                Vec::new(),
-                Default::default(),
-            ),
-        };
+                if let Err(e) = c.validate_vpp_offload() {
+                    eprintln!("vpp-offload config check failed: {e}");
+                    return ExitCode::from(EXIT_STARTUP_ERROR);
+                }
+                let ifaces = feasibility::attach_ifaces_from_config(&c);
+                let vpp_ports = feasibility::vpp_ports_from_config(&c);
+                let vpp_workers = feasibility::vpp_workers_from_config(&c);
+                let vpp_binary = feasibility::vpp_binary_from_config(&c);
+                let allowlist = feasibility::allowlist_from_config(&c);
+                let vpp_dir = feasibility::vpp_steer_direction_from_config(&c);
+                let vpp_exempts = feasibility::vpp_steer_exempts_from_config(&c);
+                (
+                    c.global.bpffs_root,
+                    ifaces,
+                    vpp_ports,
+                    vpp_workers,
+                    vpp_binary,
+                    allowlist,
+                    vpp_dir,
+                    vpp_exempts,
+                )
+            }
+            Err(e) => {
+                eprintln!("config parse error: {e}");
+                return ExitCode::from(EXIT_STARTUP_ERROR);
+            }
+        },
+        None => (
+            std::path::PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
+            Vec::new(),
+            Vec::new(),
+            0,
+            None,
+            Vec::new(),
+            Default::default(),
+            Vec::new(),
+        ),
+    };
 
     let report = feasibility::probe_and_render(
         &bpffs_root,
@@ -404,6 +415,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             workers: vpp_workers,
             binary: vpp_binary.as_deref(),
             steer_direction: vpp_dir,
+            steer_exempts: &vpp_exempts,
         },
         &allowlist,
         human,

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -204,6 +204,20 @@ pub enum ModuleDirective {
     /// it is also what sources ICMP, so PMTUD's frag-needed is only
     /// correct if an operator chose it deliberately.
     VppLoopbackAddress(Ipv4Prefix),
+    /// `steer-exempt <ip>/<len>` — a destination whose traffic stays on
+    /// the kernel path while steering is on, installed as a
+    /// higher-priority MCAM rule delivering to the PF. Repeatable.
+    ///
+    /// For the addresses that terminate ON this router: the gateway
+    /// IPs of steered service VLANs above all. Without them,
+    /// src-steered traffic destined to the router — monitoring
+    /// replies, unicast DHCP renewals, management from the service
+    /// net — matches the steer rules and dies in VPP, which has no
+    /// local delivery. Measured on the primary (w23, 2026-08-14):
+    /// 110,917 such packets blackholed in five steered minutes.
+    /// Broadcast and multicast exemptions are built in and need no
+    /// directive.
+    VppSteerExempt(Ipv4Prefix),
     /// `require-table-complete on|off` — whether a first steer waits
     /// for the route mirror to be confirmed converged against bird.
     ///
@@ -1171,9 +1185,31 @@ impl Config {
                 0,
                 "module vpp-offload has `port` lines but no `loopback-address`; member ports \
                  are unnumbered to a loopback and forward nothing without it — and do so \
-                 while reporting healthy. Add e.g. `loopback-address 198.51.100.1/32` \
-                 (an address this router owns; it also sources ICMP, so PMTUD depends on it)",
+                 while reporting healthy. Add e.g. `loopback-address 198.51.100.254/32` \
+                 (announced but UNASSIGNED: routable so ICMP/PMTUD works, held by no \
+                 kernel interface — VPP answers ARP for it, and a live address starts a \
+                 responder war; attach refuses one)",
             ));
+        }
+
+        // Duplicate exemptions are refused for the same reason
+        // duplicate ports are: each consumes an MCAM slot from a
+        // 16-per-port budget, so a pasted-twice line silently halves
+        // the room the refusal arithmetic reports.
+        let mut exempts: Vec<&Ipv4Prefix> = Vec::new();
+        for d in &vpp.directives {
+            if let ModuleDirective::VppSteerExempt(p) = d {
+                if exempts.iter().any(|e| **e == *p) {
+                    return Err(ConfigError::parse(
+                        0,
+                        format!(
+                            "duplicate `steer-exempt {}/{}` in module vpp-offload",
+                            p.addr, p.prefix_len
+                        ),
+                    ));
+                }
+                exempts.push(p);
+            }
         }
 
         let Some(fp) = fast_path else {
@@ -2070,6 +2106,12 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 .parse()
                 .map_err(|e: String| format!("loopback-address: {e}"))?;
             Ok(ModuleDirective::VppLoopbackAddress(p))
+        }),
+        "steer-exempt" => parse_single_arg(line, rest, "steer-exempt", |t| {
+            let p: Ipv4Prefix = t
+                .parse()
+                .map_err(|e: String| format!("steer-exempt: {e}"))?;
+            Ok(ModuleDirective::VppSteerExempt(p))
         }),
         "require-table-complete" => {
             parse_single_arg(line, rest, "require-table-complete", |t| match t {
@@ -3179,6 +3221,39 @@ module fast-path
         ] {
             assert!(Config::parse(bad).is_err(), "should reject: {bad}");
         }
+    }
+
+    /// `steer-exempt` exists because of w23 on the primary
+    /// (2026-08-14): 110,917 locally-terminating packets blackholed in
+    /// five steered minutes — traffic whose destination is the router
+    /// itself has to stay on the kernel path.
+    #[test]
+    fn steer_exempt_parses_and_duplicates_are_refused() {
+        let s = "module vpp-offload\n  steer-exempt 23.191.200.1/32\n  steer-exempt 10.88.1.1/32\n";
+        let c = Config::parse(s).unwrap();
+        match &c.modules[0].directives[0] {
+            ModuleDirective::VppSteerExempt(p) => {
+                assert_eq!(p.addr, std::net::Ipv4Addr::new(23, 191, 200, 1));
+                assert_eq!(p.prefix_len, 32);
+            }
+            other => panic!("expected VppSteerExempt, got {other:?}"),
+        }
+        assert!(Config::parse("module vpp-offload\n  steer-exempt not-an-ip\n").is_err());
+
+        // The duplicate refusal needs a full valid section around it,
+        // because validate_vpp_offload runs after parse.
+        let dup = "module fast-path\n  attach eth4 generic\n  allow-prefix 10.0.0.0/8\n\
+                   module vpp-offload\n  loopback-address 198.51.100.254/32\n\
+                   port eth4 cores 1 steer off\n\
+                   steer-exempt 10.88.1.1/32\n  steer-exempt 10.88.1.1/32\n";
+        let e = Config::parse(dup)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(
+            format!("{e}").contains("duplicate `steer-exempt 10.88.1.1/32`"),
+            "{e}"
+        );
     }
 
     /// The `vlans` tail exists because of w20 on the primary

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -357,7 +357,12 @@ pub fn bring_up(
                 allowlist.len() - steerable
             ));
         }
-        RuleSet::plan(allowlist, budget.clone(), cfg.steer_direction)?
+        RuleSet::plan(
+            allowlist,
+            &cfg.steer_exempts,
+            budget.clone(),
+            cfg.steer_direction,
+        )?
     } else {
         RuleSet::default()
     };
@@ -1148,6 +1153,7 @@ mod completeness_gate_tests {
             expected_routes: 1_600_000,
             hugepages: None,
             require_table_complete: require,
+            steer_exempts: vec![],
             steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1185,14 +1185,29 @@ pub fn run_feasibility_probes(
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     direction: packetframe_common::config::VppSteerDirection,
+    steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Vec<Capability> {
     #[cfg(target_os = "linux")]
     {
-        probe_linux::run(ports, workers, vpp_binary, allowlist, direction)
+        probe_linux::run(
+            ports,
+            workers,
+            vpp_binary,
+            allowlist,
+            direction,
+            steer_exempts,
+        )
     }
     #[cfg(not(target_os = "linux"))]
     {
-        let _ = (ports, workers, vpp_binary, allowlist, direction);
+        let _ = (
+            ports,
+            workers,
+            vpp_binary,
+            allowlist,
+            direction,
+            steer_exempts,
+        );
         Vec::new()
     }
 }

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -108,6 +108,13 @@ pub struct VppOffloadConfig {
     /// check and forwards nothing, which is the failure this whole
     /// module is built to make impossible.
     pub loopback_address: Option<packetframe_common::config::Ipv4Prefix>,
+    /// Destinations that stay on the kernel path while steering is on
+    /// (`steer-exempt`, repeatable) — installed as higher-priority
+    /// MCAM rules toward the PF. Broadcast and multicast are built in;
+    /// these are the operator's additions, the router's own service
+    /// addresses above all. Hot-reloadable like the allowlist: the
+    /// plan is rebuilt on every reconfigure.
+    pub steer_exempts: Vec<packetframe_common::config::Ipv4Prefix>,
     /// Which packet side the MCAM rules match. Hot-reloadable: the
     /// steering target is rebuilt from config on every reconfigure and
     /// `steer` is a reconcile, so a change installs/removes exactly
@@ -150,6 +157,7 @@ impl VppOffloadConfig {
                 ModuleDirective::VppHugepages(n) => out.hugepages = Some(*n),
                 ModuleDirective::VppRequireTableComplete(v) => out.require_table_complete = *v,
                 ModuleDirective::VppLoopbackAddress(p) => out.loopback_address = Some(*p),
+                ModuleDirective::VppSteerExempt(p) => out.steer_exempts.push(*p),
                 ModuleDirective::VppSteerDirection(d) => out.steer_direction = *d,
                 _ => {}
             }
@@ -533,7 +541,7 @@ fn steering_target(
         });
     }
     let budget = steer::McamBudget::for_ifaces(ports.iter().map(|(iface, _)| iface.as_str()))?;
-    let plan = steer::RuleSet::plan(allowlist, budget, cfg.steer_direction)?;
+    let plan = steer::RuleSet::plan(allowlist, &cfg.steer_exempts, budget, cfg.steer_direction)?;
     // `steer on` with nothing steerable is refused for the same reason
     // `bring_up` refuses it: steering would divert nothing while every
     // surface reported it on.
@@ -1559,6 +1567,7 @@ mod tests {
             expected_routes: routes,
             hugepages: None,
             require_table_complete: true,
+            steer_exempts: vec![],
             steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
@@ -1958,7 +1967,8 @@ mod tests {
         // Steering ON is refused, and names the true requirement.
         let on = cfg(&[("eth4", 1, true)], 1_600_000);
         let e = steering_target(&on, &allow).expect_err("cannot fit");
-        assert!(e.contains("600 MCAM rule(s)"), "{e}");
+        // 600 diversions plus the two built-in kernel exemptions.
+        assert!(e.contains("602 MCAM rule(s)"), "{e}");
 
         // Steering OFF succeeds with the same allowlist. This is the
         // assertion that matters: the rollback path must not consult a

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -253,7 +253,14 @@ pub fn mask_for(prefix_len: u8) -> u32 {
 fn flow_spec(rule: &SteerRule, vf_index: u32) -> RxFlowSpec {
     let mut fs = RxFlowSpec {
         flow_type: IP_USER_FLOW,
-        ring_cookie: ring_cookie(vf_index),
+        // Divert → the VF's cookie. Keep → 0, which the driver encodes
+        // as NIX_RX_ACTIONOP_UCAST toward PF queue 0 — the kernel path.
+        // The exemption rules' whole job is that second arm; see
+        // `RuleAction::Keep` for the measured traffic it rescues.
+        ring_cookie: match rule.action {
+            crate::steer::RuleAction::Divert => ring_cookie(vf_index),
+            crate::steer::RuleAction::Keep => 0,
+        },
         location: rule.location,
         ..RxFlowSpec::default()
     };
@@ -687,6 +694,22 @@ pub(super) mod sys {
         })
     }
 
+    /// Every `(iface, loc, ring_cookie)` the NIC holds — the cookie is
+    /// what separates a diversion (VF) from an exemption (kernel), so
+    /// the exemption tests assert on it.
+    pub(crate) fn rules_with_cookies() -> Vec<(String, u32, u64)> {
+        NIC.with(|n| {
+            let mut v: Vec<(String, u32, u64)> = n
+                .borrow()
+                .rules
+                .iter()
+                .map(|((i, l), fs)| (i.clone(), *l, fs.ring_cookie))
+                .collect();
+            v.sort();
+            v
+        })
+    }
+
     pub(super) fn ethtool(iface: &str, req: &mut Rxnfc) -> Result<(), std::io::Error> {
         NIC.with(|n| {
             let mut nic = n.borrow_mut();
@@ -973,9 +996,42 @@ impl NtupleSteering {
             Some(vf) if ring_cookie_vf(got.ring_cookie) == ring_cookie_vf(ring_cookie(vf)) => {
                 Ok(Occupant::IntoOurVf)
             }
+            // A cookie whose VF field is zero is a kernel-delivery rule
+            // — which is what our own EXEMPTIONS are. Cookie alone
+            // cannot separate ours from a stranger's, so the stored
+            // spec is compared against the exemption this ledger's plan
+            // put at this slot: a match (same match fields, same mask,
+            // same cookie) is ours to delete, mask-for-mask. Without
+            // this arm every `Keep` rule read as `Elsewhere` and
+            // survived unsteer — gateway traffic pinned to PF queue 0
+            // by rules nothing would ever remove (caught by
+            // `exemptions_install_with_cookie_zero_and_clear_on_unsteer`
+            // the day the exemptions were written).
+            Some(vf)
+                if ring_cookie_vf(got.ring_cookie) == 0
+                    && self
+                        .planned_keep_at(iface, loc)
+                        .is_some_and(|rule| audit_matches(&flow_spec(&rule, vf), &got)) =>
+            {
+                Ok(Occupant::IntoOurVf)
+            }
             Some(_) => Ok(Occupant::Elsewhere(got.ring_cookie)),
             None => Ok(Occupant::Unattributable),
         }
+    }
+
+    /// The `Keep` rule the outgoing install placed at this slot, if any
+    /// — the spec [`Self::occupant`] compares a cookie-zero occupant
+    /// against before claiming it.
+    fn planned_keep_at(&self, iface: &str, loc: u32) -> Option<crate::steer::SteerRule> {
+        let (ports, plan) = self.installed_as.as_ref()?;
+        if !ports.iter().any(|(i, _)| i == iface) {
+            return None;
+        }
+        plan.rules
+            .iter()
+            .find(|r| r.location == loc && r.action == crate::steer::RuleAction::Keep)
+            .copied()
     }
 
     /// Remove `victims`, **keeping whatever would not come out**.
@@ -1678,6 +1734,7 @@ mod tests {
             prefix_len: 24,
             side,
             location: loc,
+            action: crate::steer::RuleAction::Divert,
         }
     }
 
@@ -1834,10 +1891,11 @@ mod tests {
                     prefix_len: 24,
                 },
             ],
+            &[],
             small,
             VppSteerDirection::Both,
         )
-        .expect_err("six rules cannot fit four slots");
+        .expect_err("eight rules cannot fit four slots");
         assert!(e.contains("only 4 slot(s) are free"), "{e}");
 
         // Rules already in the table are excluded, not overwritten —
@@ -2073,8 +2131,14 @@ mod tests {
         use crate::runtime::Steering as _;
         sys::reset();
 
-        // The previous daemon: installs at the top of the table.
-        let mut before = steering(vec![("eth0".into(), 0)], plan_for(&[[198, 18, 0, 0]]));
+        // The previous daemon: a FULL install — diversions at the top
+        // of the table, exemptions at the bottom — because that is what
+        // any real predecessor leaves behind, and the audit must
+        // account for inherited keeps as readily as inherited diverts.
+        let mut before = steering(
+            vec![("eth0".into(), 0)],
+            plan_with_keeps(&[[198, 18, 0, 0]]),
+        );
         before.steer().expect("first run installs");
         let inherited = before.installed();
         assert!(!inherited.is_empty());
@@ -2086,7 +2150,7 @@ mod tests {
             addr: [198, 18, 0, 0],
             prefix_len: 24,
         }];
-        let fresh_plan = RuleSet::plan(&allow, budget, VppSteerDirection::Both).expect("fits");
+        let fresh_plan = RuleSet::plan(&allow, &[], budget, VppSteerDirection::Both).expect("fits");
         for r in &fresh_plan.rules {
             assert!(
                 !inherited.iter().any(|(_, l)| *l == r.location),
@@ -3058,8 +3122,8 @@ mod tests {
             addr: [23, 191, 200, 0],
             prefix_len: 24,
         }];
-        let plan =
-            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits");
+        let plan = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Both)
+            .expect("fits");
         let mut s = steering(vec![("eth0".into(), 0)], plan);
         assert!(
             s.installed().is_empty(),
@@ -3100,7 +3164,20 @@ mod tests {
         NtupleSteering::new(ports.clone(), ports, plan)
     }
 
+    /// The DIVERSION half of a plan only. These tests assert reconcile
+    /// mechanics slot-by-slot, and the built-in exemptions ride the
+    /// same ledger through the same code paths — their flow-through
+    /// has its own test (`exemptions_install_with_cookie_zero_and_
+    /// clear_on_unsteer`), so carrying them here would only smear two
+    /// extra slots across every assertion below.
     fn plan_for(prefixes: &[[u8; 4]]) -> RuleSet {
+        let mut set = plan_with_keeps(prefixes);
+        set.rules
+            .retain(|r| r.action == crate::steer::RuleAction::Divert);
+        set
+    }
+
+    fn plan_with_keeps(prefixes: &[[u8; 4]]) -> RuleSet {
         let allow: Vec<IpPrefix> = prefixes
             .iter()
             .map(|a| IpPrefix::V4 {
@@ -3108,7 +3185,51 @@ mod tests {
                 prefix_len: 24,
             })
             .collect();
-        RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits")
+        RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Both).expect("fits")
+    }
+
+    /// The exemptions' whole journey: planned at the LOW slots, encoded
+    /// with `ring_cookie` 0 (PF queue 0 — the kernel), installed by the
+    /// same steer that installs the diversions, and gone after unsteer.
+    /// w23 measured why they exist: 110,917 locally-terminating packets
+    /// blackholed in five steered minutes without them.
+    #[test]
+    fn exemptions_install_with_cookie_zero_and_clear_on_unsteer() {
+        use crate::runtime::Steering as _;
+        sys::reset();
+        let plan = plan_with_keeps(&[[23, 191, 200, 0]]);
+        let mut s = steering(vec![("eth0".into(), 0)], plan.clone());
+        s.steer().expect("steer");
+
+        let nic = sys::rules_with_cookies();
+        assert_eq!(
+            nic.len(),
+            plan.rules.len(),
+            "every planned rule lands: {nic:?}"
+        );
+        for r in &plan.rules {
+            let stored = nic
+                .iter()
+                .find(|(_, loc, _)| *loc == r.location)
+                .unwrap_or_else(|| panic!("rule at loc {} missing from NIC", r.location));
+            let want_cookie = match r.action {
+                crate::steer::RuleAction::Divert => ring_cookie(0),
+                crate::steer::RuleAction::Keep => 0,
+            };
+            assert_eq!(
+                stored.2, want_cookie,
+                "loc {}: an exemption must land on the kernel (cookie 0), a diversion on \
+                 the VF — swapped cookies are the w22 capture with extra steps",
+                r.location
+            );
+        }
+
+        s.unsteer().expect("unsteer");
+        assert!(
+            sys::rules().is_empty(),
+            "exemptions are torn down with the diversions — a Keep rule left behind \
+             pins gateway traffic to PF queue 0 forever"
+        );
     }
 
     /// The happy path, which had never executed anywhere.

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -17,6 +17,7 @@ pub(crate) fn run(
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     direction: packetframe_common::config::VppSteerDirection,
+    steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Vec<Capability> {
     let mut caps = Vec::with_capacity(5 + ports.len());
     caps.push(probe_iommu());
@@ -32,7 +33,12 @@ pub(crate) fn run(
     for iface in ports {
         caps.push(probe_sriov(iface));
     }
-    caps.push(probe_steering_budget(ports, allowlist, direction));
+    caps.push(probe_steering_budget(
+        ports,
+        allowlist,
+        direction,
+        steer_exempts,
+    ));
     caps
 }
 
@@ -117,6 +123,7 @@ fn probe_steering_budget(
     ports: &[String],
     allowlist: &[packetframe_common::fib::IpPrefix],
     direction: packetframe_common::config::VppSteerDirection,
+    steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Capability {
     use crate::steer::{McamBudget, RuleSet};
 
@@ -125,7 +132,10 @@ fn probe_steering_budget(
         Err(e) => return Capability::fail("vpp.steering.budget", e, false),
     };
     let free = budget.free.len();
-    match RuleSet::plan(allowlist, budget, direction) {
+    // The same arithmetic attach enforces: diversions + the built-in
+    // exemptions + the operator's. A probe that omitted the exemptions
+    // would pass a config attach then refuses, two-plus slots short.
+    match RuleSet::plan(allowlist, steer_exempts, budget, direction) {
         // Nothing to steer is a FAIL however it arose. The two ways there
         // read very differently to an operator, so they are named
         // separately — but neither may pass: a port that steers nothing
@@ -331,7 +341,7 @@ mod steering_probe_tests {
         // No ports: `for_ifaces` asks no NIC and yields the fallback
         // budget, so these stay tests of the ALLOWLIST logic — which is
         // what they were always about — on a host that has no rvu NIC.
-        let empty = probe_steering_budget(&[], &[], Default::default());
+        let empty = probe_steering_budget(&[], &[], Default::default(), &[]);
         assert_eq!(empty.status, CapabilityStatus::Fail, "{empty:?}");
         assert!(
             empty.detail.contains("allowlist is empty"),
@@ -346,6 +356,7 @@ mod steering_probe_tests {
                 prefix_len: 32,
             }],
             Default::default(),
+            &[],
         );
         assert_eq!(v6_only.status, CapabilityStatus::Fail, "{v6_only:?}");
         assert!(
@@ -356,7 +367,7 @@ mod steering_probe_tests {
 
         // A steerable prefix passes, so the failures above are about
         // having nothing to steer rather than the probe always failing.
-        let ok = probe_steering_budget(&[], &[v4(0, 24)], Default::default());
+        let ok = probe_steering_budget(&[], &[v4(0, 24)], Default::default(), &[]);
         assert_eq!(ok.status, CapabilityStatus::Pass, "{ok:?}");
     }
 }

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -69,6 +69,8 @@ pub struct SteerRule {
     pub side: Side,
     /// MCAM slot. Assigned by [`RuleSet::plan`], not by the driver.
     pub location: u32,
+    /// Where a match goes: into VPP, or back to the kernel.
+    pub action: RuleAction,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -76,6 +78,44 @@ pub enum Side {
     Src,
     Dst,
 }
+
+/// What a matching packet's fate is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuleAction {
+    /// Redirect to VPP's VF — the steering rules proper.
+    Divert,
+    /// Deliver to the kernel (PF queue 0) — the exemptions, installed
+    /// at HIGHER MCAM priority than any `Divert` rule so
+    /// locally-terminating traffic never enters a dataplane that
+    /// cannot deliver it.
+    ///
+    /// Why these exist, measured (w23, 2026-08-14): with `src`
+    /// steering live, 110,917 packets in five minutes — the box's own
+    /// service-monitoring replies, unicast DHCP renewals to the
+    /// gateway, service-net→router management — matched the src rules
+    /// and died at VPP's `null-node`, and 3,200 multicast frames
+    /// (IGMP among them) were RPF-dropped instead of reaching the
+    /// kernel bridge. The kernel is the only correct owner of that
+    /// traffic; a `Keep` rule is how it stays there.
+    ///
+    /// `ring_cookie` 0 = PF queue 0 (`otx2_add_flow_msg`: a cookie
+    /// with no VF bits becomes `NIX_RX_ACTIONOP_UCAST` toward the PF).
+    /// One queue instead of RSS is an accepted cost for this traffic
+    /// class — it is control-plane volume, not transit.
+    Keep,
+}
+
+/// Exemptions every steered port carries regardless of config: IPv4
+/// broadcast and multicast. Both are subnet-operational traffic the
+/// kernel must see (DHCP DISCOVER answers, IGMP membership for the
+/// bridge's snooping) and neither can ever be forwarded by VPP's
+/// unicast FIB. Router-address exemptions are the operator's
+/// (`steer-exempt`) because only the operator knows which addresses
+/// terminate locally.
+pub const BUILTIN_EXEMPTS: [(Ipv4Addr, u8); 2] = [
+    (Ipv4Addr::new(255, 255, 255, 255), 32),
+    (Ipv4Addr::new(224, 0, 0, 0), 4),
+];
 
 /// What steering *should* look like for a port, derived from the
 /// allowlist.
@@ -220,6 +260,7 @@ impl RuleSet {
     /// nobody chose.
     pub fn plan(
         allowlist: &[IpPrefix],
+        exempts: &[packetframe_common::config::Ipv4Prefix],
         budget: McamBudget,
         direction: VppSteerDirection,
     ) -> Result<Self, String> {
@@ -236,21 +277,47 @@ impl RuleSet {
             })
             .collect();
         let skipped_v6 = (allowlist.len() - steerable.len()) as u32;
-        let needed = steerable.len() * sides.len();
+        // Nothing to divert means nothing to exempt FROM — an all-v6
+        // allowlist plans no rules at all rather than exemptions that
+        // guard against a diversion that cannot happen.
+        if steerable.is_empty() {
+            return Ok(RuleSet {
+                rules: Vec::new(),
+                skipped_v6,
+            });
+        }
+        let keeps: Vec<(Ipv4Addr, u8)> = BUILTIN_EXEMPTS
+            .iter()
+            .copied()
+            .chain(exempts.iter().map(|p| (p.addr, p.prefix_len)))
+            .collect();
+        let diverts = steerable.len() * sides.len();
+        let needed = diverts + keeps.len();
 
         if needed > budget.free.len() {
             return Err(format!(
-                "the allowlist needs {needed} MCAM rule(s) ({} steerable prefix(es) × {} \
-                 direction(s), `steer-direction {direction}`) but only {} slot(s) are free \
-                 on this NIC; steering part of the allowlist would split it across both \
-                 forwarding tiers, so none is installed. The per-port ntuple table on this \
-                 hardware holds 16 rules",
+                "steering needs {needed} MCAM rule(s) ({} steerable prefix(es) × {} \
+                 direction(s), `steer-direction {direction}`, plus {} kernel exemption(s): \
+                 2 built-in [broadcast, multicast] + {} `steer-exempt`) but only {} slot(s) \
+                 are free on this NIC; steering part of the allowlist would split it across \
+                 both forwarding tiers, so none is installed. The per-port ntuple table on \
+                 this hardware holds 16 rules",
                 steerable.len(),
                 sides.len(),
+                keeps.len(),
+                exempts.len(),
                 budget.free.len()
             ));
         }
 
+        // Slot assignment carries the PRIORITY, so it is not free-form:
+        // lower loc = lower MCAM entry index = matched first (v5.15
+        // otx2_flows.c keeps flow_ent[] ascending and indexes it by
+        // location). Divert rules take the budget's front (highest
+        // locs, clear of vendor rules, as ever); Keep rules take the
+        // BACK — the lowest free locs — so every exemption outranks
+        // every diversion by construction. A `free` list sorted
+        // highest-first makes front ≥ back unconditionally.
         let mut rules = Vec::with_capacity(needed);
         for (i, (addr, prefix_len)) in steerable.into_iter().enumerate() {
             for (j, side) in sides.iter().copied().enumerate() {
@@ -259,8 +326,18 @@ impl RuleSet {
                     prefix_len,
                     side,
                     location: budget.free[i * sides.len() + j],
+                    action: RuleAction::Divert,
                 });
             }
+        }
+        for (k, (addr, prefix_len)) in keeps.into_iter().enumerate() {
+            rules.push(SteerRule {
+                prefix: addr,
+                prefix_len,
+                side: Side::Dst,
+                location: budget.free[budget.free.len() - 1 - k],
+                action: RuleAction::Keep,
+            });
         }
         Ok(RuleSet { rules, skipped_v6 })
     }
@@ -295,20 +372,98 @@ mod tests {
             },
             v4(10, 88, 1, 0, 24),
         ];
-        let set =
-            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both).expect("fits");
+        let set = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Both)
+            .expect("fits");
 
         assert_eq!(set.skipped_v6, 1, "the v6 prefix is reported, not hidden");
-        assert_eq!(set.rules.len(), 4, "two v4 prefixes, both directions");
+        assert_eq!(
+            set.rules.len(),
+            6,
+            "two v4 prefixes x both directions, plus the two built-in exemptions"
+        );
         assert_eq!(
             set.rules.iter().filter(|r| r.side == Side::Src).count(),
             2,
             "one source rule per v4 prefix"
         );
+        let diverts: Vec<u32> = set
+            .rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Divert)
+            .map(|r| r.location)
+            .collect();
+        let keeps: Vec<u32> = set
+            .rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Keep)
+            .map(|r| r.location)
+            .collect();
         assert_eq!(
-            set.locations(),
+            diverts,
             vec![15, 14, 13, 12],
-            "the highest free slots on a 16-entry table, consecutive so teardown can find them"
+            "diversions take the highest free slots, clear of vendor rules, as ever"
+        );
+        assert_eq!(
+            keeps,
+            vec![0, 1],
+            "exemptions take the LOWEST free slots — lower loc is higher MCAM priority, so \
+             every exemption outranks every diversion"
+        );
+    }
+
+    /// The two invariants the exemptions exist for: they outrank every
+    /// diversion (lower slot = higher priority on this NIC), and the
+    /// operator's `steer-exempt` entries ride alongside the built-ins.
+    #[test]
+    fn exemptions_outrank_diversions_and_include_the_operators() {
+        use packetframe_common::config::Ipv4Prefix;
+        let allow = vec![v4(23, 191, 200, 0, 24)];
+        let exempts = vec![Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(23, 191, 200, 1),
+            prefix_len: 32,
+        }];
+        let set = RuleSet::plan(
+            &allow,
+            &exempts,
+            McamBudget::default(),
+            VppSteerDirection::Src,
+        )
+        .expect("fits");
+        let max_keep = set
+            .rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Keep)
+            .map(|r| r.location)
+            .max()
+            .expect("keeps exist");
+        let min_divert = set
+            .rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Divert)
+            .map(|r| r.location)
+            .min()
+            .expect("diverts exist");
+        assert!(
+            max_keep < min_divert,
+            "every exemption must outrank every diversion: keep max {max_keep} vs divert \
+             min {min_divert}"
+        );
+        // Built-ins + the operator's router address, all Keep, all Dst.
+        let keep_prefixes: Vec<(std::net::Ipv4Addr, u8)> = set
+            .rules
+            .iter()
+            .filter(|r| r.action == RuleAction::Keep)
+            .map(|r| {
+                assert_eq!(r.side, Side::Dst, "an exemption matches destinations");
+                (r.prefix, r.prefix_len)
+            })
+            .collect();
+        assert!(keep_prefixes.contains(&(std::net::Ipv4Addr::new(255, 255, 255, 255), 32)));
+        assert!(keep_prefixes.contains(&(std::net::Ipv4Addr::new(224, 0, 0, 0), 4)));
+        assert!(
+            keep_prefixes.contains(&(std::net::Ipv4Addr::new(23, 191, 200, 1), 32)),
+            "the operator's gateway exemption is the one that rescues DHCP renews and \
+             monitoring replies (w23: 110,917 blackholed in five minutes without it)"
         );
     }
 
@@ -331,32 +486,34 @@ mod tests {
         let budget = McamBudget {
             free: (0..5).rev().collect(),
         };
-        let e = RuleSet::plan(&allow, budget, VppSteerDirection::Both).expect_err("must refuse");
+        let e =
+            RuleSet::plan(&allow, &[], budget, VppSteerDirection::Both).expect_err("must refuse");
 
         assert!(
-            e.contains("needs 8 MCAM rule(s)"),
-            "must name the TRUE requirement, not how far it got: {e}"
+            e.contains("needs 10 MCAM rule(s)"),
+            "must name the TRUE requirement — diversions AND exemptions: {e}"
         );
         assert!(
-            !e.contains("6 MCAM"),
-            "reporting budget+1 tells the operator to try a size that also fails: {e}"
+            e.contains("2 built-in"),
+            "the built-in exemptions are part of the arithmetic the operator sizes from: {e}"
         );
         assert!(
             e.contains("none is installed"),
             "the message must say the port is left unsteered: {e}"
         );
 
-        // One more slot and the same allowlist fits, so the refusal is
+        // Enough slots and the same allowlist fits, so the refusal is
         // about the budget and not about the allowlist's shape.
         let ok = RuleSet::plan(
             &allow,
+            &[],
             McamBudget {
-                free: (0..8).rev().collect(),
+                free: (0..10).rev().collect(),
             },
             VppSteerDirection::Both,
         )
         .expect("fits exactly");
-        assert_eq!(ok.rules.len(), 8);
+        assert_eq!(ok.rules.len(), 10);
     }
 
     /// The refusal counts STEERABLE prefixes, not every line in the
@@ -378,6 +535,7 @@ mod tests {
         ];
         let e = RuleSet::plan(
             &allow,
+            &[],
             McamBudget {
                 free: (0..3).rev().collect(),
             },
@@ -385,7 +543,7 @@ mod tests {
         )
         .expect_err("must refuse");
         assert!(
-            e.contains("needs 4 MCAM rule(s)") && e.contains("2 steerable prefix(es)"),
+            e.contains("needs 6 MCAM rule(s)") && e.contains("2 steerable prefix(es)"),
             "the v6 prefix is not steerable and must not inflate either number: {e}"
         );
     }
@@ -397,32 +555,44 @@ mod tests {
     #[test]
     fn src_only_builds_one_rule_per_prefix() {
         let allow = vec![v4(10, 0, 0, 0, 16), v4(10, 1, 0, 0, 16)];
-        let set =
-            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Src).expect("fits");
-        assert_eq!(set.rules.len(), 2, "{:?}", set.rules);
+        let set = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Src)
+            .expect("fits");
+        assert_eq!(
+            set.rules.len(),
+            4,
+            "2 src diverts + 2 built-in keeps: {:?}",
+            set.rules
+        );
         assert!(
-            set.rules.iter().all(|r| r.side == Side::Src),
-            "src-only must never emit a Dst rule: {:?}",
+            set.rules
+                .iter()
+                .filter(|r| r.action == RuleAction::Divert)
+                .all(|r| r.side == Side::Src),
+            "src-only must never DIVERT on a Dst match: {:?}",
             set.rules
         );
 
-        let dst =
-            RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Dst).expect("fits");
+        let dst = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Dst)
+            .expect("fits");
         assert!(
-            dst.rules.iter().all(|r| r.side == Side::Dst),
+            dst.rules
+                .iter()
+                .filter(|r| r.action == RuleAction::Divert)
+                .all(|r| r.side == Side::Dst),
             "{:?}",
             dst.rules
         );
 
-        // Half the rules means twice the prefixes fit: a budget that
+        // Half the divert rules means more prefixes fit: a budget that
         // refuses 2 prefixes under `both` takes them under `src`.
         let tight = McamBudget {
-            free: (0..2).rev().collect(),
+            free: (0..4).rev().collect(),
         };
-        RuleSet::plan(&allow, tight.clone(), VppSteerDirection::Both)
-            .expect_err("two prefixes x two sides cannot fit two slots");
-        let fits = RuleSet::plan(&allow, tight, VppSteerDirection::Src).expect("fits src-only");
-        assert_eq!(fits.rules.len(), 2);
+        RuleSet::plan(&allow, &[], tight.clone(), VppSteerDirection::Both)
+            .expect_err("four diverts + two keeps cannot fit four slots");
+        let fits =
+            RuleSet::plan(&allow, &[], tight, VppSteerDirection::Src).expect("fits src-only");
+        assert_eq!(fits.rules.len(), 4);
     }
 
     /// The refusal names the configured direction, so an operator
@@ -432,6 +602,7 @@ mod tests {
         let allow = vec![v4(10, 0, 0, 0, 16), v4(10, 1, 0, 0, 16)];
         let e = RuleSet::plan(
             &allow,
+            &[],
             McamBudget { free: vec![15] },
             VppSteerDirection::Src,
         )
@@ -449,9 +620,13 @@ mod tests {
             addr: [0x26, 0x02, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             prefix_len: 32,
         }];
-        let set = RuleSet::plan(&allow, McamBudget::default(), VppSteerDirection::Both)
+        let set = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Both)
             .expect("no rules is not an error");
-        assert!(set.rules.is_empty());
+        assert!(
+            set.rules.is_empty(),
+            "nothing to divert means nothing to exempt from — no keeps either: {:?}",
+            set.rules
+        );
         assert_eq!(
             set.skipped_v6, 1,
             "the operator has to be able to see that steering covers none of their allowlist"

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -164,6 +164,7 @@ impl Host {
             vpp_binary: Some(self.vpp_binary.to_string_lossy().into_owned()),
             expected_routes: 1_600_000,
             hugepages: None,
+            steer_exempts: vec![],
             // These fixtures have no route authority to compare
             // against, and none of them steers; the gate is exercised
             // where it lives, in `runtime`.

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1384,6 +1384,7 @@ fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {
     let allow: Vec<IpPrefix> = (0..count).map(|i| fake_vpp::v4(0, i)).collect();
     packetframe_vpp_offload::steer::RuleSet::plan(
         &allow,
+        &[],
         packetframe_vpp_offload::steer::McamBudget::default(),
         Default::default(),
     )
@@ -1482,9 +1483,9 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
     assert_eq!(
         seen,
         vec![
-            "retarget 1 ports, 4 rules".to_string(),
+            "retarget 1 ports, 6 rules".to_string(),
             "steer".into(),
-            "retarget 0 ports, 4 rules".into(),
+            "retarget 0 ports, 6 rules".into(),
             "unsteer".into(),
         ],
         "the target is recorded BEFORE the reconcile, or Steer installs the old rules"
@@ -1654,7 +1655,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
     let seen = log.lock().unwrap().clone();
     assert_eq!(
         seen,
-        vec!["retarget 1 ports, 4 rules".to_string()],
+        vec!["retarget 1 ports, 6 rules".to_string()],
         "the target is updated and nothing else — a steer here would divert traffic as a \
          side effect of editing something unrelated"
     );

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -348,6 +348,25 @@ hold) as traffic moves — it must never rise on a steer. VPP's own
 interface counters (`show interface` via the CLI socket) turning over
 at line rate on the member VF is the positive half of the same check.
 
+**Declare `steer-exempt` for every locally-terminating address before
+any steer that outlives a short canary.** A `src` steer diverts by
+source alone, so traffic from the service prefix **to the router
+itself** — the box's own monitoring replies, unicast DHCP renewals,
+management SSH from the service net — is diverted into a dataplane
+with no local delivery and dies at `null-node` while every gauge stays
+green. Measured on the primary (2026-08-14, w23): 110,917 packets in
+five steered minutes, plus 3,200 multicast frames (IGMP among them)
+RPF-dropped away from the kernel bridge's snooping. The exemptions are
+higher-priority MCAM rules that deliver matches to the kernel instead:
+broadcast and multicast are built in; each gateway IP of a steered
+VLAN needs a `steer-exempt` line. Budget math per steered port on this
+hardware: 16 slots = (steerable v4 prefixes × directions) diversions
++ 2 built-ins + your `steer-exempt` entries; the refusal message
+itemises exactly this. While steered, `ethtool -n <port>` shows the
+exemptions at the LOW locations and the diversions at the high ones —
+lower location is higher MCAM priority, which is what makes an
+exemption win.
+
 **Rung 2..N — one port at a time**, with a soak between each. There is
 no prize for going faster; the failure you are looking for is the one
 that only shows up under real traffic.
@@ -1192,6 +1211,7 @@ Be precise about this when reasoning about an incident.
 | First steer on the primary (eth4, `src`, trunk, no subifs) | MCAM+VF+VPP rx flawless at ~72 kpps; **8.7M frames punted in 2 min, zero forwarded** | 2026-08-14 w20. Tagged ingress, no dot1q subif → punt at ethernet-input. The `vlans` port directive exists because of this window. |
 | Second steer (subifs present, VF answering to the port's own MAC) | subif classified 7.19M frames in 90 s (**punt-at-VLAN-layer gone**); 7.17M then punted on dmac — hosts address switch0's `…:c7`, the VF held eth4's `…:ca` | 2026-08-14 w21. Auto-aborted by the harness's 90 s blackhole guard. The secondary-MAC acceptance exists because of this window. |
 | Third steer (bridge MAC as the member's PRIMARY) | VPP forwarded **~500M packets in 27 min**, split by best path (266M eth3, 236k eth2), zero loop, no drops on the forwarding path — **but ~300 kpps arrived from ATTACH, with the lever off** | 2026-08-14 w22. Forwarding quality proven; staging isolation broken. The primary MAC is a hardware filter on this NIC, so it must stay the port's own — acceptance belongs in secondary addresses. Undeclared trunk VLANs (`unknown vlan` 180k) were blackholed for the window. |
+| Fourth steer (secondary MAC + `.254` loopback — the clean pass) | Leak gate ~50 pps noise (lever off); 95.9M rx / 95.8M tx at +300 s; ARP replies **zero**; steered minutes ~0.1% remote loss vs 4–7%/min on the unsteered rung-0 stretch of the same window | 2026-08-14 w23. Rung 1 validated; **the steered path beat the XDP path by >10× under coexistence**. Residual: 110,917 locally-terminating packets blackholed in 5 min — the number `steer-exempt` exists to zero. |
 | Idle draw with VPP polling one worker | 33.56 W, 38/49/42 °C, fan 3780 RPM | 2026-08-11 shadow, chassis total — NOT a VPP attribution, no VPP-off baseline was taken. |
 
 **Published but never measured:**


### PR DESCRIPTION
## Why

w23 validated rung-1 forwarding (steered path >10× cleaner than XDP under coexistence) and left exactly one production gap, measured: **110,917 locally-terminating packets blackholed in five steered minutes** (monitoring replies, unicast DHCP renewals, service-net→router management — all src-matched, all dying at `null-node`), plus **3,200 multicast frames** RPF-dropped away from the kernel bridge's IGMP snooping. A `src` rule diverts by source alone; destinations the router terminates must stay on the kernel path.

## What

- **`RuleAction::{Divert, Keep}`** through the existing plan/ledger/reconcile/teardown machinery. Keep = `ring_cookie 0` → PF queue 0 (source-verified against v5.15 `otx2_add_flow_msg`: no VF bits → `NIX_RX_ACTIONOP_UCAST` toward the PF).
- **Priority by construction**: diversions keep the high locations, exemptions take the LOW ones — lower location = lower MCAM entry index = matched first on this NIC (v5.15 `otx2_flows.c` keeps `flow_ent[]` ascending). Asserted in tests as an invariant (`max keep loc < min divert loc`).
- **Built-ins**: `255.255.255.255/32` and `224.0.0.0/4` on every steered port. **Operator entries**: `steer-exempt <prefix>` (repeatable, hot-reloadable like the allowlist, duplicates refused at load). Budget refusal itemises diversions + built-ins + exemptions.
- **A real bug caught by this PR's own test before hardware could**: `unsteer` classified ledgered slots by the cookie's VF field, so Keep rules read as strangers and survived teardown. A cookie-zero occupant at a ledgered slot is now claimed only when its stored spec matches the exemption the outgoing plan placed there, mask for mask — a stranger's kernel-delivery rule still survives.
- Docs: example.conf block with the w23 numbers, canary-ladder section on when exemptions are mandatory and the per-port budget math, w23 row in the measured table. Also sweeps the last stale "address this router owns" guidance out of `validate_vpp_offload` (the w22 advice #188 corrected elsewhere).

## Reference-box config after merge

```
steer-exempt 23.191.200.1/32
steer-exempt 10.88.1.1/32
```

## Testing

`make lint` green, full workspace green (35 suites). Plan-level invariants, wire-level cookie assertions against the fake NIC, flow-through (install → cookie per action → unsteer clears both classes), adoption-path audit with inherited keeps, config parse/validate. Hardware validation is w24: same harness plus exemption checks — `ethtool -n eth4` showing keeps at low locs, box→.7 monitoring STAYING UP through the steered soak (the first window where it can), and VPP's `null-node` count staying flat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)