### PR TITLE
feat(vpp-offload): bidirectional offload — local delivery, per-port direction, the FDB tripwire, and the null-drop gauge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,9 @@ name = "packetframe-vpp-offload"
 version = "0.2.7"
 dependencies = [
  "libc",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-sys",
  "packetframe-common",
  "serde",
  "serde_json",

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -418,6 +418,35 @@ module fast-path
 #                                 # BUILT IN and need no directive. Each entry
 #                                 # costs one slot of the 16-per-port MCAM
 #                                 # budget. Hot-reloadable like the allowlist.
+#   local-route 23.191.200.0/24 port eth4 vlan 1337
+#                                 # A locally terminated prefix VPP must
+#                                 # DELIVER, not forward: installs an attached
+#                                 # route onto the port's dot1q subinterface
+#                                 # and mirrors the kernel's neighbours on the
+#                                 # backing bridge as VPP static neighbours
+#                                 # (VPP never ARPs). Three effects: (1)
+#                                 # steered traffic dst∈prefix routes to the
+#                                 # host instead of dying at `null-node`; (2)
+#                                 # the BGP mirror's view INSIDE the prefix is
+#                                 # shadowed — skipped at resync and in deltas
+#                                 # — because the kernel tier delivers to
+#                                 # bridge hosts before its FIB lookup, so a
+#                                 # mirrored route here (e.g. a host route
+#                                 # carried as `unreachable` in bird) would
+#                                 # blackhole in VPP what the kernel delivers
+#                                 # fine; (3) it is what makes `direction dst`
+#                                 # loadable — dst steering refuses without
+#                                 # full local-route coverage of steerable
+#                                 # local prefixes. Must sit inside a
+#                                 # fast-path `local-prefix` (tier agreement;
+#                                 # the kernel bridge device for the neighbour
+#                                 # mirror comes from its `via`), and the port
+#                                 # must declare the vlan. Repeatable;
+#                                 # restart-only. Multi-port VLANs (hosts for
+#                                 # one VLAN behind two member ports) are not
+#                                 # deliverable per-host yet: declare THE port
+#                                 # the hosts sit behind; the FDB scan flags
+#                                 # any host it sees elsewhere.
 #   expected-routes 1600000       # v4+v6 DFZ + growth; drives memory sizing.
 #                                 # Live table measured ~1.30M (2026-08-02);
 #                                 # DFZ grows ~100k/yr, so this is ~3 years.
@@ -436,15 +465,20 @@ module fast-path
 #                                 # shape — traffic FROM the service
 #                                 # prefix rides VPP's full-table best
 #                                 # path, while traffic TO it stays on the
-#                                 # eBPF tier, whose FDB-pin handles local
-#                                 # delivery to bridge-attached hosts that
-#                                 # VPP has no path to. dst-steering a
-#                                 # service prefix would divert inbound
-#                                 # flows into a FIB that cannot deliver
-#                                 # them. Hot-reloadable: the target is
-#                                 # rebuilt on every reconfigure and steer
-#                                 # is a reconcile, so a change (including
-#                                 # the rollback) applies as a delta.
+#                                 # eBPF tier. `dst` = inbound only —
+#                                 # loadable only with full `local-route`
+#                                 # coverage of steerable local prefixes,
+#                                 # since a dst rule diverts inbound into
+#                                 # VPP and VPP must be able to deliver
+#                                 # it. Per-port override: `port eth3
+#                                 # cores 1 steer on direction dst` — the
+#                                 # bidirectional service-edge shape is
+#                                 # `src` on the service trunk, `dst` on
+#                                 # the transit ports. Hot-reloadable:
+#                                 # the target is rebuilt on every
+#                                 # reconfigure and steer is a reconcile,
+#                                 # so a change (including the rollback)
+#                                 # applies as a delta.
 #   # require-table-complete on   # default. A first steer waits until the
 #                                 # route mirror is confirmed converged
 #                                 # against bird, because bird's initial

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -134,6 +134,69 @@ pub fn vpp_steer_exempts_from_config(
         .collect()
 }
 
+/// The `local-route` lines joined with the fast-path `local-prefix`
+/// that covers each one — the join only the loader can perform, since
+/// `Module` methods see one section. The covering prefix's `via` is the
+/// kernel bridge device whose neighbours mirror onto the subif; the
+/// longest cover wins, matching every other most-specific rule in the
+/// config. `validate_vpp_offload` guarantees a cover exists, so the
+/// error arm is a programming-order guard (extractor called on an
+/// unvalidated config), not an operator surface.
+///
+/// Gated like [`crate::loader`]'s `feed_wiring` — its only caller is
+/// the Linux module-wiring path, and a laxer gate reads as dead code on
+/// every other build.
+#[cfg(all(target_os = "linux", feature = "fast-path", feature = "vpp-offload"))]
+pub fn vpp_local_routes_from_config(
+    config: &Config,
+) -> Result<Vec<packetframe_vpp_offload::LocalRoute>, String> {
+    let covers: Vec<(&packetframe_common::config::Ipv4Prefix, &String)> = config
+        .modules
+        .iter()
+        .filter(|m| m.name == "fast-path")
+        .flat_map(|m| &m.directives)
+        .filter_map(|d| match d {
+            ModuleDirective::LocalPrefix { cidr, iface, .. } => Some((cidr, iface)),
+            _ => None,
+        })
+        .collect();
+    let mut out = Vec::new();
+    for d in config
+        .modules
+        .iter()
+        .filter(|m| m.name == "vpp-offload")
+        .flat_map(|m| &m.directives)
+    {
+        if let ModuleDirective::VppLocalRoute {
+            prefix,
+            iface,
+            vlan,
+            ..
+        } = d
+        {
+            let kernel_dev = covers
+                .iter()
+                .filter(|(c, _)| c.contains_prefix(prefix))
+                .max_by_key(|(c, _)| c.prefix_len)
+                .map(|(_, i)| (*i).clone())
+                .ok_or_else(|| {
+                    format!(
+                        "local-route {}/{} matches no fast-path local-prefix — \
+                         validate_vpp_offload should have refused this config",
+                        prefix.addr, prefix.prefix_len
+                    )
+                })?;
+            out.push(packetframe_vpp_offload::LocalRoute {
+                prefix: *prefix,
+                port: iface.clone(),
+                vlan: *vlan,
+                kernel_dev,
+            });
+        }
+    }
+    Ok(out)
+}
+
 /// The `vpp-binary` override from a `vpp-offload` section, if set, so
 /// feasibility probes the executable the module will actually run.
 pub fn vpp_binary_from_config(config: &Config) -> Option<String> {

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -71,19 +71,43 @@ pub fn vpp_workers_from_config(config: &Config) -> u32 {
     workers
 }
 
-/// The configured steer direction, defaulting like the module does.
-pub fn vpp_steer_direction_from_config(config: &Config) -> VppSteerDirection {
+/// The DISTINCT effective steer directions of the steering ports —
+/// each port's `direction` tail falling back to the global, exactly as
+/// the module derives its per-port plans, so the budget probe runs the
+/// same arithmetic attach enforces. Falls back to the global default
+/// when nothing steers yet (the staging state), so the probe still
+/// reports what the first canary step would install.
+pub fn vpp_steer_directions_from_config(config: &Config) -> Vec<VppSteerDirection> {
+    let mut global = VppSteerDirection::default();
+    let mut ports: Vec<(bool, Option<VppSteerDirection>)> = Vec::new();
     for m in &config.modules {
         if m.name != "vpp-offload" {
             continue;
         }
         for d in &m.directives {
-            if let ModuleDirective::VppSteerDirection(dir) = d {
-                return *dir;
+            match d {
+                ModuleDirective::VppSteerDirection(dir) => global = *dir,
+                ModuleDirective::VppPort {
+                    steer, direction, ..
+                } => ports.push((*steer, *direction)),
+                _ => {}
             }
         }
     }
-    VppSteerDirection::default()
+    let mut out: Vec<VppSteerDirection> = Vec::new();
+    for (steer, dir) in &ports {
+        if !steer {
+            continue;
+        }
+        let d = dir.unwrap_or(global);
+        if !out.contains(&d) {
+            out.push(d);
+        }
+    }
+    if out.is_empty() {
+        out.push(global);
+    }
+    out
 }
 
 /// The fast-path allowlist, as the steering probe needs it.
@@ -217,7 +241,7 @@ pub struct VppProbeInputs<'a> {
     pub ports: &'a [String],
     pub workers: u32,
     pub binary: Option<&'a str>,
-    pub steer_direction: VppSteerDirection,
+    pub steer_directions: &'a [VppSteerDirection],
     pub steer_exempts: &'a [packetframe_common::config::Ipv4Prefix],
 }
 
@@ -256,7 +280,7 @@ pub fn probe_and_render(
             vpp.workers,
             vpp.binary,
             allowlist,
-            vpp.steer_direction,
+            vpp.steer_directions,
             vpp.steer_exempts,
         ) {
             report.capabilities.push(cap);

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1703,7 +1703,6 @@ fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
         flatten_steer_rules, group_steer_rules, ResourceState,
     };
     use packetframe_vpp_offload::runtime::{Steering as _, TERM_GRACE};
-    use packetframe_vpp_offload::steer::RuleSet;
 
     let Some(state) = ResourceState::load(state_dir).map_err(|e| format!("vpp state: {e}"))? else {
         return Ok(()); // nothing was ever acquired
@@ -1749,7 +1748,7 @@ fn detach_vpp_offload(state_dir: &Path) -> Result<(), String> {
             .iter()
             .map(|p| (p.iface.clone(), 0u32))
             .collect();
-        let mut steering = NtupleSteering::new(members, Vec::new(), RuleSet::default());
+        let mut steering = NtupleSteering::new(members, Vec::new());
         steering.adopt_installed(recorded);
         if let Err(e) = steering.unsteer() {
             // Write back what is STILL in the NIC before refusing. The rules

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -325,6 +325,15 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                 // from that section. The loader is the only place that
                 // sees both.
                 m.set_allowlist(allowlist.clone());
+                // The `local-route` ↔ `local-prefix` join — the kernel
+                // device each mirrored neighbour set comes from. Only
+                // the loader sees both sections; the module refuses to
+                // attach if config promises local routes it was never
+                // handed.
+                match crate::feasibility::vpp_local_routes_from_config(&config) {
+                    Ok(lr) => m.set_local_routes(lr),
+                    Err(e) => return Err(RunError::Startup(e)),
+                }
                 if let Some(c) = &completeness {
                     m.set_completeness(c.clone());
                 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -359,7 +359,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
         vpp_workers,
         vpp_binary,
         allowlist,
-        vpp_dir,
+        vpp_dirs,
         vpp_exempts,
     ) = match &config {
         Some(path) => match Config::from_file(path) {
@@ -377,7 +377,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                 let vpp_workers = feasibility::vpp_workers_from_config(&c);
                 let vpp_binary = feasibility::vpp_binary_from_config(&c);
                 let allowlist = feasibility::allowlist_from_config(&c);
-                let vpp_dir = feasibility::vpp_steer_direction_from_config(&c);
+                let vpp_dirs = feasibility::vpp_steer_directions_from_config(&c);
                 let vpp_exempts = feasibility::vpp_steer_exempts_from_config(&c);
                 (
                     c.global.bpffs_root,
@@ -386,7 +386,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                     vpp_workers,
                     vpp_binary,
                     allowlist,
-                    vpp_dir,
+                    vpp_dirs,
                     vpp_exempts,
                 )
             }
@@ -402,7 +402,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             0,
             None,
             Vec::new(),
-            Default::default(),
+            Vec::new(),
             Vec::new(),
         ),
     };
@@ -414,7 +414,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             ports: &vpp_ports,
             workers: vpp_workers,
             binary: vpp_binary.as_deref(),
-            steer_direction: vpp_dir,
+            steer_directions: &vpp_dirs,
             steer_exempts: &vpp_exempts,
         },
         &allowlist,

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -175,11 +175,18 @@ pub enum ModuleDirective {
     /// routing — measured on the primary 2026-08-14 (w20): 8.7M
     /// frames in two minutes, all punted, zero forwarded. Untagged
     /// ingress (an access port, or the PVID) needs no declaration.
+    ///
+    /// `direction` overrides the global `steer-direction` for this
+    /// port's rules. The split a service-edge box wants: `src` on the
+    /// service trunk (outbound rides VPP), `dst` on the transit ports
+    /// (inbound rides VPP once `local-route` delivery exists). Absent
+    /// = the global setting.
     VppPort {
         iface: String,
         cores: u16,
         steer: bool,
         vlans: Vec<u16>,
+        direction: Option<VppSteerDirection>,
         line: usize,
     },
     /// `vpp-binary <path>` — override the probed VPP binary path.
@@ -230,19 +237,46 @@ pub enum ModuleDirective {
     ///
     /// Default `both`, which is right for pure-transit deployments
     /// where VPP can forward either direction of a flow. `src` is for
-    /// service-edge deployments: outbound traffic (src ∈ the service
-    /// prefix) rides VPP's full-table best path, while inbound
-    /// (dst ∈ prefix) stays on the eBPF tier — because inbound
-    /// terminates on bridge-attached hosts VPP has no path to (local
-    /// delivery is the fast-path FDB-pin's job), and dst-steering it
-    /// would blackhole every service flow. The split-tier flow halves
-    /// are safe under the stateless-transit invariant that steering
-    /// already requires — no different from ECMP asymmetry.
+    /// service-edge deployments staging toward bidirectional: outbound
+    /// (src ∈ the service prefix) rides VPP's full-table best path
+    /// while inbound stays on the eBPF tier. Steering `dst` (or the
+    /// `both` default) toward locally terminated prefixes additionally
+    /// requires `local-route` coverage — VPP must be able to DELIVER
+    /// what a dst rule diverts, and validation refuses the config
+    /// otherwise rather than letting a canary discover the blackhole.
+    /// The split-tier flow halves are safe under the stateless-transit
+    /// invariant that steering already requires — no different from
+    /// ECMP asymmetry. Per-port override: the `direction` tail on a
+    /// `port` line.
     ///
     /// Hot-reloadable: the steering target is rebuilt from config on
     /// every `packetframe reconfigure`, and `steer` is a reconcile, so
     /// a direction change installs/removes exactly the delta.
     VppSteerDirection(VppSteerDirection),
+    /// `local-route <v4-cidr> port <iface> vlan <vid>` — a locally
+    /// terminated prefix VPP must DELIVER, not forward: an attached
+    /// route onto the member port's dot1q subinterface, with kernel
+    /// neighbours on the backing bridge mirrored as VPP static
+    /// neighbours. Repeatable; restart-only.
+    ///
+    /// Two things hang off it. First, delivery: without it, steered
+    /// traffic destined to the prefix dies in VPP (`null-node`), which
+    /// is why dst-direction steering refuses to load unless every
+    /// steerable local prefix has one. Second, shadowing: the route
+    /// mirror's BGP view of the prefix is SKIPPED — the kernel tier
+    /// delivers to bridge hosts before its FIB lookup, so a mirrored
+    /// route inside a local prefix (the reference primary carries a
+    /// host route as `unreachable` in bird) would blackhole in VPP
+    /// what the kernel delivers fine. The prefix must match a
+    /// fast-path `local-prefix` (same tier-agreement philosophy as
+    /// the membership rule; the kernel bridge device comes from its
+    /// `via`), and the port must declare the vlan in its `vlans`.
+    VppLocalRoute {
+        prefix: Ipv4Prefix,
+        iface: String,
+        vlan: u16,
+        line: usize,
+    },
     AllowPrefix4(Ipv4Prefix),
     AllowPrefix6(Ipv6Prefix),
     /// Connected/local prefix the operator wants packetframe to
@@ -1220,6 +1254,82 @@ impl Config {
             ));
         };
 
+        // local-route structural rules. These hold whether or not
+        // anything steers: the attached route and neighbour mirror are
+        // installed at attach, so a broken declaration is a broken
+        // attach, not a broken canary.
+        let mut local_routes: Vec<(&Ipv4Prefix, usize)> = Vec::new();
+        for d in &vpp.directives {
+            if let ModuleDirective::VppLocalRoute {
+                prefix,
+                iface,
+                vlan,
+                line,
+            } = d
+            {
+                for (p, _) in &local_routes {
+                    if p.contains_prefix(prefix) || prefix.contains_prefix(p) {
+                        return Err(ConfigError::parse(
+                            *line,
+                            format!(
+                                "local-route {}/{} duplicates or overlaps local-route {}/{}: \
+                                 one attached route owns a prefix",
+                                prefix.addr, prefix.prefix_len, p.addr, p.prefix_len
+                            ),
+                        ));
+                    }
+                }
+                let port_vlans = vpp.directives.iter().find_map(|d| match d {
+                    ModuleDirective::VppPort {
+                        iface: pi, vlans, ..
+                    } if pi == iface => Some(vlans),
+                    _ => None,
+                });
+                let Some(port_vlans) = port_vlans else {
+                    return Err(ConfigError::parse(
+                        *line,
+                        format!(
+                            "local-route names port `{iface}` but module vpp-offload has no \
+                             `port {iface}` line"
+                        ),
+                    ));
+                };
+                if !port_vlans.contains(vlan) {
+                    return Err(ConfigError::parse(
+                        *line,
+                        format!(
+                            "local-route {}/{}: `port {iface}` does not declare vlan {vlan} \
+                             in its `vlans` list — the dot1q subinterface the attached \
+                             route lands on is created from that list",
+                            prefix.addr, prefix.prefix_len
+                        ),
+                    ));
+                }
+                // Tier agreement: the fallback tier must also deliver
+                // this prefix locally (fast-path `local-prefix`), both
+                // so a failover cannot change what is delivered and
+                // because the kernel bridge device the neighbour
+                // mirror watches comes from that directive's `via`.
+                let covered = fp.directives.iter().any(|d| {
+                    matches!(d, ModuleDirective::LocalPrefix { cidr, .. }
+                        if cidr.contains_prefix(prefix))
+                });
+                if !covered {
+                    return Err(ConfigError::parse(
+                        *line,
+                        format!(
+                            "local-route {}/{} is not inside any fast-path `local-prefix`: \
+                             local delivery must agree across tiers, and the kernel bridge \
+                             device for neighbour mirroring comes from \
+                             `local-prefix ... via <dev>`",
+                            prefix.addr, prefix.prefix_len
+                        ),
+                    ));
+                }
+                local_routes.push((prefix, *line));
+            }
+        }
+
         // `require-table-complete on` demands a completeness authority,
         // and `integrity-authority none` declares there is none. The two
         // together are a config that can never permit a first steer: the
@@ -1288,6 +1398,94 @@ impl Config {
                              possible egress port before any ingress is steered \
                              (missing members blackhole destinations whose best path \
                              egresses them)"
+                        ),
+                    ));
+                }
+            }
+        }
+
+        // dst-direction coverage. A dst rule steers inbound INTO VPP;
+        // for a locally terminated prefix VPP can only deliver it via
+        // a `local-route`. An uncovered local prefix would blackhole
+        // 100% of its inbound the moment the port steers (w20 shape),
+        // so it is refused at load, not discovered at a canary. Pure
+        // transit needs nothing here: a dst-steered packet for a
+        // non-local prefix is forwarded via the full table.
+        let global_dir = vpp
+            .directives
+            .iter()
+            .find_map(|d| match d {
+                ModuleDirective::VppSteerDirection(v) => Some(*v),
+                _ => None,
+            })
+            .unwrap_or_default();
+        let dst_port = vpp.directives.iter().find_map(|d| match d {
+            ModuleDirective::VppPort {
+                iface,
+                steer: true,
+                direction,
+                ..
+            } if matches!(
+                direction.unwrap_or(global_dir),
+                VppSteerDirection::Dst | VppSteerDirection::Both
+            ) =>
+            {
+                Some(iface)
+            }
+            _ => None,
+        });
+        if let Some(dst_port) = dst_port {
+            let allow4: Vec<&Ipv4Prefix> = fp
+                .directives
+                .iter()
+                .filter_map(|d| match d {
+                    ModuleDirective::AllowPrefix4(p) => Some(p),
+                    _ => None,
+                })
+                .collect();
+            // Half-open u64 ranges so /0 and broadcast+1 don't wrap.
+            let range = |p: &Ipv4Prefix| -> (u64, u64) {
+                let start = u64::from(u32::from(p.network()));
+                (start, start + (1u64 << (32 - p.prefix_len)))
+            };
+            for d in &fp.directives {
+                let ModuleDirective::LocalPrefix { cidr, line, .. } = d else {
+                    continue;
+                };
+                let steerable = allow4
+                    .iter()
+                    .any(|a| a.contains_prefix(cidr) || cidr.contains_prefix(a));
+                if !steerable {
+                    continue;
+                }
+                // Covered = the local-route set tiles the whole prefix
+                // (structural rules above guarantee each is inside it
+                // or disjoint from it, and that they don't overlap).
+                let (lp_start, lp_end) = range(cidr);
+                let mut pieces: Vec<(u64, u64)> = local_routes
+                    .iter()
+                    .filter(|(p, _)| cidr.contains_prefix(p))
+                    .map(|(p, _)| range(p))
+                    .collect();
+                pieces.sort_unstable();
+                let mut cursor = lp_start;
+                for (s, e) in pieces {
+                    if s > cursor {
+                        break;
+                    }
+                    cursor = cursor.max(e);
+                }
+                if cursor < lp_end {
+                    return Err(ConfigError::parse(
+                        *line,
+                        format!(
+                            "`port {dst_port}` steers direction dst but local prefix {}/{} \
+                             (steerable via the allowlist) is not fully covered by \
+                             vpp-offload `local-route` lines: inbound steered to an \
+                             uncovered address would blackhole in VPP, which has no \
+                             local delivery for it. Add `local-route {}/{} port <iface> \
+                             vlan <vid>` (or steer that port `direction src`)",
+                            cidr.addr, cidr.prefix_len, cidr.addr, cidr.prefix_len
                         ),
                     ));
                 }
@@ -2034,7 +2232,8 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 .next()
                 .ok_or_else(|| ConfigError::parse(line, "port requires an interface"))?;
             validate_iface_name(line, "port", iface)?;
-            let usage = "port takes: <iface> cores <n> steer on|off [vlans <id>[,<id>...]]";
+            let usage = "port takes: <iface> cores <n> steer on|off [vlans <id>[,<id>...]] \
+                         [direction src|dst|both]";
             if rest.next() != Some("cores") {
                 return Err(ConfigError::parse(line, usage));
             }
@@ -2055,30 +2254,39 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 _ => return Err(ConfigError::parse(line, "steer expects on|off")),
             };
             let mut vlans: Vec<u16> = Vec::new();
-            match rest.next() {
-                None => {}
-                Some("vlans") => {
-                    let csv = rest.next().ok_or_else(|| {
-                        ConfigError::parse(line, "vlans requires a comma-separated id list")
+            let mut direction: Option<VppSteerDirection> = None;
+            let mut tail = rest.next();
+            if tail == Some("vlans") {
+                let csv = rest.next().ok_or_else(|| {
+                    ConfigError::parse(line, "vlans requires a comma-separated id list")
+                })?;
+                for tok in csv.split(',') {
+                    let vid: u16 = tok.parse().map_err(|_| {
+                        ConfigError::parse(line, "vlans ids must be integers 1-4094")
                     })?;
-                    for tok in csv.split(',') {
-                        let vid: u16 = tok.parse().map_err(|_| {
-                            ConfigError::parse(line, "vlans ids must be integers 1-4094")
-                        })?;
-                        // 0 is priority-tagged, 4095 reserved; neither
-                        // names a subinterface anything can classify to.
-                        if !(1..=4094).contains(&vid) {
-                            return Err(ConfigError::parse(line, "vlans ids must be 1-4094"));
-                        }
-                        if vlans.contains(&vid) {
-                            return Err(ConfigError::parse(line, "duplicate vlan id"));
-                        }
-                        vlans.push(vid);
+                    // 0 is priority-tagged, 4095 reserved; neither
+                    // names a subinterface anything can classify to.
+                    if !(1..=4094).contains(&vid) {
+                        return Err(ConfigError::parse(line, "vlans ids must be 1-4094"));
                     }
+                    if vlans.contains(&vid) {
+                        return Err(ConfigError::parse(line, "duplicate vlan id"));
+                    }
+                    vlans.push(vid);
                 }
-                Some(_) => return Err(ConfigError::parse(line, usage)),
+                tail = rest.next();
             }
-            if rest.next().is_some() {
+            if tail == Some("direction") {
+                let tok = rest
+                    .next()
+                    .ok_or_else(|| ConfigError::parse(line, "direction expects src|dst|both"))?;
+                let d: VppSteerDirection = tok
+                    .parse()
+                    .map_err(|e: String| ConfigError::parse(line, e))?;
+                direction = Some(d);
+                tail = rest.next();
+            }
+            if tail.is_some() {
                 return Err(ConfigError::parse(line, usage));
             }
             Ok(ModuleDirective::VppPort {
@@ -2086,6 +2294,7 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 cores,
                 steer,
                 vlans,
+                direction,
                 line,
             })
         }
@@ -2107,6 +2316,39 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
                 .map_err(|e: String| format!("loopback-address: {e}"))?;
             Ok(ModuleDirective::VppLoopbackAddress(p))
         }),
+        "local-route" => {
+            // local-route <v4-cidr> port <iface> vlan <vid>
+            let usage = "local-route takes: <v4-cidr> port <iface> vlan <vid>";
+            let cidr_tok = rest.next().ok_or_else(|| ConfigError::parse(line, usage))?;
+            if rest.next() != Some("port") {
+                return Err(ConfigError::parse(line, usage));
+            }
+            let iface = rest.next().ok_or_else(|| ConfigError::parse(line, usage))?;
+            validate_iface_name(line, "local-route", iface)?;
+            if rest.next() != Some("vlan") {
+                return Err(ConfigError::parse(line, usage));
+            }
+            let vid: u16 = rest
+                .next()
+                .ok_or_else(|| ConfigError::parse(line, usage))?
+                .parse()
+                .map_err(|_| ConfigError::parse(line, "vlan id must be an integer 1-4094"))?;
+            if !(1..=4094).contains(&vid) {
+                return Err(ConfigError::parse(line, "vlan id must be 1-4094"));
+            }
+            if rest.next().is_some() {
+                return Err(ConfigError::parse(line, usage));
+            }
+            let prefix: Ipv4Prefix = cidr_tok
+                .parse()
+                .map_err(|e: String| ConfigError::parse(line, format!("local-route: {e}")))?;
+            Ok(ModuleDirective::VppLocalRoute {
+                prefix,
+                iface: iface.to_string(),
+                vlan: vid,
+                line,
+            })
+        }
         "steer-exempt" => parse_single_arg(line, rest, "steer-exempt", |t| {
             let p: Ipv4Prefix = t
                 .parse()
@@ -3285,6 +3527,209 @@ module fast-path
         ] {
             assert!(Config::parse(bad).is_err(), "should reject: {bad}");
         }
+    }
+
+    #[test]
+    fn vpp_port_direction_parses() {
+        // With and without a vlans clause; absent = None (global wins).
+        let s = "module vpp-offload\n  port eth3 cores 1 steer off direction dst\n\
+                 port eth4 cores 1 steer off vlans 88,1337 direction src\n\
+                 port eth5 cores 1 steer off\n";
+        let c = Config::parse(s).unwrap();
+        match &c.modules[0].directives[0] {
+            ModuleDirective::VppPort { direction, .. } => {
+                assert_eq!(*direction, Some(VppSteerDirection::Dst));
+            }
+            other => panic!("expected VppPort, got {other:?}"),
+        }
+        match &c.modules[0].directives[1] {
+            ModuleDirective::VppPort {
+                vlans, direction, ..
+            } => {
+                assert_eq!(vlans, &[88, 1337]);
+                assert_eq!(*direction, Some(VppSteerDirection::Src));
+            }
+            other => panic!("expected VppPort, got {other:?}"),
+        }
+        match &c.modules[0].directives[2] {
+            ModuleDirective::VppPort { direction, .. } => assert_eq!(*direction, None),
+            other => panic!("expected VppPort, got {other:?}"),
+        }
+        for bad in [
+            "module vpp-offload\n  port eth3 cores 1 steer off direction\n",
+            "module vpp-offload\n  port eth3 cores 1 steer off direction inbound\n",
+            // direction must follow vlans, not precede it
+            "module vpp-offload\n  port eth3 cores 1 steer off direction dst vlans 88\n",
+            "module vpp-offload\n  port eth3 cores 1 steer off direction dst extra\n",
+        ] {
+            assert!(Config::parse(bad).is_err(), "should reject: {bad}");
+        }
+    }
+
+    #[test]
+    fn local_route_parses_and_rejects_malformed() {
+        let s = "module vpp-offload\n  local-route 23.191.200.0/24 port eth4 vlan 1337\n";
+        let c = Config::parse(s).unwrap();
+        match &c.modules[0].directives[0] {
+            ModuleDirective::VppLocalRoute {
+                prefix,
+                iface,
+                vlan,
+                ..
+            } => {
+                assert_eq!(prefix.addr, std::net::Ipv4Addr::new(23, 191, 200, 0));
+                assert_eq!(prefix.prefix_len, 24);
+                assert_eq!(iface, "eth4");
+                assert_eq!(*vlan, 1337);
+            }
+            other => panic!("expected VppLocalRoute, got {other:?}"),
+        }
+        for bad in [
+            "module vpp-offload\n  local-route\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 port eth4\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 port eth4 vlan\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 port eth4 vlan 0\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 port eth4 vlan 4095\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 vlan 1337 port eth4\n",
+            "module vpp-offload\n  local-route not-a-cidr port eth4 vlan 1337\n",
+            "module vpp-offload\n  local-route 23.191.200.0/24 port eth4 vlan 1337 x\n",
+        ] {
+            assert!(Config::parse(bad).is_err(), "should reject: {bad}");
+        }
+    }
+
+    /// The structural rules hold with steering off everywhere: the
+    /// attached route and neighbour mirror install at attach, so a
+    /// broken declaration is a broken attach.
+    #[test]
+    fn local_route_cross_validation() {
+        let base = "module fast-path\n  attach eth4 generic\n  local-prefix 23.191.200.0/24 via br1337\n\n\
+                    module vpp-offload\n  loopback-address 198.51.100.254/32\n";
+
+        // Happy: port declares the vlan, prefix inside the local-prefix.
+        let good = format!(
+            "{base}  port eth4 cores 1 steer off vlans 1337\n  \
+             local-route 23.191.200.0/24 port eth4 vlan 1337\n"
+        );
+        Config::parse(&good)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap();
+
+        // Port named by the local-route has no port line.
+        let no_port = format!(
+            "{base}  port eth4 cores 1 steer off vlans 1337\n  \
+             local-route 23.191.200.0/24 port eth9 vlan 1337\n"
+        );
+        let e = Config::parse(&no_port)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(format!("{e}").contains("no `port eth9` line"), "{e}");
+
+        // The port exists but does not declare the vlan.
+        let no_vlan = format!(
+            "{base}  port eth4 cores 1 steer off vlans 88\n  \
+             local-route 23.191.200.0/24 port eth4 vlan 1337\n"
+        );
+        let e = Config::parse(&no_vlan)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(format!("{e}").contains("does not declare vlan 1337"), "{e}");
+
+        // Not inside any fast-path local-prefix: tier disagreement.
+        let no_lp = format!(
+            "{base}  port eth4 cores 1 steer off vlans 1337\n  \
+             local-route 198.18.0.0/24 port eth4 vlan 1337\n"
+        );
+        let e = Config::parse(&no_lp)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(format!("{e}").contains("local-prefix"), "{e}");
+
+        // Overlapping local-routes: refused.
+        let overlap = format!(
+            "{base}  port eth4 cores 1 steer off vlans 88,1337\n  \
+             local-route 23.191.200.0/24 port eth4 vlan 1337\n  \
+             local-route 23.191.200.0/25 port eth4 vlan 88\n"
+        );
+        let e = Config::parse(&overlap)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(format!("{e}").contains("overlaps"), "{e}");
+    }
+
+    /// dst steering into VPP without local delivery for a steerable
+    /// local prefix is a 100%-inbound blackhole (the w20 shape), so it
+    /// is a load-time refusal. Pure transit needs no local-routes.
+    #[test]
+    fn dst_direction_requires_local_route_coverage() {
+        let fp = "module fast-path\n  forwarding-mode custom-fib\n  attach eth3 generic\n  \
+                  attach eth4 generic\n  allow-prefix 23.191.200.0/24\n  \
+                  local-prefix 23.191.200.0/24 via br1337\n\n";
+        let vpp_base = "module vpp-offload\n  loopback-address 198.51.100.254/32\n  \
+                        port eth3 cores 1 steer on direction dst\n";
+
+        // dst steering, steerable local prefix, no local-route: refused.
+        let uncovered = format!("{fp}{vpp_base}  port eth4 cores 1 steer off vlans 1337\n");
+        let e = Config::parse(&uncovered)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap_err();
+        assert!(format!("{e}").contains("not fully covered"), "{e}");
+
+        // Same but covered: valid.
+        let covered = format!(
+            "{fp}{vpp_base}  port eth4 cores 1 steer off vlans 1337\n  \
+             local-route 23.191.200.0/24 port eth4 vlan 1337\n"
+        );
+        Config::parse(&covered)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap();
+
+        // Partial tiling: one /25 present, the other missing → refused;
+        // both present → the pair covers the /24 and it is valid.
+        let half = format!(
+            "{fp}{vpp_base}  port eth4 cores 1 steer off vlans 88,1337\n  \
+             local-route 23.191.200.0/25 port eth4 vlan 1337\n"
+        );
+        assert!(Config::parse(&half)
+            .unwrap()
+            .validate_vpp_offload()
+            .is_err());
+        let tiled = format!(
+            "{fp}{vpp_base}  port eth4 cores 1 steer off vlans 88,1337\n  \
+             local-route 23.191.200.0/25 port eth4 vlan 1337\n  \
+             local-route 23.191.200.128/25 port eth4 vlan 88\n"
+        );
+        Config::parse(&tiled)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap();
+
+        // src steering never needs coverage.
+        let src = format!(
+            "{fp}module vpp-offload\n  loopback-address 198.51.100.254/32\n  \
+             port eth3 cores 1 steer on direction src\n  port eth4 cores 1 steer off\n"
+        );
+        Config::parse(&src).unwrap().validate_vpp_offload().unwrap();
+
+        // dst steering with no local prefix in the allowlist's path
+        // (pure transit): nothing to cover, valid. The global default
+        // direction (`both`) triggers coverage exactly like `dst`.
+        let transit = "module fast-path\n  forwarding-mode custom-fib\n  attach eth3 generic\n  \
+                       allow-prefix 198.18.0.0/15\n\n\
+                       module vpp-offload\n  loopback-address 198.51.100.254/32\n  \
+                       port eth3 cores 1 steer on\n";
+        Config::parse(transit)
+            .unwrap()
+            .validate_vpp_offload()
+            .unwrap();
     }
 
     #[test]

--- a/crates/modules/vpp-offload/Cargo.toml
+++ b/crates/modules/vpp-offload/Cargo.toml
@@ -16,3 +16,11 @@ serde_json = { workspace = true }
 # macOS dev loop too, and one implementation of it beats a cfg-split pair
 # that can disagree.
 libc = { workspace = true }
+
+# B3 v1's bridge-FDB tripwire: one blocking AF_BRIDGE dump per minute.
+# The same message crates fast-path's resolver decodes with, minus
+# rtnetlink — this crate has no async runtime to park a connection on.
+[target.'cfg(target_os = "linux")'.dependencies]
+netlink-packet-core = { workspace = true }
+netlink-packet-route = { workspace = true }
+netlink-sys = "0.8"

--- a/crates/modules/vpp-offload/src/attach.rs
+++ b/crates/modules/vpp-offload/src/attach.rs
@@ -113,6 +113,12 @@ pub struct AttachedPort {
     /// report a device index, and nothing downstream needs it).
     pub dev_index: Option<u32>,
     pub sw_if_index: u32,
+    /// `(vlan id, sw_if_index)` for every dot1q subinterface this
+    /// port carries, created or adopted — in `vlans` declaration
+    /// order. These are what `local-route` attached routes and the
+    /// bridge neighbour mirror reference: a FIB path on the PARENT
+    /// index would transmit untagged and die on the trunk.
+    pub subifs: Vec<(u16, u32)>,
 }
 
 #[derive(Debug)]
@@ -308,11 +314,12 @@ pub fn attach_ports(
                 set_accept_macs(t, p, idx)?;
                 set_promisc_on(t, p, idx)?;
                 set_unnumbered(t, p, idx, loop_idx)?;
-                ensure_vlan_subifs(t, p, idx, loop_idx, &existing)?;
+                let subifs = ensure_vlan_subifs(t, p, idx, loop_idx, &existing)?;
                 out.push(AttachedPort {
                     port: p.port.clone(),
                     dev_index: None,
                     sw_if_index: idx,
+                    subifs,
                 });
                 continue;
             }
@@ -364,11 +371,12 @@ pub fn attach_ports(
         // A freshly created parent cannot have subifs, so the dump
         // taken before this pass is still the right reuse authority:
         // it can only say "not found", and every vid gets created.
-        ensure_vlan_subifs(t, p, sw_if_index, loop_idx, &existing)?;
+        let subifs = ensure_vlan_subifs(t, p, sw_if_index, loop_idx, &existing)?;
         out.push(AttachedPort {
             port: p.port.clone(),
             dev_index: Some(dev_index),
             sw_if_index,
+            subifs,
         });
     }
     Ok(out)
@@ -806,10 +814,11 @@ fn ensure_vlan_subifs(
     parent_idx: u32,
     loop_idx: u32,
     existing: &[Interface],
-) -> Result<(), AttachError> {
+) -> Result<Vec<(u16, u32)>, AttachError> {
     if p.vlans.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
+    let mut out = Vec::with_capacity(p.vlans.len());
     let parent_name = existing
         .iter()
         .find(|i| i.sw_if_index == parent_idx)
@@ -856,8 +865,9 @@ fn ensure_vlan_subifs(
             reused = reused.is_some(),
             "dot1q subif ready — tagged steered ingress classifies to ip4 instead of punting"
         );
+        out.push((vid, sub_idx));
     }
-    Ok(())
+    Ok(out)
 }
 
 /// Promiscuous mode on the member VF — a shared-LMAC VOTE, not a local

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -342,8 +342,8 @@ pub fn bring_up(
     // make an allowlist of more than eight v4 prefixes refuse to *attach*
     // — on a config whose ports are all `steer off`, where no rule would
     // ever be installed and the refusal decides nothing.
-    let wants_steer = cfg.ports.iter().any(|(_, _, steer, _)| *steer);
-    let steer_plan = if wants_steer {
+    let wants_steer = cfg.ports.iter().any(|(_, _, steer, _, _)| *steer);
+    if wants_steer {
         // An allowlist with nothing steerable in it is a config error,
         // and settling that needs no NIC — so it is settled BEFORE the
         // table query. Otherwise the operator's answer is whatever the
@@ -359,27 +359,38 @@ pub fn bring_up(
                 allowlist.len() - steerable
             ));
         }
-        RuleSet::plan(
-            allowlist,
-            &cfg.steer_exempts,
-            budget.clone(),
-            cfg.steer_direction,
-        )?
-    } else {
-        RuleSet::default()
-    };
+    }
 
     // Only the ports the operator asked to steer. `steer off` is the
     // designed staging state and the rollback landing zone, so a port
     // left off must get no rules at all — not rules that happen to be
     // unused. VF 0 because `acquire` creates exactly one per PF and
-    // reads it back through `virtfn0`.
-    let steer_ports: Vec<(String, u32)> = cfg
-        .ports
-        .iter()
-        .filter(|(_, _, steer, _)| *steer)
-        .map(|(iface, _, _, _)| (iface.clone(), 0u32))
-        .collect();
+    // reads it back through `virtfn0`. One planned rule set per
+    // DISTINCT effective direction (per-port `direction` falling back
+    // to the global), all drawn from the shared free-slot intersection
+    // — the same derivation `steering_target` performs on reconfigure,
+    // and it must stay the same arithmetic or attach and reload would
+    // disagree about what fits.
+    let mut steer_plans: Vec<(packetframe_common::config::VppSteerDirection, RuleSet)> = Vec::new();
+    let mut steer_targets: Vec<(String, u32, RuleSet)> = Vec::new();
+    for (iface, _, steer, _, dir) in &cfg.ports {
+        if !steer {
+            continue;
+        }
+        let d = dir.unwrap_or(cfg.steer_direction);
+        if !steer_plans.iter().any(|(pd, _)| *pd == d) {
+            steer_plans.push((
+                d,
+                RuleSet::plan(allowlist, &cfg.steer_exempts, budget.clone(), d)?,
+            ));
+        }
+        let plan = steer_plans
+            .iter()
+            .find(|(pd, _)| *pd == d)
+            .map(|(_, p)| p.clone())
+            .expect("planned above");
+        steer_targets.push((iface.clone(), 0u32, plan));
+    }
     // Every member port, unfiltered, so removal can attribute a
     // location's occupant on a port this config leaves unsteered. That
     // is not a hypothetical: a restart whose config turned a port off
@@ -390,9 +401,9 @@ pub fn bring_up(
     let member_ports: Vec<(String, u32)> = cfg
         .ports
         .iter()
-        .map(|(iface, _, _, _)| (iface.clone(), 0u32))
+        .map(|(iface, _, _, _, _)| (iface.clone(), 0u32))
         .collect();
-    let steering = NtupleSteering::new(member_ports, steer_ports, steer_plan);
+    let steering = NtupleSteering::new(member_ports, steer_targets);
 
     let workers = cfg.total_workers();
     let sizing = startup_conf::derive_sizing(cfg.expected_routes, workers)?;
@@ -406,7 +417,7 @@ pub fn bring_up(
     // management ssh dropped, birdc past its budget, and VPP itself
     // starved into a supervisor restart loop. Still pure/read-only —
     // a refused config must cost no sysfs writes.
-    let member_ifaces: Vec<String> = cfg.ports.iter().map(|(i, _, _, _)| i.clone()).collect();
+    let member_ifaces: Vec<String> = cfg.ports.iter().map(|(i, _, _, _, _)| i.clone()).collect();
     let mut vpp_cores = vec![core_map.main];
     vpp_cores.extend(&core_map.workers);
     let conflicts = cores::nic_irq_conflicts(
@@ -499,7 +510,7 @@ pub fn bring_up(
     let ports: Vec<(String, u16)> = cfg
         .ports
         .iter()
-        .map(|(iface, cores, _, _)| (iface.clone(), *cores))
+        .map(|(iface, cores, _, _, _)| (iface.clone(), *cores))
         .collect();
     // Mandatory, and checked in the pure phase so a config that cannot
     // forward costs no VF and no hugepage reservation.
@@ -529,7 +540,7 @@ pub fn bring_up(
     let port_vlans: Vec<(String, Vec<u16>)> = cfg
         .ports
         .iter()
-        .map(|(iface, _, _, vlans)| (iface.clone(), vlans.clone()))
+        .map(|(iface, _, _, vlans, _)| (iface.clone(), vlans.clone()))
         .collect();
     match finish(
         paths,
@@ -1154,7 +1165,7 @@ mod completeness_gate_tests {
 
     fn cfg(require: bool) -> VppOffloadConfig {
         VppOffloadConfig {
-            ports: vec![("eth1".into(), 1, false, vec![])],
+            ports: vec![("eth1".into(), 1, false, vec![], None)],
             vpp_binary: None,
             expected_routes: 1_600_000,
             hugepages: None,

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -277,6 +277,7 @@ fn completeness_gate(
 /// On any failure after acquisition, everything acquired is released
 /// before returning — a failed attach must leave the box as it found it,
 /// or say precisely what it could not hand back.
+#[allow(clippy::too_many_arguments)]
 pub fn bring_up(
     cfg: &VppOffloadConfig,
     paths: &AttachPaths,
@@ -285,6 +286,7 @@ pub fn bring_up(
     completeness: Option<Arc<packetframe_common::fib::TableCompleteness>>,
     feed_session: Option<Arc<packetframe_common::fib::FeedSession>>,
     budget: &McamBudget,
+    local_routes: &[crate::LocalRoute],
 ) -> Result<Attached, String> {
     // `require-table-complete on` with nothing publishing completeness
     // is refused at attach rather than discovered at the first canary
@@ -542,6 +544,7 @@ pub fn bring_up(
         feed_session,
         loopback,
         &port_vlans,
+        local_routes,
     ) {
         Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
@@ -614,6 +617,7 @@ fn finish(
     feed_session: Option<Arc<packetframe_common::fib::FeedSession>>,
     loopback: packetframe_common::config::Ipv4Prefix,
     port_vlans: &[(String, Vec<u16>)],
+    local_routes: &[crate::LocalRoute],
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
     // rewritten on every attach: it is a pure function of config, and
@@ -853,6 +857,7 @@ fn finish(
     // (see `service`), which is also why the resource owner is built in
     // here rather than passed in: it shares one record between the
     // identity store and the release seam through an `Rc`.
+    let local_routes = local_routes.to_vec();
     let factory: LoopFactory = Box::new(move || {
         let engine = ConvergenceEngine::new(
             api_socket_path,
@@ -862,7 +867,8 @@ fn finish(
             FamilyPolicy::V4Only,
             loopback,
         )
-        .with_recorded_indices(recorded);
+        .with_recorded_indices(recorded)
+        .with_local_routes(local_routes);
         // Counted before the record moves into the owner: the log line
         // below needs it, and reaching for it afterwards is what the
         // borrow checker just refused.
@@ -1154,6 +1160,7 @@ mod completeness_gate_tests {
             hugepages: None,
             require_table_complete: require,
             steer_exempts: vec![],
+            local_routes: vec![],
             steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -870,6 +870,12 @@ fn finish(
     // identity store and the release seam through an `Rc`.
     let local_routes = local_routes.to_vec();
     let factory: LoopFactory = Box::new(move || {
+        // The FDB tripwire's declarations, cloned out before the engine
+        // consumes the resolved set.
+        let fdb_declared: Vec<(u16, String)> = local_routes
+            .iter()
+            .map(|lr| (lr.vlan, lr.port.clone()))
+            .collect();
         let engine = ConvergenceEngine::new(
             api_socket_path,
             port_attach,
@@ -908,6 +914,18 @@ fn finish(
         // log is itself the diagnostic.
         #[cfg(target_os = "linux")]
         runtime.rx_mode_kick(Box::new(crate::runtime::AllmultiKick));
+        // The B3 v1 tripwire: installed exactly when local-routes exist,
+        // because it scans for hosts contradicting THEIR declarations —
+        // no declarations, nothing to contradict. Linux-only like the
+        // kick, and silent when absent for the same reason.
+        #[cfg(target_os = "linux")]
+        if !fdb_declared.is_empty() {
+            runtime.fdb_watch(Box::new(crate::fdb::KernelFdbWatch {
+                declared: fdb_declared,
+            }));
+        }
+        #[cfg(not(target_os = "linux"))]
+        let _ = fdb_declared;
         let initial = match adopted {
             Some(p) => {
                 // The API handshake MUST happen before the adoption is

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -47,8 +47,9 @@ use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
 use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
 use crate::vpp_api::generated::{
-    IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails, IpNeighborDump,
-    IpRoute, IpRouteDetails, IpRouteDump, IpTable, ADDRESS_IP4, ADDRESS_IP6,
+    FibPath, IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails,
+    IpNeighborDump, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails, IpRouteDump,
+    IpTable, ADDRESS_IP4, ADDRESS_IP6, FIB_API_PATH_FLAG_NONE, FIB_API_PATH_NH_PROTO_IP4,
     FIB_API_PATH_TYPE_NORMAL,
 };
 use crate::vpp_api::{Transport, TransportError};
@@ -272,6 +273,11 @@ pub struct ResyncPlan {
     /// Prefixes the ledger holds that the source no longer advertises.
     /// Non-zero after any outage during which routes were withdrawn.
     pub withdrawals: u64,
+    /// Mirror prefixes suppressed by a `local-route` this walk. Logged
+    /// so an operator reading the resync line can see the shadowing
+    /// working (the reference primary expects exactly its poisoned
+    /// host route here).
+    pub shadowed: u64,
 }
 
 /// What a verify pass concluded, and whether traffic may be diverted
@@ -387,6 +393,14 @@ pub enum EngineError {
         nexthop: IpAddr,
         retval: i32,
     },
+    /// A `local-route` attached route could not be installed. Fatal to
+    /// the attach rather than skippable: this prefix's delivery is the
+    /// declared reason the config steers at all, and dst steering may
+    /// be counting on it.
+    AttachedRouteFailed {
+        prefix: String,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for EngineError {
@@ -399,6 +413,11 @@ impl std::fmt::Display for EngineError {
                 f,
                 "VPP refused the static neighbour for {nexthop} (retval {retval}); \
                  every route through it would blackhole"
+            ),
+            Self::AttachedRouteFailed { prefix, detail } => write!(
+                f,
+                "the attached route for local-route {prefix} could not be installed \
+                 ({detail}); steered traffic to it would die at null-node"
             ),
         }
     }
@@ -422,6 +441,20 @@ pub struct ConvergenceEngine {
     transport: Option<Transport>,
 
     ports: Vec<PortAttach>,
+    /// Locally terminated prefixes VPP delivers itself: an attached
+    /// route onto the named port's dot1q subif, kernel neighbours on
+    /// the backing bridge mirrored as static neighbours, and the BGP
+    /// mirror's view INSIDE each prefix shadowed (skipped at resync
+    /// and in deltas). Restart-only config, resolved by the loader
+    /// against fast-path's `local-prefix` for the kernel device.
+    local_routes: Vec<crate::LocalRoute>,
+    /// Mirror prefixes currently suppressed by a `local-route` — kept
+    /// as a set so health can report a count that means "routes the
+    /// mirror carries that VPP deliberately does not", not a
+    /// monotonically growing skip tally. Entries leave when the mirror
+    /// withdraws them. Survives reconnects: it describes the mirror,
+    /// not the process.
+    shadowed: HashSet<IpPrefix>,
     /// The address the loopback holds; every member is unnumbered to it.
     loopback: packetframe_common::config::Ipv4Prefix,
     /// The loopback's index once created. `None` until the first attach
@@ -532,6 +565,8 @@ impl ConvergenceEngine {
             api_socket: api_socket.into(),
             transport: None,
             ports,
+            local_routes: Vec::new(),
+            shadowed: HashSet::new(),
             loopback,
             loop_index: None,
             recorded_indices: Vec::new(),
@@ -561,27 +596,49 @@ impl ConvergenceEngine {
         self
     }
 
-    // NOTE: there is deliberately no `add_vlan` here, even though
-    // [`NexthopMap`] supports VLAN nexthops.
-    //
-    // Teaching the mapping to return `NexthopTarget::Subif` is only half
-    // of it: FIB paths need the sub-interface's OWN `sw_if_index`, and
-    // nothing creates or discovers one. The generated API whitelist has
-    // no sub-interface message at all, so `PortIndex` could never gain a
-    // `(port, Some(vid))` entry — `build_paths` would return `None` for
-    // every route through that VLAN, the drainer would defer all of them
-    // forever, and the resync would burn the whole convergence budget
-    // installing nothing.
-    //
-    // An affordance that silently produces a permanently-deferred table
-    // is worse than a missing one, so it is missing. Re-enabling it means
-    // adding a sub-interface create message to the whitelist, calling it
-    // during attach, and recording the index VPP assigns.
-    //
-    // Not currently needed: the gate-0b nexthop histogram found exactly
-    // two egress devices across the whole table and no VLAN nexthops —
-    // the br1337/FDB-pin topology is a connected-route concern, not a BGP
-    // nexthop one.
+    /// Declare the locally terminated prefixes this engine delivers.
+    ///
+    /// This is the ONLY caller of [`NexthopMap::add_vlan`], and the
+    /// preconditions the old NOTE here demanded now hold by
+    /// construction: `create_vlan_subif` is whitelisted, attach creates
+    /// the subifs from the same config that names them here, and
+    /// `attach_devices` records the indices VPP assigns into
+    /// [`PortIndex`] under `(port, Some(vid))` — so a `Subif` target
+    /// resolves instead of deferring its routes forever. Registered at
+    /// construction because the VLAN policy is static config;
+    /// `forget_devices` deliberately keeps it.
+    pub fn with_local_routes(mut self, routes: Vec<crate::LocalRoute>) -> Self {
+        for lr in &routes {
+            self.nexthops
+                .add_vlan(lr.kernel_dev.clone(), lr.port.clone(), lr.vlan);
+        }
+        self.local_routes = routes;
+        self
+    }
+
+    /// Whether the mirror's view of `p` is suppressed by a local-route.
+    ///
+    /// The kernel tier delivers to bridge hosts BEFORE its FIB lookup,
+    /// so a mirrored route inside a locally delivered prefix describes
+    /// what bird would do, not what the box does — the reference
+    /// primary carries a service host route as `unreachable` in bird,
+    /// which the kernel path never consults and VPP would faithfully
+    /// blackhole with. Local delivery comes from the attached route +
+    /// neighbour mirror instead.
+    fn shadows(&self, p: &IpPrefix) -> bool {
+        let IpPrefix::V4 { addr, prefix_len } = p else {
+            return false;
+        };
+        self.local_routes.iter().any(|lr| {
+            lr.prefix.prefix_len <= *prefix_len
+                && lr.prefix.contains_addr(std::net::Ipv4Addr::from(*addr))
+        })
+    }
+
+    /// How many mirror prefixes a `local-route` is currently shadowing.
+    pub fn shadowed_routes(&self) -> u64 {
+        self.shadowed.len() as u64
+    }
 
     pub fn counts(&self) -> SinkCounts {
         self.ledger.counts()
@@ -855,8 +912,98 @@ impl ConvergenceEngine {
         // Only now, with VPP's own indices in hand.
         for p in &attached {
             self.port_index.insert(p.port.clone(), None, p.sw_if_index);
+            for &(vid, idx) in &p.subifs {
+                self.port_index.insert(p.port.clone(), Some(vid), idx);
+            }
         }
         self.attached = attached;
+        self.install_attached_routes()
+    }
+
+    /// Install one attached route per `local-route`, straight onto the
+    /// subif — deliberately OUTSIDE the pending/ledger path.
+    ///
+    /// These are module-owned topology, not mirror state: the resync
+    /// diff withdraws whatever the ledger holds that the source no
+    /// longer advertises, and an attached route is never advertised by
+    /// the source, so entering the ledger would get it withdrawn on
+    /// the very next resync. Not entering it is also what exempts it
+    /// from adoption's shape test (a nexthop-less route never looks
+    /// self-installed) — a restart over a live VPP re-sends it, and
+    /// VPP treats the identical add as an update.
+    ///
+    /// The nexthop-less NORMAL path on the subif is VPP's attached
+    /// route: dst inside the prefix resolves via the interface, with
+    /// per-host adjacencies coming from the mirrored static
+    /// neighbours (VPP never ARPs; a never-seen host drops here where
+    /// the kernel would ARP-queue — documented, service hosts are
+    /// static).
+    fn install_attached_routes(&mut self) -> Result<(), EngineError> {
+        if self.local_routes.is_empty() {
+            return Ok(());
+        }
+        let t = self.transport.as_mut().ok_or(EngineError::NotConnected)?;
+        for lr in &self.local_routes {
+            let target = crate::sink::NexthopTarget::Subif {
+                port: lr.port.clone(),
+                vlan: lr.vlan,
+            };
+            let Some(sw_if_index) = self.port_index.get(&target) else {
+                // Config guarantees the port declares this vlan, and
+                // attach just created every declared subif — a miss
+                // here is an ordering bug, not an operator error, and
+                // installing onto index 0 would route the prefix to
+                // local0.
+                return Err(EngineError::AttachedRouteFailed {
+                    prefix: format!("{}/{}", lr.prefix.addr, lr.prefix.prefix_len),
+                    detail: format!("no subif index for {}.{}", lr.port, lr.vlan),
+                });
+            };
+            let prefix = IpPrefix::V4 {
+                addr: lr.prefix.network().octets(),
+                prefix_len: lr.prefix.prefix_len,
+            };
+            let mut path = FibPath {
+                sw_if_index,
+                table_id: 0,
+                rpf_id: 0,
+                weight: 1,
+                preference: 0,
+                r#type: FIB_API_PATH_TYPE_NORMAL,
+                flags: FIB_API_PATH_FLAG_NONE,
+                proto: FIB_API_PATH_NH_PROTO_IP4,
+                nh: Default::default(),
+                n_labels: 0,
+                label_stack: Default::default(),
+            };
+            // Zero nexthop = attached: resolve via the interface.
+            path.nh = Default::default();
+            let reply: IpRouteAddDelReply = t.request(IpRouteAddDel {
+                context: 0,
+                is_add: true,
+                is_multipath: false,
+                route: IpRoute {
+                    table_id: 0,
+                    stats_index: 0,
+                    prefix: crate::fib_sync::to_prefix(prefix),
+                    n_paths: 1,
+                    paths: vec![path],
+                },
+            })?;
+            if reply.retval != 0 {
+                return Err(EngineError::AttachedRouteFailed {
+                    prefix: format!("{}/{}", lr.prefix.addr, lr.prefix.prefix_len),
+                    detail: format!("retval {}", reply.retval),
+                });
+            }
+            tracing::info!(
+                prefix = %format!("{}/{}", lr.prefix.addr, lr.prefix.prefix_len),
+                port = %lr.port,
+                vlan = lr.vlan,
+                sw_if_index,
+                "attached route installed — VPP delivers this prefix itself"
+            );
+        }
         Ok(())
     }
 
@@ -1301,6 +1448,17 @@ impl ConvergenceEngine {
             }
         }
         for (prefix, nhs) in changes.routes {
+            // Shadowed by a local-route: the mirror's view inside a
+            // locally delivered prefix never reaches the pending map,
+            // on the delta path exactly as at resync. The set tracks
+            // presence so health can count what is being suppressed.
+            if self.shadows(&prefix) {
+                match nhs {
+                    Some(_) => self.shadowed.insert(prefix),
+                    None => self.shadowed.remove(&prefix),
+                };
+                continue;
+            }
             match nhs {
                 Some(v) => self.pending.upsert(prefix, v),
                 None => self.pending.withdraw(prefix),
@@ -1411,7 +1569,19 @@ impl ConvergenceEngine {
         // alternative is an add-only resync that black-holes withdrawn
         // routes.
         let mut seen: HashSet<IpPrefix> = HashSet::with_capacity(1 << 20);
+        // Rebuilt from this walk, so a prefix the mirror dropped while
+        // we were not looking leaves the count too.
+        self.shadowed.clear();
         src.for_each_route(&mut |prefix, nexthops| {
+            if self.shadows(&prefix) {
+                // Deliberately NOT in `seen`: if the ledger holds a
+                // stale install of a shadowed prefix (a pre-local-route
+                // run, or adoption), the withdrawal loop below is what
+                // cleans it out of VPP.
+                self.shadowed.insert(prefix);
+                plan.shadowed += 1;
+                return;
+            }
             self.pending.upsert(prefix, nexthops.to_vec());
             seen.insert(prefix);
             plan.upserts += 1;
@@ -1442,6 +1612,16 @@ impl ConvergenceEngine {
         // Anything parked at the high-water mark gets another chance:
         // withdrawals in this same plan may have freed the headroom.
         self.pending.release_withheld();
+        if plan.shadowed > 0 {
+            // The operator-visible proof the shadowing is doing its
+            // job — the reference primary expects exactly its poisoned
+            // host route here, and a jump in this number is a mirror
+            // change worth reading about in `packetframe status`.
+            tracing::info!(
+                shadowed = plan.shadowed,
+                "local-route shadowing suppressed mirror routes this resync"
+            );
+        }
         plan
     }
 
@@ -1790,6 +1970,7 @@ mod tests {
             port: "eth4".into(),
             dev_index: Some(0),
             sw_if_index: 3,
+            subifs: vec![],
         });
         let m = mirror(4);
         e.begin_resync(&m);
@@ -2062,6 +2243,7 @@ mod tests {
             port: "eth4".into(),
             dev_index: Some(0),
             sw_if_index: 3,
+            subifs: vec![],
         });
         // No verify yet: nothing contradicts, so it reads up — bounded by
         // `nominal()` independently requiring a passing verify.

--- a/crates/modules/vpp-offload/src/engine.rs
+++ b/crates/modules/vpp-offload/src/engine.rs
@@ -47,10 +47,10 @@ use crate::sink::{Capacity, NexthopMap, PendingMap, RouteLedger, SinkCounts};
 use crate::status::PortLink;
 use crate::verify::{verify, VerifyOutcome, DEFAULT_SAMPLE};
 use crate::vpp_api::generated::{
-    FibPath, IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails,
-    IpNeighborDump, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails, IpRouteDump,
-    IpTable, ADDRESS_IP4, ADDRESS_IP6, FIB_API_PATH_FLAG_NONE, FIB_API_PATH_NH_PROTO_IP4,
-    FIB_API_PATH_TYPE_NORMAL,
+    CliInband, CliInbandReply, FibPath, IpNeighbor, IpNeighborAddDel, IpNeighborAddDelReply,
+    IpNeighborDetails, IpNeighborDump, IpRoute, IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails,
+    IpRouteDump, IpTable, ADDRESS_IP4, ADDRESS_IP6, FIB_API_PATH_FLAG_NONE,
+    FIB_API_PATH_NH_PROTO_IP4, FIB_API_PATH_TYPE_NORMAL,
 };
 use crate::vpp_api::{Transport, TransportError};
 
@@ -403,6 +403,22 @@ pub enum EngineError {
     },
 }
 
+/// Sum the `Count` column of `show errors` rows whose node is
+/// `null-node` — VPP's "matched a drop route / nothing to deliver to"
+/// counter, the residual the w23/w24 windows measured at ~370 pps of
+/// replies to spoofed and bogon sources. Column positions only
+/// (count, node, reason...), so a reason with spaces parses fine; any
+/// line that does not shape up is skipped rather than guessed at.
+pub(crate) fn parse_null_drops(text: &str) -> u64 {
+    text.lines()
+        .filter_map(|line| {
+            let mut tok = line.split_whitespace();
+            let count = tok.next()?.parse::<u64>().ok()?;
+            (tok.next()? == "null-node").then_some(count)
+        })
+        .sum()
+}
+
 impl std::fmt::Display for EngineError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -542,6 +558,15 @@ pub struct ConvergenceEngine {
     last_api_error: Option<String>,
     api_incompatible: bool,
 
+    /// Cumulative null-node drops as VPP last reported them over
+    /// `cli_inband "show errors"`. `None` until the first successful
+    /// sample and after any trouble — absent rather than 0, like the
+    /// freshness gauges, because a gauge that reads 0 while the read
+    /// path is broken hides exactly the change it exists to surface.
+    /// Metrics only; nothing here feeds a forwarding or supervision
+    /// decision.
+    null_drops: Option<u64>,
+
     /// Advanced once per verify so each pass samples a different set.
     ///
     /// Counter-derived rather than drawn from the OS, for the reason
@@ -585,6 +610,7 @@ impl ConvergenceEngine {
             last_verify: None,
             #[cfg(test)]
             test_dead_members: None,
+            null_drops: None,
             verify_seed: 0,
         }
     }
@@ -638,6 +664,44 @@ impl ConvergenceEngine {
     /// How many mirror prefixes a `local-route` is currently shadowing.
     pub fn shadowed_routes(&self) -> u64 {
         self.shadowed.len() as u64
+    }
+
+    /// The last sampled null-node drop total, if any.
+    pub fn null_drops(&self) -> Option<u64> {
+        self.null_drops
+    }
+
+    /// Sample VPP's error counters and cache the null-node total.
+    ///
+    /// Metrics only, so every failure degrades the gauge to absent and
+    /// none escalates: a counter read must not be able to restart a
+    /// forwarding VPP. A transport error still drops the socket — the
+    /// reply may be partly read, and every other path here refuses to
+    /// leave a poisoned stream looking healthy to `api_ready`.
+    pub fn sample_null_drops(&mut self) {
+        self.arm_timeout();
+        let Some(t) = self.transport.as_mut() else {
+            self.null_drops = None;
+            return;
+        };
+        match t.request::<CliInband, CliInbandReply>(CliInband {
+            context: 0,
+            cmd: "show errors".into(),
+        }) {
+            Ok(r) if r.retval == 0 => self.null_drops = Some(parse_null_drops(&r.reply)),
+            Ok(r) => {
+                tracing::debug!(
+                    retval = r.retval,
+                    "`show errors` refused; the null-drop gauge goes absent"
+                );
+                self.null_drops = None;
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "`show errors` failed; the null-drop gauge goes absent");
+                self.disconnect();
+                self.null_drops = None;
+            }
+        }
     }
 
     pub fn counts(&self) -> SinkCounts {
@@ -1763,6 +1827,9 @@ impl ConvergenceEngine {
     pub fn on_process_gone(&mut self) {
         self.disconnect();
         self.attached.clear();
+        // The counters died with the process; a stale total would read
+        // as "no new drops" across a restart that reset it to zero.
+        self.null_drops = None;
         self.port_index = PortIndex::default();
         // The state file's recorded indices belong to the dead instance
         // too. Keeping them meant the replacement process was handed
@@ -2231,6 +2298,21 @@ mod tests {
             crate::liveness::PING_BUDGET,
             "a steered resync forwards the whole time and cannot afford it"
         );
+    }
+
+    /// The `show errors` parser: column-positional, null-node rows
+    /// summed, everything malformed skipped rather than guessed at.
+    /// The sample text is the w24 forensics shape.
+    #[test]
+    fn null_drop_parsing_sums_null_node_rows_only() {
+        let text =
+            "   Count                    Node                  Reason               Severity\n\
+                    117015               null-node             blackholed packets         error\n\
+                    12                   null-node             blackholed packets         error\n\
+                    52755             ethernet-input           unknown vlan               error\n\
+                    not-a-count          null-node             garbage                    error\n";
+        assert_eq!(parse_null_drops(text), 117_027);
+        assert_eq!(parse_null_drops(""), 0);
     }
 
     /// Link state must come from an observation. An earlier version

--- a/crates/modules/vpp-offload/src/fdb.rs
+++ b/crates/modules/vpp-offload/src/fdb.rs
@@ -1,0 +1,317 @@
+//! B3 v1: the bridge-FDB tripwire for `local-route` port declarations.
+//!
+//! A `local-route` names THE member port a service VLAN's hosts sit
+//! behind, and B1's attached route delivers every packet for the
+//! prefix onto that one port's subif. That is correct for the
+//! reference topology (every service host behind the eth4 trunk) and
+//! wrong the day a host moves behind another member of the same
+//! bridge — the kernel's per-VLAN FDB would deliver to the new port,
+//! VPP would keep transmitting out the declared one, and nothing
+//! would say so.
+//!
+//! v1 is OBSERVABILITY ONLY, by decision (2026-08-15): a periodic
+//! AF_BRIDGE FDB scan that flags any non-permanent entry for a
+//! declared VLAN learned on a different member port, named host by
+//! host on the health surface. Per-host subif selection (v2) is real
+//! work deliberately deferred until this tripwire ever fires — the
+//! user's topology says hosts could straddle eth4/eth5, and this is
+//! what turns "could" into a fact before inbound goes always-on.
+//!
+//! The scan is kernel-side and read-only: one RTM_GETNEIGH dump on a
+//! blocking netlink socket, no tokio (this crate's control plane is
+//! the supervision loop, not a runtime), rate-limited by the caller
+//! the same way the steering audit is. A scan failure costs a log
+//! line and keeps the previous verdict; it must never escalate into
+//! supervision.
+
+/// One AF_BRIDGE FDB entry, reduced to what the comparison needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FdbEntry {
+    pub mac: [u8; 6],
+    /// NDA_VLAN; `None` for VLAN-unaware entries.
+    pub vlan: Option<u16>,
+    /// The member port the kernel learned the MAC on.
+    pub port: u32,
+    /// NDA_MASTER — the bridge whose FDB this is. Entries without one
+    /// are port-local ("self") records, not bridge paths.
+    pub master: Option<u32>,
+    /// NUD_PERMANENT: interface addresses and static plumbing, not
+    /// learned hosts. A bridge holds its own MAC as permanent on a
+    /// member; flagging those would page on every box ever built.
+    pub permanent: bool,
+}
+
+/// One declared scope, resolved to ifindexes for comparison: hosts on
+/// `vlan` (in `master`'s FDB) must be learned on `port`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeclaredScope {
+    pub vlan: u16,
+    pub port: u32,
+    pub master: u32,
+}
+
+/// The pure half: which entries contradict a declaration.
+///
+/// An entry is misplaced iff it is a learned (non-permanent) bridge
+/// path for a declared VLAN, in the declared bridge's FDB, on a port
+/// other than the declared one. Everything else — other VLANs, other
+/// bridges, self entries, permanent entries, the declared port itself
+/// — is somebody else's business.
+pub fn misplaced_entries<'a>(
+    entries: &'a [FdbEntry],
+    declared: &[DeclaredScope],
+) -> Vec<(&'a FdbEntry, DeclaredScope)> {
+    let mut out = Vec::new();
+    for e in entries {
+        if e.permanent {
+            continue;
+        }
+        let (Some(vlan), Some(master)) = (e.vlan, e.master) else {
+            continue;
+        };
+        if let Some(scope) = declared
+            .iter()
+            .find(|d| d.vlan == vlan && d.master == master)
+        {
+            if e.port != scope.port {
+                out.push((e, *scope));
+            }
+        }
+    }
+    out
+}
+
+/// The scan seam the runtime holds, mirroring [`crate::runtime::RxModeKick`]:
+/// a trait so tests record calls and non-Linux builds never pretend.
+pub trait FdbWatch {
+    /// Human-readable line per misplaced host, empty when the
+    /// declarations hold. `Err` = the kernel would not answer; the
+    /// caller keeps its previous verdict.
+    fn misplaced(&mut self) -> Result<Vec<String>, String>;
+}
+
+/// The production scan: resolve each declared `(vlan, port)` against
+/// the live interface table, dump the bridge FDB, compare.
+///
+/// Resolution happens per scan, not at construction — a UniFi
+/// provisioning cycle can recreate interfaces, and a cached ifindex
+/// would compare against a table it no longer names. A declared port
+/// with no bridge master is skipped rather than an error: on a
+/// non-bridge deployment there is no FDB to disagree with.
+#[cfg(target_os = "linux")]
+pub struct KernelFdbWatch {
+    /// `(vlan, port name)` straight from the resolved local-routes.
+    pub declared: Vec<(u16, String)>,
+}
+
+#[cfg(target_os = "linux")]
+impl FdbWatch for KernelFdbWatch {
+    fn misplaced(&mut self) -> Result<Vec<String>, String> {
+        let mut scopes = Vec::with_capacity(self.declared.len());
+        for (vlan, port) in &self.declared {
+            let Some(port_idx) = ifindex(port) else {
+                // The declared port vanished — a louder fact than a
+                // misplaced host, but the attach that depends on it
+                // is the surface that reports it. Skip here.
+                continue;
+            };
+            let Some(master_idx) = master_ifindex(port) else {
+                continue; // not enslaved: no bridge FDB to scan
+            };
+            scopes.push(DeclaredScope {
+                vlan: *vlan,
+                port: port_idx,
+                master: master_idx,
+            });
+        }
+        if scopes.is_empty() {
+            return Ok(Vec::new());
+        }
+        let entries = dump_bridge_fdb()?;
+        Ok(misplaced_entries(&entries, &scopes)
+            .into_iter()
+            .map(|(e, scope)| {
+                format!(
+                    "{} vlan {} learned on {} (local-route declares {})",
+                    hex_mac(&e.mac),
+                    scope.vlan,
+                    ifname(e.port),
+                    ifname(scope.port),
+                )
+            })
+            .collect())
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ifindex(name: &str) -> Option<u32> {
+    let c = std::ffi::CString::new(name).ok()?;
+    // SAFETY: `c` is NUL-terminated and outlives the call.
+    match unsafe { libc::if_nametoindex(c.as_ptr()) } {
+        0 => None,
+        n => Some(n),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn ifname(index: u32) -> String {
+    let mut buf = [0u8; libc::IF_NAMESIZE];
+    // SAFETY: `buf` is IF_NAMESIZE bytes as the contract requires.
+    let ret = unsafe { libc::if_indextoname(index, buf.as_mut_ptr().cast()) };
+    if ret.is_null() {
+        return format!("ifindex {index}");
+    }
+    let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8_lossy(&buf[..len]).into_owned()
+}
+
+#[cfg(target_os = "linux")]
+fn master_ifindex(port: &str) -> Option<u32> {
+    // The master symlink's target name, resolved to an index — the
+    // same sysfs fact `port_macs` reads the address through.
+    let link = std::fs::read_link(format!("/sys/class/net/{port}/master")).ok()?;
+    ifindex(link.file_name()?.to_str()?)
+}
+
+#[cfg(target_os = "linux")]
+fn hex_mac(mac: &[u8; 6]) -> String {
+    mac.iter()
+        .map(|b| format!("{b:02x}"))
+        .collect::<Vec<_>>()
+        .join(":")
+}
+
+/// One blocking AF_BRIDGE RTM_GETNEIGH dump.
+///
+/// Hand-rolled on `netlink-sys` rather than `rtnetlink` because this
+/// crate has no async runtime to park a connection on, and one dump
+/// per minute does not earn one. The message shapes are the same
+/// crates fast-path's resolver decodes with.
+#[cfg(target_os = "linux")]
+pub fn dump_bridge_fdb() -> Result<Vec<FdbEntry>, String> {
+    use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+    use netlink_packet_route::neighbour::{NeighbourAttribute, NeighbourMessage, NeighbourState};
+    use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
+    use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+
+    let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    socket
+        .bind_auto()
+        .map_err(|e| format!("netlink bind: {e}"))?;
+    socket
+        .connect(&SocketAddr::new(0, 0))
+        .map_err(|e| format!("netlink connect: {e}"))?;
+
+    let mut neigh = NeighbourMessage::default();
+    neigh.header.family = AddressFamily::Bridge;
+    let mut msg = NetlinkMessage::from(RouteNetlinkMessage::GetNeighbour(neigh));
+    msg.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    msg.header.sequence_number = 1;
+    msg.finalize();
+    let mut send_buf = vec![0u8; msg.header.length as usize];
+    msg.serialize(&mut send_buf);
+    socket
+        .send(&send_buf, 0)
+        .map_err(|e| format!("netlink send: {e}"))?;
+
+    let mut out = Vec::new();
+    let mut recv_buf = vec![0u8; 64 * 1024];
+    'dump: loop {
+        let n = socket
+            .recv(&mut &mut recv_buf[..], 0)
+            .map_err(|e| format!("netlink recv: {e}"))?;
+        let mut offset = 0usize;
+        while offset < n {
+            let pkt = NetlinkMessage::<RouteNetlinkMessage>::deserialize(&recv_buf[offset..n])
+                .map_err(|e| format!("netlink parse: {e}"))?;
+            let len = pkt.header.length as usize;
+            if len == 0 {
+                break;
+            }
+            match pkt.payload {
+                NetlinkPayload::Done(_) => break 'dump,
+                NetlinkPayload::Error(e) => return Err(format!("netlink error: {e}")),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewNeighbour(m)) => {
+                    let mut mac = None;
+                    let mut vlan = None;
+                    let mut master = None;
+                    for attr in &m.attributes {
+                        match attr {
+                            NeighbourAttribute::LinkLayerAddress(bytes) if bytes.len() == 6 => {
+                                let mut m6 = [0u8; 6];
+                                m6.copy_from_slice(bytes);
+                                mac = Some(m6);
+                            }
+                            NeighbourAttribute::Vlan(v) => vlan = Some(*v),
+                            NeighbourAttribute::Controller(idx) => master = Some(*idx),
+                            _ => {}
+                        }
+                    }
+                    if let Some(mac) = mac {
+                        out.push(FdbEntry {
+                            mac,
+                            vlan,
+                            port: m.header.ifindex,
+                            master,
+                            permanent: m.header.state == NeighbourState::Permanent,
+                        });
+                    }
+                }
+                _ => {}
+            }
+            offset += len;
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(mac_last: u8, vlan: Option<u16>, port: u32, master: Option<u32>) -> FdbEntry {
+        FdbEntry {
+            mac: [0x02, 0, 0, 0, 0, mac_last],
+            vlan,
+            port,
+            master,
+            permanent: false,
+        }
+    }
+
+    /// The tripwire fires on exactly the moved-host shape and nothing
+    /// else: other VLANs, other bridges, self entries, permanent
+    /// entries and the declared port are all somebody else's business.
+    #[test]
+    fn only_learned_entries_for_a_declared_scope_on_the_wrong_port_fire() {
+        let declared = [DeclaredScope {
+            vlan: 1337,
+            port: 4, // eth4
+            master: 10,
+        }];
+        let moved = entry(7, Some(1337), 5, Some(10)); // behind eth5: fires
+        let mut permanent = entry(1, Some(1337), 5, Some(10));
+        permanent.permanent = true;
+        let entries = vec![
+            entry(7, Some(1337), 4, Some(10)), // declared port: fine
+            moved.clone(),                     // wrong port: fires
+            entry(8, Some(88), 5, Some(10)),   // undeclared vlan: fine
+            entry(9, Some(1337), 5, Some(11)), // other bridge: fine
+            entry(10, Some(1337), 5, None),    // self entry: fine
+            entry(11, None, 5, Some(10)),      // vlan-unaware: fine
+            permanent,                         // interface address: fine
+        ];
+        let hits = misplaced_entries(&entries, &declared);
+        assert_eq!(hits.len(), 1, "{hits:?}");
+        assert_eq!(hits[0].0, &moved);
+        assert_eq!(hits[0].1, declared[0]);
+    }
+
+    /// No declarations, no verdicts — the scan must be inert on a
+    /// config without local-routes.
+    #[test]
+    fn no_declarations_flags_nothing() {
+        let entries = vec![entry(7, Some(1337), 5, Some(10))];
+        assert!(misplaced_entries(&entries, &[]).is_empty());
+    }
+}

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -120,6 +120,29 @@ pub struct VppOffloadConfig {
     /// `steer` is a reconcile, so a change installs/removes exactly
     /// the delta — including the rollback direction.
     pub steer_direction: packetframe_common::config::VppSteerDirection,
+    /// `(prefix, port, vlan)` per `local-route` line, in config order —
+    /// the section's own view, used for the restart-only comparison.
+    /// The loader-resolved form (with the kernel bridge device joined
+    /// in from fast-path's `local-prefix`) is [`LocalRoute`], installed
+    /// via [`VppOffloadModule::set_local_routes`]. Restart-only: the
+    /// attached route and the subif it lands on are attach-time work.
+    pub local_routes: Vec<(packetframe_common::config::Ipv4Prefix, String, u16)>,
+}
+
+/// One `local-route`, resolved for the engine: the config triple plus
+/// the kernel device whose neighbours mirror onto the subif.
+///
+/// `kernel_dev` is not in the module's own section — it is the `via`
+/// of the fast-path `local-prefix` covering `prefix` (validation
+/// guarantees exactly that cover exists). The loader performs the join
+/// because `Module` methods only see their own section; same reason
+/// the allowlist is a handle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalRoute {
+    pub prefix: packetframe_common::config::Ipv4Prefix,
+    pub port: String,
+    pub vlan: u16,
+    pub kernel_dev: String,
 }
 
 /// Default sizing input when `expected-routes` is absent.
@@ -159,6 +182,12 @@ impl VppOffloadConfig {
                 ModuleDirective::VppLoopbackAddress(p) => out.loopback_address = Some(*p),
                 ModuleDirective::VppSteerExempt(p) => out.steer_exempts.push(*p),
                 ModuleDirective::VppSteerDirection(d) => out.steer_direction = *d,
+                ModuleDirective::VppLocalRoute {
+                    prefix,
+                    iface,
+                    vlan,
+                    ..
+                } => out.local_routes.push((*prefix, iface.clone(), *vlan)),
                 _ => {}
             }
         }
@@ -263,6 +292,14 @@ impl VppOffloadConfig {
                 "`vpp-binary` changed ({:?} → {:?}); the running VPP is the one that was \
                  spawned — restart to apply",
                 self.vpp_binary, new.vpp_binary
+            ));
+        }
+        if self.local_routes != new.local_routes {
+            return Err(format!(
+                "the `local-route` lines changed ({:?} → {:?}); the attached route, its \
+                 subif, and the neighbour-mirror wiring are installed at attach — restart \
+                 to apply",
+                self.local_routes, new.local_routes
             ));
         }
         // Restart-only for a different reason than everything above:
@@ -596,6 +633,9 @@ pub struct VppOffloadModule {
     /// held. `packetframe detach --all` retries, so that is the likely
     /// path, not a hypothetical one.
     teardown_failure: Option<String>,
+    /// Loader-resolved `local-route` set (config triple + kernel bridge
+    /// device). See [`Self::set_local_routes`].
+    local_routes: Vec<LocalRoute>,
 }
 
 impl VppOffloadModule {
@@ -611,6 +651,7 @@ impl VppOffloadModule {
             attached: None,
             teardown_pending: None,
             teardown_failure: None,
+            local_routes: Vec::new(),
         }
     }
 
@@ -645,6 +686,18 @@ impl VppOffloadModule {
     /// for why a snapshot is wrong on exactly the SIGHUP path.
     pub fn set_allowlist(&mut self, allowlist: std::sync::Arc<SharedAllowlist>) {
         self.allowlist = allowlist;
+    }
+
+    /// Hand the module its resolved `local-route` set.
+    ///
+    /// A setter for the same reason the allowlist is one: the kernel
+    /// bridge device each prefix's neighbours mirror from is the `via`
+    /// of the fast-path `local-prefix` covering it, and only the loader
+    /// sees both sections. A plain Vec rather than a shared handle
+    /// because `local-route` is restart-only — there is no SIGHUP path
+    /// that could make a snapshot stale.
+    pub fn set_local_routes(&mut self, routes: Vec<LocalRoute>) {
+        self.local_routes = routes;
     }
 
     /// Hand the module the route mirror's completeness handle.
@@ -944,6 +997,24 @@ impl Module for VppOffloadModule {
             Ok(b) => b,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
         };
+        // The loader resolves `local-route` against fast-path's
+        // `local-prefix` and hands the result to `set_local_routes`.
+        // A section carrying lines the module was never handed means
+        // that wiring is missing — refused loudly here rather than
+        // attaching a VPP that silently skips the delivery this config
+        // exists to provide (the published-is-not-read class).
+        if self.cfg.local_routes.len() != self.local_routes.len() {
+            return Err(ModuleError::other(
+                MODULE_NAME,
+                format!(
+                    "config declares {} local-route line(s) but the loader resolved {} — \
+                     set_local_routes was not wired; refusing to attach without the local \
+                     delivery the config promises",
+                    self.cfg.local_routes.len(),
+                    self.local_routes.len()
+                ),
+            ));
+        }
         let attached = match bringup::bring_up(
             &self.cfg,
             &paths,
@@ -952,6 +1023,7 @@ impl Module for VppOffloadModule {
             self.completeness.clone(),
             self.feed_session.clone(),
             &budget,
+            &self.local_routes,
         ) {
             Ok(a) => a,
             Err(e) => return Err(ModuleError::other(MODULE_NAME, e)),
@@ -1583,6 +1655,7 @@ mod tests {
             hugepages: None,
             require_table_complete: true,
             steer_exempts: vec![],
+            local_routes: vec![],
             steer_direction: Default::default(),
             loopback_address: Some(packetframe_common::config::Ipv4Prefix {
                 addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
@@ -1677,6 +1750,7 @@ mod tests {
                     cores: 1,
                     steer: false,
                     vlans: vec![],
+                    direction: None,
                     line: 1,
                 },
                 ModuleDirective::VppRequireTableComplete(require),
@@ -1897,6 +1971,23 @@ mod tests {
             .restart_only_delta(&binary)
             .expect_err("vpp-binary")
             .contains("`vpp-binary` changed"));
+
+        // local-route: the attached route and its subif are installed
+        // at attach, so an edited line must refuse the reload — a
+        // reconfigure that reported OK while VPP kept delivering the
+        // old footprint would be the silent-divergence shape above.
+        let mut lr = base.clone();
+        lr.local_routes.push((
+            packetframe_common::config::Ipv4Prefix {
+                addr: std::net::Ipv4Addr::new(23, 191, 200, 0),
+                prefix_len: 24,
+            },
+            "eth4".into(),
+            1337,
+        ));
+        let e = base.restart_only_delta(&lr).expect_err("local-route");
+        assert!(e.contains("`local-route` lines changed"), "{e}");
+        assert!(e.contains("restart"), "{e}");
     }
 
     /// A reordered port list is a change, not a permutation.

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -78,7 +78,7 @@ pub mod vpp_api;
 #[cfg(target_os = "linux")]
 mod probe_linux;
 
-use packetframe_common::config::ModuleDirective;
+use packetframe_common::config::{ModuleDirective, VppSteerDirection};
 use packetframe_common::module::{
     Attachment, HealthCtx, HealthReport, HookUse, LoaderCtx, MetricsWriter, Module, ModuleConfig,
     ModuleError, ModuleResult,
@@ -90,8 +90,11 @@ pub const MODULE_NAME: &str = "vpp-offload";
 /// Parsed view of the module's section, extracted once at load.
 #[derive(Debug, Clone, Default)]
 pub struct VppOffloadConfig {
-    /// (iface, cores, steer, vlans) in config order.
-    pub ports: Vec<(String, u16, bool, Vec<u16>)>,
+    /// One entry per `port` line, in config order. The direction is
+    /// the per-port override; `None` defers to the global
+    /// `steer_direction`. Hot like the steer flag — rules reconcile on
+    /// reconfigure.
+    pub ports: Vec<PortLine>,
     pub vpp_binary: Option<String>,
     pub expected_routes: u64,
     pub hugepages: Option<u32>,
@@ -145,6 +148,9 @@ pub struct LocalRoute {
     pub kernel_dev: String,
 }
 
+/// One parsed `port` line: `(iface, cores, steer, vlans, direction)`.
+pub type PortLine = (String, u16, bool, Vec<u16>, Option<VppSteerDirection>);
+
 /// Default sizing input when `expected-routes` is absent.
 ///
 /// Measured 2026-08-02 on the reference fleet: ~1.30M nexthops across
@@ -171,10 +177,11 @@ impl VppOffloadConfig {
                     cores,
                     steer,
                     vlans,
+                    direction,
                     ..
                 } => out
                     .ports
-                    .push((iface.clone(), *cores, *steer, vlans.clone())),
+                    .push((iface.clone(), *cores, *steer, vlans.clone(), *direction)),
                 ModuleDirective::VppBinary(p) => out.vpp_binary = Some(p.clone()),
                 ModuleDirective::ExpectedRoutes(n) => out.expected_routes = *n,
                 ModuleDirective::VppHugepages(n) => out.hugepages = Some(*n),
@@ -249,12 +256,12 @@ impl VppOffloadConfig {
         let old_ports: Vec<(&str, u16, &[u16])> = self
             .ports
             .iter()
-            .map(|(i, c, _, v)| (i.as_str(), *c, v.as_slice()))
+            .map(|(i, c, _, v, _)| (i.as_str(), *c, v.as_slice()))
             .collect();
         let new_ports: Vec<(&str, u16, &[u16])> = new
             .ports
             .iter()
-            .map(|(i, c, _, v)| (i.as_str(), *c, v.as_slice()))
+            .map(|(i, c, _, v, _)| (i.as_str(), *c, v.as_slice()))
             .collect();
         if old_ports != new_ports {
             return Err(format!(
@@ -337,7 +344,7 @@ impl VppOffloadConfig {
     pub fn total_workers(&self) -> u32 {
         self.ports
             .iter()
-            .map(|(_, cores, _, _)| u32::from(*cores))
+            .map(|(_, cores, _, _, _)| u32::from(*cores))
             .sum()
     }
 }
@@ -433,8 +440,8 @@ fn reload_collateral(old: &VppOffloadConfig, new: &VppOffloadConfig) -> String {
     // ended up, which this snapshot cannot see.
     let mut rolled_back: Vec<&str> = Vec::new();
     let mut turned_on: Vec<&str> = Vec::new();
-    for (iface, _, was, _) in &old.ports {
-        let Some((_, _, now, _)) = new.ports.iter().find(|(i, _, _, _)| i == iface) else {
+    for (iface, _, was, _, _) in &old.ports {
+        let Some((_, _, now, _, _)) = new.ports.iter().find(|(i, _, _, _, _)| i == iface) else {
             continue;
         };
         match (was, now) {
@@ -526,18 +533,21 @@ fn ifaces_to_query<'a>(
     }
     cfg.ports
         .iter()
-        .filter(|(_, _, steer, _)| *steer)
-        .map(|(iface, _, _, _)| iface.as_str())
+        .filter(|(_, _, steer, _, _)| *steer)
+        .map(|(iface, _, _, _, _)| iface.as_str())
         .collect()
 }
 
 /// What steering should look like for a config + allowlist.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SteeringTarget {
-    /// `(PF iface, VF index)` for every port configured `steer on`.
-    pub ports: Vec<(String, u32)>,
-    /// The rules those ports should hold. Empty when nothing steers.
-    pub plan: steer::RuleSet,
+    /// `(PF iface, VF index, rules)` for every port configured
+    /// `steer on`. Per-port rule sets because direction is per-port —
+    /// the bidirectional service edge steers `src` on the trunk and
+    /// `dst` on the transits, and each side's rules differ. Ports
+    /// sharing a direction share one planned set (same slot numbers on
+    /// every NIC; slots are per-interface, so that costs nothing).
+    pub targets: Vec<(String, u32, steer::RuleSet)>,
     /// Whether traffic should be diverted once the target is in place.
     pub want_steer: bool,
 }
@@ -561,38 +571,61 @@ fn steering_target(
     allowlist: &[packetframe_common::fib::IpPrefix],
 ) -> Result<SteeringTarget, String> {
     // VF 0 because `acquire` creates exactly one per PF.
-    let ports: Vec<(String, u32)> = cfg
+    let ports: Vec<(String, u32, VppSteerDirection)> = cfg
         .ports
         .iter()
-        .filter(|(_, _, steer, _)| *steer)
-        .map(|(iface, _, _, _)| (iface.clone(), 0u32))
+        .filter(|(_, _, steer, _, _)| *steer)
+        .map(|(iface, _, _, _, dir)| (iface.clone(), 0u32, dir.unwrap_or(cfg.steer_direction)))
         .collect();
-    let want_steer = !ports.is_empty();
-    if !want_steer {
+    if ports.is_empty() {
         // Nothing to install and nothing that reads a plan. An empty
         // target is also the truthful one: no port steers.
         return Ok(SteeringTarget {
-            ports,
-            plan: steer::RuleSet::default(),
+            targets: Vec::new(),
             want_steer: false,
         });
     }
-    let budget = steer::McamBudget::for_ifaces(ports.iter().map(|(iface, _)| iface.as_str()))?;
-    let plan = steer::RuleSet::plan(allowlist, &cfg.steer_exempts, budget, cfg.steer_direction)?;
+    let budget = steer::McamBudget::for_ifaces(ports.iter().map(|(iface, _, _)| iface.as_str()))?;
+    // One plan per DISTINCT effective direction, all drawn from the
+    // shared free-slot intersection so a location number names the
+    // same slot on every steering port. Locations are per-interface,
+    // so ports of different directions reusing the same numbers do
+    // not collide — and each port's budget requirement is its OWN
+    // plan's size, not the union's.
+    let mut plans: Vec<(VppSteerDirection, steer::RuleSet)> = Vec::new();
+    for (_, _, d) in &ports {
+        if !plans.iter().any(|(pd, _)| pd == d) {
+            plans.push((
+                *d,
+                steer::RuleSet::plan(allowlist, &cfg.steer_exempts, budget.clone(), *d)?,
+            ));
+        }
+    }
     // `steer on` with nothing steerable is refused for the same reason
     // `bring_up` refuses it: steering would divert nothing while every
-    // surface reported it on.
-    if plan.rules.is_empty() {
+    // surface reported it on. All plans share the allowlist, so one
+    // empty means all empty.
+    if plans.iter().all(|(_, p)| p.rules.is_empty()) {
+        let skipped = plans.first().map_or(0, |(_, p)| p.skipped_v6);
         return Err(format!(
             "port(s) are configured `steer on`, but the allowlist produces no steerable \
-             rules ({} IPv6 prefix(es) skipped — `ip6` ntuple is rejected by this NIC). \
-             Steering would divert nothing while reporting Healthy",
-            plan.skipped_v6
+             rules ({skipped} IPv6 prefix(es) skipped — `ip6` ntuple is rejected by this \
+             NIC). Steering would divert nothing while reporting Healthy"
         ));
     }
+    let targets = ports
+        .into_iter()
+        .map(|(iface, vf, d)| {
+            let plan = plans
+                .iter()
+                .find(|(pd, _)| *pd == d)
+                .map(|(_, p)| p.clone())
+                .expect("every port's direction was planned above");
+            (iface, vf, plan)
+        })
+        .collect();
     Ok(SteeringTarget {
-        ports,
-        plan,
+        targets,
         want_steer: true,
     })
 }
@@ -1100,11 +1133,11 @@ impl Module for VppOffloadModule {
             .cfg
             .ports
             .iter()
-            .map(|(_, _, steer, _)| *steer)
-            .ne(new.ports.iter().map(|(_, _, steer, _)| *steer));
+            .map(|(_, _, steer, _, _)| *steer)
+            .ne(new.ports.iter().map(|(_, _, steer, _, _)| *steer));
         attached
             .service
-            .apply_steering(target.ports, target.plan, target.want_steer, lever_moved)
+            .apply_steering(target.targets, target.want_steer, lever_moved)
             .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
         // Recorded only after the change landed. A `cfg` updated ahead of
         // the apply would make the NEXT reconfigure diff against a target
@@ -1256,7 +1289,7 @@ pub fn run_feasibility_probes(
     workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
-    direction: packetframe_common::config::VppSteerDirection,
+    directions: &[packetframe_common::config::VppSteerDirection],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Vec<Capability> {
     #[cfg(target_os = "linux")]
@@ -1266,7 +1299,7 @@ pub fn run_feasibility_probes(
             workers,
             vpp_binary,
             allowlist,
-            direction,
+            directions,
             steer_exempts,
         )
     }
@@ -1277,7 +1310,7 @@ pub fn run_feasibility_probes(
             workers,
             vpp_binary,
             allowlist,
-            direction,
+            directions,
             steer_exempts,
         );
         Vec::new()
@@ -1353,8 +1386,8 @@ mod tests {
     fn nothing_steerable_means_no_nic_is_asked() {
         let cfg = VppOffloadConfig {
             ports: vec![
-                ("eth4".into(), 1, true, vec![]),
-                ("eth5".into(), 1, false, vec![]),
+                ("eth4".into(), 1, true, vec![], None),
+                ("eth5".into(), 1, false, vec![], None),
             ],
             ..VppOffloadConfig::default()
         };
@@ -1648,7 +1681,7 @@ mod tests {
         VppOffloadConfig {
             ports: ports
                 .iter()
-                .map(|(i, c, s)| (i.to_string(), *c, *s, vec![]))
+                .map(|(i, c, s)| (i.to_string(), *c, *s, vec![], None))
                 .collect(),
             vpp_binary: None,
             expected_routes: routes,
@@ -2081,14 +2114,60 @@ mod tests {
         // budget it does not spend.
         let off = cfg(&[("eth4", 1, false)], 1_600_000);
         let t = steering_target(&off, &allow).expect("rollback must be possible");
-        assert!(t.ports.is_empty() && !t.want_steer);
-        assert!(
-            t.plan.rules.is_empty(),
-            "and it carries an empty target, which is what no port steering means"
-        );
+        assert!(t.targets.is_empty() && !t.want_steer);
     }
 
     /// A `steer on` port with a v6-only allowlist is refused, not
+    /// The bidirectional service edge: per-port `direction` yields
+    /// per-port plans — src diverts on the trunk, dst diverts on the
+    /// transit — with the built-in Keep exemptions on both, drawn from
+    /// one shared free-slot intersection.
+    #[test]
+    fn per_port_direction_yields_per_port_plans() {
+        use crate::steer::{RuleAction, Side};
+        let mut on = cfg(&[("eth3", 1, true), ("eth4", 1, true)], 1_600_000);
+        on.ports[0].4 = Some(packetframe_common::config::VppSteerDirection::Dst);
+        on.ports[1].4 = Some(packetframe_common::config::VppSteerDirection::Src);
+        let allow = vec![packetframe_common::fib::IpPrefix::V4 {
+            addr: [23, 191, 200, 0],
+            prefix_len: 24,
+        }];
+        let t = steering_target(&on, &allow).expect("both plans fit");
+        assert!(t.want_steer);
+        assert_eq!(t.targets.len(), 2);
+        let plan_of = |iface: &str| {
+            &t.targets
+                .iter()
+                .find(|(i, _, _)| i == iface)
+                .expect("port present")
+                .2
+        };
+        let (eth3, eth4) = (plan_of("eth3"), plan_of("eth4"));
+        let diverts = |p: &steer::RuleSet| {
+            p.rules
+                .iter()
+                .filter(|r| r.action == RuleAction::Divert)
+                .copied()
+                .collect::<Vec<_>>()
+        };
+        let d3 = diverts(eth3);
+        let d4 = diverts(eth4);
+        assert_eq!(d3.len(), 1, "dst = one divert per prefix: {d3:?}");
+        assert_eq!(d4.len(), 1, "src = one divert per prefix: {d4:?}");
+        assert!(d3.iter().all(|r| r.side == Side::Dst), "{d3:?}");
+        assert!(d4.iter().all(|r| r.side == Side::Src), "{d4:?}");
+        for (name, plan) in [("eth3", eth3), ("eth4", eth4)] {
+            assert_eq!(
+                plan.rules
+                    .iter()
+                    .filter(|r| r.action == RuleAction::Keep)
+                    .count(),
+                2,
+                "{name} must carry the built-in broadcast+multicast keeps"
+            );
+        }
+    }
+
     /// silently accepted as steering nothing.
     #[test]
     fn steer_on_with_nothing_steerable_is_refused() {

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -58,6 +58,7 @@ pub mod cores;
 pub mod driver;
 pub mod engine;
 pub mod executor;
+pub mod fdb;
 pub mod feed;
 pub mod fib_sync;
 pub mod liveness;

--- a/crates/modules/vpp-offload/src/ntuple.rs
+++ b/crates/modules/vpp-offload/src/ntuple.rs
@@ -906,13 +906,17 @@ pub struct NtupleSteering {
     /// the set of PFs and their VFs cannot move under a running module,
     /// and `retarget` must not touch this.
     members: Vec<(String, u32)>,
-    /// `(PF iface, VF index)` for every port configured `steer on`.
+    /// `(PF iface, VF index, rules)` for every port configured
+    /// `steer on`.
     ///
     /// A list because steering is per-port — it is the canary lever, and
     /// the rollout turns it one port at a time — and because each PF
     /// steers into *its own* VF, so the ring_cookie differs per entry.
-    ports: Vec<(String, u32)>,
-    plan: RuleSet,
+    /// The rules ride per-port too, because direction is per-port: the
+    /// bidirectional service edge installs `src` rules on the trunk and
+    /// `dst` rules on the transits, and every routine below asks "what
+    /// does THIS port hold" rather than assuming one shared plan.
+    targets: Vec<(String, u32, RuleSet)>,
     /// `(iface, location)` currently installed. Per-iface because the
     /// same location number exists on every PF, and removing one from
     /// the wrong interface would leave traffic steered while reporting
@@ -942,7 +946,7 @@ pub struct NtupleSteering {
     /// `None` after a restart: the state file records locations, not
     /// what they were installed to hold, so ownership falls back to
     /// occupancy — see the non-member arm of `missing_from_nic`.
-    installed_as: Option<(Vec<(String, u32)>, RuleSet)>,
+    installed_as: Option<Vec<(String, u32, RuleSet)>>,
 }
 
 impl NtupleSteering {
@@ -952,11 +956,10 @@ impl NtupleSteering {
     /// that know the acquisition, and a `steering.set_members(..)` one
     /// of them forgets is precisely how `adopt_installed` shipped with
     /// no caller at all (#127).
-    pub fn new(members: Vec<(String, u32)>, ports: Vec<(String, u32)>, plan: RuleSet) -> Self {
+    pub fn new(members: Vec<(String, u32)>, targets: Vec<(String, u32, RuleSet)>) -> Self {
         Self {
             members,
-            ports,
-            plan,
+            targets,
             installed: Vec::new(),
             installed_as: None,
         }
@@ -974,13 +977,22 @@ impl NtupleSteering {
         let found = self
             .members
             .iter()
-            .chain(self.ports.iter())
-            .find(|(i, _)| i == iface);
-        if let Some((_, vf)) = found {
-            return Some(*vf);
+            .find(|(i, _)| i == iface)
+            .map(|(_, v)| *v)
+            .or_else(|| {
+                self.targets
+                    .iter()
+                    .find(|(i, _, _)| i == iface)
+                    .map(|(_, v, _)| *v)
+            });
+        if let Some(vf) = found {
+            return Some(vf);
         }
-        let (ports, _) = self.installed_as.as_ref()?;
-        ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v)
+        let installed_as = self.installed_as.as_ref()?;
+        installed_as
+            .iter()
+            .find(|(i, _, _)| i == iface)
+            .map(|(_, v, _)| *v)
     }
 
     /// Read a ledger location and decide what removal owes it.
@@ -1024,10 +1036,8 @@ impl NtupleSteering {
     /// — the spec [`Self::occupant`] compares a cookie-zero occupant
     /// against before claiming it.
     fn planned_keep_at(&self, iface: &str, loc: u32) -> Option<crate::steer::SteerRule> {
-        let (ports, plan) = self.installed_as.as_ref()?;
-        if !ports.iter().any(|(i, _)| i == iface) {
-            return None;
-        }
+        let installed_as = self.installed_as.as_ref()?;
+        let (_, _, plan) = installed_as.iter().find(|(i, _, _)| i == iface)?;
         plan.rules
             .iter()
             .find(|r| r.location == loc && r.action == crate::steer::RuleAction::Keep)
@@ -1249,12 +1259,13 @@ impl NtupleSteering {
         got: &RxFlowSpec,
         consumed: &mut std::collections::HashMap<String, Vec<bool>>,
     ) -> bool {
-        let Some((ports, plan)) = &self.installed_as else {
+        let Some(installed_as) = &self.installed_as else {
             return false;
         };
-        let Some(vf) = ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v) else {
+        let Some((_, vf, plan)) = installed_as.iter().find(|(i, _, _)| i == iface) else {
             return false;
         };
+        let vf = *vf;
         let taken = consumed
             .entry(iface.to_string())
             .or_insert_with(|| vec![false; plan.rules.len()]);
@@ -1279,9 +1290,9 @@ impl NtupleSteering {
 
     /// What the NIC should hold, from the current ports and plan.
     fn desired(&self) -> Vec<(String, u32)> {
-        let mut out = Vec::with_capacity(self.ports.len() * self.plan.rules.len());
-        for (iface, _) in &self.ports {
-            for rule in &self.plan.rules {
+        let mut out = Vec::new();
+        for (iface, _, plan) in &self.targets {
+            for rule in &plan.rules {
                 out.push((iface.clone(), rule.location));
             }
         }
@@ -1291,7 +1302,7 @@ impl NtupleSteering {
 
 impl crate::runtime::Steering for NtupleSteering {
     fn configured_ports(&self) -> usize {
-        self.ports.len()
+        self.targets.len()
     }
 
     fn steer(&mut self) -> Result<SteerOutcome, String> {
@@ -1314,7 +1325,11 @@ impl crate::runtime::Steering for NtupleSteering {
         // that as a clean "nothing steered" would retire the want and
         // hide a broken allowlist behind the same line a deliberate
         // `steer off` prints.
-        if !self.ports.is_empty() && self.plan.rules.is_empty() {
+        if self
+            .targets
+            .iter()
+            .any(|(_, _, plan)| plan.rules.is_empty())
+        {
             return Err(
                 "nothing to steer: the allowlist produced no rules for this NIC (see \
                  `packetframe feasibility`, capability `vpp.steering.budget`)"
@@ -1355,8 +1370,8 @@ impl crate::runtime::Steering for NtupleSteering {
             ));
         }
 
-        for (iface, vf_index) in &self.ports {
-            for rule in &self.plan.rules {
+        for (iface, vf_index, plan) in &self.targets {
+            for rule in &plan.rules {
                 if let Err(e) = insert(iface, rule, *vf_index) {
                     // All-or-nothing. A partially steered port divides
                     // traffic between the tiers along a line nobody chose,
@@ -1397,7 +1412,7 @@ impl crate::runtime::Steering for NtupleSteering {
         // intent that never reached the NIC must not overwrite this —
         // that is what made a second refused reconfigure disown rules
         // that were really there.
-        self.installed_as = Some((self.ports.clone(), self.plan.clone()));
+        self.installed_as = Some(self.targets.clone());
         // From the LEDGER, not from `ports.is_empty()`. The ledger is
         // the postcondition the caller acts on — it is what
         // `steering_in_place` reads and what the state file records —
@@ -1474,7 +1489,11 @@ impl crate::runtime::Steering for NtupleSteering {
 
         for (iface, loc) in &self.installed {
             // `None` = the current target does not steer this port.
-            let member = self.ports.iter().find(|(i, _)| i == iface).map(|(_, v)| *v);
+            let member = self
+                .targets
+                .iter()
+                .find(|(i, _, _)| i == iface)
+                .map(|(_, v, plan)| (*v, plan));
             let mut check = Rxnfc {
                 cmd: ETHTOOL_GRXCLSRULE,
                 fs: RxFlowSpec {
@@ -1517,16 +1536,16 @@ impl crate::runtime::Steering for NtupleSteering {
                     }
                 }
                 Ok(()) => {
-                    let vf = member.expect("the arm above takes the non-member case");
+                    let (vf, plan) = member.expect("the arm above takes the non-member case");
                     let taken = consumed
                         .entry(iface.as_str())
-                        .or_insert_with(|| vec![false; self.plan.rules.len()]);
+                        .or_insert_with(|| vec![false; plan.rules.len()]);
                     // Candidates are stamped with the location being
                     // CHECKED, not the one planned: `matches` compares
                     // `location`, and on an adopted start the planner
                     // chose different slots by construction, so an
                     // unstamped expectation can never match.
-                    let found = self.plan.rules.iter().enumerate().position(|(i, r)| {
+                    let found = plan.rules.iter().enumerate().position(|(i, r)| {
                         !taken[i]
                             && audit_matches(
                                 &RxFlowSpec {
@@ -1616,10 +1635,9 @@ impl crate::runtime::Steering for NtupleSteering {
         // Only reachable with a non-empty ledger — the caller skips the
         // audit otherwise — so this cannot fire on a port that has simply
         // never steered.
-        for (iface, vf) in &self.ports {
+        for (iface, vf, plan) in &self.targets {
             let taken = consumed.get(iface.as_str());
-            let homeless: Vec<&SteerRule> = self
-                .plan
+            let homeless: Vec<&SteerRule> = plan
                 .rules
                 .iter()
                 .enumerate()
@@ -1714,9 +1732,8 @@ impl crate::runtime::Steering for NtupleSteering {
         self.installed.clone()
     }
 
-    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: RuleSet) {
-        self.ports = ports;
-        self.plan = plan;
+    fn retarget(&mut self, targets: Vec<(String, u32, RuleSet)>) {
+        self.targets = targets;
     }
 }
 
@@ -1963,7 +1980,7 @@ mod tests {
         );
 
         // Every port `steer off`.
-        s.retarget(Vec::new(), RuleSet::default());
+        s.retarget(Vec::new());
         assert_eq!(
             s.steer()
                 .expect("an empty target is reconcilable, not a fault"),
@@ -1977,6 +1994,56 @@ mod tests {
                 .is_empty(),
             "the rules must be gone from the NIC, not merely forgotten by the ledger"
         );
+    }
+
+    /// Mixed directions install each port's OWN rules — src diverts on
+    /// one iface, dst diverts on the other — audit clean under the
+    /// per-port plans, and unsteer clears both NICs. The shape w27
+    /// steers: `src` on the service trunk, `dst` on a transit.
+    #[test]
+    fn mixed_direction_targets_install_each_ports_own_rules() {
+        use crate::runtime::Steering as _;
+        use crate::steer::McamBudget;
+        use packetframe_common::config::VppSteerDirection;
+        use packetframe_common::fib::IpPrefix;
+        sys::reset();
+
+        let allow = [IpPrefix::V4 {
+            addr: [23, 191, 200, 0],
+            prefix_len: 24,
+        }];
+        let src = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Src)
+            .expect("src plan");
+        let dst = RuleSet::plan(&allow, &[], McamBudget::default(), VppSteerDirection::Dst)
+            .expect("dst plan");
+        let mut s = NtupleSteering::new(
+            vec![("eth0".into(), 0), ("eth1".into(), 0)],
+            vec![
+                ("eth0".into(), 0, dst.clone()),
+                ("eth1".into(), 0, src.clone()),
+            ],
+        );
+        assert_eq!(s.steer().expect("installs"), SteerOutcome::Steered);
+        // Each NIC holds exactly its own plan's rule count — not the
+        // union's, which is what a shared plan would have installed.
+        for (iface, plan) in [("eth0", &dst), ("eth1", &src)] {
+            assert_eq!(
+                sys::rule_table(iface).expect("fake answers").occupied.len(),
+                plan.rules.len(),
+                "{iface} must hold its own direction's rules only"
+            );
+        }
+        let audit = s.missing_from_nic().expect("read the NIC");
+        assert_eq!(audit.missing, Vec::new(), "{:?}", audit.missing);
+        assert_eq!(audit.stray, Vec::new(), "{:?}", audit.stray);
+
+        s.unsteer().expect("clears both");
+        for iface in ["eth0", "eth1"] {
+            assert!(
+                sys::rule_table(iface).expect("fake").occupied.is_empty(),
+                "{iface} must be clean after unsteer"
+            );
+        }
     }
 
     /// A rule the NIC will not delete still refuses, even under an
@@ -1996,7 +2063,7 @@ mod tests {
         let stuck: Vec<u32> = s.installed().iter().map(|(_, loc)| *loc).collect();
         sys::wedge_delete(&stuck);
 
-        s.retarget(Vec::new(), RuleSet::default());
+        s.retarget(Vec::new());
         let e = s
             .steer()
             .expect_err("a rule that would not come out is still steering");
@@ -2314,7 +2381,7 @@ mod tests {
         assert_eq!(a.stray, Vec::new(), "both ports are in the target");
 
         // `steer off` on eth1, and the reconciling steer never runs.
-        s.retarget(vec![("eth0".into(), 0)], plan);
+        s.retarget(uniform(vec![("eth0".into(), 0)], plan));
 
         let a = s.missing_from_nic().expect("read the NIC");
         assert_eq!(
@@ -2401,7 +2468,7 @@ mod tests {
             plan_for(&[[198, 18, 0, 0], [203, 0, 113, 0]]),
         );
         live.adopt_installed(inherited);
-        live.retarget(vec![("eth0".into(), 0)], one);
+        live.retarget(uniform(vec![("eth0".into(), 0)], one));
         let a = live.missing_from_nic().expect("read the NIC");
         assert_eq!(a.missing, Vec::new(), "{:?}", a.missing);
         assert_eq!(a.stray.len(), owed, "{:?}", a.stray);
@@ -2467,7 +2534,7 @@ mod tests {
         // outgoing target is known. Same two facts.
         let mut live = steering(vec![("eth0".into(), 0)], plan_for(&[A, B]));
         live.adopt_installed(inherited);
-        live.retarget(vec![("eth0".into(), 0)], plan_for(&[B, C]));
+        live.retarget(uniform(vec![("eth0".into(), 0)], plan_for(&[B, C])));
         let a = live.missing_from_nic().expect("read the NIC");
         assert_eq!(a.missing.len(), per_prefix, "{:?}", a.missing);
         assert_eq!(a.stray.len(), per_prefix, "{:?}", a.stray);
@@ -2501,8 +2568,10 @@ mod tests {
         // Two reconfigures, neither reconciled — the supervisor refused
         // both at the completeness gate, so `steer` never ran again and
         // the NIC still holds A.
-        s.retarget(vec![("eth0".into(), 0)], plan_for(&[B]));
-        s.retarget(vec![("eth0".into(), 0)], plan_for(&[C]));
+        let c_plan = plan_for(&[C]);
+        let c_rules = c_plan.rules.len();
+        s.retarget(uniform(vec![("eth0".into(), 0)], plan_for(&[B])));
+        s.retarget(uniform(vec![("eth0".into(), 0)], c_plan));
 
         let a = s.missing_from_nic().expect("read the NIC");
         assert_eq!(
@@ -2515,7 +2584,7 @@ mod tests {
         );
         assert_eq!(
             a.missing.len(),
-            s.plan.rules.len(),
+            c_rules,
             "and C, which was never installed, is still absent: {:?}",
             a.missing
         );
@@ -2549,7 +2618,7 @@ mod tests {
         assert!(eth1.len() >= 2, "the fixture needs two rules on eth1");
 
         // `steer off` on eth1, reconcile refused — the round-13 state.
-        s.retarget(vec![("eth0".into(), 0)], plan);
+        s.retarget(uniform(vec![("eth0".into(), 0)], plan));
         assert_eq!(
             s.missing_from_nic().expect("read").stray.len(),
             eth1.len(),
@@ -2817,7 +2886,10 @@ mod tests {
 
         // Down to one prefix: 13 and 12 are stale. Somebody else takes 13
         // while the daemon is not looking.
-        s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        s.retarget(uniform(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0]]),
+        ));
         sys::replace_behind_back("eth0", 13);
         s.steer().expect("reconciles");
 
@@ -3035,8 +3107,7 @@ mod tests {
         // not a steering target, and nothing was installed this process.
         let mut after = NtupleSteering::new(
             vec![("eth0".into(), 0), ("eth1".into(), 0)],
-            vec![("eth0".into(), 0)],
-            plan,
+            uniform(vec![("eth0".into(), 0)], plan),
         );
         after.adopt_installed(inherited);
         assert!(
@@ -3080,7 +3151,7 @@ mod tests {
         let inherited = before.installed();
 
         // No ports at all: the shape a caller with only a location list has.
-        let mut blind = NtupleSteering::new(Vec::new(), Vec::new(), RuleSet::default());
+        let mut blind = NtupleSteering::new(Vec::new(), Vec::new());
         blind.adopt_installed(inherited);
         blind.unsteer().expect("removes what the ledger names");
         assert!(sys::rules().is_empty());
@@ -3161,7 +3232,16 @@ mod tests {
     /// The cases that differ pass the two lists explicitly, because that
     /// difference is the thing under test.
     fn steering(ports: Vec<(String, u32)>, plan: RuleSet) -> NtupleSteering {
-        NtupleSteering::new(ports.clone(), ports, plan)
+        NtupleSteering::new(ports.clone(), uniform(ports, plan))
+    }
+
+    /// Pair every port with one shared rule set — the pre-per-port
+    /// shape, which is what most of these fixtures mean.
+    fn uniform(ports: Vec<(String, u32)>, plan: RuleSet) -> Vec<(String, u32, RuleSet)> {
+        ports
+            .into_iter()
+            .map(|(i, v)| (i, v, plan.clone()))
+            .collect()
     }
 
     /// The DIVERSION half of a plan only. These tests assert reconcile
@@ -3315,7 +3395,10 @@ mod tests {
         assert_eq!(sys::rules().len(), 4);
 
         // Down to one prefix: slots 13/12 are no longer wanted.
-        s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        s.retarget(uniform(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0]]),
+        ));
         s.steer().expect("reconciles");
 
         assert_eq!(
@@ -3346,7 +3429,10 @@ mod tests {
         s.steer().expect("installs four");
 
         sys::wedge_delete(&[13]);
-        s.retarget(vec![("eth0".into(), 0)], plan_for(&[[10, 0, 0, 0]]));
+        s.retarget(uniform(
+            vec![("eth0".into(), 0)],
+            plan_for(&[[10, 0, 0, 0]]),
+        ));
         let e = s.steer().expect_err("must refuse");
 
         assert!(
@@ -3506,7 +3592,7 @@ mod tests {
         // 2. `steer off` on every port, `packetframe reconfigure` — and
         //    the NIC refuses to delete what it holds.
         sys::wedge_delete(&steered_locs);
-        fx.0.retarget(Vec::new(), RuleSet::default());
+        fx.0.retarget(Vec::new());
         settle(&mut sup, &mut fx, Event::UnsteerRequested);
         assert!(
             sup.is_steered(),

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -132,6 +132,17 @@ fn probe_steering_budget(
         Err(e) => return Capability::fail("vpp.steering.budget", e, false),
     };
     let free = budget.free.len();
+    // No directions handed in = plan the global default, exactly as
+    // the CLI extractor falls back when nothing steers yet. Without
+    // this an empty slice would skip planning entirely and misreport
+    // every allowlist as empty — caught by this probe's own test the
+    // day the parameter became a list.
+    let default_dir = [packetframe_common::config::VppSteerDirection::default()];
+    let directions = if directions.is_empty() {
+        &default_dir[..]
+    } else {
+        directions
+    };
     // One plan per distinct effective direction — the SAME derivation
     // attach and reconfigure perform, so this probe cannot pass a
     // config they refuse. The old single-direction form also reported

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -16,7 +16,7 @@ pub(crate) fn run(
     workers: u32,
     vpp_binary: Option<&str>,
     allowlist: &[packetframe_common::fib::IpPrefix],
-    direction: packetframe_common::config::VppSteerDirection,
+    directions: &[packetframe_common::config::VppSteerDirection],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Vec<Capability> {
     let mut caps = Vec::with_capacity(5 + ports.len());
@@ -36,7 +36,7 @@ pub(crate) fn run(
     caps.push(probe_steering_budget(
         ports,
         allowlist,
-        direction,
+        directions,
         steer_exempts,
     ));
     caps
@@ -122,33 +122,60 @@ fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
 fn probe_steering_budget(
     ports: &[String],
     allowlist: &[packetframe_common::fib::IpPrefix],
-    direction: packetframe_common::config::VppSteerDirection,
+    directions: &[packetframe_common::config::VppSteerDirection],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Capability {
-    use crate::steer::{McamBudget, RuleSet};
+    use crate::steer::{McamBudget, RuleAction, RuleSet};
 
     let budget = match McamBudget::for_ifaces(ports.iter().map(String::as_str)) {
         Ok(b) => b,
         Err(e) => return Capability::fail("vpp.steering.budget", e, false),
     };
     let free = budget.free.len();
-    // The same arithmetic attach enforces: diversions + the built-in
-    // exemptions + the operator's. A probe that omitted the exemptions
-    // would pass a config attach then refuses, two-plus slots short.
-    match RuleSet::plan(allowlist, steer_exempts, budget, direction) {
-        // Nothing to steer is a FAIL however it arose. The two ways there
-        // read very differently to an operator, so they are named
-        // separately — but neither may pass: a port that steers nothing
-        // diverts no traffic while every other line in this report, and
-        // the module's own health, says the offload is fine.
-        Ok(set) if set.rules.is_empty() => Capability::fail(
+    // One plan per distinct effective direction — the SAME derivation
+    // attach and reconfigure perform, so this probe cannot pass a
+    // config they refuse. The old single-direction form also reported
+    // "rules / 2 steerable prefixes", which was wrong everywhere
+    // except `both` with no exemptions: rule counts include the Keep
+    // rules, and src/dst plans carry one divert per prefix, not two.
+    // Counted from the rules' own actions now.
+    let mut details = Vec::with_capacity(directions.len());
+    let mut skipped_v6 = 0u64;
+    let mut any_rules = false;
+    for direction in directions {
+        match RuleSet::plan(allowlist, steer_exempts, budget.clone(), *direction) {
+            Ok(set) => {
+                skipped_v6 = set.skipped_v6;
+                if !set.rules.is_empty() {
+                    any_rules = true;
+                }
+                let diverts = set
+                    .rules
+                    .iter()
+                    .filter(|r| r.action == RuleAction::Divert)
+                    .count();
+                details.push(format!(
+                    "direction {direction}: {} rule(s) ({diverts} divert + {} keep)",
+                    set.rules.len(),
+                    set.rules.len() - diverts,
+                ));
+            }
+            Err(e) => return Capability::fail("vpp.steering.budget", e, false),
+        }
+    }
+    // Nothing to steer is a FAIL however it arose. The two ways there
+    // read very differently to an operator, so they are named
+    // separately — but neither may pass: a port that steers nothing
+    // diverts no traffic while every other line in this report, and
+    // the module's own health, says the offload is fine.
+    if !any_rules {
+        return Capability::fail(
             "vpp.steering.budget",
-            if set.skipped_v6 > 0 {
+            if skipped_v6 > 0 {
                 format!(
-                    "none of the allowlist can be steered: all {} prefix(es) are IPv6, and \
-                     `ip6` ntuple is rejected by this NIC's AF (gate 0b round 4). The offload \
-                     would forward nothing while reporting healthy",
-                    set.skipped_v6
+                    "none of the allowlist can be steered: all {skipped_v6} prefix(es) are \
+                     IPv6, and `ip6` ntuple is rejected by this NIC's AF (gate 0b round 4). \
+                     The offload would forward nothing while reporting healthy"
                 )
             } else {
                 "the fast-path allowlist is empty, so there is nothing to steer. Steered \
@@ -157,27 +184,21 @@ fn probe_steering_budget(
                     .to_string()
             },
             false,
-        ),
-        Ok(set) => {
-            let detail = format!(
-                "{} rule(s) for {} steerable prefix(es); the NIC reports {} free slot(s){}",
-                set.rules.len(),
-                set.rules.len() / 2,
-                free,
-                if set.skipped_v6 > 0 {
-                    format!(
-                        "; {} IPv6 prefix(es) NOT steerable on this NIC and left on the \
-                         kernel path",
-                        set.skipped_v6
-                    )
-                } else {
-                    String::new()
-                }
-            );
-            Capability::pass("vpp.steering.budget", detail, false)
-        }
-        Err(e) => Capability::fail("vpp.steering.budget", e, false),
+        );
     }
+    let detail = format!(
+        "{}; the NIC reports {free} free slot(s){}",
+        details.join("; "),
+        if skipped_v6 > 0 {
+            format!(
+                "; {skipped_v6} IPv6 prefix(es) NOT steerable on this NIC and left on the \
+                 kernel path"
+            )
+        } else {
+            String::new()
+        }
+    );
+    Capability::pass("vpp.steering.budget", detail, false)
 }
 
 /// An SMMU registered in /sys/class/iommu is the difference between

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -140,7 +140,7 @@ fn probe_steering_budget(
     // rules, and src/dst plans carry one divert per prefix, not two.
     // Counted from the rules' own actions now.
     let mut details = Vec::with_capacity(directions.len());
-    let mut skipped_v6 = 0u64;
+    let mut skipped_v6 = 0u32;
     let mut any_rules = false;
     for direction in directions {
         match RuleSet::plan(allowlist, steer_exempts, budget.clone(), *direction) {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -397,7 +397,7 @@ pub trait Steering {
     /// Splitting it that way keeps one routine — `steer` — responsible
     /// for every rule that ever reaches the NIC, so a reconfigure cannot
     /// grow its own, subtly different, installation path.
-    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet);
+    fn retarget(&mut self, targets: Vec<(String, u32, crate::steer::RuleSet)>);
     /// How many ports the CONFIG asks to steer, whether or not any rule
     /// is installed.
     ///
@@ -446,7 +446,7 @@ impl Steering for SteeringUnavailable {
     fn installed(&self) -> Vec<(String, u32)> {
         Vec::new()
     }
-    fn retarget(&mut self, _ports: Vec<(String, u32)>, _plan: crate::steer::RuleSet) {}
+    fn retarget(&mut self, _targets: Vec<(String, u32, crate::steer::RuleSet)>) {}
 }
 
 /// Everything both trait views share.
@@ -1297,8 +1297,8 @@ impl Runtime {
     /// follow it with the supervisor event that reconciles the NIC, and
     /// the supervision loop is the only caller precisely so that the two
     /// cannot be separated.
-    pub fn retarget(&self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet) {
-        self.core.borrow_mut().retarget(ports, plan);
+    pub fn retarget(&self, targets: Vec<(String, u32, crate::steer::RuleSet)>) {
+        self.core.borrow_mut().retarget(targets);
     }
 
     /// The two trait views the driver's tick takes.
@@ -1747,8 +1747,8 @@ impl Core {
     /// `reconfigure` republishes status the moment it returns — so an
     /// operator who had just been told the steer was refused could read
     /// `steering healthy` in the same breath (review finding).
-    fn retarget(&mut self, ports: Vec<(String, u32)>, plan: crate::steer::RuleSet) {
-        self.steering.retarget(ports, plan);
+    fn retarget(&mut self, targets: Vec<(String, u32, crate::steer::RuleSet)>) {
+        self.steering.retarget(targets);
         self.last_steer_audit = None;
     }
 
@@ -3428,7 +3428,7 @@ mod tests {
         fn installed(&self) -> Vec<(String, u32)> {
             self.rules.clone()
         }
-        fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+        fn retarget(&mut self, _: Vec<(String, u32, crate::steer::RuleSet)>) {}
     }
 
     /// Every ledger the store was handed, in order.
@@ -3579,7 +3579,7 @@ mod tests {
             fn installed(&self) -> Vec<(String, u32)> {
                 vec![("eth4".into(), 1024), ("eth4".into(), 1025)]
             }
-            fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+            fn retarget(&mut self, _: Vec<(String, u32, crate::steer::RuleSet)>) {}
         }
 
         let rt = Runtime::new(
@@ -3647,7 +3647,7 @@ mod tests {
             fn installed(&self) -> Vec<(String, u32)> {
                 vec![("eth4".into(), 1024)]
             }
-            fn retarget(&mut self, _: Vec<(String, u32)>, _: crate::steer::RuleSet) {}
+            fn retarget(&mut self, _: Vec<(String, u32, crate::steer::RuleSet)>) {}
         }
 
         let rt = Runtime::new(
@@ -3667,7 +3667,7 @@ mod tests {
              would pass whether or not retarget invalidates anything"
         );
 
-        rt.retarget(vec![("eth4".into(), 0)], crate::steer::RuleSet::default());
+        rt.retarget(vec![("eth4".into(), 0, crate::steer::RuleSet::default())]);
         assert_eq!(
             rt.status().steer_missing,
             1,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -523,6 +523,10 @@ struct Core {
     /// When the NIC was last audited against the steering ledger, and
     /// how many rules it was missing. See [`STEER_AUDIT_EVERY`].
     last_steer_audit: Option<std::time::Instant>,
+    /// When the null-drop counter was last sampled over `cli_inband`.
+    /// Same real-clock pacing argument as `last_steer_audit`: a
+    /// metrics poll, not a supervision deadline.
+    last_null_sample: Option<std::time::Instant>,
     steer_missing: usize,
     /// Rules still steering a port the config asks to leave unsteered,
     /// as of the last audit. Its own count because it points the other
@@ -1228,6 +1232,7 @@ impl Runtime {
                 fresh_hold: None,
                 rx_kick: Box::new(NoKick),
                 last_steer_audit: None,
+                last_null_sample: None,
                 steer_missing: 0,
                 steer_stray: 0,
                 steer_audit_error: None,
@@ -1434,6 +1439,17 @@ impl Runtime {
                 }
             }
         }
+        {
+            let mut c = self.core.borrow_mut();
+            let now = std::time::Instant::now();
+            let due = c
+                .last_null_sample
+                .is_none_or(|t| now.duration_since(t) >= NULL_DROPS_EVERY);
+            if due && c.engine.is_connected() {
+                c.last_null_sample = Some(now);
+                c.engine.sample_null_drops();
+            }
+        }
         let c = self.core.borrow();
         // ONE reading, used for both the verdict and the question of
         // whether it has been seen before: asking twice could pair a
@@ -1469,6 +1485,7 @@ impl Runtime {
             steer_stray: c.steer_stray,
             steer_audit_error: c.steer_audit_error.clone(),
             shadowed_routes: c.engine.shadowed_routes(),
+            null_drops: c.engine.null_drops(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1504,6 +1521,14 @@ impl Runtime {
 /// hardware limit — on the shadow it went two minutes and would have
 /// gone indefinitely.
 const STEER_AUDIT_EVERY: Duration = Duration::from_secs(30);
+
+/// How often to read VPP's error counters for the null-drop gauge.
+///
+/// One `cli_inband "show errors"` round trip on the API socket, which
+/// shares VPP's main thread with the route batches — 60 s keeps it
+/// invisible next to the liveness ping while still giving Prometheus a
+/// usable rate.
+const NULL_DROPS_EVERY: Duration = Duration::from_secs(60);
 
 /// What the completeness authority can currently say, for the health
 /// text.
@@ -1619,6 +1644,8 @@ pub struct RuntimeStatus {
     /// Mirror prefixes a `local-route` is currently suppressing. See
     /// [`crate::engine::ConvergenceEngine::shadowed_routes`].
     pub shadowed_routes: u64,
+    /// Cumulative null-node drops as last sampled, absent until read.
+    pub null_drops: Option<u64>,
 }
 
 impl Core {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -527,6 +527,16 @@ struct Core {
     /// Same real-clock pacing argument as `last_steer_audit`: a
     /// metrics poll, not a supervision deadline.
     last_null_sample: Option<std::time::Instant>,
+    /// The bridge-FDB tripwire, installed by bringup when local-routes
+    /// exist (Linux only). `None` everywhere else — tests, non-Linux,
+    /// configs with no local delivery — and silent there on purpose,
+    /// like the rx-mode kick: a missing scan is visible by its absent
+    /// log lines, not impersonated by a stub.
+    fdb_watch: Option<Box<dyn crate::fdb::FdbWatch>>,
+    last_fdb_scan: Option<std::time::Instant>,
+    /// The last completed scan's findings; kept across a failed scan
+    /// (an unreadable kernel is not evidence the hosts moved back).
+    fdb_misplaced: Vec<String>,
     steer_missing: usize,
     /// Rules still steering a port the config asks to leave unsteered,
     /// as of the last audit. Its own count because it points the other
@@ -1233,6 +1243,9 @@ impl Runtime {
                 rx_kick: Box::new(NoKick),
                 last_steer_audit: None,
                 last_null_sample: None,
+                fdb_watch: None,
+                last_fdb_scan: None,
+                fdb_misplaced: Vec::new(),
                 steer_missing: 0,
                 steer_stray: 0,
                 steer_audit_error: None,
@@ -1292,6 +1305,13 @@ impl Runtime {
     /// Install the kernel rx-mode kick. The attach wiring installs the
     /// ioctl-backed [`AllmultiKick`] on Linux; everything else keeps
     /// [`NoKick`]. See [`RxModeKick`] for why this exists.
+    /// Install the bridge-FDB tripwire. Same wiring rule as the
+    /// rx-mode kick: bringup installs the real one on Linux when
+    /// local-routes exist, and nothing pretends elsewhere.
+    pub fn fdb_watch(&self, w: Box<dyn crate::fdb::FdbWatch>) {
+        self.core.borrow_mut().fdb_watch = Some(w);
+    }
+
     pub fn rx_mode_kick(&self, k: Box<dyn RxModeKick>) {
         self.core.borrow_mut().rx_kick = k;
     }
@@ -1449,6 +1469,31 @@ impl Runtime {
                 c.last_null_sample = Some(now);
                 c.engine.sample_null_drops();
             }
+            let due = c
+                .last_fdb_scan
+                .is_none_or(|t| now.duration_since(t) >= FDB_SCAN_EVERY);
+            if due && c.fdb_watch.is_some() {
+                c.last_fdb_scan = Some(now);
+                let result = c.fdb_watch.as_mut().expect("checked above").misplaced();
+                match result {
+                    Ok(found) => {
+                        if !found.is_empty() && c.fdb_misplaced != found {
+                            tracing::warn!(
+                                hosts = ?found,
+                                "service-VLAN host(s) are behind a different member port \
+                                 than their local-route declares; VPP is delivering their \
+                                 prefix to the declared port. Move the host back, fix the \
+                                 declaration, or this topology needs per-host delivery \
+                                 (B3 v2)"
+                            );
+                        }
+                        c.fdb_misplaced = found;
+                    }
+                    // Keep the previous verdict: an unreadable kernel
+                    // is not evidence the hosts moved back.
+                    Err(e) => tracing::debug!(error = %e, "bridge-FDB scan failed"),
+                }
+            }
         }
         let c = self.core.borrow();
         // ONE reading, used for both the verdict and the question of
@@ -1486,6 +1531,7 @@ impl Runtime {
             steer_audit_error: c.steer_audit_error.clone(),
             shadowed_routes: c.engine.shadowed_routes(),
             null_drops: c.engine.null_drops(),
+            fdb_misplaced: c.fdb_misplaced.clone(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1529,6 +1575,12 @@ const STEER_AUDIT_EVERY: Duration = Duration::from_secs(30);
 /// invisible next to the liveness ping while still giving Prometheus a
 /// usable rate.
 const NULL_DROPS_EVERY: Duration = Duration::from_secs(60);
+
+/// How often the bridge-FDB tripwire scans for hosts behind a port
+/// other than their `local-route` declaration. One netlink dump; a
+/// moved host is a provisioning-scale event, so a minute of latency
+/// on the tripwire costs nothing.
+const FDB_SCAN_EVERY: Duration = Duration::from_secs(60);
 
 /// What the completeness authority can currently say, for the health
 /// text.
@@ -1646,6 +1698,10 @@ pub struct RuntimeStatus {
     pub shadowed_routes: u64,
     /// Cumulative null-node drops as last sampled, absent until read.
     pub null_drops: Option<u64>,
+    /// Hosts the bridge FDB places behind a different port than their
+    /// `local-route` declares, one line each. Empty = the tripwire is
+    /// quiet (or not installed).
+    pub fdb_misplaced: Vec<String>,
 }
 
 impl Core {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1468,6 +1468,7 @@ impl Runtime {
             steer_missing: c.steer_missing,
             steer_stray: c.steer_stray,
             steer_audit_error: c.steer_audit_error.clone(),
+            shadowed_routes: c.engine.shadowed_routes(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1615,6 +1616,9 @@ pub struct RuntimeStatus {
     pub steer_stray: usize,
     /// Why the last steering audit could not read the NIC, if so.
     pub steer_audit_error: Option<String>,
+    /// Mirror prefixes a `local-route` is currently suppressing. See
+    /// [`crate::engine::ConvergenceEngine::shadowed_routes`].
+    pub shadowed_routes: u64,
 }
 
 impl Core {

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1095,6 +1095,7 @@ fn run_loop(
             },
             rs.shadowed_routes,
             rs.null_drops,
+            rs.fdb_misplaced,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1094,6 +1094,7 @@ fn run_loop(
                 unreadable: rs.steer_audit_error.clone(),
             },
             rs.shadowed_routes,
+            rs.null_drops,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -154,9 +154,9 @@ pub struct SteeringRequest {
     /// Matched against the answer so a caller cannot collect the result
     /// of somebody else's request — or of its own previous one.
     seq: u64,
-    /// `(PF iface, VF index)` for every port now configured `steer on`.
-    pub ports: Vec<(String, u32)>,
-    pub plan: crate::steer::RuleSet,
+    /// `(PF iface, VF index, rules)` for every port now configured
+    /// `steer on` — per-port rules because direction is per-port.
+    pub targets: Vec<(String, u32, crate::steer::RuleSet)>,
     /// Whether traffic should be diverted once the target is in place.
     /// False is the rollback landing zone, not an error.
     pub want_steer: bool,
@@ -608,8 +608,7 @@ impl SupervisionService {
     /// happen, which is what they need to know.
     pub fn apply_steering(
         &self,
-        ports: Vec<(String, u32)>,
-        plan: crate::steer::RuleSet,
+        targets: Vec<(String, u32, crate::steer::RuleSet)>,
         want_steer: bool,
         lever_moved: bool,
     ) -> Result<(), String> {
@@ -623,8 +622,7 @@ impl SupervisionService {
             .expect("steering lock")
             .replace(SteeringRequest {
                 seq,
-                ports,
-                plan,
+                targets,
                 want_steer,
                 lever_moved,
             });
@@ -877,7 +875,7 @@ fn apply_steering(
              next successful convergence"
         ));
     }
-    runtime.retarget(req.ports.clone(), req.plan.clone());
+    runtime.retarget(req.targets.clone());
 
     let steered = driver.supervisor().is_steered();
     // INTENDED, not steered. The two differ in exactly the case an

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1095,6 +1095,7 @@ fn run_loop(
                 stray: rs.steer_stray,
                 unreadable: rs.steer_audit_error.clone(),
             },
+            rs.shadowed_routes,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -348,6 +348,14 @@ pub struct StatusSnapshot {
     /// route). Surfaced so a mirror change inside a local prefix is
     /// visible rather than silently absorbed.
     pub shadowed_routes: u64,
+    /// Cumulative null-node drops from VPP's own error counters,
+    /// sampled over `cli_inband`. `None` until a sample succeeds —
+    /// absent rather than 0, so a broken read path cannot impersonate
+    /// a quiet dataplane. What it counts on the reference primary:
+    /// replies to spoofed/bogon sources, traffic the kernel also
+    /// dropped, just less visibly (~370 pps in w23/w24). A CHANGE in
+    /// its rate is the signal; the steady residual is designed.
+    pub null_drops: Option<u64>,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -401,6 +409,7 @@ impl StatusSnapshot {
             // ledger to audit against.
             SteerAudit::default(),
             0,
+            None,
         )
     }
 
@@ -427,6 +436,7 @@ impl StatusSnapshot {
         steer_configured: bool,
         audit: SteerAudit,
         shadowed_routes: u64,
+        null_drops: Option<u64>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -451,6 +461,7 @@ impl StatusSnapshot {
             drain_error,
             source_backlog,
             shadowed_routes,
+            null_drops,
         }
     }
 
@@ -1451,6 +1462,15 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
             out,
             "packetframe_vpp_routes{{module=\"{module}\",state=\"{label}\"}} {value}"
         );
+    }
+
+    if let Some(n) = snap.null_drops {
+        gauge(
+            &mut out,
+            "packetframe_vpp_null_drops",
+            "cumulative VPP null-node drops (undeliverable traffic; absent until sampled)",
+        );
+        let _ = writeln!(out, "packetframe_vpp_null_drops{{module=\"{module}\"}} {n}");
     }
 
     gauge(
@@ -3206,6 +3226,28 @@ mod tests {
         // The boolean is still emitted — "not verified" is a fact worth
         // scraping.
         assert!(m.contains("packetframe_vpp_fib_verified{module=\"vpp-offload\"} 0"));
+    }
+
+    /// Same convention for the null-drop counter: absent until a
+    /// sample succeeded, so a broken read path cannot impersonate a
+    /// quiet dataplane — and present with the sampled total after.
+    #[test]
+    fn the_null_drop_gauge_is_absent_until_sampled() {
+        let mut s = snap_of(
+            &Supervisor::new(),
+            &ledger_with(0, 0, 0),
+            ApiHealth::NoProcess,
+            FibSync::NeverVerified,
+            Vec::new(),
+        );
+        let m = render_metrics(&s, "vpp-offload");
+        assert!(!m.contains("packetframe_vpp_null_drops"), "{m}");
+        s.null_drops = Some(117_015);
+        let m = render_metrics(&s, "vpp-offload");
+        assert!(
+            m.contains("packetframe_vpp_null_drops{module=\"vpp-offload\"} 117015"),
+            "{m}"
+        );
     }
 
     #[test]

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -340,6 +340,14 @@ pub struct StatusSnapshot {
     /// engine is not draining, a backlog there means VPP is not
     /// accepting.
     pub source_backlog: u64,
+    /// Mirror prefixes a `local-route` is currently suppressing —
+    /// routes the mirror carries that VPP deliberately does not,
+    /// because local delivery owns their footprint. Informational, not
+    /// a degradation: non-zero is the DESIGNED state on a service edge
+    /// (the reference primary expects exactly its poisoned host
+    /// route). Surfaced so a mirror change inside a local prefix is
+    /// visible rather than silently absorbed.
+    pub shadowed_routes: u64,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -392,6 +400,7 @@ impl StatusSnapshot {
             // and every caller of this form is a path with no steering
             // ledger to audit against.
             SteerAudit::default(),
+            0,
         )
     }
 
@@ -417,6 +426,7 @@ impl StatusSnapshot {
         source_backlog: u64,
         steer_configured: bool,
         audit: SteerAudit,
+        shadowed_routes: u64,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -440,6 +450,7 @@ impl StatusSnapshot {
             store_error,
             drain_error,
             source_backlog,
+            shadowed_routes,
         }
     }
 
@@ -1441,6 +1452,17 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
             "packetframe_vpp_routes{{module=\"{module}\",state=\"{label}\"}} {value}"
         );
     }
+
+    gauge(
+        &mut out,
+        "packetframe_vpp_shadowed_routes",
+        "mirror prefixes a local-route currently suppresses (local delivery owns them)",
+    );
+    let _ = writeln!(
+        out,
+        "packetframe_vpp_shadowed_routes{{module=\"{module}\"}} {}",
+        snap.shadowed_routes
+    );
 
     gauge(
         &mut out,

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -60,6 +60,8 @@ pub const SUBSYS_PORTS: &str = "ports";
 /// Reported only when a persist failed; see
 /// [`StatusSnapshot::store_error`].
 pub const SUBSYS_STATE_FILE: &str = "state-file";
+/// Only present when the bridge-FDB tripwire has findings.
+pub const SUBSYS_FDB: &str = "fdb";
 /// Subsystem name for the cross-tier route feed.
 pub const SUBSYS_ROUTE_FEED: &str = "route-feed";
 
@@ -356,6 +358,14 @@ pub struct StatusSnapshot {
     /// dropped, just less visibly (~370 pps in w23/w24). A CHANGE in
     /// its rate is the signal; the steady residual is designed.
     pub null_drops: Option<u64>,
+    /// Hosts the bridge FDB places behind a different member port than
+    /// their `local-route` declares, one line each. Non-empty is a
+    /// topology contradiction: the kernel delivers those hosts via a
+    /// port VPP is not delivering their prefix to, so steered inbound
+    /// for them is going to the wrong wire. Degraded, host named — the
+    /// v1 tripwire whose firing is what makes per-host delivery (v2)
+    /// real work instead of speculation.
+    pub fdb_misplaced: Vec<String>,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -410,6 +420,7 @@ impl StatusSnapshot {
             SteerAudit::default(),
             0,
             None,
+            Vec::new(),
         )
     }
 
@@ -437,6 +448,7 @@ impl StatusSnapshot {
         audit: SteerAudit,
         shadowed_routes: u64,
         null_drops: Option<u64>,
+        fdb_misplaced: Vec<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -462,6 +474,7 @@ impl StatusSnapshot {
             source_backlog,
             shadowed_routes,
             null_drops,
+            fdb_misplaced,
         }
     }
 
@@ -529,6 +542,20 @@ impl StatusSnapshot {
                      source and {} queued for VPP. Retried every tick — the offload is forwarding \
                      a table that is behind bird, not a wrong one.",
                     self.source_backlog, self.pending_ops
+                )),
+                last_success_age_seconds: None,
+            });
+        }
+        if !self.fdb_misplaced.is_empty() {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_FDB.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "the kernel bridge FDB contradicts local-route: {} — steered inbound \
+                     for these hosts egresses the declared port, not the one the kernel \
+                     learned them on. Move the host, fix the declaration, or this \
+                     topology needs per-host delivery (B3 v2)",
+                    self.fdb_misplaced.join("; ")
                 )),
                 last_success_age_seconds: None,
             });
@@ -633,6 +660,11 @@ impl StatusSnapshot {
             // over it by design, which is exactly why it must not read as
             // nominal.
             && self.drain_error.is_none()
+            // A host the FDB places behind an undeclared port is being
+            // delivered to the wrong wire by VPP right now. Detection
+            // only — the remedy is the operator's — but it must not
+            // read as healthy while it stands.
+            && self.fdb_misplaced.is_empty()
     }
 
     /// Whether the CURRENT failure episode is over — the release
@@ -1472,6 +1504,17 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
         );
         let _ = writeln!(out, "packetframe_vpp_null_drops{{module=\"{module}\"}} {n}");
     }
+
+    gauge(
+        &mut out,
+        "packetframe_vpp_fdb_misplaced",
+        "hosts the bridge FDB places behind a different port than their local-route declares",
+    );
+    let _ = writeln!(
+        out,
+        "packetframe_vpp_fdb_misplaced{{module=\"{module}\"}} {}",
+        snap.fdb_misplaced.len()
+    );
 
     gauge(
         &mut out,
@@ -3226,6 +3269,51 @@ mod tests {
         // The boolean is still emitted — "not verified" is a fact worth
         // scraping.
         assert!(m.contains("packetframe_vpp_fib_verified{module=\"vpp-offload\"} 0"));
+    }
+
+    /// The FDB tripwire: quiet = no subsystem row (nothing for an
+    /// operator to learn to ignore); firing = Degraded with the host
+    /// named on the report AND the gauge counting it, together.
+    #[test]
+    fn a_misplaced_fdb_host_degrades_and_is_named_on_both_surfaces() {
+        let mut s = snap_of(
+            &ready_supervisor(),
+            &ledger_with(1, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(1),
+            },
+            verified(1),
+            ports_up(),
+        );
+        assert!(
+            !s.report().subsystems.iter().any(|x| x.name == SUBSYS_FDB),
+            "quiet tripwire must add no row"
+        );
+        let m = render_metrics(&s, "vpp-offload");
+        assert!(
+            m.contains("packetframe_vpp_fdb_misplaced{module=\"vpp-offload\"} 0"),
+            "{m}"
+        );
+
+        s.fdb_misplaced =
+            vec!["02:00:00:00:00:07 vlan 1337 learned on eth5 (local-route declares eth4)".into()];
+        let report = s.report();
+        let row = report
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_FDB)
+            .expect("the tripwire row");
+        assert_eq!(row.state, HealthState::Degraded);
+        assert!(
+            row.message.as_deref().unwrap_or("").contains("eth5"),
+            "{row:?}"
+        );
+        assert_ne!(report.overall, HealthState::Healthy);
+        let m = render_metrics(&s, "vpp-offload");
+        assert!(
+            m.contains("packetframe_vpp_fdb_misplaced{module=\"vpp-offload\"} 1"),
+            "{m}"
+        );
     }
 
     /// Same convention for the null-drop counter: absent until a

--- a/crates/modules/vpp-offload/src/steer.rs
+++ b/crates/modules/vpp-offload/src/steer.rs
@@ -218,13 +218,14 @@ impl Default for McamBudget {
 /// The sides a configured [`VppSteerDirection`] matches.
 ///
 /// `both` is right for pure-transit deployments where VPP can forward
-/// either direction of a flow. `src` is the service-edge shape:
-/// outbound (src in the service prefix) rides VPP full-table best
-/// path while inbound stays on the eBPF tier, whose FDB-pin owns
-/// local delivery — dst-steering inbound service traffic would divert
-/// it into a FIB with no path to the bridge-attached hosts it
-/// terminates on. Split-tier flow halves are safe under the
-/// stateless-transit invariant steering already requires.
+/// either direction of a flow. `src` is the service-edge staging
+/// shape: outbound (src in the service prefix) rides VPP full-table
+/// best path while inbound stays on the eBPF tier. `dst` steers
+/// inbound, which is loadable only with `local-route` coverage of
+/// steerable local prefixes — VPP must be able to DELIVER what a dst
+/// rule diverts, and config validation refuses otherwise. Split-tier
+/// flow halves are safe under the stateless-transit invariant
+/// steering already requires.
 pub fn sides_for(direction: VppSteerDirection) -> &'static [Side] {
     match direction {
         VppSteerDirection::Src => &[Side::Src],

--- a/crates/modules/vpp-offload/src/vpp_api/generated.rs
+++ b/crates/modules/vpp-offload/src/vpp_api/generated.rs
@@ -61,6 +61,8 @@ pub const MESSAGE_META: &[MessageMeta] = &[
     MessageMeta { name: "dev_create_port_if_reply", crc: "0x243c2374", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "dev_remove_port_if", crc: "0x529cb13f", context_offset: 6, client_index_prefix: true },
     MessageMeta { name: "dev_remove_port_if_reply", crc: "0xc8d74455", context_offset: 2, client_index_prefix: false },
+    MessageMeta { name: "cli_inband", crc: "0xf8377302", context_offset: 6, client_index_prefix: true },
+    MessageMeta { name: "cli_inband_reply", crc: "0x05879051", context_offset: 2, client_index_prefix: false },
 ];
 
 // enum address_family : u8
@@ -2271,6 +2273,81 @@ impl Decode for DevRemovePortIfReply {
 impl Message for DevRemovePortIfReply {
     const NAME: &'static str = "dev_remove_port_if_reply";
     const CRC: &'static str = "0xc8d74455";
+    const CONTEXT_OFFSET: usize = 2;
+    const CLIENT_INDEX_PREFIX: bool = false;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `cli_inband` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CliInband {
+    pub context: u32,
+    pub cmd: String,
+}
+
+impl Encode for CliInband {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.cmd.len() as u32).to_be_bytes());
+        buf.extend_from_slice(self.cmd.as_bytes());
+    }
+}
+
+impl Decode for CliInband {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let _ = d.u32()?;
+        let context = d.u32()?;
+        let cmd = d.string_var()?;
+        Ok(Self {
+            context,
+            cmd,
+        })
+    }
+}
+
+impl Message for CliInband {
+    const NAME: &'static str = "cli_inband";
+    const CRC: &'static str = "0xf8377302";
+    const CONTEXT_OFFSET: usize = 6;
+    const CLIENT_INDEX_PREFIX: bool = true;
+    fn set_context(&mut self, context: u32) { self.context = context; }
+}
+
+/// `cli_inband_reply` — generated from the pinned .api.json.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct CliInbandReply {
+    pub context: u32,
+    pub retval: i32,
+    pub reply: String,
+}
+
+impl Encode for CliInbandReply {
+    fn encode(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&(self.context).to_be_bytes());
+        buf.extend_from_slice(&(self.retval).to_be_bytes());
+        buf.extend_from_slice(&(self.reply.len() as u32).to_be_bytes());
+        buf.extend_from_slice(self.reply.as_bytes());
+    }
+}
+
+impl Decode for CliInbandReply {
+    fn decode(d: &mut Decoder<'_>) -> Result<Self, WireError> {
+        let _ = d.u16()?;
+        let context = d.u32()?;
+        let retval = d.i32()?;
+        let reply = d.string_var()?;
+        Ok(Self {
+            context,
+            retval,
+            reply,
+        })
+    }
+}
+
+impl Message for CliInbandReply {
+    const NAME: &'static str = "cli_inband_reply";
+    const CRC: &'static str = "0x05879051";
     const CONTEXT_OFFSET: usize = 2;
     const CLIENT_INDEX_PREFIX: bool = false;
     fn set_context(&mut self, context: u32) { self.context = context; }

--- a/crates/modules/vpp-offload/tests/common/fake_vpp.rs
+++ b/crates/modules/vpp-offload/tests/common/fake_vpp.rs
@@ -30,7 +30,7 @@ mod wire;
 use wire::{name_for, read_frame, reply_head, request_context, write_frame};
 
 use packetframe_vpp_offload::vpp_api::generated::{
-    Address, AddressUnion, ControlPingReply, CreateLoopbackReply, CreateVlanSubif,
+    Address, AddressUnion, CliInbandReply, ControlPingReply, CreateLoopbackReply, CreateVlanSubif,
     CreateVlanSubifReply, DevAttachReply, DevCreatePortIfReply, FibPath, FibPathNh, IpNeighbor,
     IpNeighborAddDel, IpNeighborAddDelReply, IpNeighborDetails, IpNeighborDump, IpRoute,
     IpRouteAddDel, IpRouteAddDelReply, IpRouteDetails, IpRouteLookupReply, MessageTableEntry,
@@ -126,6 +126,10 @@ pub struct Fake {
 /// How the fake misbehaves.
 #[derive(Clone, Copy, Default)]
 pub struct Behaviour {
+    /// What `cli_inband "show errors"` answers. Empty is a legitimate
+    /// VPP answer (no counters yet), so the default keeps the
+    /// null-drop gauge absent-or-zero without special-casing.
+    pub show_errors: &'static str,
     /// Drop the connection after this many route ops.
     pub hangup_after: Option<usize>,
     /// Reject this many *deletes* with a non-zero retval before
@@ -601,6 +605,17 @@ fn serve(
                 SwInterfaceSetUnnumberedReply {
                     context: ctx,
                     retval: 0,
+                }
+                .encode(&mut out);
+                write_frame(sock, &out);
+                continue;
+            }
+            "cli_inband" => {
+                let mut out = reply_head("cli_inband_reply");
+                CliInbandReply {
+                    context: ctx,
+                    retval: 0,
+                    reply: behaviour.show_errors.to_string(),
                 }
                 .encode(&mut out);
                 write_frame(sock, &out);

--- a/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
+++ b/crates/modules/vpp-offload/tests/vpp_attach_verify.rs
@@ -945,6 +945,15 @@ fn declared_vlans_get_dot1q_subifs_up_and_unnumbered() {
     let got = attach_ports(&mut t, &p, &[], AttachMode::Fresh, TEST_LOOP_IDX).expect("attach");
     assert_eq!(got.len(), 1);
     assert_eq!(got[0].sw_if_index, 7, "the parent index is unchanged");
+    // The indices VPP assigned come back on the port, in declaration
+    // order — this is what `local-route` attached routes and the
+    // neighbour mirror reference, so dropping them on the floor (the
+    // pre-B1 behaviour) would be a silent regression here.
+    assert_eq!(
+        got[0].subifs,
+        vec![(88, 188), (1337, 1437)],
+        "each subif's (vid, sw_if_index) as the fake assigned them (100 + vid)"
+    );
 
     let seen = fake.observed();
     // Which vid landed on which parent — the detail events the fake
@@ -997,6 +1006,11 @@ fn adopted_subifs_are_reused_not_recreated() {
     let known = vec![("eth3".to_string(), 7u32)];
     let got = attach_ports(&mut t, &p, &known, AttachMode::Adopted, TEST_LOOP_IDX).expect("adopt");
     assert_eq!(got[0].sw_if_index, 7);
+    assert_eq!(
+        got[0].subifs,
+        vec![(1337, 107)],
+        "an adopted subif reports the index from the dump, not a fresh one"
+    );
 
     let seen = fake.observed();
     assert!(

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -165,6 +165,7 @@ impl Host {
             expected_routes: 1_600_000,
             hugepages: None,
             steer_exempts: vec![],
+            local_routes: vec![],
             // These fixtures have no route authority to compare
             // against, and none of them steers; the gate is exercised
             // where it lives, in `runtime`.
@@ -208,6 +209,7 @@ fn a_fresh_attach_acquires_renders_and_supervises() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("bring-up");
 
@@ -328,6 +330,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must fail");
@@ -344,6 +347,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must fail");
@@ -365,6 +369,7 @@ fn a_config_that_cannot_work_touches_nothing() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must fail");
@@ -434,6 +439,7 @@ fn an_irq_on_a_vpp_core_refuses_the_attach() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must fail");
@@ -479,6 +485,7 @@ fn a_failure_after_acquisition_releases_what_it_took() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must fail");
@@ -589,6 +596,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("steer on with nothing steerable must be refused");
@@ -616,6 +624,7 @@ fn a_steer_on_port_with_nothing_steerable_is_refused() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     );
     assert!(
         ok.is_ok(),
@@ -653,6 +662,7 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("first attach");
     drop(attached);
@@ -684,6 +694,7 @@ fn an_incomplete_recorded_identity_refuses_rather_than_spawning() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("an unverifiable identity must refuse");
@@ -736,6 +747,7 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("first attach");
     drop(attached);
@@ -769,6 +781,7 @@ fn steering_rules_from_a_dead_vpp_are_not_left_unaccounted() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("second attach");
     drop(attached);
@@ -809,6 +822,7 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("first attach");
     drop(attached);
@@ -837,6 +851,7 @@ fn a_recorded_ledger_withholds_the_vf_until_the_rules_are_confirmed_gone() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .expect("attach");
     let report = attached.service.stop();
@@ -879,6 +894,7 @@ fn requiring_completeness_with_no_publisher_is_refused_at_attach() {
         None,
         None,
         &McamBudget::default(),
+        &[],
     )
     .err()
     .expect("must refuse");

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -159,7 +159,7 @@ impl Host {
         VppOffloadConfig {
             ports: ports
                 .iter()
-                .map(|(i, c, s)| (i.to_string(), *c, *s, vec![]))
+                .map(|(i, c, s)| (i.to_string(), *c, *s, vec![], None))
                 .collect(),
             vpp_binary: Some(self.vpp_binary.to_string_lossy().into_owned()),
             expected_routes: 1_600_000,

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -1605,3 +1605,30 @@ fn a_stale_install_inside_the_local_prefix_is_withdrawn() {
         "the stale in-prefix install must be withdrawn from VPP: {deletes:?}"
     );
 }
+
+/// The null-drop sample end to end: `cli_inband` over the real socket,
+/// VPP's text parsed, the total cached — and absent again once the
+/// process the counters lived in is gone.
+#[test]
+fn null_drops_sample_over_cli_inband() {
+    let fake = Fake::start_behaving(
+        "null-drops",
+        Behaviour {
+            show_errors: "   Count            Node            Reason        Severity\n\
+                          117015         null-node       blackholed packets   error\n\
+                          52755       ethernet-input     unknown vlan         error\n",
+            ..Default::default()
+        },
+    );
+    let mut e = engine_for(&fake);
+    assert!(e.api_ready());
+    assert_eq!(e.null_drops(), None, "absent until sampled");
+    e.sample_null_drops();
+    assert_eq!(e.null_drops(), Some(117_015));
+    e.on_process_gone();
+    assert_eq!(
+        e.null_drops(),
+        None,
+        "the counters died with the process; a stale total would read as quiet"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_engine.rs
+++ b/crates/modules/vpp-offload/tests/vpp_engine.rs
@@ -1349,3 +1349,259 @@ fn the_neighbours_adj_fib_is_never_adopted_or_withdrawn() {
         "no withdrawal may reach VPP, least of all the adj-fib: {deletes:?}"
     );
 }
+
+// ------------------------------------------------------------------
+// B1: local delivery. A `local-route` produces three engine behaviours
+// — an attached route onto the subif at attach, shadowing of the
+// mirror's view inside the prefix (resync AND deltas), and bridge
+// neighbours mirrored onto the subif index. Forwarding is w26's job on
+// hardware; what these prove is that the right messages, and ONLY the
+// right messages, reach the wire.
+
+use fake_vpp::SUBIF_BASE;
+use packetframe_vpp_offload::LocalRoute;
+
+fn local_route() -> LocalRoute {
+    LocalRoute {
+        prefix: packetframe_common::config::Ipv4Prefix {
+            addr: Ipv4Addr::new(23, 191, 200, 0),
+            prefix_len: 24,
+        },
+        port: "eth4".into(),
+        vlan: 1337,
+        kernel_dev: "br1337".into(),
+    }
+}
+
+/// A prefix inside the local-route's footprint.
+fn svc(last: u8, len: u8) -> IpPrefix {
+    IpPrefix::V4 {
+        addr: [23, 191, 200, last],
+        prefix_len: len,
+    }
+}
+
+fn engine_with_local_route(fake: &Fake) -> ConvergenceEngine {
+    ConvergenceEngine::new(
+        &fake.path,
+        vec![PortAttach {
+            port: "eth4".into(),
+            pci_addr: "0002:07:00.1".into(),
+            port_id: 0,
+            num_rx_queues: 1,
+            pf_mac: [0x02, 0x00, 0x00, 0x00, 0x00, 0x01],
+            accept_macs: vec![],
+            vlans: vec![1337],
+        }],
+        vec!["eth4".into()],
+        1_000_000,
+        FamilyPolicy::V4Only,
+        packetframe_common::config::Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, 1),
+            prefix_len: 32,
+        },
+    )
+    .with_local_routes(vec![local_route()])
+}
+
+/// The attached route goes out at attach, onto the SUBIF's index — a
+/// path on the parent would transmit untagged and die on the trunk —
+/// and the mirror's view inside the prefix never reaches the wire.
+#[test]
+fn a_local_route_installs_attached_and_shadows_the_mirror() {
+    let fake = Fake::start("local-route");
+    let mut e = engine_with_local_route(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+
+    let at_attach: Vec<WireRoute> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|ev| match ev {
+            Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        at_attach.len(),
+        1,
+        "exactly the attached route: {at_attach:?}"
+    );
+    let r = &at_attach[0];
+    assert!(r.is_add);
+    assert_eq!((r.addr, r.len), ([23, 191, 200, 0], 24));
+    assert_eq!(
+        r.path_indices,
+        vec![SUBIF_BASE],
+        "the attached route must land on the subif, not the parent"
+    );
+
+    // The mirror carries the poisoned host route (bird's `unreachable`
+    // /32, the reference primary's shape) plus three transit routes.
+    let m = Mirror {
+        routes: vec![svc(7, 32), v4(0, 0), v4(0, 1), v4(0, 2)],
+    };
+    let plan = e.begin_resync(&m);
+    assert_eq!(plan.upserts, 3);
+    assert_eq!(plan.shadowed, 1);
+    drain_to_empty(&mut e);
+    assert_eq!(e.counts().installed, 3);
+    assert_eq!(e.shadowed_routes(), 1);
+    let after: Vec<WireRoute> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|ev| match ev {
+            Event::Route(r) => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        after.iter().all(|r| r.addr != [23, 191, 200, 7]),
+        "the shadowed host route must never reach the wire: {after:?}"
+    );
+}
+
+/// Kernel neighbours on the backing bridge become static neighbours on
+/// the subif — the mapping `local-route` registers is what turns the
+/// device name the feed reports into the subif's own index.
+#[test]
+fn a_bridge_neighbour_mirrors_onto_the_subif() {
+    struct BridgeNeigh;
+    impl RouteSource for BridgeNeigh {
+        fn for_each_route(&self, _visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {
+            visit(IpAddr::V4(Ipv4Addr::new(23, 191, 200, 7)), "br1337", MAC);
+        }
+        fn requeue(&self, _: packetframe_vpp_offload::engine::SourceChanges) {
+            unreachable!("static source")
+        }
+        fn route_count(&self) -> u64 {
+            0
+        }
+        fn change_seq(&self) -> u64 {
+            0
+        }
+    }
+
+    let fake = Fake::start("bridge-neigh");
+    let mut e = engine_with_local_route(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    e.begin_resync(&BridgeNeigh);
+    e.program_neighbours(&BridgeNeigh).expect("neighbours");
+
+    let neighbours: Vec<(u32, [u8; 6], bool)> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|ev| match ev {
+            Event::Neighbour {
+                sw_if_index,
+                mac,
+                is_add,
+                ..
+            } => Some((sw_if_index, mac, is_add)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        neighbours
+            .iter()
+            .any(|&(idx, mac, add)| idx == SUBIF_BASE && mac == MAC && add),
+        "the bridge host's neighbour must be programmed on the subif index: {neighbours:?}"
+    );
+}
+
+/// The delta door shadows exactly like the resync door — w-series
+/// history says every filter with two entrances eventually takes a
+/// finding through the second one.
+#[test]
+fn the_delta_path_shadows_local_prefix_routes_too() {
+    use std::cell::RefCell;
+    struct Deltas(RefCell<Vec<packetframe_vpp_offload::engine::RouteChange>>);
+    impl RouteSource for Deltas {
+        fn for_each_route(&self, _visit: &mut dyn FnMut(IpPrefix, &[IpAddr])) {}
+        fn for_each_neighbour(&self, _visit: &mut dyn FnMut(IpAddr, &str, [u8; 6])) {}
+        fn drain_changes(&self, _max: usize) -> packetframe_vpp_offload::engine::SourceChanges {
+            packetframe_vpp_offload::engine::SourceChanges {
+                routes: self.0.borrow_mut().drain(..).collect(),
+                neighbours: Vec::new(),
+            }
+        }
+        fn requeue(&self, changes: packetframe_vpp_offload::engine::SourceChanges) {
+            self.0.borrow_mut().extend(changes.routes);
+        }
+        fn route_count(&self) -> u64 {
+            0
+        }
+        fn change_seq(&self) -> u64 {
+            0
+        }
+    }
+
+    let fake = Fake::start("delta-shadow");
+    let mut e = engine_with_local_route(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    fake.drain_events();
+
+    let src = Deltas(RefCell::new(vec![
+        (svc(9, 32), Some(vec![nh()])),
+        (v4(1, 0), Some(vec![nh()])),
+    ]));
+    let n = e.apply_changes(&src, 100).expect("apply");
+    assert_eq!(n, 2);
+    assert_eq!(e.shadowed_routes(), 1, "the in-prefix delta is suppressed");
+    assert_eq!(
+        e.pending().len(),
+        1,
+        "only the transit route may reach the pending map"
+    );
+
+    // A withdrawal of the shadowed prefix leaves the count, not a
+    // stale entry.
+    src.0.borrow_mut().push((svc(9, 32), None));
+    e.apply_changes(&src, 100).expect("apply withdraw");
+    assert_eq!(e.shadowed_routes(), 0);
+}
+
+/// A stale install INSIDE the local prefix — a pre-local-route run's
+/// leftover, arriving via adoption — is withdrawn by the resync diff:
+/// shadowed prefixes are deliberately absent from `seen`, so the
+/// ledger-driven withdrawal loop is what cleans VPP.
+#[test]
+fn a_stale_install_inside_the_local_prefix_is_withdrawn() {
+    let fake = Fake::start_behaving(
+        "stale-shadowed",
+        Behaviour {
+            existing_routes: &[([23, 191, 200, 7], 32, ASSIGNED_INDEX, true)],
+            ..Default::default()
+        },
+    );
+    let mut e = engine_with_local_route(&fake);
+    assert!(e.api_ready());
+    e.attach_devices(AttachMode::Fresh).expect("attach");
+    let adopted = e.adopt_vpp_fib().expect("adopt");
+    assert_eq!(adopted, 1, "the stale route looks self-installed");
+
+    // The mirror still carries it (bird does not stop advertising just
+    // because we started shadowing) — and it must STILL be withdrawn.
+    let m = Mirror {
+        routes: vec![svc(7, 32)],
+    };
+    let plan = e.begin_resync(&m);
+    assert_eq!(plan.shadowed, 1);
+    assert_eq!(plan.withdrawals, 1);
+    drain_to_empty(&mut e);
+    let deletes: Vec<WireRoute> = fake
+        .drain_events()
+        .into_iter()
+        .filter_map(|ev| match ev {
+            Event::Route(r) if !r.is_add => Some(r),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        deletes.iter().any(|r| r.addr == [23, 191, 200, 7]),
+        "the stale in-prefix install must be withdrawn from VPP: {deletes:?}"
+    );
+}

--- a/crates/modules/vpp-offload/tests/vpp_runtime.rs
+++ b/crates/modules/vpp-offload/tests/vpp_runtime.rs
@@ -1628,8 +1628,7 @@ mod steered {
         }
         fn retarget(
             &mut self,
-            _ports: Vec<(String, u32)>,
-            _plan: packetframe_vpp_offload::steer::RuleSet,
+            _targets: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>,
         ) {
         }
     }
@@ -2728,8 +2727,7 @@ fn the_retry_does_not_steer_into_a_table_with_known_holes() {
         }
         fn retarget(
             &mut self,
-            _ports: Vec<(String, u32)>,
-            _plan: packetframe_vpp_offload::steer::RuleSet,
+            _targets: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>,
         ) {
         }
     }
@@ -2857,8 +2855,7 @@ fn an_empty_target_is_permitted_over_a_table_with_known_holes() {
         }
         fn retarget(
             &mut self,
-            _ports: Vec<(String, u32)>,
-            _plan: packetframe_vpp_offload::steer::RuleSet,
+            _targets: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>,
         ) {
         }
     }

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -746,7 +746,7 @@ fn a_loop_that_panics_after_publishing_is_not_a_clean_stop() {
         fn installed(&self) -> Vec<(String, u32)> {
             Vec::new()
         }
-        fn retarget(&mut self, _: Vec<(String, u32)>, _: packetframe_vpp_offload::steer::RuleSet) {}
+        fn retarget(&mut self, _: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>) {}
     }
 
     let fake = Fake::start("svc-panic");
@@ -1195,16 +1195,16 @@ impl packetframe_vpp_offload::runtime::Steering for SpySteering {
     fn installed(&self) -> Vec<(String, u32)> {
         Vec::new()
     }
-    fn retarget(
-        &mut self,
-        ports: Vec<(String, u32)>,
-        plan: packetframe_vpp_offload::steer::RuleSet,
-    ) {
-        self.0.lock().unwrap().push(format!(
-            "retarget {} ports, {} rules",
-            ports.len(),
-            plan.rules.len()
-        ));
+    fn retarget(&mut self, targets: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>) {
+        // The rule count reads the first target's plan: every fixture
+        // here retargets a uniform set, and an empty target genuinely
+        // carries no rules now — the unsteer request stopped hauling a
+        // plan along when targets became per-port.
+        let rules = targets.first().map_or(0, |(_, _, p)| p.rules.len());
+        self.0
+            .lock()
+            .unwrap()
+            .push(format!("retarget {} ports, {} rules", targets.len(), rules));
     }
 }
 
@@ -1243,12 +1243,7 @@ impl packetframe_vpp_offload::runtime::Steering for GatedSteer {
     fn installed(&self) -> Vec<(String, u32)> {
         Vec::new()
     }
-    fn retarget(
-        &mut self,
-        _ports: Vec<(String, u32)>,
-        _plan: packetframe_vpp_offload::steer::RuleSet,
-    ) {
-    }
+    fn retarget(&mut self, _targets: Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)>) {}
 }
 
 /// `reconfigure` must RETRY a steer that failed, not report success and
@@ -1337,7 +1332,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     }
 
     // The operator turns the lever; the steer is refused.
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), true, true)
         .expect_err("the refusal is the operator's answer");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1351,7 +1346,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // steer's own reason, and one that took the staging early return
     // answers Ok having done nothing at all.
     let again = svc
-        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+        .apply_steering(uniform1(plan_for(2)), true, false)
         .expect_err(
             "an unchanged-config reconfigure over a refused steer must re-attempt it; \
              reporting Ok while doing nothing is worse than refusing, because the \
@@ -1365,7 +1360,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // And with the blocker gone it lands, without waiting out the
     // module's own retry interval.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), true, false)
         .expect("the retry is accepted");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1378,6 +1373,14 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
         "both reconfigures must have reached the steer: {seen:?}"
     );
     assert_eq!(seen.last().map(String::as_str), Some("steer"), "{seen:?}");
+}
+
+/// One eth4 target carrying `plan` — the uniform shape these fixtures
+/// meant before targets became per-port.
+fn uniform1(
+    plan: packetframe_vpp_offload::steer::RuleSet,
+) -> Vec<(String, u32, packetframe_vpp_offload::steer::RuleSet)> {
+    vec![("eth4".into(), 0, plan)]
 }
 
 fn plan_for(count: u8) -> packetframe_vpp_offload::steer::RuleSet {
@@ -1465,7 +1468,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), true, true)
         .expect("the canary lever must turn without a restart");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1475,7 +1478,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
 
     // Rollback: membership stays, the FIB stays synced, traffic returns
     // to the fallback tier.
-    svc.apply_steering(Vec::new(), plan_for(2), false, true)
+    svc.apply_steering(Vec::new(), false, true)
         .expect("rollback");
     assert_eq!(svc.status().expect("published").state, State::Ready);
 
@@ -1485,7 +1488,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
         vec![
             "retarget 1 ports, 6 rules".to_string(),
             "steer".into(),
-            "retarget 0 ports, 6 rules".into(),
+            "retarget 0 ports, 0 rules".into(),
             "unsteer".into(),
         ],
         "the target is recorded BEFORE the reconcile, or Steer installs the old rules"
@@ -1549,7 +1552,7 @@ fn a_steering_change_before_convergence_is_refused() {
     .expect("service starts");
 
     let e = svc
-        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .apply_steering(uniform1(plan_for(2)), true, true)
         .expect_err("must refuse before convergence");
     assert!(
         e.contains("not converged"),
@@ -1644,7 +1647,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // `steer on` is in the config (ports is non-empty, want_steer true)
     // but the flag did not move in this reconfigure.
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), true, false)
         .expect("a target update is not an error");
 
     assert_eq!(
@@ -1662,7 +1665,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // And the operator turning the lever on the very next reconfigure
     // still works, so this withholds rather than latches.
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), true, true)
         .expect("the lever still turns");
     // NOT polled, deliberately: the loop publishes before it answers
     // the caller, so a returned `apply_steering` means the window
@@ -1753,7 +1756,7 @@ fn an_allowlist_change_under_live_steering_is_always_reconciled() {
 
     // The lever did NOT move — only the allowlist did.
     log.lock().unwrap().clear();
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(1), true, false)
+    svc.apply_steering(uniform1(plan_for(1)), true, false)
         .expect("a live port must be reconciled");
 
     let seen = log.lock().unwrap().clone();
@@ -1862,7 +1865,7 @@ fn a_first_steer_refused_by_the_fib_gate_is_still_remembered() {
 
     // The operator turns the lever into an incomplete table.
     let err = svc
-        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .apply_steering(uniform1(plan_for(2)), true, true)
         .expect_err("an incomplete FIB is not one to divert traffic into");
     assert!(err.contains("refusing the first steer"), "{err}");
     assert!(
@@ -2012,7 +2015,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
     // the episode is NOT over — and stays remembered until steering
     // matches intent again.
     let err = svc
-        .apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+        .apply_steering(uniform1(plan_for(2)), true, true)
         .expect_err("the gate is closed");
     assert!(err.contains("refusing to steer"), "{err}");
     let seeded = svc.status().expect("published");
@@ -2027,7 +2030,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
 
     // Recovery: the operator's retry succeeds and the module steers.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(vec![("eth4".into(), 0)], plan_for(2), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), true, true)
         .expect("the lever turns once the gate opens");
 
     // The regression, both defects at once. The episode reasons must

--- a/crates/modules/vpp-offload/vpp-api/vlib.api.json
+++ b/crates/modules/vpp-offload/vpp-api/vlib.api.json
@@ -1,0 +1,530 @@
+{
+    "module": "vlib",
+    "types": [
+        [
+            "thread_data",
+            [
+                "u32",
+                "id"
+            ],
+            [
+                "string",
+                "name",
+                64
+            ],
+            [
+                "string",
+                "type",
+                64
+            ],
+            [
+                "u32",
+                "pid"
+            ],
+            [
+                "u32",
+                "cpu_id"
+            ],
+            [
+                "u32",
+                "core"
+            ],
+            [
+                "u32",
+                "cpu_socket"
+            ],
+            {
+                "comment": "/** \\brief thread data\n    @param id - thread index\n    @param name - thread name i.e. vpp_main or vpp_wk_0\n    @param type - thread type i.e. workers or stats\n    @param pid - thread Process Id\n    @param cpu_id - thread pinned to cpu.\n    \"CPUs or Logical cores are the number of physical cores times\n    the number of threads that can run on each core through\n    the use of hyperthreading.\" (from unix.stackexchange.com)\n    @param core - thread pinned to actual physical core.\n    @param cpu_socket - thread is running on which cpu socket.\n*/"
+            }
+        ]
+    ],
+    "messages": [
+        [
+            "cli",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "u64",
+                "cmd_in_shmem"
+            ],
+            {
+                "crc": "0x23bfbfff",
+                "options": {},
+                "comment": "/** \\brief Process a vpe parser cli string request\n    @param client_index - opaque cookie to identify the sender\n    @param context - sender context, to match reply w/ request\n    @param cmd_in_shmem - pointer to cli command string\n*/"
+            }
+        ],
+        [
+            "cli_inband",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "string",
+                "cmd",
+                0
+            ],
+            {
+                "crc": "0xf8377302",
+                "options": {}
+            }
+        ],
+        [
+            "cli_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u64",
+                "reply_in_shmem"
+            ],
+            {
+                "crc": "0x06d68297",
+                "options": {},
+                "comment": "/** \\brief vpe parser cli string response\n    @param context - sender context, to match reply w/ request\n    @param retval - return code for request\n    @param reply_in_shmem - Reply string from cli processing if any\n*/"
+            }
+        ],
+        [
+            "cli_inband_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "string",
+                "reply",
+                0
+            ],
+            {
+                "crc": "0x05879051",
+                "options": {}
+            }
+        ],
+        [
+            "get_node_index",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "string",
+                "node_name",
+                64
+            ],
+            {
+                "crc": "0xf1984c64",
+                "options": {},
+                "comment": "/** \\brief Get node index using name request\n    @param client_index - opaque cookie to identify the sender\n    @param context - sender context, to match reply w/ request\n    @param node_name[] - name of the node\n*/"
+            }
+        ],
+        [
+            "get_node_index_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u32",
+                "node_index"
+            ],
+            {
+                "crc": "0xa8600b89",
+                "options": {},
+                "comment": "/** \\brief Get node index using name request\n    @param context - sender context, to match reply w/ request\n    @param retval - return code for the request\n    @param node_index - index of the desired node if found, else ~0\n*/"
+            }
+        ],
+        [
+            "add_node_next",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "string",
+                "node_name",
+                64
+            ],
+            [
+                "string",
+                "next_name",
+                64
+            ],
+            {
+                "crc": "0x2457116d",
+                "options": {},
+                "comment": "/** \\brief Set the next node for a given node request\n    @param client_index - opaque cookie to identify the sender\n    @param context - sender context, to match reply w/ request\n    @param node_name[] - node to add the next node to\n    @param next_name[] - node to add as the next node\n*/"
+            }
+        ],
+        [
+            "add_node_next_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u32",
+                "next_index"
+            ],
+            {
+                "crc": "0x2ed75f32",
+                "options": {},
+                "comment": "/** \\brief IP Set the next node for a given node response\n    @param context - sender context, to match reply w/ request\n    @param retval - return code for the add next node request\n    @param next_index - the index of the next node if success, else ~0\n*/"
+            }
+        ],
+        [
+            "show_threads",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            {
+                "crc": "0x51077d14",
+                "options": {},
+                "comment": "/** \\brief show_threads display the information about vpp\n    threads running on system along with their process id,\n    cpu id, physical core and cpu socket.\n*/"
+            }
+        ],
+        [
+            "show_threads_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u32",
+                "count"
+            ],
+            [
+                "vl_api_thread_data_t",
+                "thread_data",
+                0,
+                "count"
+            ],
+            {
+                "crc": "0xefd78e83",
+                "options": {},
+                "comment": "/** \\brief show_threads_reply\n    @param context - returned sender context, to match reply w/ request\n    @param retval - return code\n    @param count - number of threads in thread_data array\n    @param thread_data - array of thread data\n*/"
+            }
+        ],
+        [
+            "get_node_graph",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            {
+                "crc": "0x51077d14",
+                "options": {}
+            }
+        ],
+        [
+            "get_node_graph_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u64",
+                "reply_in_shmem"
+            ],
+            {
+                "crc": "0x06d68297",
+                "options": {}
+            }
+        ],
+        [
+            "get_next_index",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "string",
+                "node_name",
+                64
+            ],
+            [
+                "string",
+                "next_name",
+                64
+            ],
+            {
+                "crc": "0x2457116d",
+                "options": {},
+                "comment": "/** \\brief Query relative index via node names\n    @param client_index - opaque cookie to identify the sender\n    @param context - sender context, to match reply w/ request\n    @param node_name - name of node to find relative index from\n    @param next_name - next node from node_name to find relative index of\n*/"
+            }
+        ],
+        [
+            "get_next_index_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "i32",
+                "retval"
+            ],
+            [
+                "u32",
+                "next_index"
+            ],
+            {
+                "crc": "0x2ed75f32",
+                "options": {},
+                "comment": "/** \\brief Reply for get next node index\n    @param context - sender context which was passed in the request\n    @param retval - return value\n    @param next_index - index of the next_node\n*/"
+            }
+        ],
+        [
+            "get_f64_endian_value",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "f64",
+                "f64_one",
+                {
+                    "default": 1.0
+                }
+            ],
+            {
+                "crc": "0x809fcd44",
+                "options": {},
+                "comment": "/** \\brief f64 types are not standardized across the wire. Sense wire format in each direction by sending the f64 value 1.0.\n    @param client_index - opaque cookie to identify the sender\n    @param context - sender context, to match reply w/ request\n    @param f64_one - The constant of 1.0.  If you send a different value, expect an rv=VNET_API_ERROR_API_ENDIAN_FAILED.\n*/"
+            }
+        ],
+        [
+            "get_f64_endian_value_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "u32",
+                "retval"
+            ],
+            [
+                "f64",
+                "f64_one_result"
+            ],
+            {
+                "crc": "0x7e02e404",
+                "options": {},
+                "comment": "/** \\brief get_f64_endian_value reply message\n    @param context - sender context which was passed in the request\n    @param retval - return value - VNET_API_ERROR_API_ENDIAN_FAILED if f64_one != 1.0\n    @param f64_one_result - The value of 'f64 1.0'\n*/"
+            }
+        ],
+        [
+            "get_f64_increment_by_one",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "client_index"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "f64",
+                "f64_value",
+                {
+                    "default": 1.0
+                }
+            ],
+            {
+                "crc": "0xb64f027e",
+                "options": {},
+                "comment": "/** \\brief Verify f64 wire format by sending a value and receiving the value + 1.0\n    @param client_index - opaque cookie to identify the sender.\n    @param context - sender context, to match reply w/ request.\n    @param f64_value - The value you want to test.  Default: 1.0.\n*/"
+            }
+        ],
+        [
+            "get_f64_increment_by_one_reply",
+            [
+                "u16",
+                "_vl_msg_id"
+            ],
+            [
+                "u32",
+                "context"
+            ],
+            [
+                "u32",
+                "retval"
+            ],
+            [
+                "f64",
+                "f64_value"
+            ],
+            {
+                "crc": "0xd25dbaa3",
+                "options": {},
+                "comment": "/** \\brief get_f64_increment_by_one reply\n    @param client_index - opaque cookie to identify the sender.\n    @param context - sender context, to match reply w/ request.\n    @param f64_value - The input f64_value incremented by 1.0.\n*/"
+            }
+        ]
+    ],
+    "unions": [],
+    "enums": [],
+    "enumflags": [],
+    "services": {
+        "cli": {
+            "reply": "cli_reply"
+        },
+        "cli_inband": {
+            "reply": "cli_inband_reply"
+        },
+        "get_node_index": {
+            "reply": "get_node_index_reply"
+        },
+        "add_node_next": {
+            "reply": "add_node_next_reply"
+        },
+        "show_threads": {
+            "reply": "show_threads_reply"
+        },
+        "get_node_graph": {
+            "reply": "get_node_graph_reply"
+        },
+        "get_next_index": {
+            "reply": "get_next_index_reply"
+        },
+        "get_f64_endian_value": {
+            "reply": "get_f64_endian_value_reply"
+        },
+        "get_f64_increment_by_one": {
+            "reply": "get_f64_increment_by_one_reply"
+        }
+    },
+    "options": {
+        "version": "1.0.0"
+    },
+    "aliases": {},
+    "vl_api_version": "0x9a9e84e4",
+    "imports": [],
+    "counters": [],
+    "paths": []
+}

--- a/crates/tools/vpp-api-codegen/src/main.rs
+++ b/crates/tools/vpp-api-codegen/src/main.rs
@@ -142,6 +142,20 @@ const MESSAGES: &[&str] = &[
     "dev_create_port_if_reply",
     "dev_remove_port_if",
     "dev_remove_port_if_reply",
+    //   The one CLI-text message, for METRICS ONLY — never forwarding
+    //   decisions. VPP keeps error counters in the stats segment,
+    //   which has no binary-API reader and whose shared-memory parser
+    //   this module deliberately does not build; `cli_inband "show
+    //   errors"` is the one sanctioned way to read them over the
+    //   socket. The consumer is the null-node drop gauge (user
+    //   decision 2026-08-15: a visibility surface for the ~370 pps
+    //   undeliverable-reply residual ships BEFORE always-on), and its
+    //   parse failure degrades the gauge to absent, never the
+    //   dataplane. verify.rs records the same message as owed for
+    //   `show ip fib summary`; this vendors vlib.api.json and pays
+    //   that debt's entry fee.
+    "cli_inband",
+    "cli_inband_reply",
 ];
 
 const FILES: &[&str] = &[
@@ -155,6 +169,7 @@ const FILES: &[&str] = &[
     "ethernet_types",
     "interface_types",
     "mfib_types",
+    "vlib",
 ];
 
 /// One field of a message or composite type.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -53,6 +53,7 @@ running badly.
 - [Everyday inspection commands](#everyday-inspection-commands)
 - [The canary ladder](#the-canary-ladder)
 - [Rollback](#rollback)
+- [Bidirectional offload: local-route and direction dst](#bidirectional-offload-local-route-and-direction-dst)
 - [Triage by symptom](#triage-by-symptom)
 - [Numbers: measured vs published-on-faith](#numbers-measured-vs-published-on-faith)
 - [Install and upgrade on the router](#install-and-upgrade-on-the-router)
@@ -467,6 +468,121 @@ If `fib-synced` shows the deferral persisting on a box that SHOULD
 release: check the feed session actually started (`BGP client
 connected` + at least one UPDATE in the log), then check the mirror
 count against the floor in the health text.
+
+## Bidirectional offload: local-route and direction dst
+
+The pieces that carry the offload from `steer-direction src` staging
+to both directions. Three config facts, then the surfaces that watch
+them.
+
+### local-route: VPP delivers a prefix instead of forwarding it
+
+```
+module vpp-offload
+  port eth4 cores 1 steer on vlans 88,1337
+  local-route 23.191.200.0/24 port eth4 vlan 1337
+```
+
+One line does three things at attach:
+
+1. **An attached route** for the prefix onto the port's dot1q subif —
+   `show ip fib 23.191.200.0/24` shows the subif adjacency, not a
+   drop. Installed outside the route ledger (module-owned topology,
+   like the loopback), so resyncs never withdraw it.
+2. **The neighbour mirror**: kernel neighbours on the backing bridge
+   (the `via` of the covering fast-path `local-prefix`) become VPP
+   static neighbours on the subif. VPP never ARPs — a host the kernel
+   has never resolved drops in VPP where the kernel would ARP-queue.
+   Service hosts are static; if one ever matters, ping it from the
+   router once.
+3. **Shadowing**: mirror routes INSIDE the prefix are skipped, at
+   resync and in deltas. The kernel tier delivers to bridge hosts
+   before its FIB lookup, so bird's view inside a local prefix (the
+   reference primary carries a service host route as `unreachable`)
+   describes what bird would do, not what the box does.
+   `packetframe_vpp_shadowed_routes` counts what is currently
+   suppressed — on the reference primary the expected value is
+   exactly its poisoned host route, and a JUMP in it is a mirror
+   change worth reading about.
+
+Validation refuses: a port the section does not declare, a vlan
+missing from the port's `vlans` list, a prefix outside every
+fast-path `local-prefix` (tier agreement — a failover must not change
+what is delivered), and overlapping declarations. Restart-only; the
+reload names it.
+
+### direction dst: steering inbound
+
+Per-port, because the bidirectional service edge is asymmetric by
+nature:
+
+```
+  port eth4 cores 1 steer on vlans 88,1337 direction src   # outbound rides VPP
+  port eth3 cores 1 steer on direction dst                 # inbound rides VPP
+```
+
+A dst rule diverts inbound INTO VPP, so `direction dst` (and the
+global `both` default) refuses to load unless every steerable local
+prefix is fully covered by `local-route` lines — an uncovered address
+would blackhole 100% of its inbound the moment the port steers (the
+w20 shape), and that is a load-time refusal, not a canary discovery.
+Pure transit needs no local-routes: dst-steered traffic for a
+non-local prefix forwards via the full table.
+
+Each direction gets its own rule plan; `packetframe feasibility`
+itemises them per direction (divert + keep counts against the free
+slots). The exemptions install on every steered port, so
+internet→gateway traffic stays kernel-side on the transit ports too.
+
+### The FDB tripwire
+
+`local-route` names THE port a VLAN's hosts sit behind. If a host
+moves behind another member of the same bridge, the kernel follows it
+and VPP does not — so a per-minute AF_BRIDGE scan compares the
+kernel's FDB against the declarations and degrades health with the
+host named:
+
+```
+fdb: degraded — the kernel bridge FDB contradicts local-route:
+  02:...:07 vlan 1337 learned on eth5 (local-route declares eth4)
+```
+
+`packetframe_vpp_fdb_misplaced` carries the count. Remedies, in
+order: move the host back; fix the declaration; or the topology has
+outgrown single-port delivery and needs per-host subif selection
+(B3 v2 — scoped, deliberately unbuilt until this fires).
+
+### Dashboards under-count steered traffic — where it went
+
+The moment a port steers, UniFi's port graphs (and anything else
+reading kernel netdev counters) drop by roughly the steered share:
+steered ingress is diverted to the VF before the PF counter
+increments, and VPP's egress leaves through the egress port's VF,
+which the PF counters never see. Measured on the primary (w25,
+2026-08-15): eth3's kernel tx fell to ~211 kB/s while `octeon3/0`
+carried ~261 MB/s — same wire, different ledger.
+
+The counters to trust while steered: `packetframe_vpp_*` gauges and
+`vppctl show interface` for the offloaded share; kernel counters for
+the exempt/kernel-side residual. Two-sample rate check:
+
+```sh
+vppctl -s /run/packetframe/vpp/api.sock.cli show interface \
+  | tr -d '\r' | awk '/^octeon/{i=$1} /tx bytes/{print i, $NF}'
+# wait 10s, run again; delta/10 = B/s per VPP interface
+```
+
+### The null-drop gauge
+
+`packetframe_vpp_null_drops` is VPP's own null-node counter, sampled
+over the binary API every 60 s (absent until the first sample, and
+after any read trouble — absent is "cannot read", never "zero").
+What it counts on the reference primary: replies to spoofed/bogon
+sources — traffic the kernel also dropped, just less visibly
+(~370 pps steady in w23/w24). The steady residual is
+correct-by-design; a CHANGE in its rate after a config or mirror
+change is the signal, and with local-routes in place a large step up
+usually means something local stopped being delivered.
 
 ## Triage by symptom
 


### PR DESCRIPTION
Part B of the bidirectional-offload plan, in one PR by request, structured as six per-slice commits (review commit-by-commit). Everything here is what w27 — the first `direction dst` transit canary — needs to exist.

## What each commit does

1. **config grammar** — `local-route <v4-cidr> port <iface> vlan <vid>` (repeatable, restart-only) and the per-port `direction src|dst|both` tail on `port` lines. Validation: the port must declare the vlan; the prefix must sit inside a fast-path `local-prefix` (tier agreement — a failover must not change what is delivered; the neighbour mirror's kernel device comes from its `via`); overlaps refused; and **dst-direction steering refuses to load unless every steerable local prefix is fully tiled by local-routes** — an uncovered address blackholes 100% of its inbound the moment the port steers (the w20 shape), so it is a load-time refusal, not a canary discovery. Pure transit needs nothing.
2. **B1: local delivery** — `ensure_vlan_subifs` finally returns the indices VPP assigns (`engine.rs`'s old NOTE named exactly this as the missing third step); one attached route per local-route straight onto the subif, deliberately outside the pending/ledger path so resyncs cannot withdraw it and adoption's shape test exempts it; the mirror's view INSIDE a local prefix shadowed at both the resync and delta doors (the reference primary's `unreachable` host route is the poison this kills), with stale pre-local-route installs cleaned by the existing withdrawal diff; and the bridge neighbour mirror opened end to end — the feed already carried bridge-host neighbours, they just died at `target_for_device`.
3. **B2: per-port direction** — `SteeringTarget`/`NtupleSteering` trade their single `(ports, plan)` for per-port `(iface, vf, RuleSet)` targets; one plan per distinct effective direction from the shared free-slot intersection; every ledger routine now asks what THIS port holds. The feasibility budget probe runs the same derivation, which also fixes its long-standing `rules/2` mis-count.
4. **null-drop gauge** — `vlib.api.json` vendored (byte-bound like the rest), `cli_inband` whitelisted for METRICS ONLY; the engine samples `show errors` every 60 s and `packetframe_vpp_null_drops` carries the null-node total, absent (never zero) on any read trouble, cleared with the process.
5. **B3 v1: the FDB tripwire** — a per-minute blocking AF_BRIDGE dump compares the kernel's per-VLAN FDB against the local-route declarations; a learned host behind a different member port degrades health with the host named (`packetframe_vpp_fdb_misplaced` counts). Detection only; per-host delivery (v2) stays scoped-but-unbuilt until this fires.
6. **runbook** — the operator section for all of the above, including the w25 measurement that dashboards under-count steered traffic (kernel counters lost ~261 MB/s to `octeon3/0` on the same wire) and which counters to trust.

## Evidence

- Full workspace green on host; clippy `-D warnings` clean; `cargo check --target aarch64-unknown-linux-gnu` clean for the module and CLI (the cross-check caught two Linux-gated errors the host build cannot see — the #189 lesson, applied).
- New tests: config grammar/validation clusters (incl. coverage tiling), subif-index assertions in `vpp_attach_verify`, four B1 engine tests against the fake VPP (attached-route placement, resync+delta shadowing, bridge-neighbour-to-subif, stale-install withdrawal), mixed-direction install/audit/unsteer in `ntuple`, per-port plan derivation in `lib`, the `show errors` parser + end-to-end `cli_inband` sample, FDB comparison logic, and both new health surfaces asserted on report+gauge together.
- Hardware validation is w26 (local delivery on the eth4 canary) and w27 (first `direction dst` transit port) — none of the delivery paths here are claimed proven until those run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)