### PR TITLE
feat(vpp-offload): the exemption tripwire — kernel paths VPP cannot take, watched on a clock

### DIFF
--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -556,6 +556,7 @@ pub fn bring_up(
         loopback,
         &port_vlans,
         local_routes,
+        &cfg.steer_exempts,
     ) {
         Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
@@ -629,6 +630,7 @@ fn finish(
     loopback: packetframe_common::config::Ipv4Prefix,
     port_vlans: &[(String, Vec<u16>)],
     local_routes: &[crate::LocalRoute],
+    steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
     // rewritten on every attach: it is a pure function of config, and
@@ -869,6 +871,7 @@ fn finish(
     // here rather than passed in: it shares one record between the
     // identity store and the release seam through an `Rc`.
     let local_routes = local_routes.to_vec();
+    let drift_exempts = steer_exempts.to_vec();
     let factory: LoopFactory = Box::new(move || {
         // The FDB tripwire's declarations, cloned out before the engine
         // consumes the resolved set.
@@ -876,6 +879,17 @@ fn finish(
             .iter()
             .map(|lr| (lr.vlan, lr.port.clone()))
             .collect();
+        // What VPP can egress, for the exemption tripwire: the member
+        // ports plus the kernel bridges `local-route` delivers into.
+        // Everything else the kernel routes through is a path VPP
+        // cannot take.
+        let drift_reach = crate::drift::VppReach {
+            members: members.clone(),
+            local_devices: local_routes
+                .iter()
+                .map(|lr| lr.kernel_dev.clone())
+                .collect(),
+        };
         let engine = ConvergenceEngine::new(
             api_socket_path,
             port_attach,
@@ -926,6 +940,17 @@ fn finish(
         }
         #[cfg(not(target_os = "linux"))]
         let _ = fdb_declared;
+        // The exemption tripwire, installed whenever this box could
+        // steer at all — the hole it names opens the instant a port
+        // does, so an operator wants it BEFORE the canary rather than
+        // after the traffic is gone.
+        #[cfg(target_os = "linux")]
+        runtime.drift_watch(Box::new(crate::drift::KernelDriftWatch {
+            reach: drift_reach,
+            exempts: drift_exempts,
+        }));
+        #[cfg(not(target_os = "linux"))]
+        let _ = (drift_reach, drift_exempts);
         let initial = match adopted {
             Some(p) => {
                 // The API handshake MUST happen before the adoption is

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -962,6 +962,15 @@ fn finish(
             exempts: drift_exempts,
             dst_only: dst_only_scope,
         }));
+        // Rules from a previous process are adopted below, and the
+        // config on disk may have been edited while the daemon was
+        // down — an exemption added in that window would make the
+        // tripwire suppress a path the inherited rule still diverts.
+        // The watcher is told it cannot trust the match until a steer
+        // reconciles the NIC (review finding).
+        if inherited_rule_count > 0 {
+            runtime.note_inherited_steering();
+        }
         #[cfg(not(target_os = "linux"))]
         let _ = (drift_reach, drift_exempts, dst_only_scope);
         let initial = match adopted {

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -412,17 +412,7 @@ pub fn bring_up(
     // Any src (or `both`) port anywhere means any destination is
     // reachable — the conservative default, including when the config
     // declares no direction at all.
-    let dst_only_scope: Option<Vec<packetframe_common::fib::IpPrefix>> = {
-        let mut all_dst = !cfg.ports.is_empty();
-        for (_, _, _, _, dir) in &cfg.ports {
-            if dir.unwrap_or(cfg.steer_direction)
-                != packetframe_common::config::VppSteerDirection::Dst
-            {
-                all_dst = false;
-            }
-        }
-        all_dst.then(|| allowlist.to_vec())
-    };
+    let dst_only_scope = crate::drift::divertible_scope(&cfg.ports, cfg.steer_direction, allowlist);
     let steering = NtupleSteering::new(member_ports, steer_targets);
 
     let workers = cfg.total_workers();

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -403,6 +403,26 @@ pub fn bring_up(
         .iter()
         .map(|(iface, _, _, _, _)| (iface.clone(), 0u32))
         .collect();
+    // Can steering divert anything, or only allowlisted destinations?
+    // Derived from CONFIG rather than from the lever, so the answer
+    // does not change under an operator turning a port on: if every
+    // port this config could ever steer matches on dst, a path
+    // outside the allowlist can never enter VPP and demanding an
+    // exemption slot for it would spend a scarce resource on nothing.
+    // Any src (or `both`) port anywhere means any destination is
+    // reachable — the conservative default, including when the config
+    // declares no direction at all.
+    let dst_only_scope: Option<Vec<packetframe_common::fib::IpPrefix>> = {
+        let mut all_dst = !cfg.ports.is_empty();
+        for (_, _, _, _, dir) in &cfg.ports {
+            if dir.unwrap_or(cfg.steer_direction)
+                != packetframe_common::config::VppSteerDirection::Dst
+            {
+                all_dst = false;
+            }
+        }
+        all_dst.then(|| allowlist.to_vec())
+    };
     let steering = NtupleSteering::new(member_ports, steer_targets);
 
     let workers = cfg.total_workers();
@@ -557,6 +577,7 @@ pub fn bring_up(
         &port_vlans,
         local_routes,
         &cfg.steer_exempts,
+        dst_only_scope,
     ) {
         Ok(attached) => Ok(attached),
         // A supervision panic is the one failure that must NOT roll back.
@@ -631,6 +652,7 @@ fn finish(
     port_vlans: &[(String, Vec<u16>)],
     local_routes: &[crate::LocalRoute],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
+    dst_only_scope: Option<Vec<packetframe_common::fib::IpPrefix>>,
 ) -> Result<Attached, String> {
     // --- startup.conf. Written before any process could read it, and
     // rewritten on every attach: it is a pure function of config, and
@@ -948,9 +970,10 @@ fn finish(
         runtime.drift_watch(Box::new(crate::drift::KernelDriftWatch {
             reach: drift_reach,
             exempts: drift_exempts,
+            dst_only: dst_only_scope,
         }));
         #[cfg(not(target_os = "linux"))]
-        let _ = (drift_reach, drift_exempts);
+        let _ = (drift_reach, drift_exempts, dst_only_scope);
         let initial = match adopted {
             Some(p) => {
                 // The API handshake MUST happen before the adoption is

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -36,9 +36,12 @@ use packetframe_common::config::Ipv4Prefix;
 pub struct KernelRoute {
     /// Destination prefix. A default route is `0.0.0.0/0`.
     pub prefix: Ipv4Prefix,
-    /// Output device name, or `None` for routes with no oif (which
-    /// this check ignores — nothing to compare against).
-    pub oif: Option<String>,
+    /// Output device name(s). More than one for a multipath route —
+    /// ECMP encodes its nexthops in `RTA_MULTIPATH` rather than
+    /// `RTA_OIF`, and a route read as having no device at all would
+    /// be skipped silently (review finding). Empty means the kernel
+    /// named no interface, which this check has nothing to say about.
+    pub oifs: Vec<String>,
     /// Routing table id, for the operator-facing message: "table 100"
     /// is how they will find it again.
     pub table: u32,
@@ -46,6 +49,14 @@ pub struct KernelRoute {
     /// unreachable, prohibit). VPP dropping the same packet is
     /// equivalent behaviour, so these are not findings.
     pub drops: bool,
+    /// `RTN_LOCAL`: an address the kernel TERMINATES rather than a
+    /// path it forwards over. Its `oif` names the interface that owns
+    /// the address, which is not an egress VPP could take — so device
+    /// reachability says nothing about it and must not be consulted
+    /// (review finding: the local class this scan exists to cover was
+    /// being skipped precisely because those addresses sit on member
+    /// ports and bridges).
+    pub local: bool,
 }
 
 /// What VPP can actually egress, from config: member ports and the
@@ -66,31 +77,91 @@ impl VppReach {
     }
 }
 
+/// Which destinations steering can actually divert into VPP.
+///
+/// `Any` — some port matches on SOURCE, so a steered host's packet
+/// reaches VPP whatever it is addressed to, and every kernel path is
+/// at risk. `OnlyDst(prefixes)` — every steering port matches on
+/// destination, so only packets addressed inside the allowlist are
+/// diverted at all, and demanding an MCAM slot for a path no packet
+/// can reach would spend a scarce resource on nothing (review
+/// finding).
+#[derive(Debug, Clone)]
+pub enum Divertible<'a> {
+    Any,
+    OnlyDst(&'a [packetframe_common::fib::IpPrefix]),
+}
+
+impl Divertible<'_> {
+    /// Can a packet for `prefix` be diverted into VPP at all?
+    ///
+    /// OVERLAP, not containment: a dst rule for one address inside a
+    /// route's prefix is enough to send traffic for that route into
+    /// VPP, so the route is at risk even though the allowlist does
+    /// not cover all of it.
+    fn reaches(&self, prefix: &Ipv4Prefix) -> bool {
+        match self {
+            Self::Any => true,
+            Self::OnlyDst(allow) => allow.iter().any(|a| {
+                let packetframe_common::fib::IpPrefix::V4 { addr, prefix_len } = a else {
+                    return false;
+                };
+                let a = Ipv4Prefix {
+                    addr: std::net::Ipv4Addr::from(*addr),
+                    prefix_len: *prefix_len,
+                };
+                a.contains_prefix(prefix) || prefix.contains_prefix(&a)
+            }),
+        }
+    }
+}
+
 /// A kernel path VPP cannot take that nothing exempts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Uncovered {
     pub prefix: Ipv4Prefix,
     pub oif: String,
     pub table: u32,
+    /// A terminated address rather than a forwarding path — the
+    /// message says so, because the remedy reads differently.
+    pub local: bool,
 }
 
 impl std::fmt::Display for Uncovered {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}/{} via {} (table {})",
-            self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
-        )
+        if self.local {
+            write!(
+                f,
+                "{}/{} terminates on {} (table {}, the router's own address)",
+                self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
+            )
+        } else {
+            write!(
+                f,
+                "{}/{} via {} (table {})",
+                self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
+            )
+        }
     }
 }
 
 /// The pure half: which kernel routes would blackhole under steering.
 ///
-/// A route is a finding iff it egresses a device VPP cannot use, the
-/// kernel does not drop it itself, and no `steer-exempt` covers its
-/// prefix. Deliberately NOT filtered by the allowlist: with source
-/// steering, which packets get diverted is decided by where they came
-/// FROM, so any destination a steered host can reach is at risk.
+/// A route is a finding iff steering can divert traffic for it, the
+/// kernel does not drop it itself, VPP has no way to deliver it, and
+/// no `steer-exempt` covers its prefix.
+///
+/// "No way to deliver it" is two different questions:
+///
+/// - a FORWARDED route is unreachable when none of its nexthop
+///   devices is a member port or a `local-route` bridge. Multipath
+///   counts as reachable if ANY path is, because VPP installs the
+///   paths it can resolve and forwards over those;
+/// - a LOCAL route is an address the kernel terminates. VPP has no
+///   local delivery at all, so device reachability is irrelevant and
+///   asking it is the bug this arm exists to fix — the w23 blackhole
+///   was traffic to a gateway address sitting on a bridge that this
+///   scan would otherwise have called covered.
 ///
 /// Coverage is by prefix containment, and an exempt must contain the
 /// route — not merely overlap it. A `/32` exemption does not cover the
@@ -101,14 +172,27 @@ pub fn uncovered_paths(
     routes: &[KernelRoute],
     reach: &VppReach,
     exempts: &[Ipv4Prefix],
+    divertible: &Divertible<'_>,
 ) -> Vec<Uncovered> {
     let mut out = Vec::new();
     for r in routes {
-        if r.drops {
+        if r.drops || !divertible.reaches(&r.prefix) {
             continue;
         }
-        let Some(oif) = &r.oif else { continue };
-        if reach.covers_device(oif) {
+        let Some(oif) = r.oifs.first() else { continue };
+        if r.local {
+            // Only the segments whose hosts steering diverts. A
+            // transit port's own address is reachable from a steered
+            // host only by a route that would itself be a finding,
+            // and reporting every address on the box would demand
+            // more exemptions than the 16-slot budget holds — an
+            // alarm with no available remedy is one operators learn
+            // to ignore. Documented in the runbook, with the
+            // null-drop gauge as the backstop for the rest.
+            if !reach.local_devices.iter().any(|d| d == oif) {
+                continue;
+            }
+        } else if r.oifs.iter().any(|d| reach.covers_device(d)) {
             continue;
         }
         // Built-in exemptions cover these on every steered port.
@@ -128,6 +212,7 @@ pub fn uncovered_paths(
             prefix: r.prefix,
             oif: oif.clone(),
             table: r.table,
+            local: r.local,
         });
     }
     out.sort_by_key(|u| (u.prefix.prefix_len, u32::from(u.prefix.addr)));
@@ -142,23 +227,48 @@ pub trait DriftWatch {
     /// hold. `Err` = the kernel would not answer; the caller keeps its
     /// previous verdict.
     fn uncovered(&mut self) -> Result<Vec<String>, String>;
+
+    /// Adopt a reloaded exemption set. Called from the same place the
+    /// steering target is retargeted, so the scan judges the config
+    /// the operator just applied rather than the one at attach.
+    fn set_exempts(&mut self, exempts: Vec<Ipv4Prefix>);
 }
 
 /// The production scan: dump every IPv4 route in every table, compare.
 #[cfg(target_os = "linux")]
 pub struct KernelDriftWatch {
     pub reach: VppReach,
+    /// The CURRENT exemptions. `steer-exempt` is hot-reloadable, so
+    /// this is refreshed on every accepted reconfigure — a watcher
+    /// frozen at attach would call a newly-unexempted path covered
+    /// (the blackhole this exists to catch) and, worse, keep
+    /// reporting a path the operator had just exempted BECAUSE the
+    /// health message told them to (review finding).
     pub exempts: Vec<Ipv4Prefix>,
+    /// Whether steering can divert anything, or only allowlisted
+    /// destinations. Config-derived and restart-only, like the port
+    /// directions it comes from.
+    pub dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
 }
 
 #[cfg(target_os = "linux")]
 impl DriftWatch for KernelDriftWatch {
     fn uncovered(&mut self) -> Result<Vec<String>, String> {
         let routes = dump_routes()?;
-        Ok(uncovered_paths(&routes, &self.reach, &self.exempts)
-            .into_iter()
-            .map(|u| u.to_string())
-            .collect())
+        let divertible = match &self.dst_only {
+            Some(allow) => Divertible::OnlyDst(allow),
+            None => Divertible::Any,
+        };
+        Ok(
+            uncovered_paths(&routes, &self.reach, &self.exempts, &divertible)
+                .into_iter()
+                .map(|u| u.to_string())
+                .collect(),
+        )
+    }
+
+    fn set_exempts(&mut self, exempts: Vec<Ipv4Prefix>) {
+        self.exempts = exempts;
     }
 }
 
@@ -224,12 +334,21 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                 NetlinkPayload::Error(e) => return Err(format!("netlink error: {e}")),
                 NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewRoute(m)) => {
                     let mut dst: Option<std::net::Ipv4Addr> = None;
-                    let mut oif: Option<u32> = None;
+                    let mut oifs: Vec<u32> = Vec::new();
                     let mut table = u32::from(m.header.table);
                     for attr in &m.attributes {
                         match attr {
                             RouteAttribute::Destination(RouteAddress::Inet(a)) => dst = Some(*a),
-                            RouteAttribute::Oif(i) => oif = Some(*i),
+                            RouteAttribute::Oif(i) => oifs.push(*i),
+                            // ECMP puts its nexthops HERE and leaves
+                            // RTA_OIF unset, so a route read only for
+                            // RTA_OIF looks device-less and gets
+                            // skipped — an all-tunnel ECMP route would
+                            // blackhole under a clean health surface
+                            // (review finding).
+                            RouteAttribute::MultiPath(hops) => {
+                                oifs.extend(hops.iter().map(|h| h.interface_index))
+                            }
                             // RTA_TABLE carries ids past the u8 header
                             // field — policy tables live up there.
                             RouteAttribute::Table(t) => table = *t,
@@ -242,17 +361,21 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             addr: dst.unwrap_or(std::net::Ipv4Addr::UNSPECIFIED),
                             prefix_len: m.header.destination_prefix_length,
                         },
-                        oif: oif.map(|i| {
-                            names
-                                .entry(i)
-                                .or_insert_with(|| crate::fdb::ifname(i))
-                                .clone()
-                        }),
+                        oifs: oifs
+                            .into_iter()
+                            .map(|i| {
+                                names
+                                    .entry(i)
+                                    .or_insert_with(|| crate::fdb::ifname(i))
+                                    .clone()
+                            })
+                            .collect(),
                         table,
                         drops: matches!(
                             m.header.kind,
                             RouteType::BlackHole | RouteType::Unreachable | RouteType::Prohibit
                         ),
+                        local: m.header.kind == RouteType::Local,
                     });
                 }
                 _ => {}
@@ -278,9 +401,10 @@ mod tests {
     fn route(prefix: Ipv4Prefix, oif: &str) -> KernelRoute {
         KernelRoute {
             prefix,
-            oif: Some(oif.to_string()),
+            oifs: vec![oif.to_string()],
             table: 100,
             drops: false,
+            local: false,
         }
     }
 
@@ -289,6 +413,10 @@ mod tests {
             members: vec!["eth3".into(), "eth4".into()],
             local_devices: vec!["br1337".into()],
         }
+    }
+
+    fn find(routes: &[KernelRoute], exempts: &[Ipv4Prefix]) -> Vec<Uncovered> {
+        uncovered_paths(routes, &reach(), exempts, &Divertible::Any)
     }
 
     /// The w26 shape: tunnel-bound routes are findings, and only the
@@ -302,65 +430,144 @@ mod tests {
             route(p(23, 191, 200, 0, 24), "br1337"), // local delivery: fine
             route(p(10, 0, 0, 0, 8), "eth4"),       // member: fine
         ];
-        let found = uncovered_paths(&routes, &reach(), &[]);
+        let found = find(&routes, &[]);
         assert_eq!(found.len(), 2, "{found:?}");
-        assert!(found.iter().any(|u| u.oif == "vti64"));
+        assert!(found.iter().all(|u| u.oif == "vti64"));
 
-        // Exempting both silences it.
         let exempts = [p(23, 191, 201, 0, 24), p(23, 191, 200, 2, 32)];
-        assert!(uncovered_paths(&routes, &reach(), &exempts).is_empty());
+        assert!(find(&routes, &exempts).is_empty());
     }
 
     /// Containment, not overlap: a /32 exemption inside a /24 route
-    /// does NOT cover the /24. Reporting it as handled because one
-    /// host is exempted is the silent-hole shape this exists to end.
+    /// does NOT cover the /24.
     #[test]
     fn an_exemption_must_contain_the_route_not_merely_overlap_it() {
         let routes = vec![route(p(23, 191, 201, 0, 24), "vti64")];
-        let too_narrow = [p(23, 191, 201, 5, 32)];
         assert_eq!(
-            uncovered_paths(&routes, &reach(), &too_narrow).len(),
+            find(&routes, &[p(23, 191, 201, 5, 32)]).len(),
             1,
             "a /32 inside the route must not silence the /24"
         );
-        // The other direction is genuine cover.
-        let wide = [p(23, 191, 0, 0, 16)];
-        assert!(uncovered_paths(&routes, &reach(), &wide).is_empty());
+        assert!(find(&routes, &[p(23, 191, 0, 0, 16)]).is_empty());
     }
 
     /// Routes the kernel drops itself are not findings: VPP dropping
-    /// the same packet is the same outcome, one hop earlier. The
-    /// reference primary's bird carries a service host as
-    /// `unreachable`, and flagging it would be permanent noise.
+    /// the same packet is the same outcome, one hop earlier.
     #[test]
     fn routes_the_kernel_itself_drops_are_not_findings() {
         let mut blackhole = route(p(198, 18, 0, 0, 15), "vti64");
         blackhole.drops = true;
         let mut no_oif = route(p(203, 0, 113, 0, 24), "vti64");
-        no_oif.oif = None;
-        let found = uncovered_paths(&[blackhole, no_oif], &reach(), &[]);
-        assert!(found.is_empty(), "{found:?}");
+        no_oif.oifs.clear();
+        assert!(find(&[blackhole, no_oif], &[]).is_empty());
     }
 
     /// Broadcast and multicast are exempted on every steered port
-    /// without a directive, so the scan must not demand config for
-    /// what is already handled.
+    /// without a directive.
     #[test]
     fn the_built_in_exemptions_count_as_cover() {
         let routes = vec![
             route(p(224, 0, 0, 0, 4), "vti64"),
             route(p(255, 255, 255, 255, 32), "vti64"),
         ];
-        assert!(uncovered_paths(&routes, &reach(), &[]).is_empty());
+        assert!(find(&routes, &[]).is_empty());
+    }
+
+    /// A LOCAL route is an address the kernel terminates, so device
+    /// reachability says nothing about it — VPP has no local delivery
+    /// at any interface. Skipping these because their oif is a member
+    /// or bridge is exactly how the w23 class (110,917 packets to a
+    /// gateway address in five minutes) would go unreported by a scan
+    /// whose docs claimed to cover it (review finding).
+    #[test]
+    fn a_local_address_on_a_service_bridge_is_a_finding_despite_the_device() {
+        let mut gw = route(p(23, 191, 200, 1, 32), "br1337");
+        gw.local = true;
+        gw.table = 255;
+        let found = find(&[gw.clone()], &[]);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert!(found[0].local);
+        assert!(
+            found[0].to_string().contains("terminates on br1337"),
+            "the message must read as termination, not a path: {}",
+            found[0]
+        );
+        // And the exemption an operator would add silences it.
+        assert!(find(&[gw], &[p(23, 191, 200, 1, 32)]).is_empty());
+    }
+
+    /// Local addresses NOT on a steered segment are deliberately out
+    /// of scope: the 16-slot budget cannot hold an exemption for every
+    /// address on the box, and an alarm with no available remedy is
+    /// one operators learn to ignore. Documented, with the null-drop
+    /// gauge as the backstop.
+    #[test]
+    fn local_addresses_off_the_steered_segments_are_out_of_scope() {
+        let mut transit = route(p(194, 110, 60, 51, 32), "eth3");
+        transit.local = true;
+        let mut loopback = route(p(127, 0, 0, 1, 32), "lo");
+        loopback.local = true;
+        assert!(find(&[transit, loopback], &[]).is_empty());
+    }
+
+    /// ECMP encodes nexthops in RTA_MULTIPATH, leaving RTA_OIF unset.
+    /// A route read only for RTA_OIF looks device-less and is skipped
+    /// — so an all-tunnel ECMP route would blackhole under a clean
+    /// health surface (review finding). Any reachable path makes the
+    /// route deliverable, because VPP installs the paths it can
+    /// resolve and forwards over those.
+    #[test]
+    fn a_multipath_route_is_judged_by_all_its_nexthops() {
+        let all_tunnel = KernelRoute {
+            prefix: p(198, 51, 100, 0, 24),
+            oifs: vec!["vti64".into(), "wg0".into()],
+            table: 254,
+            drops: false,
+            local: false,
+        };
+        assert_eq!(find(&[all_tunnel], &[]).len(), 1);
+
+        let mixed = KernelRoute {
+            prefix: p(198, 51, 100, 0, 24),
+            oifs: vec!["vti64".into(), "eth3".into()],
+            table: 254,
+            drops: false,
+            local: false,
+        };
+        assert!(
+            find(&[mixed], &[]).is_empty(),
+            "one resolvable path is enough for VPP to forward the prefix"
+        );
+    }
+
+    /// Under dst-only steering the NIC diverts only packets addressed
+    /// inside the allowlist, so a path outside it can never enter VPP
+    /// and must not cost an exemption slot (review finding). Any src
+    /// rule anywhere restores the everything-is-at-risk scope.
+    #[test]
+    fn dst_only_steering_scopes_the_scan_to_divertible_destinations() {
+        use packetframe_common::fib::IpPrefix;
+        let allow = [IpPrefix::V4 {
+            addr: [23, 191, 200, 0],
+            prefix_len: 24,
+        }];
+        let routes = vec![
+            route(p(23, 191, 200, 2, 32), "vti64"), // inside the allowlist
+            route(p(198, 51, 100, 0, 24), "vti64"), // outside it
+        ];
+        let scoped = uncovered_paths(&routes, &reach(), &[], &Divertible::OnlyDst(&allow));
+        assert_eq!(scoped.len(), 1, "{scoped:?}");
+        assert_eq!(scoped[0].prefix.addr, Ipv4Addr::new(23, 191, 200, 2));
+
+        // A src rule anywhere means any destination can be diverted.
+        assert_eq!(find(&routes, &[]).len(), 2);
     }
 
     /// The operator-facing line names the three things needed to act:
     /// what, out of where, and which table to look in.
     #[test]
     fn a_finding_names_prefix_device_and_table() {
-        let mut r = route(p(23, 191, 201, 0, 24), "vti64");
-        r.table = 100;
-        let found = uncovered_paths(&[r], &reach(), &[]);
+        let found = find(&[route(p(23, 191, 201, 0, 24), "vti64")], &[]);
         let line = found[0].to_string();
         assert!(line.contains("23.191.201.0/24"), "{line}");
         assert!(line.contains("vti64"), "{line}");

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -452,6 +452,15 @@ struct ScannerInbox {
     /// A scope waiting to be adopted. Only the newest matters — an
     /// older pending scope is superseded, not queued.
     pending: Option<ScopeUpdate>,
+    /// Which scope the pending (or last adopted) one IS. Lives HERE,
+    /// under the same lock as `pending`, because the two must move
+    /// together: an atomic bumped outside the lock let the worker
+    /// adopt nothing, read the incremented counter, and stamp a scan
+    /// of the OLD exemptions as belonging to the NEW scope — the
+    /// stale-result check would then accept it as current and publish
+    /// a clean verdict over a path the new config had just stopped
+    /// exempting (review finding). One lock, one truth.
+    generation: u64,
     stop: bool,
 }
 
@@ -491,26 +500,26 @@ struct ScannerInbox {
 pub struct DriftScanner {
     latest: std::sync::Arc<std::sync::Mutex<Option<StampedResult>>>,
     inbox: std::sync::Arc<(std::sync::Mutex<ScannerInbox>, std::sync::Condvar)>,
-    generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
 impl DriftScanner {
     /// Start scanning every `every`, beginning immediately.
     pub fn spawn(mut watch: Box<dyn DriftWatch + Send>, every: std::time::Duration) -> Self {
-        use std::sync::atomic::Ordering;
         let latest: std::sync::Arc<std::sync::Mutex<Option<StampedResult>>> =
             std::sync::Arc::new(std::sync::Mutex::new(None));
         let inbox = std::sync::Arc::new((
             std::sync::Mutex::new(ScannerInbox::default()),
             std::sync::Condvar::new(),
         ));
-        let generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
-        let (l, ib, gen) = (latest.clone(), inbox.clone(), generation.clone());
+        let (l, ib) = (latest.clone(), inbox.clone());
         let handle = std::thread::Builder::new()
             .name("pf-drift-scan".into())
             .spawn(move || loop {
-                {
+                // Adopt and stamp under ONE lock hold, so
+                // `scanned_under` names exactly the scope the watcher
+                // is about to scan with.
+                let scanned_under = {
                     let mut inbox = ib.0.lock().expect("drift inbox lock");
                     if inbox.stop {
                         return;
@@ -518,10 +527,8 @@ impl DriftScanner {
                     if let Some((exempts, dst_only)) = inbox.pending.take() {
                         watch.set_scope(exempts, dst_only);
                     }
-                }
-                // Read AFTER adopting: this is the generation the pass
-                // about to run actually judges under.
-                let scanned_under = gen.load(Ordering::SeqCst);
+                    inbox.generation
+                };
                 let result = watch.uncovered();
                 *l.lock().expect("drift result lock") = Some((scanned_under, result));
 
@@ -544,7 +551,6 @@ impl DriftScanner {
         Self {
             latest,
             inbox,
-            generation,
             handle,
         }
     }
@@ -561,7 +567,7 @@ impl DriftScanner {
 
     /// The scope generation currently in force.
     pub fn generation(&self) -> u64 {
-        self.generation.load(std::sync::atomic::Ordering::SeqCst)
+        self.inbox.0.lock().expect("drift inbox lock").generation
     }
 
     /// Hand the scanner a scope to adopt, and wake it to re-scan now.
@@ -570,9 +576,11 @@ impl DriftScanner {
         exempts: Vec<Ipv4Prefix>,
         dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     ) {
-        self.generation
-            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
         let mut inbox = self.inbox.0.lock().expect("drift inbox lock");
+        // Both under the lock the worker adopts and stamps under, so
+        // there is no window where the counter has moved and the
+        // scope has not.
+        inbox.generation += 1;
         inbox.pending = Some((exempts, dst_only));
         self.inbox.1.notify_all();
     }
@@ -1318,6 +1326,75 @@ mod tests {
             },
         );
         assert!(scoped.is_empty(), "{scoped:?}");
+    }
+
+    /// The scanner's scope hand-off is atomic: a result is stamped
+    /// with the scope it actually scanned under, never one that
+    /// arrived mid-pass.
+    ///
+    /// A bare counter bumped outside the inbox lock let the worker
+    /// adopt nothing, read the incremented value, and stamp a scan of
+    /// the OLD exemptions as the NEW scope's — which the loop would
+    /// then accept as current (review finding). This drives the seam
+    /// directly rather than racing threads, which is the part that
+    /// can actually be asserted.
+    #[test]
+    fn a_result_is_stamped_with_the_scope_it_scanned_under() {
+        use std::sync::{Arc, Mutex};
+
+        /// Records the scope in force at each `uncovered()` call.
+        struct Recorder {
+            seen: Arc<Mutex<Vec<usize>>>,
+            exempts: usize,
+        }
+        impl DriftWatch for Recorder {
+            fn uncovered(&mut self) -> Result<DriftFindings, String> {
+                self.seen.lock().unwrap().push(self.exempts);
+                Ok(DriftFindings::default())
+            }
+            fn set_scope(
+                &mut self,
+                exempts: Vec<Ipv4Prefix>,
+                _dst: Option<Vec<packetframe_common::fib::IpPrefix>>,
+            ) {
+                self.exempts = exempts.len();
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let scanner = DriftScanner::spawn(
+            Box::new(Recorder {
+                seen: seen.clone(),
+                exempts: 0,
+            }),
+            std::time::Duration::from_millis(50),
+        );
+        // Generation starts at zero and only a hand-off moves it.
+        assert_eq!(scanner.generation(), 0);
+        scanner.set_scope(vec![p(10, 0, 0, 0, 8)], None);
+        assert_eq!(scanner.generation(), 1, "the hand-off bumps it");
+
+        // Whatever the worker publishes, its stamp is a generation
+        // that existed, and the newest one is eventually reported.
+        let mut stamped_current = false;
+        for _ in 0..200 {
+            if let Some((gen, _)) = scanner.take_result() {
+                assert!(gen <= scanner.generation(), "no stamp from the future");
+                if gen == 1 {
+                    stamped_current = true;
+                    break;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        assert!(
+            stamped_current,
+            "a scan under the new scope must be published"
+        );
+        assert!(
+            seen.lock().unwrap().contains(&1),
+            "and it must have scanned with the new exemptions"
+        );
     }
 
     /// The operator-facing line names the three things needed to act:

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -631,19 +631,57 @@ impl DriftScanner {
     }
 }
 
+/// How long teardown waits for the scan thread before abandoning it.
+///
+/// A sleeping worker is woken by the stop notify and exits in
+/// microseconds, which is the overwhelmingly common case; this only
+/// has to be long enough to cover that wake.
+const TEARDOWN_GRACE: std::time::Duration = std::time::Duration::from_millis(50);
+
 impl Drop for DriftScanner {
+    /// Ask the scan to stop, wait briefly, and ABANDON it if a dump is
+    /// in flight.
+    ///
+    /// This runs on the supervision thread as it unwinds, AFTER the
+    /// real teardown has killed VPP, released the VF and published its
+    /// result — and `SupervisionService::stop()` gives that thread 900
+    /// ms to finish before it tells the operator the teardown is
+    /// incomplete and resources may still be held. A netlink dump has
+    /// no cancellation and takes seconds on a DFZ table, so joining it
+    /// unconditionally made a completed teardown report itself as an
+    /// unfinished one, over a monitoring scan holding nothing (review
+    /// finding).
+    ///
+    /// Abandoning is safe here in a way it would not be for the
+    /// resource owners: this thread holds a read-only netlink socket,
+    /// its watcher, and `Arc` clones of a result slot nobody reads any
+    /// more. It owns no VPP process, no VF, no hugepage reservation —
+    /// nothing whose lifetime a detach must account for — and the stop
+    /// flag is already set, so it exits the moment its dump returns.
+    /// (The previous comment here defended the join by calling the
+    /// open socket a reason to wait; that conflated a thread holding a
+    /// file descriptor with a thread holding the resources teardown
+    /// exists to release.) A bounded receive keeps "the moment its
+    /// dump returns" finite even if the kernel goes quiet.
     fn drop(&mut self) {
         {
             let mut inbox = self.inbox.0.lock().expect("drift inbox lock");
             inbox.stop = true;
             self.inbox.1.notify_all();
         }
-        if let Some(h) = self.handle.take() {
-            // A pass in flight runs to completion — a netlink dump has
-            // no cancellation, and abandoning the thread with its
-            // socket open is worse than waiting for it.
-            let _ = h.join();
+        let Some(h) = self.handle.take() else { return };
+        let deadline = std::time::Instant::now() + TEARDOWN_GRACE;
+        while !h.is_finished() && std::time::Instant::now() < deadline {
+            std::thread::sleep(std::time::Duration::from_millis(2));
         }
+        if h.is_finished() {
+            let _ = h.join();
+            return;
+        }
+        // Dropping the handle detaches the thread.
+        tracing::debug!(
+            "drift scan still in flight at teardown; detaching it rather than delaying detach"
+        );
     }
 }
 
@@ -757,6 +795,11 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
     }
 
     let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    // A receive that can block forever is a scan thread that never
+    // settles — and teardown abandons an in-flight scan rather than
+    // waiting on it, so "forever" would mean a thread and its socket
+    // held for the daemon's life.
+    crate::fdb::bound_recv(&socket)?;
     socket
         .bind_auto()
         .map_err(|e| format!("netlink bind: {e}"))?;
@@ -932,6 +975,7 @@ pub fn dump_rule_tables() -> Result<Option<Vec<u32>>, String> {
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
 
     let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    crate::fdb::bound_recv(&socket)?;
     socket
         .bind_auto()
         .map_err(|e| format!("netlink bind: {e}"))?;
@@ -1537,6 +1581,69 @@ mod tests {
         assert!(
             seen.lock().unwrap().contains(&1),
             "and it must have scanned with the new exemptions"
+        );
+    }
+
+    /// Teardown does not wait out a scan in flight.
+    ///
+    /// This drop runs on the supervision thread after the real
+    /// teardown is done, and `SupervisionService::stop()` gives that
+    /// thread 900 ms before it tells the operator resources may still
+    /// be held. A full route dump takes seconds, so joining it made a
+    /// finished teardown report itself unfinished (review finding).
+    #[test]
+    fn teardown_abandons_a_scan_in_flight_instead_of_waiting_for_it() {
+        use std::sync::{Arc, Condvar, Mutex};
+
+        /// Blocks inside `uncovered()` the way a real dump does, and
+        /// says when it has entered.
+        struct Blocking {
+            entered: Arc<(Mutex<bool>, Condvar)>,
+        }
+        impl DriftWatch for Blocking {
+            fn uncovered(&mut self) -> Result<DriftFindings, String> {
+                {
+                    let mut in_dump = self.entered.0.lock().unwrap();
+                    *in_dump = true;
+                    self.entered.1.notify_all();
+                }
+                std::thread::sleep(std::time::Duration::from_millis(1500));
+                Ok(DriftFindings::default())
+            }
+            fn set_scope(
+                &mut self,
+                _e: Vec<Ipv4Prefix>,
+                _d: Option<Vec<packetframe_common::fib::IpPrefix>>,
+            ) {
+            }
+        }
+
+        let entered = Arc::new((Mutex::new(false), Condvar::new()));
+        let scanner = DriftScanner::spawn(
+            Box::new(Blocking {
+                entered: entered.clone(),
+            }),
+            std::time::Duration::from_secs(60),
+        );
+        // Only meaningful once the worker is actually inside the dump.
+        let mut in_dump = entered.0.lock().unwrap();
+        while !*in_dump {
+            let (g, timed_out) = entered
+                .1
+                .wait_timeout(in_dump, std::time::Duration::from_secs(5))
+                .unwrap();
+            in_dump = g;
+            assert!(!timed_out.timed_out(), "the scan never started");
+        }
+        drop(in_dump);
+
+        let started = std::time::Instant::now();
+        drop(scanner);
+        let waited = started.elapsed();
+        assert!(
+            waited < std::time::Duration::from_millis(500),
+            "teardown waited {waited:?} on a monitoring scan; the detach budget is 900 ms for \
+             the whole supervision thread"
         );
     }
 

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -318,7 +318,7 @@ impl DriftWatch for KernelDriftWatch {
         // scan costs the blackhole.
         let tables = dump_rule_tables().unwrap_or_else(|e| {
             tracing::debug!(error = %e, "policy-rule dump failed; not filtering by table");
-            Vec::new()
+            None
         });
         let divertible = match &self.dst_only {
             Some(allow) => Divertible::OnlyDst(allow),
@@ -328,7 +328,7 @@ impl DriftWatch for KernelDriftWatch {
             reach: &self.reach,
             exempts: &self.exempts,
             divertible,
-            selected_tables: (!tables.is_empty()).then_some(tables.as_slice()),
+            selected_tables: tables.as_deref(),
         };
         Ok(uncovered_paths(&routes, &scope)
             .into_iter()
@@ -460,12 +460,28 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
     Ok(out)
 }
 
-/// The table ids some policy rule can select.
+/// The table ids some policy rule can select, or `None` when they
+/// cannot be enumerated safely and NOTHING may be filtered.
 ///
 /// One `RTM_GETRULE` dump. See [`Scope::selected_tables`] for what
 /// this models and, more importantly, what it deliberately does not.
+///
+/// `None` has two producers, and both are the safe direction:
+///
+/// - **an l3mdev rule** (`from all lookup [l3mdev-table]`), which
+///   carries table id 0 and resolves to a VRF's table at forwarding
+///   time. Its tables are not in the rule set at all, so filtering by
+///   what IS there would drop every VRF route — and a tunnel route in
+///   an active VRF would go unreported while steered traffic
+///   blackholed (review finding). Mapping l3mdev to its VRF tables
+///   means enumerating VRF devices and their table ids; until that
+///   exists, a host with one gets no filtering, which is exactly the
+///   behaviour before the filter was added.
+/// - **an empty result.** Filtering by an empty set would skip every
+///   route and report a permanently clean scan, which is the failure
+///   this whole module exists to prevent.
 #[cfg(target_os = "linux")]
-pub fn dump_rule_tables() -> Result<Vec<u32>, String> {
+pub fn dump_rule_tables() -> Result<Option<Vec<u32>>, String> {
     use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
     use netlink_packet_route::rule::{RuleAttribute, RuleMessage};
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
@@ -513,8 +529,13 @@ pub fn dump_rule_tables() -> Result<Vec<u32>, String> {
                     // exactly as RTA_TABLE does for routes.
                     let mut table = u32::from(m.header.table);
                     for attr in &m.attributes {
-                        if let RuleAttribute::Table(t) = attr {
-                            table = *t;
+                        match attr {
+                            RuleAttribute::Table(t) => table = *t,
+                            // The VRF case: this rule names no table
+                            // of its own and picks one per packet, so
+                            // the enumeration cannot be complete.
+                            RuleAttribute::L3MDev(true) => return Ok(None),
+                            _ => {}
                         }
                     }
                     if table != 0 && !out.contains(&table) {
@@ -526,7 +547,9 @@ pub fn dump_rule_tables() -> Result<Vec<u32>, String> {
             offset += len;
         }
     }
-    Ok(out)
+    // Empty means "no rule named a table", which cannot be used to
+    // filter — see this function's doc.
+    Ok((!out.is_empty()).then_some(out))
 }
 
 #[cfg(test)]
@@ -747,9 +770,30 @@ mod tests {
         );
         assert_eq!(found.len(), 1, "{found:?}");
         assert_eq!(found[0].table, 100);
-        // Unknown rule set (dump failed) filters nothing: losing the
-        // narrowing costs noise, losing the scan costs the blackhole.
+        // Unknown rule set filters nothing: losing the narrowing
+        // costs noise, losing the scan costs the blackhole. This is
+        // the arm an l3mdev (VRF) rule takes — its tables resolve per
+        // packet and are absent from the rule set, so filtering by
+        // what IS there would drop every VRF route and report clean
+        // while steered traffic blackholed (review finding). Same arm
+        // for a failed dump, and for an empty enumeration, which
+        // would otherwise skip every route on the box.
         assert_eq!(find(&routes, &[]).len(), 2);
+        let empty_selection: [u32; 0] = [];
+        let blind = uncovered_paths(
+            &routes,
+            &Scope {
+                reach: &reach(),
+                exempts: &[],
+                divertible: Divertible::Any,
+                selected_tables: Some(&empty_selection),
+            },
+        );
+        assert!(
+            blind.is_empty(),
+            "an empty selection filters everything — which is why the dump returns None \
+             for it rather than an empty Vec: {blind:?}"
+        );
     }
 
     /// The scope derivation is shared by attach and reconfigure, so a

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -437,6 +437,24 @@ pub trait DriftWatch {
     );
 }
 
+/// The exemptions and diversion scope a scan judges against, as the
+/// loop hands them over.
+pub type ScopeUpdate = (
+    Vec<Ipv4Prefix>,
+    Option<Vec<packetframe_common::fib::IpPrefix>>,
+);
+
+/// A completed pass and the scope generation it judged under.
+type StampedResult = (u64, Result<DriftFindings, String>);
+
+#[derive(Default)]
+struct ScannerInbox {
+    /// A scope waiting to be adopted. Only the newest matters — an
+    /// older pending scope is superseded, not queued.
+    pending: Option<ScopeUpdate>,
+    stop: bool,
+}
+
 /// The scan, running on its OWN thread.
 ///
 /// A full `RTM_GETROUTE` dump on the reference primary walks ~1.05M
@@ -449,24 +467,31 @@ pub trait DriftWatch {
 /// delay the thing it monitors.
 ///
 /// So the scan lives here: one thread, its own cadence, publishing
-/// COMPLETED results into a slot the loop reads without blocking. The
-/// loop's only cost is a mutex it never contends for more than the
-/// length of a `Vec` clone.
-/// The exemptions and diversion scope a scan judges against, as the
-/// loop hands them over.
-pub type ScopeUpdate = (
-    Vec<Ipv4Prefix>,
-    Option<Vec<packetframe_common::fib::IpPrefix>>,
-);
-
+/// COMPLETED results into a slot the loop reads without blocking.
+///
+/// ## Every result is stamped with the scope it judged
+///
+/// Moving the scan off-thread created two ways to publish an answer
+/// about the wrong configuration, and both hide a blackhole (review
+/// findings on the async version):
+///
+/// - a scan already IN FLIGHT when the loop commits a new scope
+///   finishes and publishes a verdict about the OLD exemptions;
+/// - the worker then sleeps out its interval before adopting the new
+///   one, so up to a minute passes with nothing re-examined.
+///
+/// The generation counter answers both. The loop bumps it when it
+/// hands over a scope; the worker stamps each result with the
+/// generation it actually scanned under; the loop discards any result
+/// whose stamp is stale. And a handover WAKES the worker, so the
+/// re-scan starts immediately rather than at the end of a sleep.
+/// Until a result for the current generation arrives, the tripwire
+/// reports that it has not scanned this configuration yet — never a
+/// clean zero it has not earned.
 pub struct DriftScanner {
-    latest: std::sync::Arc<std::sync::Mutex<Option<Result<DriftFindings, String>>>>,
-    /// A scope the loop staged for the scanner to adopt before its
-    /// next pass. `Mutex` rather than a channel because only the
-    /// newest one matters — an older pending scope is superseded, not
-    /// queued.
-    scope: std::sync::Arc<std::sync::Mutex<Option<ScopeUpdate>>>,
-    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    latest: std::sync::Arc<std::sync::Mutex<Option<StampedResult>>>,
+    inbox: std::sync::Arc<(std::sync::Mutex<ScannerInbox>, std::sync::Condvar)>,
+    generation: std::sync::Arc<std::sync::atomic::AtomicU64>,
     handle: Option<std::thread::JoinHandle<()>>,
 }
 
@@ -474,61 +499,95 @@ impl DriftScanner {
     /// Start scanning every `every`, beginning immediately.
     pub fn spawn(mut watch: Box<dyn DriftWatch + Send>, every: std::time::Duration) -> Self {
         use std::sync::atomic::Ordering;
-        let latest = std::sync::Arc::new(std::sync::Mutex::new(None));
-        let scope = std::sync::Arc::new(std::sync::Mutex::new(None));
-        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let (l, sc, st) = (latest.clone(), scope.clone(), stop.clone());
+        let latest: std::sync::Arc<std::sync::Mutex<Option<StampedResult>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let inbox = std::sync::Arc::new((
+            std::sync::Mutex::new(ScannerInbox::default()),
+            std::sync::Condvar::new(),
+        ));
+        let generation = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let (l, ib, gen) = (latest.clone(), inbox.clone(), generation.clone());
         let handle = std::thread::Builder::new()
             .name("pf-drift-scan".into())
-            .spawn(move || {
-                while !st.load(Ordering::Relaxed) {
-                    if let Some((exempts, dst_only)) = sc.lock().expect("drift scope lock").take() {
+            .spawn(move || loop {
+                {
+                    let mut inbox = ib.0.lock().expect("drift inbox lock");
+                    if inbox.stop {
+                        return;
+                    }
+                    if let Some((exempts, dst_only)) = inbox.pending.take() {
                         watch.set_scope(exempts, dst_only);
                     }
-                    let result = watch.uncovered();
-                    *l.lock().expect("drift result lock") = Some(result);
-                    // Chunked so a teardown is not waiting out a full
-                    // interval; the loop's own stop path joins this.
-                    let mut slept = std::time::Duration::ZERO;
-                    while slept < every && !st.load(Ordering::Relaxed) {
-                        std::thread::sleep(std::time::Duration::from_millis(100));
-                        slept += std::time::Duration::from_millis(100);
-                    }
+                }
+                // Read AFTER adopting: this is the generation the pass
+                // about to run actually judges under.
+                let scanned_under = gen.load(Ordering::SeqCst);
+                let result = watch.uncovered();
+                *l.lock().expect("drift result lock") = Some((scanned_under, result));
+
+                let mut inbox = ib.0.lock().expect("drift inbox lock");
+                let mut waited = std::time::Duration::ZERO;
+                // Wake early for a new scope or a teardown; otherwise
+                // sleep out the interval in slices so a stop is not
+                // waiting on a full one.
+                while !inbox.stop && inbox.pending.is_none() && waited < every {
+                    let slice = std::time::Duration::from_millis(200);
+                    let (guard, _) = ib.1.wait_timeout(inbox, slice).expect("drift inbox wait");
+                    inbox = guard;
+                    waited += slice;
+                }
+                if inbox.stop {
+                    return;
                 }
             })
             .ok();
         Self {
             latest,
-            scope,
-            stop,
+            inbox,
+            generation,
             handle,
         }
     }
 
-    /// The newest COMPLETED result, if the scanner has finished a pass
-    /// since the last look. `None` means nothing new — the caller
-    /// keeps whatever it had.
-    pub fn take_result(&self) -> Option<Result<DriftFindings, String>> {
+    /// The newest COMPLETED result, if one has arrived since the last
+    /// look. `None` means nothing new — the caller keeps what it had.
+    ///
+    /// Returns the generation it was scanned under so the caller can
+    /// tell a verdict about the current configuration from one about
+    /// a superseded scope.
+    pub fn take_result(&self) -> Option<StampedResult> {
         self.latest.lock().expect("drift result lock").take()
     }
 
-    /// Hand the scanner a scope to adopt before its next pass.
+    /// The scope generation currently in force.
+    pub fn generation(&self) -> u64 {
+        self.generation.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Hand the scanner a scope to adopt, and wake it to re-scan now.
     pub fn set_scope(
         &self,
         exempts: Vec<Ipv4Prefix>,
         dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     ) {
-        *self.scope.lock().expect("drift scope lock") = Some((exempts, dst_only));
+        self.generation
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let mut inbox = self.inbox.0.lock().expect("drift inbox lock");
+        inbox.pending = Some((exempts, dst_only));
+        self.inbox.1.notify_all();
     }
 }
 
 impl Drop for DriftScanner {
     fn drop(&mut self) {
-        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        {
+            let mut inbox = self.inbox.0.lock().expect("drift inbox lock");
+            inbox.stop = true;
+            self.inbox.1.notify_all();
+        }
         if let Some(h) = self.handle.take() {
-            // The thread checks the flag every 100 ms between passes,
-            // but a pass in flight runs to completion — a netlink dump
-            // has no cancellation, and abandoning the thread with the
+            // A pass in flight runs to completion — a netlink dump has
+            // no cancellation, and abandoning the thread with its
             // socket open is worse than waiting for it.
             let _ = h.join();
         }

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -437,6 +437,104 @@ pub trait DriftWatch {
     );
 }
 
+/// The scan, running on its OWN thread.
+///
+/// A full `RTM_GETROUTE` dump on the reference primary walks ~1.05M
+/// prefixes — parsed and allocated one message at a time — and the
+/// supervision loop it used to run on is the same thread that answers
+/// liveness pings, wedge detection, stop requests and steering
+/// changes. A dump that outran the 3 s steering budget would time out
+/// an operator's `steer off`: the rollback lever, blocked by a
+/// monitoring scan (review finding). Monitoring must never be able to
+/// delay the thing it monitors.
+///
+/// So the scan lives here: one thread, its own cadence, publishing
+/// COMPLETED results into a slot the loop reads without blocking. The
+/// loop's only cost is a mutex it never contends for more than the
+/// length of a `Vec` clone.
+/// The exemptions and diversion scope a scan judges against, as the
+/// loop hands them over.
+pub type ScopeUpdate = (
+    Vec<Ipv4Prefix>,
+    Option<Vec<packetframe_common::fib::IpPrefix>>,
+);
+
+pub struct DriftScanner {
+    latest: std::sync::Arc<std::sync::Mutex<Option<Result<DriftFindings, String>>>>,
+    /// A scope the loop staged for the scanner to adopt before its
+    /// next pass. `Mutex` rather than a channel because only the
+    /// newest one matters — an older pending scope is superseded, not
+    /// queued.
+    scope: std::sync::Arc<std::sync::Mutex<Option<ScopeUpdate>>>,
+    stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl DriftScanner {
+    /// Start scanning every `every`, beginning immediately.
+    pub fn spawn(mut watch: Box<dyn DriftWatch + Send>, every: std::time::Duration) -> Self {
+        use std::sync::atomic::Ordering;
+        let latest = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let scope = std::sync::Arc::new(std::sync::Mutex::new(None));
+        let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let (l, sc, st) = (latest.clone(), scope.clone(), stop.clone());
+        let handle = std::thread::Builder::new()
+            .name("pf-drift-scan".into())
+            .spawn(move || {
+                while !st.load(Ordering::Relaxed) {
+                    if let Some((exempts, dst_only)) = sc.lock().expect("drift scope lock").take() {
+                        watch.set_scope(exempts, dst_only);
+                    }
+                    let result = watch.uncovered();
+                    *l.lock().expect("drift result lock") = Some(result);
+                    // Chunked so a teardown is not waiting out a full
+                    // interval; the loop's own stop path joins this.
+                    let mut slept = std::time::Duration::ZERO;
+                    while slept < every && !st.load(Ordering::Relaxed) {
+                        std::thread::sleep(std::time::Duration::from_millis(100));
+                        slept += std::time::Duration::from_millis(100);
+                    }
+                }
+            })
+            .ok();
+        Self {
+            latest,
+            scope,
+            stop,
+            handle,
+        }
+    }
+
+    /// The newest COMPLETED result, if the scanner has finished a pass
+    /// since the last look. `None` means nothing new — the caller
+    /// keeps whatever it had.
+    pub fn take_result(&self) -> Option<Result<DriftFindings, String>> {
+        self.latest.lock().expect("drift result lock").take()
+    }
+
+    /// Hand the scanner a scope to adopt before its next pass.
+    pub fn set_scope(
+        &self,
+        exempts: Vec<Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
+    ) {
+        *self.scope.lock().expect("drift scope lock") = Some((exempts, dst_only));
+    }
+}
+
+impl Drop for DriftScanner {
+    fn drop(&mut self) {
+        self.stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        if let Some(h) = self.handle.take() {
+            // The thread checks the flag every 100 ms between passes,
+            // but a pass in flight runs to completion — a netlink dump
+            // has no cancellation, and abandoning the thread with the
+            // socket open is worse than waiting for it.
+            let _ = h.join();
+        }
+    }
+}
+
 /// The production scan: dump every IPv4 route in every table, compare.
 #[cfg(target_os = "linux")]
 pub struct KernelDriftWatch {

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -319,17 +319,23 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
     // stops being read.
     let mut opaque = 0usize;
     for r in routes {
-        if r.via_nexthop_object && r.oifs.is_empty() && !r.drops {
-            if scope.divertible.reaches(&r.prefix) && !scope.covers(&r.prefix) {
-                opaque += 1;
-            }
-            continue;
-        }
         if r.drops || !scope.divertible.reaches(&r.prefix) {
             continue;
         }
         // A table no policy rule names is inert for every packet.
+        // BEFORE the opaque branch below, not after: an nhid route
+        // parked in an unreferenced VRF is no more reachable than a
+        // readable one, and counting it would send the operator to
+        // inspect nexthops for traffic that cannot exist (review
+        // finding — this filter, bypassed by a branch added two
+        // rounds after it).
         if scope.selected_tables.is_some_and(|t| !t.contains(&r.table)) {
+            continue;
+        }
+        if r.via_nexthop_object && r.oifs.is_empty() {
+            if !scope.covers(&r.prefix) {
+                opaque += 1;
+            }
             continue;
         }
         let Some(oif) = r.oifs.first() else { continue };
@@ -1066,7 +1072,25 @@ mod tests {
 
         // An exemption covering it makes it a non-issue, exactly as
         // for a route whose device we CAN see.
-        assert!(find(&[opaque], &[p(198, 51, 100, 0, 24)]).is_empty());
+        assert!(find(std::slice::from_ref(&opaque), &[p(198, 51, 100, 0, 24)]).is_empty());
+
+        // And a table no rule selects silences it for the same reason
+        // it silences a readable route: no packet can use it, so
+        // nobody should be sent to inspect nexthops for it (review
+        // finding — this branch bypassed the filter).
+        let mut parked = opaque;
+        parked.table = 4242;
+        let selected = [254u32, 255];
+        let scoped = uncovered_paths(
+            &[parked],
+            &Scope {
+                reach: &reach(),
+                exempts: &[],
+                divertible: Divertible::Any,
+                selected_tables: Some(&selected),
+            },
+        );
+        assert!(scoped.is_empty(), "{scoped:?}");
     }
 
     /// The operator-facing line names the three things needed to act:

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -57,6 +57,16 @@ pub struct KernelRoute {
     /// being skipped precisely because those addresses sit on member
     /// ports and bridges).
     pub local: bool,
+    /// The route names a NEXTHOP OBJECT (`ip route ... nhid N`,
+    /// `RTA_NH_ID`) instead of carrying its devices inline. Those
+    /// routes are opaque here: the vendored netlink crate does not
+    /// parse the attribute, and resolving it means a second
+    /// `RTM_GETNEXTHOP` dump this module does not have. Left as a
+    /// device-less route it would be SKIPPED — a tunnel-backed nhid
+    /// route blackholing under a clean scan (review finding) — so it
+    /// is counted and reported as a gap in the scan's own coverage
+    /// rather than silently dropped or guessed at.
+    pub via_nexthop_object: bool,
 }
 
 /// What VPP can actually egress, from config: member ports and the
@@ -212,31 +222,65 @@ pub struct Scope<'a> {
     pub selected_tables: Option<&'a [u32]>,
 }
 
-/// A kernel path VPP cannot take that nothing exempts.
+/// A kernel path VPP cannot take that nothing exempts — or, for
+/// [`Uncovered::Opaque`], a count of routes this scan could not judge
+/// at all.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Uncovered {
-    pub prefix: Ipv4Prefix,
-    pub oif: String,
-    pub table: u32,
-    /// A terminated address rather than a forwarding path — the
-    /// message says so, because the remedy reads differently.
-    pub local: bool,
+pub enum Uncovered {
+    Path {
+        prefix: Ipv4Prefix,
+        oif: String,
+        table: u32,
+        /// A terminated address rather than a forwarding path — the
+        /// message says so, because the remedy reads differently.
+        local: bool,
+    },
+    /// Routes using nexthop objects, whose devices this scan cannot
+    /// see. Reported so the operator knows the coverage is partial
+    /// rather than believing a quiet scan means a clean box.
+    Opaque(usize),
+}
+
+impl Uncovered {
+    /// The table this finding sits in, for tests and log context.
+    /// `None` for the coverage-gap summary, which names no route.
+    pub fn table(&self) -> Option<u32> {
+        match self {
+            Self::Path { table, .. } => Some(*table),
+            Self::Opaque(_) => None,
+        }
+    }
 }
 
 impl std::fmt::Display for Uncovered {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.local {
-            write!(
+        match self {
+            Self::Path {
+                prefix,
+                oif,
+                table,
+                local: true,
+            } => write!(
                 f,
-                "{}/{} terminates on {} (table {}, the router's own address)",
-                self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
-            )
-        } else {
-            write!(
+                "{}/{} terminates on {oif} (table {table}, the router's own address)",
+                prefix.addr, prefix.prefix_len
+            ),
+            Self::Path {
+                prefix,
+                oif,
+                table,
+                local: false,
+            } => write!(
                 f,
-                "{}/{} via {} (table {})",
-                self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
-            )
+                "{}/{} via {oif} (table {table})",
+                prefix.addr, prefix.prefix_len
+            ),
+            Self::Opaque(n) => write!(
+                f,
+                "{n} route(s) use nexthop objects (`ip route ... nhid`) whose devices this \
+                 scan cannot read, so it cannot tell whether VPP can take them — inspect \
+                 with `ip nexthop show` and exempt any that leave via a tunnel"
+            ),
         }
     }
 }
@@ -267,7 +311,20 @@ impl std::fmt::Display for Uncovered {
 pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncovered> {
     let reach = scope.reach;
     let mut out = Vec::new();
+    // Routes whose devices this scan cannot see at all. Counted
+    // across the whole dump and reported once, because the answer is
+    // "this scan does not cover N of your routes", not N separate
+    // hazards — and flooding a finding per route would make an
+    // nhid-using box's tripwire unreadable, which is how an alarm
+    // stops being read.
+    let mut opaque = 0usize;
     for r in routes {
+        if r.via_nexthop_object && r.oifs.is_empty() && !r.drops {
+            if scope.divertible.reaches(&r.prefix) && !scope.covers(&r.prefix) {
+                opaque += 1;
+            }
+            continue;
+        }
         if r.drops || !scope.divertible.reaches(&r.prefix) {
             continue;
         }
@@ -304,15 +361,21 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
         if scope.covers(&r.prefix) {
             continue;
         }
-        out.push(Uncovered {
+        out.push(Uncovered::Path {
             prefix: r.prefix,
             oif: oif.clone(),
             table: r.table,
             local: r.local,
         });
     }
-    out.sort_by_key(|u| (u.prefix.prefix_len, u32::from(u.prefix.addr)));
+    out.sort_by_key(|u| match u {
+        Uncovered::Path { prefix, .. } => (prefix.prefix_len, u32::from(prefix.addr)),
+        Uncovered::Opaque(_) => (u8::MAX, u32::MAX),
+    });
     out.dedup();
+    if opaque > 0 {
+        out.push(Uncovered::Opaque(opaque));
+    }
     out
 }
 
@@ -410,7 +473,13 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
     };
     use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteMessage, RouteType};
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
+    // The `kind()` accessor for an unparsed attribute. Same crate
+    // the message types come from, already a direct dependency.
+    use netlink_packet_core::Nla as _;
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+
+    /// `RTA_NH_ID` — see [`KernelRoute::via_nexthop_object`].
+    const RTA_NH_ID: u16 = 30;
 
     let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
     socket
@@ -470,6 +539,7 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                 NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewRoute(m)) => {
                     let mut dst: Option<std::net::Ipv4Addr> = None;
                     let mut oifs: Vec<u32> = Vec::new();
+                    let mut nexthop_object = false;
                     let mut table = u32::from(m.header.table);
                     for attr in &m.attributes {
                         match attr {
@@ -487,6 +557,14 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             // RTA_TABLE carries ids past the u8 header
                             // field — policy tables live up there.
                             RouteAttribute::Table(t) => table = *t,
+                            // RTA_NH_ID (30). The vendored crate does
+                            // not parse it — the constant is commented
+                            // out in its source — so it lands here,
+                            // and a route carrying it names its
+                            // devices nowhere this scan can read.
+                            RouteAttribute::Other(nla) if nla.kind() == RTA_NH_ID => {
+                                nexthop_object = true
+                            }
                             _ => {}
                         }
                     }
@@ -511,6 +589,7 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             RouteType::BlackHole | RouteType::Unreachable | RouteType::Prohibit
                         ),
                         local: m.header.kind == RouteType::Local,
+                        via_nexthop_object: nexthop_object,
                     });
                 }
                 _ => {}
@@ -648,6 +727,7 @@ mod tests {
             table: 100,
             drops: false,
             local: false,
+            via_nexthop_object: false,
         }
     }
 
@@ -683,7 +763,7 @@ mod tests {
         ];
         let found = find(&routes, &[]);
         assert_eq!(found.len(), 2, "{found:?}");
-        assert!(found.iter().all(|u| u.oif == "vti64"));
+        assert!(found.iter().all(|u| u.to_string().contains("via vti64")));
 
         let exempts = [p(23, 191, 201, 0, 24), p(23, 191, 200, 2, 32)];
         assert!(find(&routes, &exempts).is_empty());
@@ -737,7 +817,7 @@ mod tests {
         gw.table = 255;
         let found = find(&[gw.clone()], &[]);
         assert_eq!(found.len(), 1, "{found:?}");
-        assert!(found[0].local);
+        assert!(matches!(found[0], Uncovered::Path { local: true, .. }));
         assert!(
             found[0].to_string().contains("terminates on br1337"),
             "the message must read as termination, not a path: {}",
@@ -775,6 +855,7 @@ mod tests {
             table: 254,
             drops: false,
             local: false,
+            via_nexthop_object: false,
         };
         assert_eq!(find(&[all_tunnel], &[]).len(), 1);
 
@@ -784,6 +865,7 @@ mod tests {
             table: 254,
             drops: false,
             local: false,
+            via_nexthop_object: false,
         };
         assert!(
             find(&[mixed], &[]).is_empty(),
@@ -816,7 +898,10 @@ mod tests {
             },
         );
         assert_eq!(scoped.len(), 1, "{scoped:?}");
-        assert_eq!(scoped[0].prefix.addr, Ipv4Addr::new(23, 191, 200, 2));
+        assert!(
+            scoped[0].to_string().contains("23.191.200.2/32"),
+            "{scoped:?}"
+        );
 
         // A src rule anywhere means any destination can be diverted.
         assert_eq!(find(&routes, &[]).len(), 2);
@@ -846,7 +931,7 @@ mod tests {
             },
         );
         assert_eq!(found.len(), 1, "{found:?}");
-        assert_eq!(found[0].table, 100);
+        assert_eq!(found[0].table(), Some(100));
         // Unknown rule set filters nothing: losing the narrowing
         // costs noise, losing the scan costs the blackhole. This is
         // the arm an l3mdev (VRF) rule takes — its tables resolve per
@@ -954,6 +1039,34 @@ mod tests {
             },
         );
         assert_eq!(any.len(), 1, "{any:?}");
+    }
+
+    /// A route using a nexthop object names its devices nowhere this
+    /// scan can read. Left as a device-less route it would be SKIPPED
+    /// — a tunnel-backed nhid route blackholing under a clean scan
+    /// (review finding) — so the scan reports its own blind spot
+    /// instead, once, rather than flooding a finding per route or
+    /// guessing at reachability.
+    #[test]
+    fn routes_via_nexthop_objects_are_reported_as_a_coverage_gap() {
+        let opaque = KernelRoute {
+            prefix: p(198, 51, 100, 0, 24),
+            oifs: Vec::new(),
+            table: 254,
+            drops: false,
+            local: false,
+            via_nexthop_object: true,
+        };
+        let found = find(&[opaque.clone(), opaque.clone()], &[]);
+        assert_eq!(found.len(), 1, "one summary, not one per route: {found:?}");
+        assert_eq!(found[0], Uncovered::Opaque(2));
+        let line = found[0].to_string();
+        assert!(line.contains("nhid"), "{line}");
+        assert!(line.contains("ip nexthop show"), "names the tool: {line}");
+
+        // An exemption covering it makes it a non-issue, exactly as
+        // for a route whose device we CAN see.
+        assert!(find(&[opaque], &[p(198, 51, 100, 0, 24)]).is_empty());
     }
 
     /// The operator-facing line names the three things needed to act:

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -1,0 +1,369 @@
+//! The exemption tripwire: kernel paths VPP cannot take, unexempted.
+//!
+//! VPP owns member VFs and the dot1q subinterfaces on them, and
+//! nothing else. Any destination the kernel forwards through some
+//! OTHER device — an IPSec VTI, WireGuard, a GRE tunnel — has no path
+//! in VPP: the mirror route resolves to no member and never installs,
+//! so a steered packet for it dies at VPP's default route instead of
+//! falling back to the kernel that would have delivered it.
+//!
+//! The eBPF tier PASSes those flows to the kernel, which is why they
+//! work unsteered; steering removes that safety net, and VPP cannot
+//! do IPSec, so the kernel path is their permanent, correct home. One
+//! `steer-exempt` per such destination keeps them there.
+//!
+//! Found the hard way on the reference primary (w26, 2026-08-16):
+//! inter-site IPSec carried a remote /24 plus seven host routes INSIDE
+//! the local service /24, and every steered window for three weeks had
+//! been silently one-way-blackholing them — invisible to every
+//! watchdog, visible only as a steady rate on a drop counter nobody
+//! had decomposed.
+//!
+//! ## Why a tripwire and not automatic exemption
+//!
+//! Deriving MCAM rules from kernel state would change forwarding
+//! without an operator asking, and could exhaust a 16-slot budget
+//! silently. The route sets that produce this are also frequently
+//! dynamic — bird announces a new remote host route and the hole
+//! re-opens — which is exactly the argument for CONTINUOUS detection
+//! rather than a one-time audit. So this names what is uncovered and
+//! degrades health; installing the rule stays the operator's decision.
+
+use packetframe_common::config::Ipv4Prefix;
+
+/// One kernel route, reduced to what the comparison needs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KernelRoute {
+    /// Destination prefix. A default route is `0.0.0.0/0`.
+    pub prefix: Ipv4Prefix,
+    /// Output device name, or `None` for routes with no oif (which
+    /// this check ignores — nothing to compare against).
+    pub oif: Option<String>,
+    /// Routing table id, for the operator-facing message: "table 100"
+    /// is how they will find it again.
+    pub table: u32,
+    /// Whether the kernel would DROP this itself (blackhole,
+    /// unreachable, prohibit). VPP dropping the same packet is
+    /// equivalent behaviour, so these are not findings.
+    pub drops: bool,
+}
+
+/// What VPP can actually egress, from config: member ports and the
+/// kernel bridge devices `local-route` delivers into.
+#[derive(Debug, Clone, Default)]
+pub struct VppReach {
+    /// `port` lines — VPP owns a VF on each.
+    pub members: Vec<String>,
+    /// Bridge devices named (indirectly) by `local-route`: VPP
+    /// delivers those prefixes on a subif, so a kernel route out the
+    /// bridge is covered.
+    pub local_devices: Vec<String>,
+}
+
+impl VppReach {
+    fn covers_device(&self, dev: &str) -> bool {
+        self.members.iter().any(|m| m == dev) || self.local_devices.iter().any(|d| d == dev)
+    }
+}
+
+/// A kernel path VPP cannot take that nothing exempts.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Uncovered {
+    pub prefix: Ipv4Prefix,
+    pub oif: String,
+    pub table: u32,
+}
+
+impl std::fmt::Display for Uncovered {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}/{} via {} (table {})",
+            self.prefix.addr, self.prefix.prefix_len, self.oif, self.table
+        )
+    }
+}
+
+/// The pure half: which kernel routes would blackhole under steering.
+///
+/// A route is a finding iff it egresses a device VPP cannot use, the
+/// kernel does not drop it itself, and no `steer-exempt` covers its
+/// prefix. Deliberately NOT filtered by the allowlist: with source
+/// steering, which packets get diverted is decided by where they came
+/// FROM, so any destination a steered host can reach is at risk.
+///
+/// Coverage is by prefix containment, and an exempt must contain the
+/// route — not merely overlap it. A `/32` exemption does not cover the
+/// `/24` around it, and reporting the `/24` as handled because one
+/// host inside it is exempted would be the silent-hole shape all over
+/// again.
+pub fn uncovered_paths(
+    routes: &[KernelRoute],
+    reach: &VppReach,
+    exempts: &[Ipv4Prefix],
+) -> Vec<Uncovered> {
+    let mut out = Vec::new();
+    for r in routes {
+        if r.drops {
+            continue;
+        }
+        let Some(oif) = &r.oif else { continue };
+        if reach.covers_device(oif) {
+            continue;
+        }
+        // Built-in exemptions cover these on every steered port.
+        if crate::steer::BUILTIN_EXEMPTS.iter().any(|(addr, len)| {
+            Ipv4Prefix {
+                addr: *addr,
+                prefix_len: *len,
+            }
+            .contains_prefix(&r.prefix)
+        }) {
+            continue;
+        }
+        if exempts.iter().any(|e| e.contains_prefix(&r.prefix)) {
+            continue;
+        }
+        out.push(Uncovered {
+            prefix: r.prefix,
+            oif: oif.clone(),
+            table: r.table,
+        });
+    }
+    out.sort_by_key(|u| (u.prefix.prefix_len, u32::from(u.prefix.addr)));
+    out.dedup();
+    out
+}
+
+/// The scan seam the runtime holds, mirroring [`crate::fdb::FdbWatch`]:
+/// a trait so tests record calls and non-Linux builds never pretend.
+pub trait DriftWatch {
+    /// One line per uncovered kernel path, empty when the exemptions
+    /// hold. `Err` = the kernel would not answer; the caller keeps its
+    /// previous verdict.
+    fn uncovered(&mut self) -> Result<Vec<String>, String>;
+}
+
+/// The production scan: dump every IPv4 route in every table, compare.
+#[cfg(target_os = "linux")]
+pub struct KernelDriftWatch {
+    pub reach: VppReach,
+    pub exempts: Vec<Ipv4Prefix>,
+}
+
+#[cfg(target_os = "linux")]
+impl DriftWatch for KernelDriftWatch {
+    fn uncovered(&mut self) -> Result<Vec<String>, String> {
+        let routes = dump_routes()?;
+        Ok(uncovered_paths(&routes, &self.reach, &self.exempts)
+            .into_iter()
+            .map(|u| u.to_string())
+            .collect())
+    }
+}
+
+/// One blocking RTM_GETROUTE dump across every table.
+///
+/// Hand-rolled on `netlink-sys` for the same reason [`crate::fdb`] is:
+/// this crate runs a supervision loop, not an async runtime, and one
+/// dump per minute does not earn one.
+///
+/// The LOCAL table is included deliberately. Its entries are the
+/// router's own addresses, and steered traffic to those dies in VPP
+/// exactly like tunnel-bound traffic does — that is the w23 blackhole
+/// (110,917 packets in five minutes) which `steer-exempt` was
+/// introduced to fix. A check that only looked at forwarding would
+/// have missed the first instance of the very class it exists for.
+#[cfg(target_os = "linux")]
+pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
+    use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+    use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteMessage, RouteType};
+    use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
+    use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+
+    let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    socket
+        .bind_auto()
+        .map_err(|e| format!("netlink bind: {e}"))?;
+    socket
+        .connect(&SocketAddr::new(0, 0))
+        .map_err(|e| format!("netlink connect: {e}"))?;
+
+    let mut route = RouteMessage::default();
+    route.header.address_family = AddressFamily::Inet;
+    let mut msg = NetlinkMessage::from(RouteNetlinkMessage::GetRoute(route));
+    msg.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    msg.header.sequence_number = 1;
+    msg.finalize();
+    let mut send_buf = vec![0u8; msg.header.length as usize];
+    msg.serialize(&mut send_buf);
+    socket
+        .send(&send_buf, 0)
+        .map_err(|e| format!("netlink send: {e}"))?;
+
+    // Interface names are resolved once per dump rather than per
+    // route: a full table can carry thousands of entries out of a
+    // handful of devices.
+    let mut names: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
+    let mut out = Vec::new();
+    let mut recv_buf = vec![0u8; 64 * 1024];
+    'dump: loop {
+        let n = socket
+            .recv(&mut &mut recv_buf[..], 0)
+            .map_err(|e| format!("netlink recv: {e}"))?;
+        let mut offset = 0usize;
+        while offset < n {
+            let pkt = NetlinkMessage::<RouteNetlinkMessage>::deserialize(&recv_buf[offset..n])
+                .map_err(|e| format!("netlink parse: {e}"))?;
+            let len = pkt.header.length as usize;
+            if len == 0 {
+                break;
+            }
+            match pkt.payload {
+                NetlinkPayload::Done(_) => break 'dump,
+                NetlinkPayload::Error(e) => return Err(format!("netlink error: {e}")),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewRoute(m)) => {
+                    let mut dst: Option<std::net::Ipv4Addr> = None;
+                    let mut oif: Option<u32> = None;
+                    let mut table = u32::from(m.header.table);
+                    for attr in &m.attributes {
+                        match attr {
+                            RouteAttribute::Destination(RouteAddress::Inet(a)) => dst = Some(*a),
+                            RouteAttribute::Oif(i) => oif = Some(*i),
+                            // RTA_TABLE carries ids past the u8 header
+                            // field — policy tables live up there.
+                            RouteAttribute::Table(t) => table = *t,
+                            _ => {}
+                        }
+                    }
+                    out.push(KernelRoute {
+                        prefix: Ipv4Prefix {
+                            // No RTA_DST = the default route.
+                            addr: dst.unwrap_or(std::net::Ipv4Addr::UNSPECIFIED),
+                            prefix_len: m.header.destination_prefix_length,
+                        },
+                        oif: oif.map(|i| {
+                            names
+                                .entry(i)
+                                .or_insert_with(|| crate::fdb::ifname(i))
+                                .clone()
+                        }),
+                        table,
+                        drops: matches!(
+                            m.header.kind,
+                            RouteType::BlackHole | RouteType::Unreachable | RouteType::Prohibit
+                        ),
+                    });
+                }
+                _ => {}
+            }
+            offset += len;
+        }
+    }
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    fn p(a: u8, b: u8, c: u8, d: u8, len: u8) -> Ipv4Prefix {
+        Ipv4Prefix {
+            addr: Ipv4Addr::new(a, b, c, d),
+            prefix_len: len,
+        }
+    }
+
+    fn route(prefix: Ipv4Prefix, oif: &str) -> KernelRoute {
+        KernelRoute {
+            prefix,
+            oif: Some(oif.to_string()),
+            table: 100,
+            drops: false,
+        }
+    }
+
+    fn reach() -> VppReach {
+        VppReach {
+            members: vec!["eth3".into(), "eth4".into()],
+            local_devices: vec!["br1337".into()],
+        }
+    }
+
+    /// The w26 shape: tunnel-bound routes are findings, and only the
+    /// ones no exemption covers.
+    #[test]
+    fn tunnel_paths_are_findings_until_an_exemption_covers_them() {
+        let routes = vec![
+            route(p(23, 191, 201, 0, 24), "vti64"), // remote site: finding
+            route(p(23, 191, 200, 2, 32), "vti64"), // host inside the local /24
+            route(p(0, 0, 0, 0, 0), "eth3"),        // default via a member: fine
+            route(p(23, 191, 200, 0, 24), "br1337"), // local delivery: fine
+            route(p(10, 0, 0, 0, 8), "eth4"),       // member: fine
+        ];
+        let found = uncovered_paths(&routes, &reach(), &[]);
+        assert_eq!(found.len(), 2, "{found:?}");
+        assert!(found.iter().any(|u| u.oif == "vti64"));
+
+        // Exempting both silences it.
+        let exempts = [p(23, 191, 201, 0, 24), p(23, 191, 200, 2, 32)];
+        assert!(uncovered_paths(&routes, &reach(), &exempts).is_empty());
+    }
+
+    /// Containment, not overlap: a /32 exemption inside a /24 route
+    /// does NOT cover the /24. Reporting it as handled because one
+    /// host is exempted is the silent-hole shape this exists to end.
+    #[test]
+    fn an_exemption_must_contain_the_route_not_merely_overlap_it() {
+        let routes = vec![route(p(23, 191, 201, 0, 24), "vti64")];
+        let too_narrow = [p(23, 191, 201, 5, 32)];
+        assert_eq!(
+            uncovered_paths(&routes, &reach(), &too_narrow).len(),
+            1,
+            "a /32 inside the route must not silence the /24"
+        );
+        // The other direction is genuine cover.
+        let wide = [p(23, 191, 0, 0, 16)];
+        assert!(uncovered_paths(&routes, &reach(), &wide).is_empty());
+    }
+
+    /// Routes the kernel drops itself are not findings: VPP dropping
+    /// the same packet is the same outcome, one hop earlier. The
+    /// reference primary's bird carries a service host as
+    /// `unreachable`, and flagging it would be permanent noise.
+    #[test]
+    fn routes_the_kernel_itself_drops_are_not_findings() {
+        let mut blackhole = route(p(198, 18, 0, 0, 15), "vti64");
+        blackhole.drops = true;
+        let mut no_oif = route(p(203, 0, 113, 0, 24), "vti64");
+        no_oif.oif = None;
+        let found = uncovered_paths(&[blackhole, no_oif], &reach(), &[]);
+        assert!(found.is_empty(), "{found:?}");
+    }
+
+    /// Broadcast and multicast are exempted on every steered port
+    /// without a directive, so the scan must not demand config for
+    /// what is already handled.
+    #[test]
+    fn the_built_in_exemptions_count_as_cover() {
+        let routes = vec![
+            route(p(224, 0, 0, 0, 4), "vti64"),
+            route(p(255, 255, 255, 255, 32), "vti64"),
+        ];
+        assert!(uncovered_paths(&routes, &reach(), &[]).is_empty());
+    }
+
+    /// The operator-facing line names the three things needed to act:
+    /// what, out of where, and which table to look in.
+    #[test]
+    fn a_finding_names_prefix_device_and_table() {
+        let mut r = route(p(23, 191, 201, 0, 24), "vti64");
+        r.table = 100;
+        let found = uncovered_paths(&[r], &reach(), &[]);
+        let line = found[0].to_string();
+        assert!(line.contains("23.191.201.0/24"), "{line}");
+        assert!(line.contains("vti64"), "{line}");
+        assert!(line.contains("table 100"), "{line}");
+    }
+}

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -49,14 +49,19 @@ pub struct KernelRoute {
     /// unreachable, prohibit). VPP dropping the same packet is
     /// equivalent behaviour, so these are not findings.
     pub drops: bool,
-    /// `RTN_LOCAL`: an address the kernel TERMINATES rather than a
-    /// path it forwards over. Its `oif` names the interface that owns
-    /// the address, which is not an egress VPP could take — so device
-    /// reachability says nothing about it and must not be consulted
-    /// (review finding: the local class this scan exists to cover was
+    /// The kernel DELIVERS this itself rather than forwarding over a
+    /// path — `RTN_LOCAL` (its own addresses), `RTN_BROADCAST` (the
+    /// segment's directed broadcast, `.255` on a service bridge) and
+    /// `RTN_ANYCAST`. The `oif` names the interface that owns the
+    /// address or segment, which is not an egress VPP could take, so
+    /// device reachability says nothing about these and must not be
+    /// consulted — the local class this scan exists to cover was
     /// being skipped precisely because those addresses sit on member
-    /// ports and bridges).
-    pub local: bool,
+    /// ports and bridges, and directed broadcast was being skipped
+    /// the same way one round later (both review findings). VPP has
+    /// no local delivery and cannot reproduce a broadcast, so
+    /// steered traffic to any of them dies unless exempted.
+    pub kernel_delivers: bool,
     /// The route names a NEXTHOP OBJECT (`ip route ... nhid N`,
     /// `RTA_NH_ID`) instead of carrying its devices inline. Those
     /// routes are opaque here: the vendored netlink crate does not
@@ -233,7 +238,10 @@ pub enum Uncovered {
         table: u32,
         /// A terminated address rather than a forwarding path — the
         /// message says so, because the remedy reads differently.
-        local: bool,
+        /// Kernel-owned delivery (an address or a broadcast) rather
+        /// than a forwarding path — the message says so, because the
+        /// remedy reads differently.
+        kernel_delivers: bool,
     },
     /// Routes using nexthop objects, whose devices this scan cannot
     /// see. Reported so the operator knows the coverage is partial
@@ -242,6 +250,16 @@ pub enum Uncovered {
 }
 
 impl Uncovered {
+    /// How many kernel routes this finding stands for — one, except
+    /// for the coverage-gap summary, which stands for as many as it
+    /// counted.
+    pub fn routes(&self) -> usize {
+        match self {
+            Self::Path { .. } => 1,
+            Self::Opaque(n) => *n,
+        }
+    }
+
     /// The table this finding sits in, for tests and log context.
     /// `None` for the coverage-gap summary, which names no route.
     pub fn table(&self) -> Option<u32> {
@@ -259,17 +277,18 @@ impl std::fmt::Display for Uncovered {
                 prefix,
                 oif,
                 table,
-                local: true,
+                kernel_delivers: true,
             } => write!(
                 f,
-                "{}/{} terminates on {oif} (table {table}, the router's own address)",
+                "{}/{} is delivered by the kernel on {oif} (table {table}) — an address or \
+                 broadcast VPP cannot reproduce",
                 prefix.addr, prefix.prefix_len
             ),
             Self::Path {
                 prefix,
                 oif,
                 table,
-                local: false,
+                kernel_delivers: false,
             } => write!(
                 f,
                 "{}/{} via {oif} (table {table})",
@@ -339,7 +358,7 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
             continue;
         }
         let Some(oif) = r.oifs.first() else { continue };
-        if r.local {
+        if r.kernel_delivers {
             // Only the segments whose hosts steering diverts. A
             // transit port's own address is reachable from a steered
             // host only by a route that would itself be a finding,
@@ -371,7 +390,7 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
             prefix: r.prefix,
             oif: oif.clone(),
             table: r.table,
-            local: r.local,
+            kernel_delivers: r.kernel_delivers,
         });
     }
     out.sort_by_key(|u| match u {
@@ -387,11 +406,24 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
 
 /// The scan seam the runtime holds, mirroring [`crate::fdb::FdbWatch`]:
 /// a trait so tests record calls and non-Linux builds never pretend.
+/// What one scan concluded.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct DriftFindings {
+    /// One line per finding, for the health surface.
+    pub lines: Vec<String>,
+    /// How many ROUTES those lines represent. Not `lines.len()`: the
+    /// nexthop-object summary is one line for `n` routes, and a gauge
+    /// derived from the line count published `1` however much of the
+    /// table the scan could not see — undercounting exactly the blind
+    /// portion it exists to report (review finding).
+    pub routes: usize,
+}
+
 pub trait DriftWatch {
-    /// One line per uncovered kernel path, empty when the exemptions
-    /// hold. `Err` = the kernel would not answer; the caller keeps its
-    /// previous verdict.
-    fn uncovered(&mut self) -> Result<Vec<String>, String>;
+    /// The scan's findings, empty when the exemptions hold. `Err` =
+    /// the kernel would not answer; the caller keeps its previous
+    /// verdict.
+    fn uncovered(&mut self) -> Result<DriftFindings, String>;
 
     /// Adopt a reloaded exemption set AND diversion scope. Called
     /// from the same place the steering target is retargeted, so the
@@ -424,7 +456,7 @@ pub struct KernelDriftWatch {
 
 #[cfg(target_os = "linux")]
 impl DriftWatch for KernelDriftWatch {
-    fn uncovered(&mut self) -> Result<Vec<String>, String> {
+    fn uncovered(&mut self) -> Result<DriftFindings, String> {
         let routes = dump_routes()?;
         // A rule dump that fails filters nothing rather than failing
         // the scan: the routes are the finding, the rules only narrow
@@ -444,10 +476,11 @@ impl DriftWatch for KernelDriftWatch {
             divertible,
             selected_tables: tables.as_deref(),
         };
-        Ok(uncovered_paths(&routes, &scope)
-            .into_iter()
-            .map(|u| u.to_string())
-            .collect())
+        let found = uncovered_paths(&routes, &scope);
+        Ok(DriftFindings {
+            routes: found.iter().map(Uncovered::routes).sum(),
+            lines: found.iter().map(Uncovered::to_string).collect(),
+        })
     }
 
     fn set_scope(
@@ -594,7 +627,10 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             m.header.kind,
                             RouteType::BlackHole | RouteType::Unreachable | RouteType::Prohibit
                         ),
-                        local: m.header.kind == RouteType::Local,
+                        kernel_delivers: matches!(
+                            m.header.kind,
+                            RouteType::Local | RouteType::Broadcast | RouteType::Anycast
+                        ),
                         via_nexthop_object: nexthop_object,
                     });
                 }
@@ -732,7 +768,7 @@ mod tests {
             oifs: vec![oif.to_string()],
             table: 100,
             drops: false,
-            local: false,
+            kernel_delivers: false,
             via_nexthop_object: false,
         }
     }
@@ -819,18 +855,47 @@ mod tests {
     #[test]
     fn a_local_address_on_a_service_bridge_is_a_finding_despite_the_device() {
         let mut gw = route(p(23, 191, 200, 1, 32), "br1337");
-        gw.local = true;
+        gw.kernel_delivers = true;
         gw.table = 255;
         let found = find(&[gw.clone()], &[]);
         assert_eq!(found.len(), 1, "{found:?}");
-        assert!(matches!(found[0], Uncovered::Path { local: true, .. }));
+        assert!(matches!(
+            found[0],
+            Uncovered::Path {
+                kernel_delivers: true,
+                ..
+            }
+        ));
         assert!(
-            found[0].to_string().contains("terminates on br1337"),
+            found[0]
+                .to_string()
+                .contains("delivered by the kernel on br1337"),
             "the message must read as termination, not a path: {}",
             found[0]
         );
         // And the exemption an operator would add silences it.
         assert!(find(&[gw], &[p(23, 191, 200, 1, 32)]).is_empty());
+    }
+
+    /// A service bridge's directed broadcast (`.255`) is
+    /// `RTN_BROADCAST` with the bridge as its oif — kernel-owned
+    /// delivery VPP cannot reproduce, not a forwarding path — so the
+    /// device check must not wave it through just because the bridge
+    /// is a local device (review finding, one round after the same
+    /// thing was fixed for `RTN_LOCAL`).
+    #[test]
+    fn a_service_bridges_directed_broadcast_is_kernel_delivery_too() {
+        let mut bcast = route(p(23, 191, 200, 255, 32), "br1337");
+        bcast.kernel_delivers = true;
+        bcast.table = 255;
+        let found = find(std::slice::from_ref(&bcast), &[]);
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert!(
+            found[0].to_string().contains("delivered by the kernel"),
+            "{}",
+            found[0]
+        );
+        assert!(find(&[bcast], &[p(23, 191, 200, 255, 32)]).is_empty());
     }
 
     /// Local addresses NOT on a steered segment are deliberately out
@@ -841,9 +906,9 @@ mod tests {
     #[test]
     fn local_addresses_off_the_steered_segments_are_out_of_scope() {
         let mut transit = route(p(194, 110, 60, 51, 32), "eth3");
-        transit.local = true;
+        transit.kernel_delivers = true;
         let mut loopback = route(p(127, 0, 0, 1, 32), "lo");
-        loopback.local = true;
+        loopback.kernel_delivers = true;
         assert!(find(&[transit, loopback], &[]).is_empty());
     }
 
@@ -860,7 +925,7 @@ mod tests {
             oifs: vec!["vti64".into(), "wg0".into()],
             table: 254,
             drops: false,
-            local: false,
+            kernel_delivers: false,
             via_nexthop_object: false,
         };
         assert_eq!(find(&[all_tunnel], &[]).len(), 1);
@@ -870,7 +935,7 @@ mod tests {
             oifs: vec!["vti64".into(), "eth3".into()],
             table: 254,
             drops: false,
-            local: false,
+            kernel_delivers: false,
             via_nexthop_object: false,
         };
         assert!(
@@ -1060,12 +1125,17 @@ mod tests {
             oifs: Vec::new(),
             table: 254,
             drops: false,
-            local: false,
+            kernel_delivers: false,
             via_nexthop_object: true,
         };
         let found = find(&[opaque.clone(), opaque.clone()], &[]);
         assert_eq!(found.len(), 1, "one summary, not one per route: {found:?}");
         assert_eq!(found[0], Uncovered::Opaque(2));
+        assert_eq!(
+            found[0].routes(),
+            2,
+            "one LINE, but it stands for two routes — the gauge counts routes"
+        );
         let line = found[0].to_string();
         assert!(line.contains("nhid"), "{line}");
         assert!(line.contains("ip nexthop show"), "names the tool: {line}");

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -92,6 +92,51 @@ pub enum Divertible<'a> {
     OnlyDst(&'a [packetframe_common::fib::IpPrefix]),
 }
 
+impl Scope<'_> {
+    /// Is every DIVERTIBLE packet for this route already exempted?
+    ///
+    /// Under `Any`, that is every address in the route, so the
+    /// exemption must contain the whole prefix. Under `OnlyDst` only
+    /// the route's intersection with the allowlist can be diverted at
+    /// all — an allowlisted `/32` inside a tunnel-backed `/24` puts
+    /// exactly one host at risk — so a `/32` exemption covering that
+    /// host covers the risk, and demanding one for the whole `/24`
+    /// would send the operator to install a broader rule than the
+    /// hazard warrants (review finding).
+    ///
+    /// Cover is tested against single exemptions, never their union: a
+    /// pair of `/25`s covering a `/24` between them still reports. That
+    /// under-approximates coverage, which over-reports, which is the
+    /// direction this scan is allowed to be wrong in.
+    fn covers(&self, route: &Ipv4Prefix) -> bool {
+        let covered = |p: &Ipv4Prefix| self.exempts.iter().any(|e| e.contains_prefix(p));
+        match &self.divertible {
+            Divertible::Any => covered(route),
+            Divertible::OnlyDst(allow) => allow
+                .iter()
+                .filter_map(|a| {
+                    let packetframe_common::fib::IpPrefix::V4 { addr, prefix_len } = a else {
+                        return None;
+                    };
+                    let a = Ipv4Prefix {
+                        addr: std::net::Ipv4Addr::from(*addr),
+                        prefix_len: *prefix_len,
+                    };
+                    // Two CIDRs that overlap are nested, so the
+                    // intersection is whichever is more specific.
+                    if a.contains_prefix(route) {
+                        Some(*route)
+                    } else if route.contains_prefix(&a) {
+                        Some(a)
+                    } else {
+                        None
+                    }
+                })
+                .all(|intersection| covered(&intersection)),
+        }
+    }
+}
+
 impl Divertible<'_> {
     /// Can a packet for `prefix` be diverted into VPP at all?
     ///
@@ -256,7 +301,7 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
         }) {
             continue;
         }
-        if scope.exempts.iter().any(|e| e.contains_prefix(&r.prefix)) {
+        if scope.covers(&r.prefix) {
             continue;
         }
         out.push(Uncovered {
@@ -360,7 +405,9 @@ impl DriftWatch for KernelDriftWatch {
 /// have missed the first instance of the very class it exists for.
 #[cfg(target_os = "linux")]
 pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
-    use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+    use netlink_packet_core::{
+        NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_REQUEST,
+    };
     use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteMessage, RouteType};
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
@@ -402,6 +449,20 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
             let len = pkt.header.length as usize;
             if len == 0 {
                 break;
+            }
+            // The kernel sets NLM_F_DUMP_INTR when the table changed
+            // under the dump, which makes the result a mix of two
+            // states rather than a snapshot. On a box with a live BGP
+            // feed that is not rare, and a partial list fails the
+            // dangerous way: a missing route reads as "no such path"
+            // and a missing rule narrows the filter onto an active
+            // table. Refuse it; the caller keeps its previous verdict
+            // and the next scan is a minute away (review finding).
+            if pkt.header.flags & NLM_F_DUMP_INTR != 0 {
+                return Err("the kernel interrupted the dump (NLM_F_DUMP_INTR): the \
+                            table changed underneath it, so this result is not a \
+                            snapshot"
+                    .into());
             }
             match pkt.payload {
                 NetlinkPayload::Done(_) => break 'dump,
@@ -482,7 +543,9 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
 ///   this whole module exists to prevent.
 #[cfg(target_os = "linux")]
 pub fn dump_rule_tables() -> Result<Option<Vec<u32>>, String> {
-    use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+    use netlink_packet_core::{
+        NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_REQUEST,
+    };
     use netlink_packet_route::rule::{RuleAttribute, RuleMessage};
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
@@ -520,6 +583,20 @@ pub fn dump_rule_tables() -> Result<Option<Vec<u32>>, String> {
             let len = pkt.header.length as usize;
             if len == 0 {
                 break;
+            }
+            // The kernel sets NLM_F_DUMP_INTR when the table changed
+            // under the dump, which makes the result a mix of two
+            // states rather than a snapshot. On a box with a live BGP
+            // feed that is not rare, and a partial list fails the
+            // dangerous way: a missing route reads as "no such path"
+            // and a missing rule narrows the filter onto an active
+            // table. Refuse it; the caller keeps its previous verdict
+            // and the next scan is a minute away (review finding).
+            if pkt.header.flags & NLM_F_DUMP_INTR != 0 {
+                return Err("the kernel interrupted the dump (NLM_F_DUMP_INTR): the \
+                            table changed underneath it, so this result is not a \
+                            snapshot"
+                    .into());
             }
             match pkt.payload {
                 NetlinkPayload::Done(_) => break 'dump,
@@ -831,6 +908,52 @@ mod tests {
         );
         // No ports at all: conservative.
         assert!(divertible_scope(&[], D::Dst, &allow).is_none());
+    }
+
+    /// Under dst-only steering only the route's INTERSECTION with the
+    /// allowlist can be diverted, so an exemption covering that
+    /// intersection covers the whole hazard — demanding one for the
+    /// entire route would send the operator to install a broader rule
+    /// than the risk warrants (review finding).
+    #[test]
+    fn dst_only_coverage_is_judged_on_the_divertible_intersection() {
+        use packetframe_common::fib::IpPrefix;
+        // One host of a tunnel-backed /24 is allowlisted, so only that
+        // host can be diverted at all.
+        let allow = [IpPrefix::V4 {
+            addr: [23, 191, 201, 7],
+            prefix_len: 32,
+        }];
+        let routes = [route(p(23, 191, 201, 0, 24), "vti64")];
+        let scoped = |exempts: &[Ipv4Prefix]| {
+            uncovered_paths(
+                &routes,
+                &Scope {
+                    reach: &reach(),
+                    exempts,
+                    divertible: Divertible::OnlyDst(&allow),
+                    selected_tables: None,
+                },
+            )
+        };
+        assert_eq!(scoped(&[]).len(), 1, "uncovered: the /32 can be diverted");
+        assert!(
+            scoped(&[p(23, 191, 201, 7, 32)]).is_empty(),
+            "exempting the one divertible host covers the whole hazard"
+        );
+
+        // Under src steering the same /32 exemption is NOT enough:
+        // every address in the /24 can be diverted there.
+        let any = uncovered_paths(
+            &routes,
+            &Scope {
+                reach: &reach(),
+                exempts: &[p(23, 191, 201, 7, 32)],
+                divertible: Divertible::Any,
+                selected_tables: None,
+            },
+        );
+        assert_eq!(any.len(), 1, "{any:?}");
     }
 
     /// The operator-facing line names the three things needed to act:

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -72,6 +72,20 @@ pub struct KernelRoute {
     /// is counted and reported as a gap in the scan's own coverage
     /// rather than silently dropped or guessed at.
     pub via_nexthop_object: bool,
+    /// The route carries a LIGHTWEIGHT ENCAPSULATION action —
+    /// `ip route ... encap mpls|seg6|ip|xfrm ... dev eth3` — named
+    /// here by its kernel type for the operator-facing message.
+    ///
+    /// This one is nastier than a tunnel device, because the `oif` is
+    /// an ORDINARY device: a member port, usually. Read for
+    /// reachability alone the route looks perfectly coverable, so the
+    /// scan would call it clean while the mirror — which encodes
+    /// prefix, nexthop and interface, and has nowhere to put a label
+    /// stack or a segment list — forwarded the packet bare out the
+    /// same port. Bare is not a slower path, it is a different
+    /// destination (review finding). The encapsulation is a property
+    /// of the PATH, so a multipath hop carrying one counts too.
+    pub encap: Option<String>,
 }
 
 /// What VPP can actually egress, from config: member ports and the
@@ -242,6 +256,12 @@ pub enum Uncovered {
         /// than a forwarding path — the message says so, because the
         /// remedy reads differently.
         kernel_delivers: bool,
+        /// The lightweight-encapsulation type this path applies, when
+        /// it applies one. Present means the finding is about what
+        /// the kernel puts ON the packet, not where it sends it, so
+        /// the message must not read "via a device VPP does not own"
+        /// — VPP very likely owns it, which is the trap.
+        encap: Option<String>,
     },
     /// Routes using nexthop objects, whose devices this scan cannot
     /// see. Reported so the operator knows the coverage is partial
@@ -273,11 +293,27 @@ impl Uncovered {
 impl std::fmt::Display for Uncovered {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            // Encapsulation first: it is true of a path whatever the
+            // route type, and its remedy is the one an operator would
+            // never reach from a reachability message.
+            Self::Path {
+                prefix,
+                oif,
+                table,
+                encap: Some(kind),
+                ..
+            } => write!(
+                f,
+                "{}/{} via {oif} (table {table}) applies {kind} encapsulation — VPP's mirror \
+                 carries no encap action, so steered packets would leave {oif} bare",
+                prefix.addr, prefix.prefix_len
+            ),
             Self::Path {
                 prefix,
                 oif,
                 table,
                 kernel_delivers: true,
+                ..
             } => write!(
                 f,
                 "{}/{} is delivered by the kernel on {oif} (table {table}) — an address or \
@@ -289,6 +325,7 @@ impl std::fmt::Display for Uncovered {
                 oif,
                 table,
                 kernel_delivers: false,
+                ..
             } => write!(
                 f,
                 "{}/{} via {oif} (table {table})",
@@ -358,20 +395,27 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
             continue;
         }
         let Some(oif) = r.oifs.first() else { continue };
-        if r.kernel_delivers {
-            // Only the segments whose hosts steering diverts. A
-            // transit port's own address is reachable from a steered
-            // host only by a route that would itself be a finding,
-            // and reporting every address on the box would demand
-            // more exemptions than the 16-slot budget holds — an
-            // alarm with no available remedy is one operators learn
-            // to ignore. Documented in the runbook, with the
-            // null-drop gauge as the backstop for the rest.
-            if !reach.local_devices.iter().any(|d| d == oif) {
+        // A lightweight-encap path is unreproducible REGARDLESS of
+        // which device it leaves by, so both reachability arms below
+        // are skipped for it — they would clear the route on the
+        // strength of an `oif` that is not the problem.
+        if r.encap.is_none() {
+            if r.kernel_delivers {
+                // Only the segments whose hosts steering diverts. A
+                // transit port's own address is reachable from a
+                // steered host only by a route that would itself be a
+                // finding, and reporting every address on the box
+                // would demand more exemptions than the 16-slot
+                // budget holds — an alarm with no available remedy is
+                // one operators learn to ignore. Documented in the
+                // runbook, with the null-drop gauge as the backstop
+                // for the rest.
+                if !reach.local_devices.iter().any(|d| d == oif) {
+                    continue;
+                }
+            } else if r.oifs.iter().any(|d| reach.covers_device(d)) {
                 continue;
             }
-        } else if r.oifs.iter().any(|d| reach.covers_device(d)) {
-            continue;
         }
         // Built-in exemptions cover these on every steered port.
         if crate::steer::BUILTIN_EXEMPTS.iter().any(|(addr, len)| {
@@ -391,6 +435,7 @@ pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncover
             oif: oif.clone(),
             table: r.table,
             kernel_delivers: r.kernel_delivers,
+            encap: r.encap.clone(),
         });
     }
     out.sort_by_key(|u| match u {
@@ -675,7 +720,9 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
     use netlink_packet_core::{
         NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_DUMP_INTR, NLM_F_REQUEST,
     };
-    use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteMessage, RouteType};
+    use netlink_packet_route::route::{
+        RouteAddress, RouteAttribute, RouteLwEnCapType, RouteMessage, RouteType,
+    };
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
     // The `kind()` accessor for an unparsed attribute. Same crate
     // the message types come from, already a direct dependency.
@@ -684,6 +731,30 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
 
     /// `RTA_NH_ID` — see [`KernelRoute::via_nexthop_object`].
     const RTA_NH_ID: u16 = 30;
+
+    /// The kernel's name for a lightweight-encap action, for the
+    /// operator's message. `None` is the overwhelming majority and is
+    /// not an encapsulation — the kernel emits `RTA_ENCAP_TYPE` on
+    /// plain routes too.
+    fn encap_name(t: RouteLwEnCapType) -> Option<String> {
+        Some(match t {
+            RouteLwEnCapType::None => return None,
+            RouteLwEnCapType::Mpls => "MPLS".to_string(),
+            RouteLwEnCapType::Ip => "IP-in-IP".to_string(),
+            RouteLwEnCapType::Ila => "ILA".to_string(),
+            RouteLwEnCapType::Ip6 => "IPv6 tunnel".to_string(),
+            RouteLwEnCapType::Seg6 => "SRv6".to_string(),
+            RouteLwEnCapType::Seg6Local => "SRv6-local".to_string(),
+            RouteLwEnCapType::Bpf => "BPF".to_string(),
+            RouteLwEnCapType::Rpl => "RPL".to_string(),
+            RouteLwEnCapType::Ioam6 => "IOAM6".to_string(),
+            RouteLwEnCapType::Xfrm => "XFRM".to_string(),
+            // The enum is `#[non_exhaustive]` and the kernel adds
+            // types; an unrecognised one is still an encap action
+            // and must still be reported, by number.
+            other => format!("encap type {}", u16::from(other)),
+        })
+    }
 
     let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
     socket
@@ -744,11 +815,20 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                     let mut dst: Option<std::net::Ipv4Addr> = None;
                     let mut oifs: Vec<u32> = Vec::new();
                     let mut nexthop_object = false;
+                    let mut encap: Option<String> = None;
                     let mut table = u32::from(m.header.table);
                     for attr in &m.attributes {
                         match attr {
                             RouteAttribute::Destination(RouteAddress::Inet(a)) => dst = Some(*a),
                             RouteAttribute::Oif(i) => oifs.push(*i),
+                            // `RTA_ENCAP_TYPE`: the route hands the
+                            // packet to a lightweight tunnel before it
+                            // leaves. See `KernelRoute::encap` for why
+                            // the ordinary `oif` makes this the
+                            // quietest failure in the dump.
+                            RouteAttribute::EncapType(t) => {
+                                encap = encap.take().or_else(|| encap_name(*t))
+                            }
                             // ECMP puts its nexthops HERE and leaves
                             // RTA_OIF unset, so a route read only for
                             // RTA_OIF looks device-less and gets
@@ -756,7 +836,21 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             // blackhole under a clean health surface
                             // (review finding).
                             RouteAttribute::MultiPath(hops) => {
-                                oifs.extend(hops.iter().map(|h| h.interface_index))
+                                oifs.extend(hops.iter().map(|h| h.interface_index));
+                                // Encapsulation is per PATH, and ECMP
+                                // puts each path's attributes here. A
+                                // route with one plain path and one
+                                // encapped path is reported: VPP would
+                                // install both and hash traffic into
+                                // the one it cannot reproduce.
+                                encap = encap.take().or_else(|| {
+                                    hops.iter().flat_map(|h| h.attributes.iter()).find_map(|a| {
+                                        match a {
+                                            RouteAttribute::EncapType(t) => encap_name(*t),
+                                            _ => None,
+                                        }
+                                    })
+                                });
                             }
                             // RTA_TABLE carries ids past the u8 header
                             // field — policy tables live up there.
@@ -797,6 +891,7 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             RouteType::Local | RouteType::Broadcast | RouteType::Anycast
                         ),
                         via_nexthop_object: nexthop_object,
+                        encap,
                     });
                 }
                 _ => {}
@@ -935,6 +1030,7 @@ mod tests {
             drops: false,
             kernel_delivers: false,
             via_nexthop_object: false,
+            encap: None,
         }
     }
 
@@ -1092,6 +1188,7 @@ mod tests {
             drops: false,
             kernel_delivers: false,
             via_nexthop_object: false,
+            encap: None,
         };
         assert_eq!(find(&[all_tunnel], &[]).len(), 1);
 
@@ -1102,11 +1199,56 @@ mod tests {
             drops: false,
             kernel_delivers: false,
             via_nexthop_object: false,
+            encap: None,
         };
         assert!(
             find(&[mixed], &[]).is_empty(),
             "one resolvable path is enough for VPP to forward the prefix"
         );
+    }
+
+    /// A lightweight-encap route (`ip route ... encap mpls 100 dev
+    /// eth3`) leaves by an ORDINARY device — a member port, here — so
+    /// every reachability test in this scan passes it, and the mirror,
+    /// which has nowhere to put a label stack, would forward the
+    /// packet bare out the same port (review finding). The device is
+    /// not the hazard; the action is.
+    #[test]
+    fn an_encapsulating_route_is_a_finding_even_out_a_member_port() {
+        let mut mpls = route(p(203, 0, 113, 0, 24), "eth3");
+        mpls.encap = Some("MPLS".into());
+        let found = find(std::slice::from_ref(&mpls), &[]);
+        assert_eq!(
+            found.len(),
+            1,
+            "a member-port oif must not clear an encap action: {found:?}"
+        );
+        let msg = found[0].to_string();
+        assert!(
+            msg.contains("MPLS") && msg.contains("bare"),
+            "the message must name the action, not the reachability: {msg}"
+        );
+        // And an exemption still silences it — exempted traffic never
+        // reaches VPP, so there is nothing to misforward.
+        assert!(find(&[mpls], &[p(203, 0, 113, 0, 24)]).is_empty());
+    }
+
+    /// Encapsulation is a property of a PATH, so an ECMP route with
+    /// one plain member path and one encapped path is still a finding:
+    /// VPP installs both and hashes traffic into the one it cannot
+    /// reproduce. The any-path-reachable rule must not clear it.
+    #[test]
+    fn one_encapped_path_in_an_ecmp_group_is_enough() {
+        let mixed = KernelRoute {
+            prefix: p(203, 0, 113, 0, 24),
+            oifs: vec!["eth3".into(), "eth4".into()],
+            table: 254,
+            drops: false,
+            kernel_delivers: false,
+            via_nexthop_object: false,
+            encap: Some("SRv6".into()),
+        };
+        assert_eq!(find(&[mixed], &[]).len(), 1);
     }
 
     /// Under dst-only steering the NIC diverts only packets addressed
@@ -1292,6 +1434,7 @@ mod tests {
             drops: false,
             kernel_delivers: false,
             via_nexthop_object: true,
+            encap: None,
         };
         let found = find(&[opaque.clone(), opaque.clone()], &[]);
         assert_eq!(found.len(), 1, "one summary, not one per route: {found:?}");

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -116,6 +116,57 @@ impl Divertible<'_> {
     }
 }
 
+/// Derive the diversion scope from config — the ONE place it is
+/// computed, called at attach and again on every accepted
+/// reconfigure.
+///
+/// A function rather than a value each caller builds, because the
+/// inputs are hot: the allowlist and both direction knobs are rebuilt
+/// on reconfigure, and a scope captured at attach goes stale the
+/// moment either changes — a dst-only deployment that adds an
+/// allow-prefix, or flips a port to `src`, starts diverting traffic
+/// the frozen scope tells the scan to ignore (review finding, and the
+/// same freeze the exemption set had one field over).
+///
+/// `None` = every destination is at risk: some port matches on
+/// source, or nothing steers yet, or the config declares no ports.
+/// The conservative answer is the default in all three.
+pub fn divertible_scope(
+    ports: &[crate::PortLine],
+    global: packetframe_common::config::VppSteerDirection,
+    allowlist: &[packetframe_common::fib::IpPrefix],
+) -> Option<Vec<packetframe_common::fib::IpPrefix>> {
+    use packetframe_common::config::VppSteerDirection;
+    if ports.is_empty() {
+        return None;
+    }
+    ports
+        .iter()
+        .all(|(_, _, _, _, dir)| dir.unwrap_or(global) == VppSteerDirection::Dst)
+        .then(|| allowlist.to_vec())
+}
+
+/// Everything the comparison judges against, bundled so the parameter
+/// list stops growing by one per question asked.
+pub struct Scope<'a> {
+    pub reach: &'a VppReach,
+    pub exempts: &'a [Ipv4Prefix],
+    pub divertible: Divertible<'a>,
+    /// Tables some policy rule can select. `None` = the rule set could
+    /// not be read, so nothing is filtered.
+    ///
+    /// This models table SELECTION only, never the finer predicates —
+    /// fwmark, iif, from/to — deliberately. "A table no rule names
+    /// cannot be consulted by any packet" is unconditionally true, so
+    /// filtering on it cannot hide a real path; evaluating the rest
+    /// would mean reimplementing the kernel's rule walk, where a
+    /// permissive mistake re-opens exactly the hole this scan closes.
+    /// Over-reporting is the safe direction, and this takes only the
+    /// share of it that is provably noise (an unreferenced VRF or
+    /// auxiliary table — review finding).
+    pub selected_tables: Option<&'a [u32]>,
+}
+
 /// A kernel path VPP cannot take that nothing exempts.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Uncovered {
@@ -168,15 +219,15 @@ impl std::fmt::Display for Uncovered {
 /// `/24` around it, and reporting the `/24` as handled because one
 /// host inside it is exempted would be the silent-hole shape all over
 /// again.
-pub fn uncovered_paths(
-    routes: &[KernelRoute],
-    reach: &VppReach,
-    exempts: &[Ipv4Prefix],
-    divertible: &Divertible<'_>,
-) -> Vec<Uncovered> {
+pub fn uncovered_paths(routes: &[KernelRoute], scope: &Scope<'_>) -> Vec<Uncovered> {
+    let reach = scope.reach;
     let mut out = Vec::new();
     for r in routes {
-        if r.drops || !divertible.reaches(&r.prefix) {
+        if r.drops || !scope.divertible.reaches(&r.prefix) {
+            continue;
+        }
+        // A table no policy rule names is inert for every packet.
+        if scope.selected_tables.is_some_and(|t| !t.contains(&r.table)) {
             continue;
         }
         let Some(oif) = r.oifs.first() else { continue };
@@ -205,7 +256,7 @@ pub fn uncovered_paths(
         }) {
             continue;
         }
-        if exempts.iter().any(|e| e.contains_prefix(&r.prefix)) {
+        if scope.exempts.iter().any(|e| e.contains_prefix(&r.prefix)) {
             continue;
         }
         out.push(Uncovered {
@@ -228,10 +279,16 @@ pub trait DriftWatch {
     /// previous verdict.
     fn uncovered(&mut self) -> Result<Vec<String>, String>;
 
-    /// Adopt a reloaded exemption set. Called from the same place the
-    /// steering target is retargeted, so the scan judges the config
-    /// the operator just applied rather than the one at attach.
-    fn set_exempts(&mut self, exempts: Vec<Ipv4Prefix>);
+    /// Adopt a reloaded exemption set AND diversion scope. Called
+    /// from the same place the steering target is retargeted, so the
+    /// scan judges the config the operator just applied rather than
+    /// the one at attach. Both travel together because both come from
+    /// the same reconfigure and freezing either one re-opens the hole.
+    fn set_scope(
+        &mut self,
+        exempts: Vec<Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
+    );
 }
 
 /// The production scan: dump every IPv4 route in every table, compare.
@@ -255,20 +312,37 @@ pub struct KernelDriftWatch {
 impl DriftWatch for KernelDriftWatch {
     fn uncovered(&mut self) -> Result<Vec<String>, String> {
         let routes = dump_routes()?;
+        // A rule dump that fails filters nothing rather than failing
+        // the scan: the routes are the finding, the rules only narrow
+        // them, and losing the narrowing costs noise where losing the
+        // scan costs the blackhole.
+        let tables = dump_rule_tables().unwrap_or_else(|e| {
+            tracing::debug!(error = %e, "policy-rule dump failed; not filtering by table");
+            Vec::new()
+        });
         let divertible = match &self.dst_only {
             Some(allow) => Divertible::OnlyDst(allow),
             None => Divertible::Any,
         };
-        Ok(
-            uncovered_paths(&routes, &self.reach, &self.exempts, &divertible)
-                .into_iter()
-                .map(|u| u.to_string())
-                .collect(),
-        )
+        let scope = Scope {
+            reach: &self.reach,
+            exempts: &self.exempts,
+            divertible,
+            selected_tables: (!tables.is_empty()).then_some(tables.as_slice()),
+        };
+        Ok(uncovered_paths(&routes, &scope)
+            .into_iter()
+            .map(|u| u.to_string())
+            .collect())
     }
 
-    fn set_exempts(&mut self, exempts: Vec<Ipv4Prefix>) {
+    fn set_scope(
+        &mut self,
+        exempts: Vec<Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
+    ) {
         self.exempts = exempts;
+        self.dst_only = dst_only;
     }
 }
 
@@ -386,6 +460,75 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
     Ok(out)
 }
 
+/// The table ids some policy rule can select.
+///
+/// One `RTM_GETRULE` dump. See [`Scope::selected_tables`] for what
+/// this models and, more importantly, what it deliberately does not.
+#[cfg(target_os = "linux")]
+pub fn dump_rule_tables() -> Result<Vec<u32>, String> {
+    use netlink_packet_core::{NetlinkMessage, NetlinkPayload, NLM_F_DUMP, NLM_F_REQUEST};
+    use netlink_packet_route::rule::{RuleAttribute, RuleMessage};
+    use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
+    use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
+
+    let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    socket
+        .bind_auto()
+        .map_err(|e| format!("netlink bind: {e}"))?;
+    socket
+        .connect(&SocketAddr::new(0, 0))
+        .map_err(|e| format!("netlink connect: {e}"))?;
+
+    let mut rule = RuleMessage::default();
+    rule.header.family = AddressFamily::Inet;
+    let mut msg = NetlinkMessage::from(RouteNetlinkMessage::GetRule(rule));
+    msg.header.flags = NLM_F_REQUEST | NLM_F_DUMP;
+    msg.header.sequence_number = 1;
+    msg.finalize();
+    let mut send_buf = vec![0u8; msg.header.length as usize];
+    msg.serialize(&mut send_buf);
+    socket
+        .send(&send_buf, 0)
+        .map_err(|e| format!("netlink send: {e}"))?;
+
+    let mut out: Vec<u32> = Vec::new();
+    let mut recv_buf = vec![0u8; 64 * 1024];
+    'dump: loop {
+        let n = socket
+            .recv(&mut &mut recv_buf[..], 0)
+            .map_err(|e| format!("netlink recv: {e}"))?;
+        let mut offset = 0usize;
+        while offset < n {
+            let pkt = NetlinkMessage::<RouteNetlinkMessage>::deserialize(&recv_buf[offset..n])
+                .map_err(|e| format!("netlink parse: {e}"))?;
+            let len = pkt.header.length as usize;
+            if len == 0 {
+                break;
+            }
+            match pkt.payload {
+                NetlinkPayload::Done(_) => break 'dump,
+                NetlinkPayload::Error(e) => return Err(format!("netlink error: {e}")),
+                NetlinkPayload::InnerMessage(RouteNetlinkMessage::NewRule(m)) => {
+                    // FRA_TABLE carries ids past the u8 header field,
+                    // exactly as RTA_TABLE does for routes.
+                    let mut table = u32::from(m.header.table);
+                    for attr in &m.attributes {
+                        if let RuleAttribute::Table(t) = attr {
+                            table = *t;
+                        }
+                    }
+                    if table != 0 && !out.contains(&table) {
+                        out.push(table);
+                    }
+                }
+                _ => {}
+            }
+            offset += len;
+        }
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -416,7 +559,15 @@ mod tests {
     }
 
     fn find(routes: &[KernelRoute], exempts: &[Ipv4Prefix]) -> Vec<Uncovered> {
-        uncovered_paths(routes, &reach(), exempts, &Divertible::Any)
+        uncovered_paths(
+            routes,
+            &Scope {
+                reach: &reach(),
+                exempts,
+                divertible: Divertible::Any,
+                selected_tables: None,
+            },
+        )
     }
 
     /// The w26 shape: tunnel-bound routes are findings, and only the
@@ -555,12 +706,87 @@ mod tests {
             route(p(23, 191, 200, 2, 32), "vti64"), // inside the allowlist
             route(p(198, 51, 100, 0, 24), "vti64"), // outside it
         ];
-        let scoped = uncovered_paths(&routes, &reach(), &[], &Divertible::OnlyDst(&allow));
+        let scoped = uncovered_paths(
+            &routes,
+            &Scope {
+                reach: &reach(),
+                exempts: &[],
+                divertible: Divertible::OnlyDst(&allow),
+                selected_tables: None,
+            },
+        );
         assert_eq!(scoped.len(), 1, "{scoped:?}");
         assert_eq!(scoped[0].prefix.addr, Ipv4Addr::new(23, 191, 200, 2));
 
         // A src rule anywhere means any destination can be diverted.
         assert_eq!(find(&routes, &[]).len(), 2);
+    }
+
+    /// A table no policy rule names cannot be consulted by any
+    /// packet, so a tunnel route parked in an unreferenced VRF must
+    /// not cost an exemption slot (review finding). Only SELECTION is
+    /// modelled — fwmark/iif/from are not, because over-reporting is
+    /// the safe direction and a permissive mistake in a rule walk
+    /// re-opens the hole this scan closes.
+    #[test]
+    fn routes_in_tables_no_rule_selects_are_not_findings() {
+        let mut in_use = route(p(23, 191, 201, 0, 24), "vti64");
+        in_use.table = 100;
+        let mut orphan = route(p(198, 51, 100, 0, 24), "vti64");
+        orphan.table = 4242;
+        let routes = [in_use, orphan];
+        let selected = [100u32, 254, 255];
+        let found = uncovered_paths(
+            &routes,
+            &Scope {
+                reach: &reach(),
+                exempts: &[],
+                divertible: Divertible::Any,
+                selected_tables: Some(&selected),
+            },
+        );
+        assert_eq!(found.len(), 1, "{found:?}");
+        assert_eq!(found[0].table, 100);
+        // Unknown rule set (dump failed) filters nothing: losing the
+        // narrowing costs noise, losing the scan costs the blackhole.
+        assert_eq!(find(&routes, &[]).len(), 2);
+    }
+
+    /// The scope derivation is shared by attach and reconfigure, so a
+    /// hot allowlist or direction edit cannot leave the scan judging
+    /// the config from attach time (review finding).
+    #[test]
+    fn the_diversion_scope_follows_config_not_attach_time() {
+        use packetframe_common::config::VppSteerDirection as D;
+        use packetframe_common::fib::IpPrefix;
+        let allow = [IpPrefix::V4 {
+            addr: [23, 191, 200, 0],
+            prefix_len: 24,
+        }];
+        let port = |steer: bool, dir: Option<D>| ("eth4".to_string(), 1u16, steer, Vec::new(), dir);
+
+        // Every port dst → scoped to the allowlist.
+        let scoped = divertible_scope(&[port(true, Some(D::Dst))], D::Both, &allow);
+        assert_eq!(scoped.as_deref(), Some(&allow[..]));
+
+        // One src port anywhere → everything is at risk.
+        assert!(
+            divertible_scope(
+                &[port(true, Some(D::Dst)), port(false, Some(D::Src))],
+                D::Dst,
+                &allow
+            )
+            .is_none(),
+            "a src port makes any destination divertible"
+        );
+        // The global default applies to ports that declare nothing.
+        assert!(divertible_scope(&[port(true, None)], D::Both, &allow).is_none());
+        assert_eq!(
+            divertible_scope(&[port(true, None)], D::Dst, &allow).as_deref(),
+            Some(&allow[..])
+        );
+        // No ports at all: conservative.
+        assert!(divertible_scope(&[], D::Dst, &allow).is_none());
     }
 
     /// The operator-facing line names the three things needed to act:

--- a/crates/modules/vpp-offload/src/fdb.rs
+++ b/crates/modules/vpp-offload/src/fdb.rs
@@ -167,6 +167,44 @@ pub(crate) fn ifname(index: u32) -> String {
     String::from_utf8_lossy(&buf[..len]).into_owned()
 }
 
+/// Bound how long ONE `recv` on a dump socket may block, shared with
+/// [`crate::drift`]'s route dump.
+///
+/// Netlink has no cancellation, so an unbounded receive is a thread
+/// that never settles: on the supervision loop that is a liveness
+/// stall, and on the scan thread it is a teardown that can never
+/// complete. The kernel produces dump batches promptly — 5 s is orders
+/// of magnitude past any real one — so a timeout here means something
+/// is wrong, and the caller's error path (scan unreadable, gauge
+/// absent) already says so honestly. A monitoring read must never be
+/// able to wedge anything, including itself (review finding).
+#[cfg(target_os = "linux")]
+pub(crate) fn bound_recv(socket: &netlink_sys::Socket) -> Result<(), String> {
+    use std::os::fd::AsRawFd as _;
+    let tv = libc::timeval {
+        tv_sec: 5,
+        tv_usec: 0,
+    };
+    // SAFETY: `socket` owns the fd for the call, and `tv` is a
+    // `timeval` of exactly the length passed.
+    let ret = unsafe {
+        libc::setsockopt(
+            socket.as_raw_fd(),
+            libc::SOL_SOCKET,
+            libc::SO_RCVTIMEO,
+            std::ptr::addr_of!(tv).cast(),
+            std::mem::size_of::<libc::timeval>() as libc::socklen_t,
+        )
+    };
+    if ret != 0 {
+        return Err(format!(
+            "netlink SO_RCVTIMEO: {}",
+            std::io::Error::last_os_error()
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(target_os = "linux")]
 fn master_ifindex(port: &str) -> Option<u32> {
     // The master symlink's target name, resolved to an index — the
@@ -197,6 +235,9 @@ pub fn dump_bridge_fdb() -> Result<Vec<FdbEntry>, String> {
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
 
     let mut socket = Socket::new(NETLINK_ROUTE).map_err(|e| format!("netlink socket: {e}"))?;
+    // This dump runs ON the supervision loop, so an unbounded receive
+    // would stall liveness, wedge detection and `steer off` alike.
+    bound_recv(&socket)?;
     socket
         .bind_auto()
         .map_err(|e| format!("netlink bind: {e}"))?;

--- a/crates/modules/vpp-offload/src/fdb.rs
+++ b/crates/modules/vpp-offload/src/fdb.rs
@@ -153,8 +153,10 @@ fn ifindex(name: &str) -> Option<u32> {
     }
 }
 
+/// `if_indextoname`, shared with [`crate::drift`]'s route dump — both
+/// turn kernel ifindexes into the names an operator reads.
 #[cfg(target_os = "linux")]
-fn ifname(index: u32) -> String {
+pub(crate) fn ifname(index: u32) -> String {
     let mut buf = [0u8; libc::IF_NAMESIZE];
     // SAFETY: `buf` is IF_NAMESIZE bytes as the contract requires.
     let ret = unsafe { libc::if_indextoname(index, buf.as_mut_ptr().cast()) };

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1139,7 +1139,12 @@ impl Module for VppOffloadModule {
             .ne(new.ports.iter().map(|(_, _, steer, _, _)| *steer));
         attached
             .service
-            .apply_steering(target.targets, target.want_steer, lever_moved)
+            .apply_steering(
+                target.targets,
+                new.steer_exempts.clone(),
+                target.want_steer,
+                lever_moved,
+            )
             .map_err(|e| ModuleError::other(MODULE_NAME, e))?;
         // Recorded only after the change landed. A `cfg` updated ahead of
         // the apply would make the NEXT reconfigure diff against a target

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -55,6 +55,7 @@ pub mod acquire;
 pub mod attach;
 pub mod bringup;
 pub mod cores;
+pub mod drift;
 pub mod driver;
 pub mod engine;
 pub mod executor;

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1142,6 +1142,11 @@ impl Module for VppOffloadModule {
             .apply_steering(
                 target.targets,
                 new.steer_exempts.clone(),
+                // The SAME derivation attach uses, run against the
+                // config just accepted — allowlist and directions are
+                // both hot, so a scope captured at attach goes stale
+                // the moment either moves.
+                drift::divertible_scope(&new.ports, new.steer_direction, &self.allowlist.get()),
                 target.want_steer,
                 lever_moved,
             )

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -560,6 +560,19 @@ struct Core {
         Vec<packetframe_common::config::Ipv4Prefix>,
         Option<Vec<packetframe_common::fib::IpPrefix>>,
     )>,
+    /// Set when a steering change failed PARTWAY and left rules on
+    /// the NIC, so neither the old exemption set nor the new one
+    /// describes what is installed.
+    ///
+    /// `NtupleSteering::steer` rolls back a partial install, and a
+    /// rollback that itself fails deliberately keeps those rules in
+    /// the ledger — they are still diverting traffic. The scope gate
+    /// is `is_ok()`, so the watcher stayed on the old exemptions
+    /// while a surviving divert rule blackholed a prefix the
+    /// reconfigure had just unexempted (review finding). There is no
+    /// correct set to adopt in that state, so the scan says it does
+    /// not know rather than answering from either one.
+    drift_scope_stale: Option<String>,
     /// Why the last scan could not read the kernel, if it could not.
     ///
     /// Its own field for the same reason `steer_audit_error` is: a
@@ -1286,6 +1299,7 @@ impl Runtime {
                 last_drift_scan: None,
                 drift_uncovered: Vec::new(),
                 drift_unreadable: None,
+                drift_scope_stale: None,
                 pending_drift_scope: None,
                 steer_missing: 0,
                 steer_stray: 0,
@@ -1635,6 +1649,7 @@ impl Runtime {
             fdb_misplaced: c.fdb_misplaced.clone(),
             drift_uncovered: c.drift_uncovered.clone(),
             drift_unreadable: c.drift_unreadable.clone(),
+            drift_scope_stale: c.drift_scope_stale.clone(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1818,6 +1833,8 @@ pub struct RuntimeStatus {
     pub drift_uncovered: Vec<String>,
     /// Why the last drift scan could not read the kernel, if so.
     pub drift_unreadable: Option<String>,
+    /// Why the scan cannot say which exemptions the NIC holds, if so.
+    pub drift_scope_stale: Option<String>,
 }
 
 impl Core {
@@ -1971,6 +1988,20 @@ impl Core {
         }
     }
 
+    /// A steering change failed. If it left rules installed while a
+    /// new scope was waiting, the NIC now holds some of one config
+    /// and some of another and the scan must say so — see
+    /// [`Self::drift_scope_stale`].
+    fn note_partial_steer(&mut self) {
+        if self.pending_drift_scope.is_some() && !self.steering.installed().is_empty() {
+            self.drift_scope_stale = Some(
+                "a steering change failed partway and left rules installed, so the \
+                 exemptions the NIC holds are neither the old set nor the new one"
+                    .into(),
+            );
+        }
+    }
+
     /// Adopt the staged scope, if any — called where a steering action
     /// has just succeeded, so the watcher only ever describes rules
     /// the NIC took.
@@ -1980,6 +2011,9 @@ impl Core {
         };
         if let Some(w) = self.drift_watch.as_mut() {
             w.set_scope(exempts, dst_only);
+            // Whatever ambiguity a failed reconcile left is settled:
+            // the NIC just took this scope.
+            self.drift_scope_stale = None;
             // Re-read on the next poll rather than serving a verdict
             // about a config that no longer exists. The findings go
             // with it; the READ failure does not, because whether the
@@ -2709,6 +2743,8 @@ impl Effects for EffectsView {
         // never when the NIC refused.
         if outcome.is_ok() {
             c.commit_drift_scope();
+        } else {
+            c.note_partial_steer();
         }
         outcome
     }
@@ -2833,6 +2869,8 @@ impl Effects for EffectsView {
         // never when the NIC refused.
         if outcome.is_ok() {
             c.commit_drift_scope();
+        } else {
+            c.note_partial_steer();
         }
         outcome
     }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1343,6 +1343,11 @@ impl Runtime {
         self.core.borrow_mut().retarget(targets);
     }
 
+    /// Hand the exemption tripwire a reloaded exemption set.
+    pub fn set_drift_exempts(&self, exempts: Vec<packetframe_common::config::Ipv4Prefix>) {
+        self.core.borrow_mut().set_drift_exempts(exempts);
+    }
+
     /// The two trait views the driver's tick takes.
     pub fn views(&self) -> (ObserveView, EffectsView) {
         (
@@ -1884,6 +1889,24 @@ impl Core {
     fn retarget(&mut self, targets: Vec<(String, u32, crate::steer::RuleSet)>) {
         self.steering.retarget(targets);
         self.last_steer_audit = None;
+    }
+
+    /// Hand the exemption tripwire the reloaded `steer-exempt` set.
+    ///
+    /// Called from the same place as `retarget` and for the same
+    /// reason the audit is invalidated there: the scan's verdict was
+    /// computed against the OLD config the moment this one is
+    /// accepted. Also clears the scan clock, so the next status poll
+    /// re-reads rather than serving a verdict about a config that no
+    /// longer exists — the operator who just added the exemption the
+    /// health line asked for should not have to wait out a minute of
+    /// it still complaining.
+    fn set_drift_exempts(&mut self, exempts: Vec<packetframe_common::config::Ipv4Prefix>) {
+        if let Some(w) = self.drift_watch.as_mut() {
+            w.set_exempts(exempts);
+            self.last_drift_scan = None;
+            self.drift_uncovered.clear();
+        }
     }
 
     /// Whether a steer against the current target would divert traffic

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -538,8 +538,9 @@ struct Core {
     /// `steer-exempt` covers. Installed on Linux whenever steering is
     /// configured at all — the hole it finds opens the moment a port
     /// steers, and an operator wants it named BEFORE that.
-    drift_watch: Option<Box<dyn crate::drift::DriftWatch>>,
-    last_drift_scan: Option<std::time::Instant>,
+    /// The scan runs on its own thread — see [`crate::drift::DriftScanner`]
+    /// for why a full route dump must never sit on this loop.
+    drift_scanner: Option<crate::drift::DriftScanner>,
     /// Last completed scan's findings, kept across a failed scan (an
     /// unreadable kernel is not evidence the routes went away).
     drift_uncovered: Vec<String>,
@@ -1299,8 +1300,7 @@ impl Runtime {
                 fdb_watch: None,
                 last_fdb_scan: None,
                 fdb_misplaced: Vec::new(),
-                drift_watch: None,
-                last_drift_scan: None,
+                drift_scanner: None,
                 drift_uncovered: Vec::new(),
                 drift_routes: 0,
                 drift_unreadable: None,
@@ -1373,8 +1373,9 @@ impl Runtime {
     }
 
     /// Install the exemption tripwire. Same wiring rule as the others.
-    pub fn drift_watch(&self, w: Box<dyn crate::drift::DriftWatch>) {
-        self.core.borrow_mut().drift_watch = Some(w);
+    pub fn drift_watch(&self, w: Box<dyn crate::drift::DriftWatch + Send>) {
+        self.core.borrow_mut().drift_scanner =
+            Some(crate::drift::DriftScanner::spawn(w, DRIFT_SCAN_EVERY));
     }
 
     /// Declare that the NIC holds rules INHERITED from a previous
@@ -1579,12 +1580,13 @@ impl Runtime {
                 c.last_null_sample = Some(now);
                 c.engine.sample_null_drops();
             }
-            let due = c
-                .last_drift_scan
-                .is_none_or(|t| now.duration_since(t) >= DRIFT_SCAN_EVERY);
-            if due && c.drift_watch.is_some() {
-                c.last_drift_scan = Some(now);
-                let result = c.drift_watch.as_mut().expect("checked above").uncovered();
+            // A COMPLETED result, if the scanner finished a pass
+            // since the last look. Never a scan performed here: this
+            // is the thread that answers pings, stops and steering
+            // requests, and a 1.05M-prefix dump on it would delay all
+            // three (review finding).
+            let result = c.drift_scanner.as_ref().and_then(|s| s.take_result());
+            if let Some(result) = result {
                 match result {
                     Ok(found) => {
                         if !found.lines.is_empty() && c.drift_uncovered != found.lines {
@@ -2012,7 +2014,7 @@ impl Core {
         exempts: Vec<packetframe_common::config::Ipv4Prefix>,
         dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     ) {
-        if self.drift_watch.is_some() {
+        if self.drift_scanner.is_some() {
             self.pending_drift_scope = Some((exempts, dst_only));
         }
     }
@@ -2038,17 +2040,16 @@ impl Core {
         let Some((exempts, dst_only)) = self.pending_drift_scope.take() else {
             return;
         };
-        if let Some(w) = self.drift_watch.as_mut() {
-            w.set_scope(exempts, dst_only);
+        if let Some(s) = self.drift_scanner.as_ref() {
+            s.set_scope(exempts, dst_only);
             // Whatever ambiguity a failed reconcile left is settled:
             // the NIC just took this scope.
             self.drift_scope_stale = None;
-            // Re-read on the next poll rather than serving a verdict
-            // about a config that no longer exists. The findings go
-            // with it; the READ failure does not, because whether the
-            // kernel answers has nothing to do with which config we
-            // are judging.
-            self.last_drift_scan = None;
+            // The findings described the OLD config, so they go —
+            // the scanner republishes against the new one on its next
+            // pass. The READ failure does not go with them: whether
+            // the kernel answers has nothing to do with which config
+            // we are judging.
             self.drift_uncovered.clear();
             self.drift_routes = 0;
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1344,8 +1344,12 @@ impl Runtime {
     }
 
     /// Hand the exemption tripwire a reloaded exemption set.
-    pub fn set_drift_exempts(&self, exempts: Vec<packetframe_common::config::Ipv4Prefix>) {
-        self.core.borrow_mut().set_drift_exempts(exempts);
+    pub fn set_drift_scope(
+        &self,
+        exempts: Vec<packetframe_common::config::Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
+    ) {
+        self.core.borrow_mut().set_drift_scope(exempts, dst_only);
     }
 
     /// The two trait views the driver's tick takes.
@@ -1901,9 +1905,13 @@ impl Core {
     /// longer exists — the operator who just added the exemption the
     /// health line asked for should not have to wait out a minute of
     /// it still complaining.
-    fn set_drift_exempts(&mut self, exempts: Vec<packetframe_common::config::Ipv4Prefix>) {
+    fn set_drift_scope(
+        &mut self,
+        exempts: Vec<packetframe_common::config::Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
+    ) {
         if let Some(w) = self.drift_watch.as_mut() {
-            w.set_exempts(exempts);
+            w.set_scope(exempts, dst_only);
             self.last_drift_scan = None;
             self.drift_uncovered.clear();
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -534,6 +534,15 @@ struct Core {
     /// log lines, not impersonated by a stub.
     fdb_watch: Option<Box<dyn crate::fdb::FdbWatch>>,
     last_fdb_scan: Option<std::time::Instant>,
+    /// The exemption tripwire: kernel paths VPP cannot take that no
+    /// `steer-exempt` covers. Installed on Linux whenever steering is
+    /// configured at all — the hole it finds opens the moment a port
+    /// steers, and an operator wants it named BEFORE that.
+    drift_watch: Option<Box<dyn crate::drift::DriftWatch>>,
+    last_drift_scan: Option<std::time::Instant>,
+    /// Last completed scan's findings, kept across a failed scan (an
+    /// unreadable kernel is not evidence the routes went away).
+    drift_uncovered: Vec<String>,
     /// The last completed scan's findings; kept across a failed scan
     /// (an unreadable kernel is not evidence the hosts moved back).
     fdb_misplaced: Vec<String>,
@@ -1246,6 +1255,9 @@ impl Runtime {
                 fdb_watch: None,
                 last_fdb_scan: None,
                 fdb_misplaced: Vec::new(),
+                drift_watch: None,
+                last_drift_scan: None,
+                drift_uncovered: Vec::new(),
                 steer_missing: 0,
                 steer_stray: 0,
                 steer_audit_error: None,
@@ -1310,6 +1322,11 @@ impl Runtime {
     /// local-routes exist, and nothing pretends elsewhere.
     pub fn fdb_watch(&self, w: Box<dyn crate::fdb::FdbWatch>) {
         self.core.borrow_mut().fdb_watch = Some(w);
+    }
+
+    /// Install the exemption tripwire. Same wiring rule as the others.
+    pub fn drift_watch(&self, w: Box<dyn crate::drift::DriftWatch>) {
+        self.core.borrow_mut().drift_watch = Some(w);
     }
 
     pub fn rx_mode_kick(&self, k: Box<dyn RxModeKick>) {
@@ -1470,6 +1487,28 @@ impl Runtime {
                 c.engine.sample_null_drops();
             }
             let due = c
+                .last_drift_scan
+                .is_none_or(|t| now.duration_since(t) >= DRIFT_SCAN_EVERY);
+            if due && c.drift_watch.is_some() {
+                c.last_drift_scan = Some(now);
+                let result = c.drift_watch.as_mut().expect("checked above").uncovered();
+                match result {
+                    Ok(found) => {
+                        if !found.is_empty() && c.drift_uncovered != found {
+                            tracing::warn!(
+                                paths = ?found,
+                                "kernel path(s) VPP cannot take are not covered by any \
+                                 `steer-exempt`; steered traffic for them dies at VPP's \
+                                 default route instead of falling back to the kernel. Add \
+                                 a steer-exempt for each, or stop steering the port"
+                            );
+                        }
+                        c.drift_uncovered = found;
+                    }
+                    Err(e) => tracing::debug!(error = %e, "route-drift scan failed"),
+                }
+            }
+            let due = c
                 .last_fdb_scan
                 .is_none_or(|t| now.duration_since(t) >= FDB_SCAN_EVERY);
             if due && c.fdb_watch.is_some() {
@@ -1532,6 +1571,7 @@ impl Runtime {
             shadowed_routes: c.engine.shadowed_routes(),
             null_drops: c.engine.null_drops(),
             fdb_misplaced: c.fdb_misplaced.clone(),
+            drift_uncovered: c.drift_uncovered.clone(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1581,6 +1621,15 @@ const NULL_DROPS_EVERY: Duration = Duration::from_secs(60);
 /// moved host is a provisioning-scale event, so a minute of latency
 /// on the tripwire costs nothing.
 const FDB_SCAN_EVERY: Duration = Duration::from_secs(60);
+
+/// How often to check the kernel's routes against the exemptions.
+///
+/// One route dump per minute. The sets this watches are edited by
+/// routing daemons, not by hand — the reference primary's tunnel host
+/// routes come from bird — so the interesting change arrives without
+/// anyone touching packetframe, which is the whole argument for
+/// scanning on a clock rather than at config load.
+const DRIFT_SCAN_EVERY: Duration = Duration::from_secs(60);
 
 /// What the completeness authority can currently say, for the health
 /// text.
@@ -1702,6 +1751,8 @@ pub struct RuntimeStatus {
     /// `local-route` declares, one line each. Empty = the tripwire is
     /// quiet (or not installed).
     pub fdb_misplaced: Vec<String>,
+    /// Kernel paths VPP cannot take that no `steer-exempt` covers.
+    pub drift_uncovered: Vec<String>,
 }
 
 impl Core {

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -543,6 +543,16 @@ struct Core {
     /// Last completed scan's findings, kept across a failed scan (an
     /// unreadable kernel is not evidence the routes went away).
     drift_uncovered: Vec<String>,
+    /// Why the last scan could not read the kernel, if it could not.
+    ///
+    /// Its own field for the same reason `steer_audit_error` is: a
+    /// check that cannot run must not be indistinguishable from one
+    /// that ran and found nothing. Without it a permanently broken
+    /// netlink read published an empty finding list, no health row and
+    /// a zero gauge — the newest safety check presenting as clean
+    /// while blind, which is the shape it exists to catch (review
+    /// finding). Same rule as the null-drop gauge's absent-not-zero.
+    drift_unreadable: Option<String>,
     /// The last completed scan's findings; kept across a failed scan
     /// (an unreadable kernel is not evidence the hosts moved back).
     fdb_misplaced: Vec<String>,
@@ -1258,6 +1268,7 @@ impl Runtime {
                 drift_watch: None,
                 last_drift_scan: None,
                 drift_uncovered: Vec::new(),
+                drift_unreadable: None,
                 steer_missing: 0,
                 steer_stray: 0,
                 steer_audit_error: None,
@@ -1513,8 +1524,16 @@ impl Runtime {
                             );
                         }
                         c.drift_uncovered = found;
+                        c.drift_unreadable = None;
                     }
-                    Err(e) => tracing::debug!(error = %e, "route-drift scan failed"),
+                    // The previous findings stand — an unreadable
+                    // kernel is not evidence the routes went away —
+                    // but the failure is published, so a scan that
+                    // never succeeds cannot pass for a quiet one.
+                    Err(e) => {
+                        tracing::debug!(error = %e, "route-drift scan failed");
+                        c.drift_unreadable = Some(e);
+                    }
                 }
             }
             let due = c
@@ -1581,6 +1600,7 @@ impl Runtime {
             null_drops: c.engine.null_drops(),
             fdb_misplaced: c.fdb_misplaced.clone(),
             drift_uncovered: c.drift_uncovered.clone(),
+            drift_unreadable: c.drift_unreadable.clone(),
             authority: authority_posture(
                 c.completeness.is_some(),
                 matches!(
@@ -1762,6 +1782,8 @@ pub struct RuntimeStatus {
     pub fdb_misplaced: Vec<String>,
     /// Kernel paths VPP cannot take that no `steer-exempt` covers.
     pub drift_uncovered: Vec<String>,
+    /// Why the last drift scan could not read the kernel, if so.
+    pub drift_unreadable: Option<String>,
 }
 
 impl Core {
@@ -1912,6 +1934,11 @@ impl Core {
     ) {
         if let Some(w) = self.drift_watch.as_mut() {
             w.set_scope(exempts, dst_only);
+            // Re-read on the next poll rather than serving a verdict
+            // about a config that no longer exists. The findings go
+            // with it; the READ failure does not, because whether the
+            // kernel answers has nothing to do with which config we
+            // are judging.
             self.last_drift_scan = None;
             self.drift_uncovered.clear();
         }

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -548,6 +548,17 @@ struct Core {
     /// lines because the nexthop-object summary is one line for many
     /// routes, and the gauge must count routes.
     drift_routes: usize,
+    /// The scope generation the retained findings were scanned under,
+    /// and whether that is still the current one. A million-route
+    /// dump takes seconds, so "attached but not yet scanned" is a
+    /// real window an operator can steer inside — and an empty
+    /// finding list there is not a clean verdict, it is no verdict
+    /// (review finding).
+    drift_result_gen: Option<u64>,
+    /// A scanner exists and has not yet reported on the CURRENT
+    /// scope. False when no scanner is installed — nothing to wait
+    /// for — and false once a current-generation verdict lands.
+    drift_pending: bool,
     /// A drift scope the config asked for that the NIC has not taken
     /// yet.
     ///
@@ -1303,6 +1314,8 @@ impl Runtime {
                 drift_scanner: None,
                 drift_uncovered: Vec::new(),
                 drift_routes: 0,
+                drift_result_gen: None,
+                drift_pending: false,
                 drift_unreadable: None,
                 drift_scope_stale: None,
                 pending_drift_scope: None,
@@ -1585,8 +1598,44 @@ impl Runtime {
             // is the thread that answers pings, stops and steering
             // requests, and a 1.05M-prefix dump on it would delay all
             // three (review finding).
-            let result = c.drift_scanner.as_ref().and_then(|s| s.take_result());
-            if let Some(result) = result {
+            // A COMPLETED result, and only one scanned under the
+            // CURRENT scope: a pass already in flight when a
+            // reconfigure landed is answering about the exemptions
+            // that were in force when it started, and publishing that
+            // as the new config's verdict is how a newly blackholed
+            // path would read as covered (review finding).
+            let fresh = c.drift_scanner.as_ref().and_then(|s| {
+                let current = s.generation();
+                match s.take_result() {
+                    Some((gen, r)) if gen == current => Some(r),
+                    Some((gen, _)) => {
+                        tracing::debug!(
+                            scanned_under = gen,
+                            current,
+                            "discarding a drift result about a superseded scope"
+                        );
+                        None
+                    }
+                    None => None,
+                }
+            });
+            // Whether a verdict about the CURRENT config exists at
+            // all. Until one does — the first pass after attach, or
+            // after a scope change — the tripwire has nothing to say
+            // and must not say `0`.
+            if let Some(s) = c.drift_scanner.as_ref() {
+                let current = s.generation();
+                if fresh.is_some() {
+                    c.drift_result_gen = Some(current);
+                }
+                // PENDING, not "unscanned": a deployment with no
+                // tripwire installed at all (non-Linux, or a config
+                // the loader gave no watcher) is not waiting for
+                // anything, and degrading it would report a missing
+                // feature as a broken one.
+                c.drift_pending = c.drift_result_gen != Some(current);
+            }
+            if let Some(result) = fresh {
                 match result {
                     Ok(found) => {
                         if !found.lines.is_empty() && c.drift_uncovered != found.lines {
@@ -1677,6 +1726,7 @@ impl Runtime {
             fdb_misplaced: c.fdb_misplaced.clone(),
             drift_uncovered: c.drift_uncovered.clone(),
             drift_routes: c.drift_routes,
+            drift_pending: c.drift_pending,
             drift_unreadable: c.drift_unreadable.clone(),
             drift_scope_stale: c.drift_scope_stale.clone(),
             authority: authority_posture(
@@ -1862,6 +1912,10 @@ pub struct RuntimeStatus {
     pub drift_uncovered: Vec<String>,
     /// How many routes those findings stand for — the gauge's value.
     pub drift_routes: usize,
+    /// A scan is outstanding for the CURRENT configuration — the
+    /// tripwire has no verdict yet, which is not the same as a clean
+    /// one. False when no tripwire is installed.
+    pub drift_pending: bool,
     /// Why the last drift scan could not read the kernel, if so.
     pub drift_unreadable: Option<String>,
     /// Why the scan cannot say which exemptions the NIC holds, if so.

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -2091,14 +2091,20 @@ impl Core {
     /// has just succeeded, so the watcher only ever describes rules
     /// the NIC took.
     fn commit_drift_scope(&mut self) {
+        // A successful steering action means the NIC now holds what
+        // the current target asks for — including, on the adoption
+        // path, rules that were INHERITED and have just been
+        // reconciled. That settles the staleness whether or not a
+        // scope was staged: startup adoption stages none, so gating
+        // this on `pending` left every adopted restart permanently
+        // Degraded with the gauge absent until an unrelated
+        // reconfigure happened along (review finding).
+        self.drift_scope_stale = None;
         let Some((exempts, dst_only)) = self.pending_drift_scope.take() else {
             return;
         };
         if let Some(s) = self.drift_scanner.as_ref() {
             s.set_scope(exempts, dst_only);
-            // Whatever ambiguity a failed reconcile left is settled:
-            // the NIC just took this scope.
-            self.drift_scope_stale = None;
             // The findings described the OLD config, so they go —
             // the scanner republishes against the new one on its next
             // pass. The READ failure does not go with them: whether

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -1373,6 +1373,22 @@ impl Runtime {
     }
 
     /// Hand the exemption tripwire a reloaded exemption set.
+    /// Whether the NIC holds any steering rule right now.
+    ///
+    /// Read by the reconfigure path to decide whether a request that
+    /// installs nothing may still commit its drift scope: with no
+    /// rules installed there are no old exemptions to describe, so the
+    /// staged config IS what a scan should judge.
+    pub fn steering_rules_installed(&self) -> bool {
+        !self.core.borrow().steering.installed().is_empty()
+    }
+
+    /// Adopt the staged scope now — for the path where the request
+    /// performs no steering action at all.
+    pub fn commit_drift_scope(&self) {
+        self.core.borrow_mut().commit_drift_scope();
+    }
+
     pub fn stage_drift_scope(
         &self,
         exempts: Vec<packetframe_common::config::Ipv4Prefix>,

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -543,6 +543,10 @@ struct Core {
     /// Last completed scan's findings, kept across a failed scan (an
     /// unreadable kernel is not evidence the routes went away).
     drift_uncovered: Vec<String>,
+    /// How many ROUTES those findings stand for. Tracked beside the
+    /// lines because the nexthop-object summary is one line for many
+    /// routes, and the gauge must count routes.
+    drift_routes: usize,
     /// A drift scope the config asked for that the NIC has not taken
     /// yet.
     ///
@@ -1298,6 +1302,7 @@ impl Runtime {
                 drift_watch: None,
                 last_drift_scan: None,
                 drift_uncovered: Vec::new(),
+                drift_routes: 0,
                 drift_unreadable: None,
                 drift_scope_stale: None,
                 pending_drift_scope: None,
@@ -1370,6 +1375,26 @@ impl Runtime {
     /// Install the exemption tripwire. Same wiring rule as the others.
     pub fn drift_watch(&self, w: Box<dyn crate::drift::DriftWatch>) {
         self.core.borrow_mut().drift_watch = Some(w);
+    }
+
+    /// Declare that the NIC holds rules INHERITED from a previous
+    /// process, so the tripwire is judging a config it cannot assume
+    /// matches them.
+    ///
+    /// The watcher is built from the config on disk, and a restart
+    /// that adopts a live VPP re-adopts whatever rules the last
+    /// process installed — which the operator may have edited the
+    /// config away from in between. An exemption added while the
+    /// daemon was down would then suppress a path the inherited
+    /// divert rule still sends into VPP (review finding). The first
+    /// successful steer reconciles the NIC to the current target and
+    /// clears this.
+    pub fn note_inherited_steering(&self) {
+        self.core.borrow_mut().drift_scope_stale = Some(
+            "steering rules were inherited from a previous process and have not been \
+             reconciled with the running config yet"
+                .into(),
+        );
     }
 
     pub fn rx_mode_kick(&self, k: Box<dyn RxModeKick>) {
@@ -1562,7 +1587,7 @@ impl Runtime {
                 let result = c.drift_watch.as_mut().expect("checked above").uncovered();
                 match result {
                     Ok(found) => {
-                        if !found.is_empty() && c.drift_uncovered != found {
+                        if !found.lines.is_empty() && c.drift_uncovered != found.lines {
                             tracing::warn!(
                                 paths = ?found,
                                 "kernel path(s) VPP cannot take are not covered by any \
@@ -1571,7 +1596,8 @@ impl Runtime {
                                  a steer-exempt for each, or stop steering the port"
                             );
                         }
-                        c.drift_uncovered = found;
+                        c.drift_routes = found.routes;
+                        c.drift_uncovered = found.lines;
                         c.drift_unreadable = None;
                     }
                     // The previous findings stand — an unreadable
@@ -1648,6 +1674,7 @@ impl Runtime {
             null_drops: c.engine.null_drops(),
             fdb_misplaced: c.fdb_misplaced.clone(),
             drift_uncovered: c.drift_uncovered.clone(),
+            drift_routes: c.drift_routes,
             drift_unreadable: c.drift_unreadable.clone(),
             drift_scope_stale: c.drift_scope_stale.clone(),
             authority: authority_posture(
@@ -1831,6 +1858,8 @@ pub struct RuntimeStatus {
     pub fdb_misplaced: Vec<String>,
     /// Kernel paths VPP cannot take that no `steer-exempt` covers.
     pub drift_uncovered: Vec<String>,
+    /// How many routes those findings stand for — the gauge's value.
+    pub drift_routes: usize,
     /// Why the last drift scan could not read the kernel, if so.
     pub drift_unreadable: Option<String>,
     /// Why the scan cannot say which exemptions the NIC holds, if so.
@@ -2021,6 +2050,7 @@ impl Core {
             // are judging.
             self.last_drift_scan = None;
             self.drift_uncovered.clear();
+            self.drift_routes = 0;
         }
     }
 

--- a/crates/modules/vpp-offload/src/runtime.rs
+++ b/crates/modules/vpp-offload/src/runtime.rs
@@ -543,6 +543,23 @@ struct Core {
     /// Last completed scan's findings, kept across a failed scan (an
     /// unreadable kernel is not evidence the routes went away).
     drift_uncovered: Vec<String>,
+    /// A drift scope the config asked for that the NIC has not taken
+    /// yet.
+    ///
+    /// Staged rather than applied, because the scan judges what the
+    /// NIC is BELIEVED TO HOLD and a reconfigure's rules do not reach
+    /// it until a steer succeeds. Committing at request time hid a
+    /// path whose exemption had been refused; committing only on the
+    /// synchronous success then missed the OTHER door — a first steer
+    /// deferred by the FIB gate is retried automatically by the
+    /// driver, installs the new rules with nobody replaying the
+    /// request, and would have left the watcher on the old exemptions
+    /// (both review findings). It is committed at the places every
+    /// steering action goes through, whichever path asked for it.
+    pending_drift_scope: Option<(
+        Vec<packetframe_common::config::Ipv4Prefix>,
+        Option<Vec<packetframe_common::fib::IpPrefix>>,
+    )>,
     /// Why the last scan could not read the kernel, if it could not.
     ///
     /// Its own field for the same reason `steer_audit_error` is: a
@@ -1269,6 +1286,7 @@ impl Runtime {
                 last_drift_scan: None,
                 drift_uncovered: Vec::new(),
                 drift_unreadable: None,
+                pending_drift_scope: None,
                 steer_missing: 0,
                 steer_stray: 0,
                 steer_audit_error: None,
@@ -1355,12 +1373,12 @@ impl Runtime {
     }
 
     /// Hand the exemption tripwire a reloaded exemption set.
-    pub fn set_drift_scope(
+    pub fn stage_drift_scope(
         &self,
         exempts: Vec<packetframe_common::config::Ipv4Prefix>,
         dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     ) {
-        self.core.borrow_mut().set_drift_scope(exempts, dst_only);
+        self.core.borrow_mut().stage_drift_scope(exempts, dst_only);
     }
 
     /// The two trait views the driver's tick takes.
@@ -1927,11 +1945,23 @@ impl Core {
     /// longer exists — the operator who just added the exemption the
     /// health line asked for should not have to wait out a minute of
     /// it still complaining.
-    fn set_drift_scope(
+    fn stage_drift_scope(
         &mut self,
         exempts: Vec<packetframe_common::config::Ipv4Prefix>,
         dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     ) {
+        if self.drift_watch.is_some() {
+            self.pending_drift_scope = Some((exempts, dst_only));
+        }
+    }
+
+    /// Adopt the staged scope, if any — called where a steering action
+    /// has just succeeded, so the watcher only ever describes rules
+    /// the NIC took.
+    fn commit_drift_scope(&mut self) {
+        let Some((exempts, dst_only)) = self.pending_drift_scope.take() else {
+            return;
+        };
         if let Some(w) = self.drift_watch.as_mut() {
             w.set_scope(exempts, dst_only);
             // Re-read on the next poll rather than serving a verdict
@@ -2634,6 +2664,12 @@ impl Effects for EffectsView {
         let mut c = self.core.borrow_mut();
         let outcome = c.steering.unsteer();
         c.record_steering();
+        // A confirmed removal is the config taking effect too: nothing
+        // is diverted, so the scan turns predictive, and it should
+        // predict from the config the operator just applied.
+        if outcome.is_ok() {
+            c.commit_drift_scope();
+        }
         outcome
     }
 
@@ -2651,6 +2687,13 @@ impl Effects for EffectsView {
         let mut c = self.core.borrow_mut();
         let outcome = c.steering.steer();
         c.record_steering();
+        // One of the places every steer passes through — the
+        // operator's reconfigure and the driver's automatic retry
+        // alike — so the staged scope lands whichever asked, and
+        // never when the NIC refused.
+        if outcome.is_ok() {
+            c.commit_drift_scope();
+        }
         outcome
     }
 
@@ -2768,6 +2811,13 @@ impl Effects for EffectsView {
         }
         let outcome = c.steering.steer();
         c.record_steering();
+        // One of the places every steer passes through — the
+        // operator's reconfigure and the driver's automatic retry
+        // alike — so the staged scope lands whichever asked, and
+        // never when the NIC refused.
+        if outcome.is_ok() {
+            c.commit_drift_scope();
+        }
         outcome
     }
 

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -891,7 +891,6 @@ fn apply_steering(
         ));
     }
     runtime.retarget(req.targets.clone());
-    runtime.set_drift_scope(req.exempts.clone(), req.dst_only.clone());
 
     let steered = driver.supervisor().is_steered();
     // INTENDED, not steered. The two differ in exactly the case an
@@ -1002,6 +1001,19 @@ fn apply_steering(
     // injected outcomes. Here they are also the operator's answer.
     let failures = fmt_failures(&tick.outcome);
     if failures.is_empty() {
+        // ONLY here. The drift scan judges what the NIC is believed to
+        // hold, and until the reconcile succeeds the NIC holds the
+        // PREVIOUS rules — including the previous exemptions. Teaching
+        // the watcher about a new exemption whose rule was refused
+        // makes it hide the one path still being diverted and
+        // blackholed, which is the failure this whole module exists to
+        // catch (review finding).
+        //
+        // Every earlier return in this function leaves the scope alone
+        // for the same reason: a refused first steer, a state that
+        // does not accept changes, and the staging early-return all
+        // end with the NIC exactly as it was.
+        runtime.set_drift_scope(req.exempts.clone(), req.dst_only.clone());
         Ok(())
     } else {
         Err(failures.join("; "))
@@ -1113,6 +1125,7 @@ fn run_loop(
             rs.null_drops,
             rs.fdb_misplaced,
             rs.drift_uncovered,
+            rs.drift_unreadable,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -163,6 +163,11 @@ pub struct SteeringRequest {
     /// the scan's notion of what is covered, and letting them travel
     /// separately is how the watcher ended up frozen at attach.
     pub exempts: Vec<packetframe_common::config::Ipv4Prefix>,
+    /// The diversion scope the same reconfigure produced — see
+    /// [`crate::drift::divertible_scope`]. Travels with the exemptions
+    /// because freezing either half re-opens the hole the tripwire
+    /// closes.
+    pub dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
     /// Whether traffic should be diverted once the target is in place.
     /// False is the rollback landing zone, not an error.
     pub want_steer: bool,
@@ -616,6 +621,7 @@ impl SupervisionService {
         &self,
         targets: Vec<(String, u32, crate::steer::RuleSet)>,
         exempts: Vec<packetframe_common::config::Ipv4Prefix>,
+        dst_only: Option<Vec<packetframe_common::fib::IpPrefix>>,
         want_steer: bool,
         lever_moved: bool,
     ) -> Result<(), String> {
@@ -631,6 +637,7 @@ impl SupervisionService {
                 seq,
                 targets,
                 exempts,
+                dst_only,
                 want_steer,
                 lever_moved,
             });
@@ -884,7 +891,7 @@ fn apply_steering(
         ));
     }
     runtime.retarget(req.targets.clone());
-    runtime.set_drift_exempts(req.exempts.clone());
+    runtime.set_drift_scope(req.exempts.clone(), req.dst_only.clone());
 
     let steered = driver.supervisor().is_steered();
     // INTENDED, not steered. The two differ in exactly the case an

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -891,6 +891,12 @@ fn apply_steering(
         ));
     }
     runtime.retarget(req.targets.clone());
+    // STAGED here, committed where a steering action succeeds. The
+    // NIC has the previous rules until then — and this request may
+    // never reach one synchronously: a deferred first steer is
+    // retried by the driver on its own, with nobody replaying this
+    // function (review finding).
+    runtime.stage_drift_scope(req.exempts.clone(), req.dst_only.clone());
 
     let steered = driver.supervisor().is_steered();
     // INTENDED, not steered. The two differ in exactly the case an
@@ -1001,19 +1007,6 @@ fn apply_steering(
     // injected outcomes. Here they are also the operator's answer.
     let failures = fmt_failures(&tick.outcome);
     if failures.is_empty() {
-        // ONLY here. The drift scan judges what the NIC is believed to
-        // hold, and until the reconcile succeeds the NIC holds the
-        // PREVIOUS rules — including the previous exemptions. Teaching
-        // the watcher about a new exemption whose rule was refused
-        // makes it hide the one path still being diverted and
-        // blackholed, which is the failure this whole module exists to
-        // catch (review finding).
-        //
-        // Every earlier return in this function leaves the scope alone
-        // for the same reason: a refused first steer, a state that
-        // does not accept changes, and the staging early-return all
-        // end with the NIC exactly as it was.
-        runtime.set_drift_scope(req.exempts.clone(), req.dst_only.clone());
         Ok(())
     } else {
         Err(failures.join("; "))

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -157,6 +157,12 @@ pub struct SteeringRequest {
     /// `(PF iface, VF index, rules)` for every port now configured
     /// `steer on` — per-port rules because direction is per-port.
     pub targets: Vec<(String, u32, crate::steer::RuleSet)>,
+    /// The reloaded `steer-exempt` set, for the drift tripwire. It
+    /// rides the steering request because it IS part of the steering
+    /// config — the same directive produces both the Keep rules and
+    /// the scan's notion of what is covered, and letting them travel
+    /// separately is how the watcher ended up frozen at attach.
+    pub exempts: Vec<packetframe_common::config::Ipv4Prefix>,
     /// Whether traffic should be diverted once the target is in place.
     /// False is the rollback landing zone, not an error.
     pub want_steer: bool,
@@ -609,6 +615,7 @@ impl SupervisionService {
     pub fn apply_steering(
         &self,
         targets: Vec<(String, u32, crate::steer::RuleSet)>,
+        exempts: Vec<packetframe_common::config::Ipv4Prefix>,
         want_steer: bool,
         lever_moved: bool,
     ) -> Result<(), String> {
@@ -623,6 +630,7 @@ impl SupervisionService {
             .replace(SteeringRequest {
                 seq,
                 targets,
+                exempts,
                 want_steer,
                 lever_moved,
             });
@@ -876,6 +884,7 @@ fn apply_steering(
         ));
     }
     runtime.retarget(req.targets.clone());
+    runtime.set_drift_exempts(req.exempts.clone());
 
     let steered = driver.supervisor().is_steered();
     // INTENDED, not steered. The two differ in exactly the case an

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -929,6 +929,18 @@ fn apply_steering(
         // effect of editing something else is precisely the decision this
         // module is not allowed to make.
         if !intended && !req.lever_moved {
+            // No effect will run, so nothing will commit the staged
+            // scope — and if the NIC holds no rules there are no old
+            // exemptions for the scan to be describing. Committing
+            // here is what keeps the tripwire PREDICTIVE before the
+            // first canary: a newly allowlisted tunnel prefix should
+            // be named while the port is still unsteered, which is
+            // the whole point of scanning before traffic moves
+            // (review finding). With rules installed, the old config
+            // is what the NIC has and the scope waits for a steer.
+            if !runtime.steering_rules_installed() {
+                runtime.commit_drift_scope();
+            }
             return Ok(());
         }
         // The same gate the automatic path uses, and applied on the same

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1131,6 +1131,7 @@ fn run_loop(
             rs.fdb_misplaced,
             rs.drift_uncovered,
             rs.drift_unreadable,
+            rs.drift_scope_stale,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1130,6 +1130,7 @@ fn run_loop(
             rs.null_drops,
             rs.fdb_misplaced,
             rs.drift_uncovered,
+            rs.drift_routes,
             rs.drift_unreadable,
             rs.drift_scope_stale,
         );

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1131,6 +1131,7 @@ fn run_loop(
             rs.fdb_misplaced,
             rs.drift_uncovered,
             rs.drift_routes,
+            rs.drift_pending,
             rs.drift_unreadable,
             rs.drift_scope_stale,
         );

--- a/crates/modules/vpp-offload/src/service.rs
+++ b/crates/modules/vpp-offload/src/service.rs
@@ -1096,6 +1096,7 @@ fn run_loop(
             rs.shadowed_routes,
             rs.null_drops,
             rs.fdb_misplaced,
+            rs.drift_uncovered,
         );
         let report = snap.report();
         let episode_over = snap.failure_episode_over();

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -62,6 +62,8 @@ pub const SUBSYS_PORTS: &str = "ports";
 pub const SUBSYS_STATE_FILE: &str = "state-file";
 /// Only present when the bridge-FDB tripwire has findings.
 pub const SUBSYS_FDB: &str = "fdb";
+/// Only present when the exemption tripwire has findings.
+pub const SUBSYS_EXEMPT_DRIFT: &str = "exempt-drift";
 /// Subsystem name for the cross-tier route feed.
 pub const SUBSYS_ROUTE_FEED: &str = "route-feed";
 
@@ -374,6 +376,14 @@ pub struct StatusSnapshot {
     /// v1 tripwire whose firing is what makes per-host delivery (v2)
     /// real work instead of speculation.
     pub fdb_misplaced: Vec<String>,
+    /// Kernel paths VPP cannot take (tunnels, and the router's own
+    /// addresses) that no `steer-exempt` covers — steered traffic for
+    /// them dies at VPP's default route where the kernel would have
+    /// delivered it. Degraded, path named: this is the shape that
+    /// blackholed inter-site traffic for three weeks before anything
+    /// looked (w26), and the sets that produce it are edited by
+    /// routing daemons, so it is watched rather than validated once.
+    pub drift_uncovered: Vec<String>,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -429,6 +439,7 @@ impl StatusSnapshot {
             0,
             None,
             Vec::new(),
+            Vec::new(),
         )
     }
 
@@ -457,6 +468,7 @@ impl StatusSnapshot {
         shadowed_routes: u64,
         null_drops: Option<u64>,
         fdb_misplaced: Vec<String>,
+        drift_uncovered: Vec<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -483,6 +495,7 @@ impl StatusSnapshot {
             shadowed_routes,
             null_drops,
             fdb_misplaced,
+            drift_uncovered,
         }
     }
 
@@ -550,6 +563,20 @@ impl StatusSnapshot {
                      source and {} queued for VPP. Retried every tick — the offload is forwarding \
                      a table that is behind bird, not a wrong one.",
                     self.source_backlog, self.pending_ops
+                )),
+                last_success_age_seconds: None,
+            });
+        }
+        if !self.drift_uncovered.is_empty() {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_EXEMPT_DRIFT.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "kernel path(s) VPP cannot take, with no `steer-exempt` covering them: \
+                     {} — steered traffic for these dies at VPP's default route instead of \
+                     falling back to the kernel that would deliver it. Add a `steer-exempt` \
+                     per path (each costs one MCAM slot), or leave the port unsteered",
+                    self.drift_uncovered.join("; ")
                 )),
                 last_success_age_seconds: None,
             });
@@ -673,6 +700,10 @@ impl StatusSnapshot {
             // only — the remedy is the operator's — but it must not
             // read as healthy while it stands.
             && self.fdb_misplaced.is_empty()
+            // An uncovered kernel path is traffic that will vanish the
+            // moment the port steers — and did, for three weeks,
+            // under a health surface that said Healthy throughout.
+            && self.drift_uncovered.is_empty()
     }
 
     /// Whether the CURRENT failure episode is over — the release
@@ -1512,6 +1543,17 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
         );
         let _ = writeln!(out, "packetframe_vpp_null_drops{{module=\"{module}\"}} {n}");
     }
+
+    gauge(
+        &mut out,
+        "packetframe_vpp_exempt_drift",
+        "kernel paths VPP cannot take that no steer-exempt covers (steered = blackholed)",
+    );
+    let _ = writeln!(
+        out,
+        "packetframe_vpp_exempt_drift{{module=\"{module}\"}} {}",
+        snap.drift_uncovered.len()
+    );
 
     gauge(
         &mut out,
@@ -3277,6 +3319,47 @@ mod tests {
         // The boolean is still emitted — "not verified" is a fact worth
         // scraping.
         assert!(m.contains("packetframe_vpp_fib_verified{module=\"vpp-offload\"} 0"));
+    }
+
+    /// The exemption tripwire: quiet = no row, firing = Degraded with
+    /// the path named on the report AND counted on the gauge. Both
+    /// surfaces or neither — a Degraded report beside a healthy gauge
+    /// is how the store-error bug hid, and this is the same shape.
+    #[test]
+    fn an_uncovered_kernel_path_degrades_and_is_named_on_both_surfaces() {
+        let mut s = snap_of(
+            &ready_supervisor(),
+            &ledger_with(1, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(1),
+            },
+            verified(1),
+            ports_up(),
+        );
+        assert!(
+            !s.report()
+                .subsystems
+                .iter()
+                .any(|x| x.name == SUBSYS_EXEMPT_DRIFT),
+            "a quiet tripwire adds no row"
+        );
+        assert!(render_metrics(&s, "vpp-offload")
+            .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 0"));
+
+        s.drift_uncovered = vec!["23.191.201.0/24 via vti64 (table 100)".into()];
+        let report = s.report();
+        let row = report
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .expect("the tripwire row");
+        assert_eq!(row.state, HealthState::Degraded);
+        let msg = row.message.as_deref().unwrap_or("");
+        assert!(msg.contains("vti64"), "{msg}");
+        assert!(msg.contains("steer-exempt"), "and names the remedy: {msg}");
+        assert_ne!(report.overall, HealthState::Healthy);
+        assert!(render_metrics(&s, "vpp-offload")
+            .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 1"));
     }
 
     /// The FDB tripwire: quiet = no subsystem row (nothing for an

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -388,6 +388,13 @@ pub struct StatusSnapshot {
     /// publishes. Distinct from `drift_uncovered.len()`, since the
     /// nexthop-object summary is one line for many routes.
     pub drift_routes: usize,
+    /// A scan is outstanding for the CURRENT configuration: the
+    /// tripwire has no verdict yet, which must not be rendered as a
+    /// clean one — a full route dump takes seconds, and an operator
+    /// can reach the first steer inside that window believing the
+    /// predictive scan already ran. False when no tripwire is
+    /// installed, since nothing is being waited for.
+    pub drift_pending: bool,
     /// Why the drift scan could not read the kernel, if it could not.
     /// Degraded on its own: a safety check that cannot run must not
     /// be indistinguishable from one that ran and found nothing.
@@ -454,6 +461,9 @@ impl StatusSnapshot {
             Vec::new(),
             Vec::new(),
             0,
+            // The shorthand has no scanner behind it, so nothing is
+            // outstanding.
+            false,
             None,
             None,
         )
@@ -486,6 +496,7 @@ impl StatusSnapshot {
         fdb_misplaced: Vec<String>,
         drift_uncovered: Vec<String>,
         drift_routes: usize,
+        drift_pending: bool,
         drift_unreadable: Option<String>,
         drift_scope_stale: Option<String>,
     ) -> Self {
@@ -516,6 +527,7 @@ impl StatusSnapshot {
             fdb_misplaced,
             drift_uncovered,
             drift_routes,
+            drift_pending,
             drift_unreadable,
             drift_scope_stale,
         }
@@ -636,6 +648,19 @@ impl StatusSnapshot {
                      blackhole steered traffic unreported. The scan retries every minute; a \
                      persistent failure needs looking at"
                 )),
+                last_success_age_seconds: None,
+            });
+        } else if self.drift_pending {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_EXEMPT_DRIFT.into(),
+                state: HealthState::Degraded,
+                message: Some(
+                    "the exemption tripwire has not finished a scan for this configuration \
+                     yet — on a full-table box the route dump takes seconds, and an empty \
+                     finding list before it lands is no verdict rather than a clean one. It \
+                     clears itself; a first steer is worth holding until it does"
+                        .into(),
+                ),
                 last_success_age_seconds: None,
             });
         }
@@ -765,8 +790,10 @@ impl StatusSnapshot {
             // And a tripwire that cannot read the kernel is not a
             // quiet tripwire.
             && self.drift_unreadable.is_none()
-            // Nor is one that cannot tell which config the NIC holds.
+            // Nor is one that cannot tell which config the NIC holds,
+            // nor one that has not yet looked at this config at all.
             && self.drift_scope_stale.is_none()
+            && !self.drift_pending
     }
 
     /// Whether the CURRENT failure episode is over — the release
@@ -1614,7 +1641,7 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
     // blind, which is the failure this whole module exists to catch
     // (review finding). `absent()` is the alarm for that case; the
     // health report carries the reason.
-    if snap.drift_unreadable.is_none() && snap.drift_scope_stale.is_none() {
+    if snap.drift_unreadable.is_none() && snap.drift_scope_stale.is_none() && !snap.drift_pending {
         gauge(
             &mut out,
             "packetframe_vpp_exempt_drift",
@@ -3445,6 +3472,51 @@ mod tests {
             render_metrics(&s, "vpp-offload")
                 .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 7"),
             "one line standing for seven routes must publish 7"
+        );
+    }
+
+    /// A scan that has not finished is not a clean scan.
+    ///
+    /// The route dump moved off the supervision loop, which created a
+    /// window: attached, scanner still walking a million prefixes,
+    /// findings empty. Rendering that as a quiet tripwire would let an
+    /// operator take the first steer believing the predictive scan
+    /// already ran (review finding). A deployment with NO tripwire is
+    /// a different thing and must not degrade.
+    #[test]
+    fn a_scan_that_has_not_finished_is_not_a_clean_one() {
+        let mut s = snap_of(
+            &ready_supervisor(),
+            &ledger_with(1, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(1),
+            },
+            verified(1),
+            ports_up(),
+        );
+        // No tripwire installed: nothing outstanding, nothing to say.
+        assert!(!s.drift_pending);
+        assert_eq!(s.report().overall, HealthState::Healthy);
+
+        s.drift_pending = true;
+        let report = s.report();
+        let row = report
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .expect("a pending scan must be visible");
+        assert_eq!(row.state, HealthState::Degraded);
+        assert!(
+            row.message
+                .as_deref()
+                .unwrap_or("")
+                .contains("has not finished a scan"),
+            "{row:?}"
+        );
+        assert_ne!(report.overall, HealthState::Healthy);
+        assert!(
+            !render_metrics(&s, "vpp-offload").contains("packetframe_vpp_exempt_drift"),
+            "and publishes no count it has not earned"
         );
     }
 

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -601,22 +601,18 @@ impl StatusSnapshot {
                 )),
                 last_success_age_seconds: None,
             });
-        } else if self.drift_uncovered.is_empty() {
-            if let Some(why) = &self.drift_unreadable {
-                subsystems.push(SubsystemHealth {
-                    name: SUBSYS_EXEMPT_DRIFT.into(),
-                    state: HealthState::Degraded,
-                    message: Some(format!(
-                        "the exemption tripwire could not read the kernel's routes ({why}), \
-                         so it is not watching for paths VPP cannot take — an uncovered one \
-                         would blackhole steered traffic unreported. The scan retries every \
-                         minute; a persistent failure needs looking at"
-                    )),
-                    last_success_age_seconds: None,
-                });
-            }
-        }
-        if !self.drift_uncovered.is_empty() {
+        } else if !self.drift_uncovered.is_empty() {
+            // The read failure travels WITH the findings when both
+            // exist. The runtime deliberately retains findings across
+            // a failed scan (an unreadable kernel is not evidence the
+            // routes went away), and presenting them alone reads as
+            // current — while a route added since could be invisible
+            // and a named one already gone (review finding).
+            let stale = self.drift_unreadable.as_ref().map(|why| {
+                format!(
+                    ". NOTE: the latest scan could not read the kernel ({why}), so this list                      is the last good one — newly added routes are invisible and a named one                      may already be gone"
+                )
+            });
             subsystems.push(SubsystemHealth {
                 name: SUBSYS_EXEMPT_DRIFT.into(),
                 state: HealthState::Degraded,
@@ -624,8 +620,21 @@ impl StatusSnapshot {
                     "kernel path(s) VPP cannot take, with no `steer-exempt` covering them: \
                      {} — steered traffic for these dies at VPP's default route instead of \
                      falling back to the kernel that would deliver it. Add a `steer-exempt` \
-                     per path (each costs one MCAM slot), or leave the port unsteered",
-                    self.drift_uncovered.join("; ")
+                     per path (each costs one MCAM slot), or leave the port unsteered{}",
+                    self.drift_uncovered.join("; "),
+                    stale.unwrap_or_default()
+                )),
+                last_success_age_seconds: None,
+            });
+        } else if let Some(why) = &self.drift_unreadable {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_EXEMPT_DRIFT.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "the exemption tripwire could not read the kernel's routes ({why}), so \
+                     it is not watching for paths VPP cannot take — an uncovered one would \
+                     blackhole steered traffic unreported. The scan retries every minute; a \
+                     persistent failure needs looking at"
                 )),
                 last_success_age_seconds: None,
             });
@@ -3490,6 +3499,23 @@ mod tests {
             verified(1),
             ports_up(),
         );
+        // Findings RETAINED across a failed scan must say they are
+        // stale — presenting the last good list as current hides both
+        // a route added since and one already gone (review finding).
+        let mut both = s.clone();
+        both.drift_uncovered = vec!["23.191.201.0/24 via vti64 (table 100)".into()];
+        both.drift_routes = 1;
+        both.drift_unreadable = Some("netlink recv: EIO".into());
+        let msg = both
+            .report()
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .and_then(|r| r.message.clone())
+            .unwrap_or_default();
+        assert!(msg.contains("vti64"), "the findings are still named: {msg}");
+        assert!(msg.contains("last good one"), "and marked stale: {msg}");
+
         s.drift_unreadable = Some("netlink socket: permission denied".into());
         assert!(
             !render_metrics(&s, "vpp-offload").contains("packetframe_vpp_exempt_drift"),

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -384,6 +384,10 @@ pub struct StatusSnapshot {
     /// looked (w26), and the sets that produce it are edited by
     /// routing daemons, so it is watched rather than validated once.
     pub drift_uncovered: Vec<String>,
+    /// How many kernel routes the findings stand for — what the gauge
+    /// publishes. Distinct from `drift_uncovered.len()`, since the
+    /// nexthop-object summary is one line for many routes.
+    pub drift_routes: usize,
     /// Why the drift scan could not read the kernel, if it could not.
     /// Degraded on its own: a safety check that cannot run must not
     /// be indistinguishable from one that ran and found nothing.
@@ -449,6 +453,7 @@ impl StatusSnapshot {
             None,
             Vec::new(),
             Vec::new(),
+            0,
             None,
             None,
         )
@@ -480,6 +485,7 @@ impl StatusSnapshot {
         null_drops: Option<u64>,
         fdb_misplaced: Vec<String>,
         drift_uncovered: Vec<String>,
+        drift_routes: usize,
         drift_unreadable: Option<String>,
         drift_scope_stale: Option<String>,
     ) -> Self {
@@ -509,6 +515,7 @@ impl StatusSnapshot {
             null_drops,
             fdb_misplaced,
             drift_uncovered,
+            drift_routes,
             drift_unreadable,
             drift_scope_stale,
         }
@@ -1607,7 +1614,7 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
         let _ = writeln!(
             out,
             "packetframe_vpp_exempt_drift{{module=\"{module}\"}} {}",
-            snap.drift_uncovered.len()
+            snap.drift_routes
         );
     }
 
@@ -3403,6 +3410,7 @@ mod tests {
             .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 0"));
 
         s.drift_uncovered = vec!["23.191.201.0/24 via vti64 (table 100)".into()];
+        s.drift_routes = 1;
         let report = s.report();
         let row = report
             .subsystems
@@ -3416,6 +3424,19 @@ mod tests {
         assert_ne!(report.overall, HealthState::Healthy);
         assert!(render_metrics(&s, "vpp-offload")
             .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 1"));
+
+        // The gauge counts ROUTES, not lines. The nexthop-object
+        // summary is ONE line standing for many routes, and deriving
+        // the gauge from the line count published `1` however much of
+        // the table the scan could not see — undercounting exactly
+        // the blind portion it exists to report (review finding).
+        s.drift_uncovered = vec!["7 route(s) use nexthop objects ...".into()];
+        s.drift_routes = 7;
+        assert!(
+            render_metrics(&s, "vpp-offload")
+                .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 7"),
+            "one line standing for seven routes must publish 7"
+        );
     }
 
     /// A steering change that failed partway leaves the NIC holding

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -1569,16 +1569,25 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
         let _ = writeln!(out, "packetframe_vpp_null_drops{{module=\"{module}\"}} {n}");
     }
 
-    gauge(
-        &mut out,
-        "packetframe_vpp_exempt_drift",
-        "kernel paths VPP cannot take that no steer-exempt covers (steered = blackholed)",
-    );
-    let _ = writeln!(
-        out,
-        "packetframe_vpp_exempt_drift{{module=\"{module}\"}} {}",
-        snap.drift_uncovered.len()
-    );
+    // ABSENT while the scan cannot read the kernel, never zero — the
+    // same rule as the freshness gauges and the null-drop counter. A
+    // dashboard alarming on `> 0` would read a retained (or
+    // never-populated) count as proof of health while the check was
+    // blind, which is the failure this whole module exists to catch
+    // (review finding). `absent()` is the alarm for that case; the
+    // health report carries the reason.
+    if snap.drift_unreadable.is_none() {
+        gauge(
+            &mut out,
+            "packetframe_vpp_exempt_drift",
+            "kernel paths VPP cannot take that no steer-exempt covers (steered = blackholed)",
+        );
+        let _ = writeln!(
+            out,
+            "packetframe_vpp_exempt_drift{{module=\"{module}\"}} {}",
+            snap.drift_uncovered.len()
+        );
+    }
 
     gauge(
         &mut out,
@@ -3403,6 +3412,10 @@ mod tests {
             ports_up(),
         );
         s.drift_unreadable = Some("netlink socket: permission denied".into());
+        assert!(
+            !render_metrics(&s, "vpp-offload").contains("packetframe_vpp_exempt_drift"),
+            "a blind scan must not publish a count a dashboard would read as clean"
+        );
         let report = s.report();
         let row = report
             .subsystems

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -388,6 +388,11 @@ pub struct StatusSnapshot {
     /// Degraded on its own: a safety check that cannot run must not
     /// be indistinguishable from one that ran and found nothing.
     pub drift_unreadable: Option<String>,
+    /// Why the scan cannot say which exemptions the NIC holds — a
+    /// steering change that failed partway and left rules installed.
+    /// Degraded for the same reason an unreadable scan is: neither
+    /// answer it could give would be true.
+    pub drift_scope_stale: Option<String>,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -445,6 +450,7 @@ impl StatusSnapshot {
             Vec::new(),
             Vec::new(),
             None,
+            None,
         )
     }
 
@@ -475,6 +481,7 @@ impl StatusSnapshot {
         fdb_misplaced: Vec<String>,
         drift_uncovered: Vec<String>,
         drift_unreadable: Option<String>,
+        drift_scope_stale: Option<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -503,6 +510,7 @@ impl StatusSnapshot {
             fdb_misplaced,
             drift_uncovered,
             drift_unreadable,
+            drift_scope_stale,
         }
     }
 
@@ -574,7 +582,19 @@ impl StatusSnapshot {
                 last_success_age_seconds: None,
             });
         }
-        if self.drift_uncovered.is_empty() {
+        if let Some(why) = &self.drift_scope_stale {
+            subsystems.push(SubsystemHealth {
+                name: SUBSYS_EXEMPT_DRIFT.into(),
+                state: HealthState::Degraded,
+                message: Some(format!(
+                    "{why}, so the exemption tripwire cannot judge them — a surviving \
+                     divert rule may be blackholing a prefix this config exempts. \
+                     `packetframe reconfigure` reconciles the NIC and settles it; \
+                     `ethtool -n <port>` shows what is actually installed"
+                )),
+                last_success_age_seconds: None,
+            });
+        } else if self.drift_uncovered.is_empty() {
             if let Some(why) = &self.drift_unreadable {
                 subsystems.push(SubsystemHealth {
                     name: SUBSYS_EXEMPT_DRIFT.into(),
@@ -729,6 +749,8 @@ impl StatusSnapshot {
             // And a tripwire that cannot read the kernel is not a
             // quiet tripwire.
             && self.drift_unreadable.is_none()
+            // Nor is one that cannot tell which config the NIC holds.
+            && self.drift_scope_stale.is_none()
     }
 
     /// Whether the CURRENT failure episode is over — the release
@@ -1576,7 +1598,7 @@ pub fn render_metrics(snap: &StatusSnapshot, module: &str) -> String {
     // blind, which is the failure this whole module exists to catch
     // (review finding). `absent()` is the alarm for that case; the
     // health report carries the reason.
-    if snap.drift_unreadable.is_none() {
+    if snap.drift_unreadable.is_none() && snap.drift_scope_stale.is_none() {
         gauge(
             &mut out,
             "packetframe_vpp_exempt_drift",
@@ -3394,6 +3416,42 @@ mod tests {
         assert_ne!(report.overall, HealthState::Healthy);
         assert!(render_metrics(&s, "vpp-offload")
             .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 1"));
+    }
+
+    /// A steering change that failed partway leaves the NIC holding
+    /// some of one config and some of another, so the tripwire says
+    /// it cannot judge rather than answering from either set — a
+    /// surviving divert rule may be blackholing a prefix the new
+    /// config exempts (review finding).
+    #[test]
+    fn a_partial_steer_makes_the_tripwire_say_it_cannot_judge() {
+        let mut s = snap_of(
+            &ready_supervisor(),
+            &ledger_with(1, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(1),
+            },
+            verified(1),
+            ports_up(),
+        );
+        s.drift_scope_stale =
+            Some("a steering change failed partway and left rules installed".into());
+        let report = s.report();
+        let row = report
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .expect("the tripwire must say something");
+        assert_eq!(row.state, HealthState::Degraded);
+        assert!(
+            row.message.as_deref().unwrap_or("").contains("reconfigure"),
+            "and name the remedy: {row:?}"
+        );
+        assert_ne!(report.overall, HealthState::Healthy);
+        assert!(
+            !render_metrics(&s, "vpp-offload").contains("packetframe_vpp_exempt_drift"),
+            "a count from either config would be a claim the scan cannot make"
+        );
     }
 
     /// A tripwire that cannot read the kernel is Degraded, not quiet.

--- a/crates/modules/vpp-offload/src/status.rs
+++ b/crates/modules/vpp-offload/src/status.rs
@@ -384,6 +384,10 @@ pub struct StatusSnapshot {
     /// looked (w26), and the sets that produce it are edited by
     /// routing daemons, so it is watched rather than validated once.
     pub drift_uncovered: Vec<String>,
+    /// Why the drift scan could not read the kernel, if it could not.
+    /// Degraded on its own: a safety check that cannot run must not
+    /// be indistinguishable from one that ran and found nothing.
+    pub drift_unreadable: Option<String>,
 }
 
 /// The steering audit, as the health surface consumes it.
@@ -440,6 +444,7 @@ impl StatusSnapshot {
             None,
             Vec::new(),
             Vec::new(),
+            None,
         )
     }
 
@@ -469,6 +474,7 @@ impl StatusSnapshot {
         null_drops: Option<u64>,
         fdb_misplaced: Vec<String>,
         drift_uncovered: Vec<String>,
+        drift_unreadable: Option<String>,
     ) -> Self {
         Self {
             state: sup.state(),
@@ -496,6 +502,7 @@ impl StatusSnapshot {
             null_drops,
             fdb_misplaced,
             drift_uncovered,
+            drift_unreadable,
         }
     }
 
@@ -566,6 +573,21 @@ impl StatusSnapshot {
                 )),
                 last_success_age_seconds: None,
             });
+        }
+        if self.drift_uncovered.is_empty() {
+            if let Some(why) = &self.drift_unreadable {
+                subsystems.push(SubsystemHealth {
+                    name: SUBSYS_EXEMPT_DRIFT.into(),
+                    state: HealthState::Degraded,
+                    message: Some(format!(
+                        "the exemption tripwire could not read the kernel's routes ({why}), \
+                         so it is not watching for paths VPP cannot take — an uncovered one \
+                         would blackhole steered traffic unreported. The scan retries every \
+                         minute; a persistent failure needs looking at"
+                    )),
+                    last_success_age_seconds: None,
+                });
+            }
         }
         if !self.drift_uncovered.is_empty() {
             subsystems.push(SubsystemHealth {
@@ -704,6 +726,9 @@ impl StatusSnapshot {
             // moment the port steers — and did, for three weeks,
             // under a health surface that said Healthy throughout.
             && self.drift_uncovered.is_empty()
+            // And a tripwire that cannot read the kernel is not a
+            // quiet tripwire.
+            && self.drift_unreadable.is_none()
     }
 
     /// Whether the CURRENT failure episode is over — the release
@@ -3360,6 +3385,51 @@ mod tests {
         assert_ne!(report.overall, HealthState::Healthy);
         assert!(render_metrics(&s, "vpp-offload")
             .contains("packetframe_vpp_exempt_drift{module=\"vpp-offload\"} 1"));
+    }
+
+    /// A tripwire that cannot read the kernel is Degraded, not quiet.
+    /// Same rule as the null-drop gauge's absent-not-zero: a check
+    /// that never ran must not be indistinguishable from one that ran
+    /// and found nothing (review finding).
+    #[test]
+    fn a_drift_scan_that_cannot_read_the_kernel_is_not_a_clean_one() {
+        let mut s = snap_of(
+            &ready_supervisor(),
+            &ledger_with(1, 0, 0),
+            ApiHealth::Answering {
+                silent_for: Duration::from_millis(1),
+            },
+            verified(1),
+            ports_up(),
+        );
+        s.drift_unreadable = Some("netlink socket: permission denied".into());
+        let report = s.report();
+        let row = report
+            .subsystems
+            .iter()
+            .find(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .expect("an unreadable scan must still say something");
+        assert_eq!(row.state, HealthState::Degraded);
+        assert!(
+            row.message
+                .as_deref()
+                .unwrap_or("")
+                .contains("could not read"),
+            "{row:?}"
+        );
+        assert_ne!(report.overall, HealthState::Healthy);
+
+        // Findings outrank the read failure: when the scan DID run and
+        // found something, that is the more actionable line.
+        s.drift_uncovered = vec!["23.191.201.0/24 via vti64 (table 100)".into()];
+        let report = s.report();
+        let rows: Vec<_> = report
+            .subsystems
+            .iter()
+            .filter(|x| x.name == SUBSYS_EXEMPT_DRIFT)
+            .collect();
+        assert_eq!(rows.len(), 1, "one row, not two: {rows:?}");
+        assert!(rows[0].message.as_deref().unwrap_or("").contains("vti64"));
     }
 
     /// The FDB tripwire: quiet = no subsystem row (nothing for an

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1332,7 +1332,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     }
 
     // The operator turns the lever; the steer is refused.
-    svc.apply_steering(uniform1(plan_for(2)), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect_err("the refusal is the operator's answer");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1346,7 +1346,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // steer's own reason, and one that took the staging early return
     // answers Ok having done nothing at all.
     let again = svc
-        .apply_steering(uniform1(plan_for(2)), true, false)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
         .expect_err(
             "an unchanged-config reconfigure over a refused steer must re-attempt it; \
              reporting Ok while doing nothing is worse than refusing, because the \
@@ -1360,7 +1360,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // And with the blocker gone it lands, without waiting out the
     // module's own retry interval.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(uniform1(plan_for(2)), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
         .expect("the retry is accepted");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1468,7 +1468,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    svc.apply_steering(uniform1(plan_for(2)), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect("the canary lever must turn without a restart");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1478,7 +1478,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
 
     // Rollback: membership stays, the FIB stays synced, traffic returns
     // to the fallback tier.
-    svc.apply_steering(Vec::new(), false, true)
+    svc.apply_steering(Vec::new(), Vec::new(), false, true)
         .expect("rollback");
     assert_eq!(svc.status().expect("published").state, State::Ready);
 
@@ -1552,7 +1552,7 @@ fn a_steering_change_before_convergence_is_refused() {
     .expect("service starts");
 
     let e = svc
-        .apply_steering(uniform1(plan_for(2)), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect_err("must refuse before convergence");
     assert!(
         e.contains("not converged"),
@@ -1647,7 +1647,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // `steer on` is in the config (ports is non-empty, want_steer true)
     // but the flag did not move in this reconfigure.
-    svc.apply_steering(uniform1(plan_for(2)), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
         .expect("a target update is not an error");
 
     assert_eq!(
@@ -1665,7 +1665,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // And the operator turning the lever on the very next reconfigure
     // still works, so this withholds rather than latches.
-    svc.apply_steering(uniform1(plan_for(2)), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect("the lever still turns");
     // NOT polled, deliberately: the loop publishes before it answers
     // the caller, so a returned `apply_steering` means the window
@@ -1756,7 +1756,7 @@ fn an_allowlist_change_under_live_steering_is_always_reconciled() {
 
     // The lever did NOT move — only the allowlist did.
     log.lock().unwrap().clear();
-    svc.apply_steering(uniform1(plan_for(1)), true, false)
+    svc.apply_steering(uniform1(plan_for(1)), Vec::new(), true, false)
         .expect("a live port must be reconciled");
 
     let seen = log.lock().unwrap().clone();
@@ -1865,7 +1865,7 @@ fn a_first_steer_refused_by_the_fib_gate_is_still_remembered() {
 
     // The operator turns the lever into an incomplete table.
     let err = svc
-        .apply_steering(uniform1(plan_for(2)), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect_err("an incomplete FIB is not one to divert traffic into");
     assert!(err.contains("refusing the first steer"), "{err}");
     assert!(
@@ -2015,7 +2015,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
     // the episode is NOT over — and stays remembered until steering
     // matches intent again.
     let err = svc
-        .apply_steering(uniform1(plan_for(2)), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect_err("the gate is closed");
     assert!(err.contains("refusing to steer"), "{err}");
     let seeded = svc.status().expect("published");
@@ -2030,7 +2030,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
 
     // Recovery: the operator's retry succeeds and the module steers.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(uniform1(plan_for(2)), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
         .expect("the lever turns once the gate opens");
 
     // The regression, both defects at once. The episode reasons must

--- a/crates/modules/vpp-offload/tests/vpp_service.rs
+++ b/crates/modules/vpp-offload/tests/vpp_service.rs
@@ -1332,7 +1332,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     }
 
     // The operator turns the lever; the steer is refused.
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect_err("the refusal is the operator's answer");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1346,7 +1346,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // steer's own reason, and one that took the staging early return
     // answers Ok having done nothing at all.
     let again = svc
-        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, false)
         .expect_err(
             "an unchanged-config reconfigure over a refused steer must re-attempt it; \
              reporting Ok while doing nothing is worse than refusing, because the \
@@ -1360,7 +1360,7 @@ fn a_reconfigure_retries_a_steer_that_was_refused() {
     // And with the blocker gone it lands, without waiting out the
     // module's own retry interval.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, false)
         .expect("the retry is accepted");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1468,7 +1468,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
         std::thread::sleep(Duration::from_millis(20));
     }
 
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect("the canary lever must turn without a restart");
     assert_eq!(
         svc.status().expect("published").state,
@@ -1478,7 +1478,7 @@ fn an_operator_can_steer_and_unsteer_a_converged_service() {
 
     // Rollback: membership stays, the FIB stays synced, traffic returns
     // to the fallback tier.
-    svc.apply_steering(Vec::new(), Vec::new(), false, true)
+    svc.apply_steering(Vec::new(), Vec::new(), None, false, true)
         .expect("rollback");
     assert_eq!(svc.status().expect("published").state, State::Ready);
 
@@ -1552,7 +1552,7 @@ fn a_steering_change_before_convergence_is_refused() {
     .expect("service starts");
 
     let e = svc
-        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect_err("must refuse before convergence");
     assert!(
         e.contains("not converged"),
@@ -1647,7 +1647,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // `steer on` is in the config (ports is non-empty, want_steer true)
     // but the flag did not move in this reconfigure.
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, false)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, false)
         .expect("a target update is not an error");
 
     assert_eq!(
@@ -1665,7 +1665,7 @@ fn a_reconfigure_that_did_not_move_the_lever_does_not_steer() {
 
     // And the operator turning the lever on the very next reconfigure
     // still works, so this withholds rather than latches.
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect("the lever still turns");
     // NOT polled, deliberately: the loop publishes before it answers
     // the caller, so a returned `apply_steering` means the window
@@ -1756,7 +1756,7 @@ fn an_allowlist_change_under_live_steering_is_always_reconciled() {
 
     // The lever did NOT move — only the allowlist did.
     log.lock().unwrap().clear();
-    svc.apply_steering(uniform1(plan_for(1)), Vec::new(), true, false)
+    svc.apply_steering(uniform1(plan_for(1)), Vec::new(), None, true, false)
         .expect("a live port must be reconciled");
 
     let seen = log.lock().unwrap().clone();
@@ -1865,7 +1865,7 @@ fn a_first_steer_refused_by_the_fib_gate_is_still_remembered() {
 
     // The operator turns the lever into an incomplete table.
     let err = svc
-        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect_err("an incomplete FIB is not one to divert traffic into");
     assert!(err.contains("refusing the first steer"), "{err}");
     assert!(
@@ -2015,7 +2015,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
     // the episode is NOT over — and stays remembered until steering
     // matches intent again.
     let err = svc
-        .apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+        .apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect_err("the gate is closed");
     assert!(err.contains("refusing to steer"), "{err}");
     let seeded = svc.status().expect("published");
@@ -2030,7 +2030,7 @@ fn a_dark_idle_member_neither_pages_nor_pins_failure_history() {
 
     // Recovery: the operator's retry succeeds and the module steers.
     allow.store(true, std::sync::atomic::Ordering::SeqCst);
-    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), true, true)
+    svc.apply_steering(uniform1(plan_for(2)), Vec::new(), None, true, true)
         .expect("the lever turns once the gate opens");
 
     // The regression, both defects at once. The episode reasons must

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -639,7 +639,12 @@ loop it would otherwise sit on is the one that answers liveness
 pings, wedge detection and steering changes — including the `steer
 off` an operator reaches for when something is wrong. Monitoring must
 never be able to delay the thing it monitors, so the loop only ever
-reads a completed result.
+reads a completed result. **Detach does not wait for it either:** a
+dump in flight is abandoned rather than joined, because a netlink dump
+cannot be cancelled and a monitoring scan holds none of the resources
+a detach must release. A `detach` that reported "resources may still
+be held" while only a scan remained would be a false alarm about the
+one thing that alarm must stay trustworthy for.
 
 `packetframe_vpp_exempt_drift` carries the count; **alarm on `> 0`,
 and on `absent()` while the module is attached** — the gauge is

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -670,10 +670,24 @@ Coverage is by containment, not overlap: a `/32` exemption does not
 silence the `/24` around it. That asymmetry is deliberate — treating
 one exempted host as covering its whole prefix is how a hole hides.
 
-`steer-exempt` is hot-reloadable, and so is this: an accepted
-`packetframe reconfigure` hands the scan the new exemption set and
-re-runs it, so adding the exemption the health line asked for clears
-the line on the next status poll rather than a minute later.
+Two more things it does not treat as active paths: a route in a table
+NO policy rule names (an unreferenced VRF or auxiliary table cannot be
+consulted by any packet, so it must not cost an exemption slot), and —
+under dst-only steering — anything outside the allowlist. Only table
+SELECTION is modelled, never the finer rule predicates (fwmark, iif,
+from/to): "no rule names this table" is unconditionally true, while
+evaluating the rest would mean reimplementing the kernel's rule walk,
+where a permissive mistake re-opens the hole. Over-reporting is the
+safe direction and the scan stays on that side of it.
+
+Everything the scan judges against is hot: `steer-exempt`, the
+allowlist, and both direction knobs are rebuilt on `packetframe
+reconfigure`, and the scan's copy is replaced in the same step (then
+re-run immediately). So adding the exemption the health line asked
+for clears the line on the next status poll rather than a minute
+later — and flipping a port to `src`, or widening the allowlist,
+widens what the scan watches at the same instant it widens what the
+NIC diverts.
 
 It is detection only. Deriving the exemptions automatically was
 considered and rejected for v1: it would change forwarding without an

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -633,6 +633,14 @@ exempt-drift: degraded — kernel path(s) VPP cannot take, with no
   falling back to the kernel that would deliver it.
 ```
 
+The scan runs on its **own thread**, not the supervision loop: a full
+route dump on a DFZ-carrying box walks a million prefixes, and the
+loop it would otherwise sit on is the one that answers liveness
+pings, wedge detection and steering changes — including the `steer
+off` an operator reaches for when something is wrong. Monitoring must
+never be able to delay the thing it monitors, so the loop only ever
+reads a completed result.
+
 `packetframe_vpp_exempt_drift` carries the count; **alarm on `> 0`,
 and on `absent()` while the module is attached** — the gauge is
 omitted rather than zeroed whenever the scan cannot read the kernel,

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -168,6 +168,8 @@ current value without a mapping table:
 | `packetframe_vpp_fib_verified` | `0` while steered |
 | `packetframe_vpp_source_backlog` | sustained non-zero — deltas are not draining |
 | `packetframe_vpp_drain_failing` | `1` — the steady-state delta apply is retrying |
+| `packetframe_vpp_exempt_drift` | `> 0` — a kernel path VPP cannot take has no `steer-exempt`; steered traffic for it is (or will be) blackholed |
+| `packetframe_vpp_fdb_misplaced` | `> 0` — a service-VLAN host sits behind a port its `local-route` does not declare |
 | `packetframe_vpp_undead` | `1` — a killed VPP survived and blocks the restart |
 | `packetframe_vpp_api_silent_seconds` | approaching the wedge budget (1.5 s steered) |
 
@@ -613,6 +615,47 @@ bird-managed and DYNAMIC — a new host route at the remote site
 re-opens the hole silently until the exempt list catches up. Until an
 automated drift check ships, the null-drop gauge's RATE is the
 tripwire: re-profile on any step change.
+
+### The exemption tripwire (`exempt-drift`)
+
+The rule above is only as good as the exemption list staying complete,
+and the sets that produce it are edited by routing daemons — bird
+announces a remote host route and the hole re-opens with nobody
+touching packetframe. So it is watched on a clock rather than
+validated once: every 60 s the module dumps the kernel's IPv4 routes
+across all tables and reports any path VPP cannot take that no
+`steer-exempt` covers.
+
+```
+exempt-drift: degraded — kernel path(s) VPP cannot take, with no
+  `steer-exempt` covering them: 23.191.201.0/24 via vti64 (table 100)
+  — steered traffic for these dies at VPP's default route instead of
+  falling back to the kernel that would deliver it.
+```
+
+`packetframe_vpp_exempt_drift` carries the count; **alarm on `> 0`**.
+Each finding names the prefix, the device, and the table, which is
+what `ip route show table <n>` needs to find it again. The remedy is
+one `steer-exempt` per path (one MCAM slot each — check the budget
+line in `packetframe feasibility`), or leaving that port unsteered.
+
+What it deliberately does NOT report: routes the kernel itself drops
+(blackhole, unreachable, prohibit — VPP dropping the same packet is
+the same outcome), paths out member ports or the bridges
+`local-route` delivers into, and the built-in broadcast/multicast
+exemptions. It DOES include the local table, because traffic to the
+router's own addresses dies in VPP the same way — that is the w23
+blackhole (110,917 packets in five minutes), and a check that only
+looked at forwarding would have missed the first instance of the very
+class it exists for.
+
+Coverage is by containment, not overlap: a `/32` exemption does not
+silence the `/24` around it. That asymmetry is deliberate — treating
+one exempted host as covering its whole prefix is how a hole hides.
+
+It is detection only. Deriving the exemptions automatically was
+considered and rejected for v1: it would change forwarding without an
+operator asking and could exhaust the 16-slot budget silently.
 
 ### The null-drop gauge
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -673,6 +673,13 @@ Coverage is by containment, not overlap: a `/32` exemption does not
 silence the `/24` around it. That asymmetry is deliberate — treating
 one exempted host as covering its whole prefix is how a hole hides.
 
+One thing it reports about ITSELF: routes installed with **nexthop
+objects** (`ip route ... nhid N`) name their devices in a structure
+this scan does not read, so it says so — one line naming the count
+and `ip nexthop show` — rather than skipping them silently or
+guessing. bird's classic routes are unaffected; FRR deployments and
+large ECMP setups are the ones that will see it.
+
 Two more things it does not treat as active paths: a route in a table
 NO policy rule names (an unreferenced VRF or auxiliary table cannot be
 consulted by any packet, so it must not cost an exemption slot), and —

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -639,19 +639,41 @@ what `ip route show table <n>` needs to find it again. The remedy is
 one `steer-exempt` per path (one MCAM slot each — check the budget
 line in `packetframe feasibility`), or leaving that port unsteered.
 
-What it deliberately does NOT report: routes the kernel itself drops
-(blackhole, unreachable, prohibit — VPP dropping the same packet is
-the same outcome), paths out member ports or the bridges
-`local-route` delivers into, and the built-in broadcast/multicast
-exemptions. It DOES include the local table, because traffic to the
-router's own addresses dies in VPP the same way — that is the w23
-blackhole (110,917 packets in five minutes), and a check that only
-looked at forwarding would have missed the first instance of the very
-class it exists for.
+What it reports, and what it deliberately does not:
+
+- **Forwarded routes** are findings when NO nexthop device is a
+  member port or a `local-route` bridge. Multipath is judged across
+  every nexthop (ECMP hides its devices in `RTA_MULTIPATH`, not
+  `RTA_OIF`); one resolvable path is enough for VPP to forward the
+  prefix, so only an all-unreachable route is reported.
+- **Local addresses** — the router's own, which VPP cannot deliver to
+  at all — are findings on the **steered segments** (the
+  `local-route` bridges). That is the w23 class: 110,917 packets to a
+  gateway address in five minutes. Device reachability is deliberately
+  NOT consulted for these, since the interface named on a local route
+  owns the address rather than being a path.
+- **Out of scope, on purpose:** local addresses elsewhere (transit
+  port IPs, mgmt, loopback). The 16-slot MCAM budget cannot hold an
+  exemption for every address on the box, and an alarm with no
+  available remedy is one operators learn to ignore. The null-drop
+  gauge is the backstop for that remainder.
+- **Not reported:** routes the kernel itself drops (blackhole,
+  unreachable, prohibit — VPP dropping the same packet is the same
+  outcome), and the built-in broadcast/multicast exemptions.
+- **Under `direction dst` on every steering port**, the scan is scoped
+  to destinations the allowlist can actually divert: a path no packet
+  can reach must not cost an exemption slot. Any `src` or `both` port
+  anywhere restores the full scope, because a source-matched packet
+  reaches VPP whatever it is addressed to.
 
 Coverage is by containment, not overlap: a `/32` exemption does not
 silence the `/24` around it. That asymmetry is deliberate — treating
 one exempted host as covering its whole prefix is how a hole hides.
+
+`steer-exempt` is hot-reloadable, and so is this: an accepted
+`packetframe reconfigure` hands the scan the new exemption set and
+re-runs it, so adding the exemption the health line asked for clears
+the line on the next status poll rather than a minute later.
 
 It is detection only. Deriving the exemptions automatically was
 considered and rejected for v1: it would change forwarding without an

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -680,6 +680,14 @@ evaluating the rest would mean reimplementing the kernel's rule walk,
 where a permissive mistake re-opens the hole. Over-reporting is the
 safe direction and the scan stays on that side of it.
 
+**On a VRF host the table filter switches itself off.** An l3mdev
+rule carries table id 0 and resolves to a VRF's table per packet, so
+the enumeration cannot be complete — filtering by the tables that ARE
+named would drop every VRF route and report clean while steered
+traffic blackholed. A host with one gets no table filtering at all
+(the behaviour before the filter existed), and so does a rule dump
+that fails or comes back empty.
+
 Everything the scan judges against is hot: `steer-exempt`, the
 allowlist, and both direction knobs are rebuilt on `packetframe
 reconfigure`, and the scan's copy is replaced in the same step (then

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -669,6 +669,16 @@ What it reports, and what it deliberately does not:
   exemption for every address on the box, and an alarm with no
   available remedy is one operators learn to ignore. The null-drop
   gauge is the backstop for that remainder.
+- **Lightweight-encap routes** (`ip route ... encap mpls|seg6|ip ...
+  dev eth3`) are findings **whatever device they leave by**, including
+  a member port. The mirror carries prefix, nexthop and interface, and
+  has nowhere to put a label stack or a segment list, so VPP would send
+  the packet bare out the same port — a different destination, not a
+  slower path. The message names the action (`applies MPLS
+  encapsulation`) rather than the device, because the device is
+  usually fine and reading it as a reachability problem sends the
+  operator the wrong way. MPLS and SRv6 deployments see this one;
+  bird's classic routes do not.
 - **Not reported:** routes the kernel itself drops (blackhole,
   unreachable, prohibit — VPP dropping the same packet is the same
   outcome), and the built-in broadcast/multicast exemptions.

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -168,7 +168,7 @@ current value without a mapping table:
 | `packetframe_vpp_fib_verified` | `0` while steered |
 | `packetframe_vpp_source_backlog` | sustained non-zero — deltas are not draining |
 | `packetframe_vpp_drain_failing` | `1` — the steady-state delta apply is retrying |
-| `packetframe_vpp_exempt_drift` | `> 0` — a kernel path VPP cannot take has no `steer-exempt`; steered traffic for it is (or will be) blackholed |
+| `packetframe_vpp_exempt_drift` | `> 0` — a kernel path VPP cannot take has no `steer-exempt`; steered traffic for it is (or will be) blackholed. ALSO alarm on `absent()` while attached: the gauge is omitted, never zeroed, when the scan cannot read the kernel |
 | `packetframe_vpp_fdb_misplaced` | `> 0` — a service-VLAN host sits behind a port its `local-route` does not declare |
 | `packetframe_vpp_undead` | `1` — a killed VPP survived and blocks the restart |
 | `packetframe_vpp_api_silent_seconds` | approaching the wedge budget (1.5 s steered) |
@@ -633,7 +633,10 @@ exempt-drift: degraded — kernel path(s) VPP cannot take, with no
   falling back to the kernel that would deliver it.
 ```
 
-`packetframe_vpp_exempt_drift` carries the count; **alarm on `> 0`**.
+`packetframe_vpp_exempt_drift` carries the count; **alarm on `> 0`,
+and on `absent()` while the module is attached** — the gauge is
+omitted rather than zeroed whenever the scan cannot read the kernel,
+so a dashboard cannot mistake a blind check for a clean one.
 Each finding names the prefix, the device, and the table, which is
 what `ip route show table <n>` needs to find it again. The remedy is
 one `steer-exempt` per path (one MCAM slot each — check the budget

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -680,6 +680,13 @@ evaluating the rest would mean reimplementing the kernel's rule walk,
 where a permissive mistake re-opens the hole. Over-reporting is the
 safe direction and the scan stays on that side of it.
 
+An `exempt-drift` row also appears when the scan **cannot read** the
+kernel (netlink refused, or a dump came back interrupted). That is
+Degraded too, and deliberately: a check that never ran must not look
+like one that ran and found nothing — the same rule as the null-drop
+gauge being absent rather than zero. The scan retries every minute,
+so a row that persists means the read itself needs looking at.
+
 **On a VRF host the table filter switches itself off.** An l3mdev
 rule carries table id 0 and resolves to a VRF's table per packet, so
 the enumeration cannot be complete — filtering by the tables that ARE

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -649,8 +649,9 @@ What it reports, and what it deliberately does not:
   every nexthop (ECMP hides its devices in `RTA_MULTIPATH`, not
   `RTA_OIF`); one resolvable path is enough for VPP to forward the
   prefix, so only an all-unreachable route is reported.
-- **Local addresses** — the router's own, which VPP cannot deliver to
-  at all — are findings on the **steered segments** (the
+- **Kernel-delivered destinations** — the router's own addresses, and
+  a segment's directed broadcast (`.255`), neither of which VPP can
+  reproduce — are findings on the **steered segments** (the
   `local-route` bridges). That is the w23 class: 110,917 packets to a
   gateway address in five minutes. Device reachability is deliberately
   NOT consulted for these, since the interface named on a local route

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -690,6 +690,14 @@ evaluating the rest would mean reimplementing the kernel's rule walk,
 where a permissive mistake re-opens the hole. Over-reporting is the
 safe direction and the scan stays on that side of it.
 
+An `exempt-drift` row also appears when a steering change **failed
+partway and left rules installed** — the NIC then holds some of one
+config and some of another, so the tripwire says it cannot judge
+rather than answering from either set (a surviving divert rule may be
+blackholing a prefix the new config exempts). `packetframe
+reconfigure` reconciles and settles it; `ethtool -n <port>` shows what
+is actually installed.
+
 An `exempt-drift` row also appears when the scan **cannot read** the
 kernel (netlink refused, or a dump came back interrupted). That is
 Degraded too, and deliberately: a check that never ran must not look


### PR DESCRIPTION
The follow-up w26 earned, and the last piece owed before inbound steering (w27).

## Why a scan and not a one-time check

Tunnel-bound destinations must carry a `steer-exempt` or steered traffic for them dies at VPP's default route — that is the w26 finding, now documented. But the sets that produce them are edited by *routing daemons*: bird announces a new remote host route and the hole re-opens with nobody touching packetframe. Config validation cannot see that; only a clock can.

Every 60 s the module dumps the kernel's IPv4 routes across all tables and reports any path VPP cannot take that no exemption covers:

```
exempt-drift: degraded — kernel path(s) VPP cannot take, with no `steer-exempt`
  covering them: 23.191.201.0/24 via vti64 (table 100) — steered traffic for
  these dies at VPP's default route instead of falling back to the kernel...
```

Prefix, device and table, because `ip route show table <n>` is how an operator finds it again. `packetframe_vpp_exempt_drift` carries the count for alarming. What VPP *can* take comes from config: member ports plus the bridges `local-route` delivers into.

## Deliberate exclusions (and one deliberate inclusion)

- **Not reported:** routes the kernel itself drops (blackhole/unreachable/prohibit) — VPP dropping the same packet is the same outcome, and the reference primary's bird carries a service host as `unreachable`, which would be permanent noise. Also the built-in broadcast/multicast exemptions.
- **Reported:** the local table. Traffic to the router's own addresses dies in VPP the same way — that is the w23 blackhole (110,917 packets in five minutes). A check that only looked at forwarding would have missed the first instance of the very class it exists for.
- **Containment, never overlap:** a `/32` exemption does not silence the `/24` around it. Treating one exempted host as covering its prefix is precisely how the w26 hole hid.

Detection only. Auto-deriving exemptions was considered and rejected for v1: it would change forwarding without an operator asking and could exhaust the 16-slot MCAM budget silently.

## Testing

The comparison lives **outside** the platform gate — it depends on nothing but data — so all five of its tests run on every host, including the macOS dev loop where the Linux-gated scans are invisible. That is this week's two probe bugs (#190, #191) applied before a third. Health-surface coverage asserts the report row and the gauge together.

Verified: workspace tests green, clippy clean on host **and** on `aarch64-unknown-linux-gnu` (where the netlink code actually compiles), CLI cross-check clean.

Hardware: the scan runs read-only and can be observed on the primary before w27 — an unsteered box will report the current tunnel routes as covered (they are, since w26b) and stay quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)