### PR TITLE
feat(fast-path): anyip phantom listen for the BGP route source

### DIFF
--- a/conf/example.conf
+++ b/conf/example.conf
@@ -203,6 +203,18 @@ module fast-path
   # inside a private network, e.g. a netns or VPC the operator owns):
   # route-source bgp 10.0.0.1:1179 local-as 401401 peer-as 401401 \
   #   allow-remote peer-from 10.0.0.0/24 peer-ip 10.0.0.5
+  #
+  # `anyip` (FRR pairing): FRR refuses to peer with any address its
+  # host owns and cannot complete a session over loopback, so an FRR
+  # feed needs a *phantom* listen address — one no interface holds.
+  # With `anyip`, packetframe installs `local <addr>/32 dev lo`
+  # (kernel AnyIP) before binding and removes it on shutdown, so the
+  # only durable artifact is this config line. Give FRR a small
+  # subnet nothing forwards on (e.g. a bridge with no member ports),
+  # point packetframe at the unused host address in it, and FRR at
+  # `neighbor <that addr>` with `update-source <its own addr>`:
+  # route-source bgp 10.255.0.2:1179 local-as 401401 peer-as 401401 \
+  #   allow-remote peer-from 10.255.0.1/32 anyip
 
   # Which authority the integrity checker cross-checks the mirror
   # against. Default (directive omitted) is `birdc` at /usr/sbin/birdc:

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -2888,6 +2888,23 @@ fn parse_endpoint(
             format!("route-source {kind_label}: bad port `{port_str}`: {e}"),
         )
     })?;
+    // Brackets are IPv6 endpoint syntax. A bracketed IPv4 —
+    // `[10.255.0.2]:1179` — passed every validation (they all strip
+    // brackets) but reached consumers with the brackets stored:
+    // SocketAddr parsing silently dropped the feed, and the anyip
+    // preflight panicked on an addr its own validator had accepted
+    // (review finding, PR #196). Reject the shape by name instead.
+    if let Some(inner) = addr.strip_prefix('[').and_then(|a| a.strip_suffix(']')) {
+        if inner.parse::<std::net::Ipv4Addr>().is_ok() {
+            return Err(ConfigError::parse(
+                line,
+                format!(
+                    "route-source {kind_label}: `{addr}` is a bracketed IPv4 address; \
+                     brackets are IPv6 syntax — write `{inner}:{port}`"
+                ),
+            ));
+        }
+    }
     Ok((addr.to_string(), port))
 }
 
@@ -4385,6 +4402,18 @@ module fast-path
                 assert_eq!(peer_from.len(), 2);
             }
             other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bracketed_ipv4_rejected() {
+        let e = parse_module_body("  route-source bgp [10.255.0.2]:1179 local-as 1 peer-as 1\n")
+            .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("bracketed IPv4"), "got: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
         }
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -639,6 +639,23 @@ pub enum RouteSourceSpec {
         /// real identity binding available in the absence of
         /// TCP-MD5 / TCP-AO.
         peer_ip: Option<std::net::IpAddr>,
+        /// When true, the controller installs a `local <addr>/32
+        /// dev lo` kernel route (AnyIP) before binding, and removes
+        /// it on shutdown. This makes a *phantom* listen address —
+        /// one no interface owns — bindable and locally deliverable.
+        ///
+        /// Exists for daemons that refuse to peer with an address
+        /// their host owns: FRR rejects `neighbor <addr>` for any
+        /// interface-owned address at config time ("Can not
+        /// configure the local system as neighbor") and cannot
+        /// complete a session over loopback (zebra treats 127/8 as
+        /// martian, so NHT never resolves and `nexthop_set` finds
+        /// no owning interface). The phantom address sidesteps both:
+        /// FRR sees an ordinary connected neighbor, packetframe
+        /// answers on it. Requires `allow-remote` (the address is
+        /// by definition not loopback) and is v4-only today, like
+        /// the router-id defaulting it composes with.
+        anyip: bool,
     },
 }
 
@@ -2588,11 +2605,16 @@ fn parse_route_source<'a>(
             let mut allow_remote = false;
             let mut peer_from: Vec<ipnet::IpNet> = Vec::new();
             let mut peer_ip: Option<std::net::IpAddr> = None;
+            let mut anyip = false;
             while let Some(key) = rest.next() {
                 // `allow-remote` is a no-value flag; everything
                 // else takes one argument.
                 if key == "allow-remote" {
                     allow_remote = true;
+                    continue;
+                }
+                if key == "anyip" {
+                    anyip = true;
                     continue;
                 }
                 let value = rest.next().ok_or_else(|| {
@@ -2648,7 +2670,7 @@ fn parse_route_source<'a>(
                         return Err(ConfigError::parse(
                             line,
                             format!(
-                                "route-source bgp: unknown key `{other}` (known: local-as, peer-as, router-id, allow-remote, peer-from, peer-ip)"
+                                "route-source bgp: unknown key `{other}` (known: local-as, peer-as, router-id, allow-remote, peer-from, peer-ip, anyip)"
                             ),
                         ));
                     }
@@ -2668,6 +2690,36 @@ fn parse_route_source<'a>(
                 !peer_from.is_empty(),
                 peer_ip.is_some(),
             )?;
+            // `anyip` describes a non-loopback phantom address, so it
+            // inherits allow-remote's obligations (a peer-from ACL on
+            // a routable listen). Checked after validate_listener_auth
+            // so the operator fixes auth-shape errors first and this
+            // one second, not interleaved.
+            if anyip && !allow_remote {
+                return Err(ConfigError::parse(
+                    line,
+                    "route-source bgp: `anyip` requires `allow-remote peer-from <cidr>` — \
+                     the phantom listen address is non-loopback by definition",
+                ));
+            }
+            if anyip {
+                let parsed = addr
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .parse::<std::net::IpAddr>()
+                    .map_err(|e| {
+                        ConfigError::parse(
+                            line,
+                            format!("route-source bgp: bad listen address `{addr}`: {e}"),
+                        )
+                    })?;
+                if !parsed.is_ipv4() {
+                    return Err(ConfigError::parse(
+                        line,
+                        "route-source bgp: `anyip` supports IPv4 listen addresses only",
+                    ));
+                }
+            }
             Ok(ModuleDirective::RouteSource(RouteSourceSpec::Bgp {
                 addr,
                 port,
@@ -2677,6 +2729,7 @@ fn parse_route_source<'a>(
                 allow_remote,
                 peer_from,
                 peer_ip,
+                anyip,
             }))
         }
         other => Err(ConfigError::parse(
@@ -4164,6 +4217,7 @@ module fast-path
                 allow_remote,
                 peer_from,
                 peer_ip,
+                anyip,
             } => {
                 assert_eq!(addr, "127.0.0.1");
                 assert_eq!(port, 1179);
@@ -4173,6 +4227,7 @@ module fast-path
                 assert!(!allow_remote, "loopback default does not need opt-in");
                 assert!(peer_from.is_empty());
                 assert!(peer_ip.is_none());
+                assert!(!anyip, "anyip defaults off");
             }
             other => panic!("expected Bgp, got {other:?}"),
         }
@@ -4296,6 +4351,58 @@ module fast-path
                 assert_eq!(peer_from.len(), 2);
             }
             other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_anyip_parses() {
+        let s = "  route-source bgp 10.255.0.2:1179 local-as 401401 peer-as 401401 \
+                 allow-remote peer-from 10.255.0.1/32 anyip\n";
+        match extract_route_source(s) {
+            RouteSourceSpec::Bgp {
+                addr,
+                allow_remote,
+                peer_from,
+                anyip,
+                ..
+            } => {
+                assert_eq!(addr, "10.255.0.2");
+                assert!(allow_remote);
+                assert_eq!(peer_from.len(), 1);
+                assert!(anyip);
+            }
+            other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_anyip_without_allow_remote_errors() {
+        // `anyip` on a loopback listen is doubly wrong (a loopback
+        // address is never a phantom), and the allow-remote
+        // requirement is what rejects it.
+        let e = parse_module_body("  route-source bgp 127.0.0.1:1179 local-as 1 peer-as 1 anyip\n")
+            .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("anyip"), "got: {message}");
+                assert!(message.contains("allow-remote"), "got: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_anyip_v6_listen_errors() {
+        let e = parse_module_body(
+            "  route-source bgp [2001:db8::2]:1179 local-as 1 peer-as 1 \
+             allow-remote peer-from 2001:db8::1/128 anyip\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(message.contains("IPv4"), "got: {message}");
+            }
+            other => panic!("expected Parse, got {other:?}"),
         }
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1673,6 +1673,25 @@ fn parse(input: &str) -> Result<Config, ConfigError> {
                 }
                 Cursor::Module(i) => {
                     let d = parse_module_directive(line, stripped)?;
+                    // The controller spawns at most one route source
+                    // and every consumer selects "the first" — a
+                    // second directive could silently diverge from
+                    // the first (the anyip preflight vs the
+                    // controller's selection, review finding on
+                    // PR #196). The runbook has always said "exactly
+                    // one route-source"; now the parser does too.
+                    if matches!(d, ModuleDirective::RouteSource(_))
+                        && modules[i]
+                            .directives
+                            .iter()
+                            .any(|e| matches!(e, ModuleDirective::RouteSource(_)))
+                    {
+                        return Err(ConfigError::parse(
+                            line,
+                            "duplicate `route-source` in one module section; exactly one \
+                             feed is supported per module",
+                        ));
+                    }
                     modules[i].directives.push(d);
                 }
             },
@@ -4366,6 +4385,24 @@ module fast-path
                 assert_eq!(peer_from.len(), 2);
             }
             other => panic!("expected Bgp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn duplicate_route_source_rejected() {
+        let e = parse_module_body(
+            "  route-source bmp 127.0.0.1:6543 require-loc-rib\n  \
+             route-source bgp 127.0.0.1:1179 local-as 1 peer-as 1\n",
+        )
+        .unwrap_err();
+        match e {
+            ConfigError::Parse { message, .. } => {
+                assert!(
+                    message.contains("duplicate `route-source`"),
+                    "got: {message}"
+                );
+            }
+            other => panic!("expected Parse, got {other:?}"),
         }
     }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -2713,10 +2713,25 @@ fn parse_route_source<'a>(
                             format!("route-source bgp: bad listen address `{addr}`: {e}"),
                         )
                     })?;
-                if !parsed.is_ipv4() {
+                let std::net::IpAddr::V4(v4) = parsed else {
                     return Err(ConfigError::parse(
                         line,
                         "route-source bgp: `anyip` supports IPv4 listen addresses only",
+                    ));
+                };
+                // A phantom must be a concrete unicast host: the
+                // wildcard would install a meaningless `local
+                // 0.0.0.0/32` while binding every interface, and
+                // multicast/broadcast can never act as an FRR
+                // neighbor — the listener would retry forever.
+                if v4.is_unspecified() || v4.is_multicast() || v4.is_broadcast() {
+                    return Err(ConfigError::parse(
+                        line,
+                        format!(
+                            "route-source bgp: `anyip` requires a concrete unicast listen \
+                             address, got `{v4}` (unspecified/multicast/broadcast cannot \
+                             be a phantom neighbor)"
+                        ),
                     ));
                 }
             }
@@ -4388,6 +4403,23 @@ module fast-path
                 assert!(message.contains("allow-remote"), "got: {message}");
             }
             other => panic!("expected Parse, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn route_source_bgp_anyip_non_unicast_listen_errors() {
+        for addr in ["0.0.0.0", "224.0.0.9", "255.255.255.255"] {
+            let e = parse_module_body(&format!(
+                "  route-source bgp {addr}:1179 local-as 1 peer-as 1 \
+                 allow-remote peer-from 10.0.0.1/32 anyip\n"
+            ))
+            .unwrap_err();
+            match e {
+                ConfigError::Parse { message, .. } => {
+                    assert!(message.contains("unicast"), "addr {addr}: got {message}");
+                }
+                other => panic!("expected Parse for {addr}, got {other:?}"),
+            }
         }
     }
 

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -1,0 +1,160 @@
+//! AnyIP phantom-listen support for `route-source bgp ... anyip`.
+//!
+//! Some routing daemons refuse to peer with any address their host
+//! owns: FRR rejects `neighbor <addr>` for every interface-owned
+//! address at config time ("Can not configure the local system as
+//! neighbor"), and cannot complete a session over loopback either
+//! (zebra treats 127/8 as martian, so peer NHT never resolves and
+//! `bgp_nexthop_set` finds no owning interface). bird has neither
+//! restriction, which is why the BgpListener's loopback default was
+//! sufficient until an FRR deployment appeared.
+//!
+//! The escape hatch is the kernel's AnyIP mechanism: a route of type
+//! `local` makes its destination bindable and locally deliverable
+//! without assigning the address to any interface. From FRR's view
+//! the phantom address is an ordinary connected neighbor; from the
+//! kernel's view packets to it are local traffic; from every other
+//! host's view it doesn't exist (the /32 lives only in this box's
+//! `local` table).
+//!
+//! This module owns exactly that one route. The controller calls
+//! [`ensure_local_route`] before the listener's first bind and again
+//! before each retry (replace semantics make it idempotent and
+//! self-healing), and [`remove_local_route`] during shutdown so the
+//! route's lifetime is a strict subset of the daemon's — no kernel
+//! state survives that a restart doesn't recreate, which is the
+//! property that lets the operator's config file remain the single
+//! source of truth on fleets where hand-installed routes are
+//! prohibited (they don't survive firmware upgrades).
+//!
+//! [`ensure_local_route`] refuses an address some interface already
+//! owns, for the same reason the vpp-offload loader refuses a live
+//! loopback IP (#188): an owned address means the operator pointed
+//! `anyip` at a real interface address, and FRR would reject the
+//! neighbor outright — better to fail attach loudly than converge
+//! into a feed that can never establish.
+
+#![cfg(target_os = "linux")]
+
+use std::net::{IpAddr, Ipv4Addr};
+
+use futures::TryStreamExt;
+use netlink_packet_route::address::AddressAttribute;
+use netlink_packet_route::route::{RouteProtocol, RouteScope, RouteType};
+use rtnetlink::{Handle, RouteMessageBuilder};
+use tracing::info;
+
+/// The kernel's `local` routing table, where type-`local` routes
+/// conventionally live (`ip route show table local`).
+const LOCAL_TABLE: u32 = 255;
+
+#[derive(Debug, thiserror::Error)]
+pub enum AnyipError {
+    #[error("netlink connection failed: {0}")]
+    Connection(#[from] std::io::Error),
+    #[error("netlink request failed: {0}")]
+    Request(#[from] rtnetlink::Error),
+    #[error(
+        "anyip address {addr} is already owned by interface index {ifindex}; \
+         a phantom listen address must not be assigned to any interface \
+         (FRR refuses interface-owned addresses as neighbors — pick an \
+         unassigned address, e.g. the unused host in the feed /30)"
+    )]
+    AddressOwned { addr: Ipv4Addr, ifindex: u32 },
+    #[error("interface `lo` not found via RTM_GETLINK")]
+    NoLoopbackIface,
+}
+
+/// Ensure `local <addr>/32 dev lo` exists in the `local` table.
+///
+/// Idempotent (`NLM_F_REPLACE`), so the controller can call it before
+/// every listener (re)start: a route someone flushed at runtime is
+/// healed on the next retry rather than requiring a daemon restart.
+///
+/// Fails with [`AnyipError::AddressOwned`] if any interface holds
+/// `addr` — see the module docs for why that is a hard refusal.
+pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
+    let (conn, handle, _) = rtnetlink::new_connection()?;
+    tokio::spawn(conn);
+
+    if let Some(ifindex) = owning_ifindex(&handle, addr).await? {
+        return Err(AnyipError::AddressOwned { addr, ifindex });
+    }
+
+    let lo = lo_ifindex(&handle).await?;
+    let route = RouteMessageBuilder::<Ipv4Addr>::new()
+        .destination_prefix(addr, 32)
+        .output_interface(lo)
+        .table_id(LOCAL_TABLE)
+        .scope(RouteScope::Host)
+        .kind(RouteType::Local)
+        // `Static` rather than the kernel/boot defaults so `ip route
+        // show table local` visibly distinguishes our route from the
+        // kernel's own local entries.
+        .protocol(RouteProtocol::Static)
+        .build();
+    handle.route().add(route).replace().execute().await?;
+    info!(%addr, "anyip: local /32 ensured on lo (kernel AnyIP)");
+    Ok(())
+}
+
+/// Remove the route [`ensure_local_route`] installed. Best-effort by
+/// contract: an already-absent route is success, not an error, so
+/// shutdown never fails on a route someone else already cleaned up.
+pub async fn remove_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
+    let (conn, handle, _) = rtnetlink::new_connection()?;
+    tokio::spawn(conn);
+
+    let lo = lo_ifindex(&handle).await?;
+    let route = RouteMessageBuilder::<Ipv4Addr>::new()
+        .destination_prefix(addr, 32)
+        .output_interface(lo)
+        .table_id(LOCAL_TABLE)
+        .scope(RouteScope::Host)
+        .kind(RouteType::Local)
+        .protocol(RouteProtocol::Static)
+        .build();
+    match handle.route().del(route).execute().await {
+        Ok(()) => {
+            info!(%addr, "anyip: local /32 removed");
+            Ok(())
+        }
+        // ESRCH/ENOENT: the route is already gone. That is the state
+        // we wanted; report success.
+        Err(rtnetlink::Error::NetlinkError(e))
+            if e.raw_code() == -libc::ESRCH || e.raw_code() == -libc::ENOENT =>
+        {
+            Ok(())
+        }
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// The ifindex of whichever interface holds `addr`, if any. Both the
+/// `Address` and `Local` attributes are checked: point-to-point
+/// interfaces carry the local address in `Local` with the peer in
+/// `Address`, and either shape means the address is owned.
+async fn owning_ifindex(handle: &Handle, addr: Ipv4Addr) -> Result<Option<u32>, AnyipError> {
+    let mut addrs = handle.address().get().execute();
+    while let Some(msg) = addrs.try_next().await? {
+        let owned = msg.attributes.iter().any(|attr| {
+            matches!(
+                attr,
+                AddressAttribute::Address(IpAddr::V4(a)) | AddressAttribute::Local(IpAddr::V4(a))
+                    if *a == addr
+            )
+        });
+        if owned {
+            return Ok(Some(msg.header.index));
+        }
+    }
+    Ok(None)
+}
+
+async fn lo_ifindex(handle: &Handle) -> Result<u32, AnyipError> {
+    let mut links = handle.link().get().match_name("lo".to_string()).execute();
+    match links.try_next().await? {
+        Some(link) => Ok(link.header.index),
+        None => Err(AnyipError::NoLoopbackIface),
+    }
+}

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -108,6 +108,18 @@ pub enum AnyipError {
         addr: Ipv4Addr,
         proto: RouteProtocol,
     },
+    #[error(
+        "anyip address {addr} is the directed broadcast of a subnet on \
+         interface index {ifindex}; the kernel owns a broadcast route for \
+         it that a local /32 would clobber (in a /30 feed subnet the usable \
+         phantom is the OTHER host address, not .3)"
+    )]
+    DirectedBroadcast { addr: Ipv4Addr, ifindex: u32 },
+    #[error(
+        "a {kind:?} route for {addr}/32 already exists in the local table; \
+         refusing to replace a kernel-owned entry with an anyip local route"
+    )]
+    RouteKindConflict { addr: Ipv4Addr, kind: RouteType },
 }
 
 /// Ensure `local <addr>/32 dev lo` exists in the `local` table.
@@ -122,14 +134,28 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
     let (conn, handle, _) = rtnetlink::new_connection()?;
     tokio::spawn(conn);
 
-    if let Some(ifindex) = owning_ifindex(&handle, addr).await? {
-        return Err(AnyipError::AddressOwned { addr, ifindex });
+    match address_conflict(&handle, addr).await? {
+        Some(AddrConflict::Owned(ifindex)) => {
+            return Err(AnyipError::AddressOwned { addr, ifindex });
+        }
+        Some(AddrConflict::DirectedBroadcast(ifindex)) => {
+            return Err(AnyipError::DirectedBroadcast { addr, ifindex });
+        }
+        None => {}
     }
-    // A pre-existing local /32 for this address is adopted only when
-    // it wears our protocol tag (a previous daemon life); any other
-    // protocol means another owner got here first, and replacing
-    // their route now means deleting it at our shutdown later.
-    if let Some(proto) = existing_local_route_protocol(&handle, addr).await? {
+    // A pre-existing table-local entry for this /32 is adopted only
+    // when it is a `local` route wearing our protocol tag (a previous
+    // daemon life). A foreign-protocol local route means another
+    // owner got here first — replacing it now means deleting it at
+    // our shutdown later. A non-`local` kind (the kernel's own
+    // `broadcast` entry, an `anycast`, ...) is kernel-owned state we
+    // must not clobber at all; this is the second line of defense
+    // behind the directed-broadcast check above, driven by what the
+    // routing table actually holds rather than address arithmetic.
+    if let Some((kind, proto)) = existing_local_table_entry(&handle, addr).await? {
+        if kind != RouteType::Local {
+            return Err(AnyipError::RouteKindConflict { addr, kind });
+        }
         if proto != ANYIP_ROUTE_PROTOCOL {
             return Err(AnyipError::RouteContested { addr, proto });
         }
@@ -186,40 +212,63 @@ pub async fn remove_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
     }
 }
 
-/// The ifindex of whichever interface holds `addr`, if any. Both the
-/// `Address` and `Local` attributes are checked: point-to-point
+/// How `addr` collides with the host's interface addressing, if at
+/// all.
+enum AddrConflict {
+    /// Some interface holds the address itself.
+    Owned(u32),
+    /// The address is the directed broadcast of a subnet on this
+    /// interface. The kernel declares it via the `Broadcast` address
+    /// attribute, so no mask arithmetic is needed — and /31 and /32
+    /// subnets, which have no broadcast (RFC 3021), are handled for
+    /// free because the attribute is simply absent.
+    DirectedBroadcast(u32),
+}
+
+/// Walk the interface addresses once, checking `addr` against the
+/// `Address` and `Local` attributes (ownership — point-to-point
 /// interfaces carry the local address in `Local` with the peer in
-/// `Address`, and either shape means the address is owned.
-async fn owning_ifindex(handle: &Handle, addr: Ipv4Addr) -> Result<Option<u32>, AnyipError> {
+/// `Address`) and the `Broadcast` attribute (directed broadcast of a
+/// configured subnet, which `Ipv4Addr::is_broadcast()` cannot see:
+/// it only knows 255.255.255.255; review finding, PR #196).
+async fn address_conflict(
+    handle: &Handle,
+    addr: Ipv4Addr,
+) -> Result<Option<AddrConflict>, AnyipError> {
     let mut addrs = handle.address().get().execute();
     while let Some(msg) = addrs.try_next().await? {
-        let owned = msg.attributes.iter().any(|attr| {
-            matches!(
-                attr,
-                AddressAttribute::Address(IpAddr::V4(a)) | AddressAttribute::Local(IpAddr::V4(a))
-                    if *a == addr
-            )
-        });
-        if owned {
-            return Ok(Some(msg.header.index));
+        for attr in &msg.attributes {
+            match attr {
+                AddressAttribute::Address(IpAddr::V4(a))
+                | AddressAttribute::Local(IpAddr::V4(a))
+                    if *a == addr =>
+                {
+                    return Ok(Some(AddrConflict::Owned(msg.header.index)));
+                }
+                AddressAttribute::Broadcast(b) if *b == addr => {
+                    return Ok(Some(AddrConflict::DirectedBroadcast(msg.header.index)));
+                }
+                _ => {}
+            }
         }
     }
     Ok(None)
 }
 
-/// The protocol of an existing `local <addr>/32` in the local table,
-/// or `None` when no such route exists. This is the ownership probe:
-/// the caller compares the result against [`ANYIP_ROUTE_PROTOCOL`].
-async fn existing_local_route_protocol(
+/// The (kind, protocol) of an existing `<addr>/32` entry in the
+/// local table, or `None` when no such entry exists. This is the
+/// ownership probe: the caller adopts only `(Local,
+/// ANYIP_ROUTE_PROTOCOL)` and refuses everything else — a foreign
+/// `local` route, the kernel's own `broadcast` entry, or any other
+/// kind a replace would silently clobber.
+async fn existing_local_table_entry(
     handle: &Handle,
     addr: Ipv4Addr,
-) -> Result<Option<RouteProtocol>, AnyipError> {
+) -> Result<Option<(RouteType, RouteProtocol)>, AnyipError> {
     let filter = RouteMessageBuilder::<Ipv4Addr>::new().build();
     let mut routes = handle.route().get(filter).execute();
     while let Some(msg) = routes.try_next().await? {
-        if msg.header.kind != RouteType::Local
-            || msg.header.destination_prefix_length != 32
-            || u32::from(msg.header.table) != LOCAL_TABLE
+        if msg.header.destination_prefix_length != 32 || u32::from(msg.header.table) != LOCAL_TABLE
         {
             continue;
         }
@@ -230,7 +279,7 @@ async fn existing_local_route_protocol(
             )
         });
         if dst_matches {
-            return Ok(Some(msg.header.protocol));
+            return Ok(Some((msg.header.kind, msg.header.protocol)));
         }
     }
     Ok(None)

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -24,8 +24,11 @@
 //! flushed (SYNs silently stop being delivered; review finding,
 //! PR #196), so only time-based replacement can heal that case.
 //! Replace semantics make every call idempotent. The controller
-//! calls [`remove_local_route`] during shutdown so the
-//! route's lifetime is a strict subset of the daemon's — no kernel
+//! calls [`remove_local_route`] during explicit shutdown AND from
+//! its `Drop` impl — the latter because the §8.5 preserve-attach
+//! exit (the normal `systemctl stop`) drops the controller without
+//! ever calling `shutdown()` — so the route's lifetime is a strict
+//! subset of the daemon's on every exit path short of SIGKILL — no kernel
 //! state survives that a restart doesn't recreate, which is the
 //! property that lets the operator's config file remain the single
 //! source of truth on fleets where hand-installed routes are

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -18,9 +18,13 @@
 //! `local` table).
 //!
 //! This module owns exactly that one route. The controller calls
-//! [`ensure_local_route`] before the listener's first bind and again
-//! before each retry (replace semantics make it idempotent and
-//! self-healing), and [`remove_local_route`] during shutdown so the
+//! [`ensure_local_route`] before the listener's first bind, before
+//! each listener retry, and on a periodic reconcile tick — the last
+//! because a *bound* listener emits no error when the route is
+//! flushed (SYNs silently stop being delivered; review finding,
+//! PR #196), so only time-based replacement can heal that case.
+//! Replace semantics make every call idempotent. The controller
+//! calls [`remove_local_route`] during shutdown so the
 //! route's lifetime is a strict subset of the daemon's — no kernel
 //! state survives that a restart doesn't recreate, which is the
 //! property that lets the operator's config file remain the single

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -265,7 +265,17 @@ async fn existing_local_table_entry(
     handle: &Handle,
     addr: Ipv4Addr,
 ) -> Result<Option<(RouteType, RouteProtocol)>, AnyipError> {
-    let filter = RouteMessageBuilder::<Ipv4Addr>::new().build();
+    // Destination-less GetRoute is an NLM_F_DUMP; without a table
+    // filter the kernel exports the ENTIRE v4 FIB — on a full-table
+    // edge that is 1M+ routes serialized and scanned every 30 s
+    // reconcile tick just to check one /32 (review finding, PR
+    // #196). Setting the header's table field makes 4.20+ kernels
+    // filter the dump to table local (hundreds of entries); the
+    // userspace re-check below keeps correctness on anything that
+    // ignores the filter.
+    let filter = RouteMessageBuilder::<Ipv4Addr>::new()
+        .table_id(LOCAL_TABLE)
+        .build();
     let mut routes = handle.route().get(filter).execute();
     while let Some(msg) = routes.try_next().await? {
         if msg.header.destination_prefix_length != 32 || u32::from(msg.header.table) != LOCAL_TABLE

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -36,7 +36,13 @@
 //! loopback IP (#188): an owned address means the operator pointed
 //! `anyip` at a real interface address, and FRR would reject the
 //! neighbor outright — better to fail attach loudly than converge
-//! into a feed that can never establish.
+//! into a feed that can never establish. It likewise refuses a
+//! same-destination local route installed by anything else: routes
+//! we install wear [`ANYIP_ROUTE_PROTOCOL`] as an ownership tag, so
+//! a crash-orphaned route from a previous daemon life is adopted
+//! silently while a foreign owner's route is neither replaced at
+//! startup nor deletable at shutdown (the kernel's protocol-scoped
+//! delete cannot match it).
 
 #![cfg(target_os = "linux")]
 
@@ -44,13 +50,34 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use futures::TryStreamExt;
 use netlink_packet_route::address::AddressAttribute;
-use netlink_packet_route::route::{RouteProtocol, RouteScope, RouteType};
+use netlink_packet_route::route::{
+    RouteAddress, RouteAttribute, RouteProtocol, RouteScope, RouteType,
+};
 use rtnetlink::{Handle, RouteMessageBuilder};
 use tracing::info;
 
 /// The kernel's `local` routing table, where type-`local` routes
 /// conventionally live (`ip route show table local`).
 const LOCAL_TABLE: u32 = 255;
+
+/// The route-protocol value that marks the AnyIP route as OURS.
+///
+/// This is the ownership tag that makes three behaviors possible at
+/// once (review finding, PR #196):
+/// - crash adoption: a route left behind by a SIGKILL'd daemon wears
+///   the tag, so the next start adopts it silently instead of
+///   refusing its own leftovers;
+/// - contested refusal: a `local <addr>/32` installed by anything
+///   else does NOT wear it, so [`ensure_local_route`] refuses rather
+///   than silently replacing another owner's route;
+/// - scoped delete: `RTM_DELROUTE` with a nonzero protocol only
+///   matches routes carrying that protocol, so shutdown removal is
+///   structurally unable to delete a route we don't own.
+///
+/// 199 is unassigned in iproute2's `rt_protos` (186 bgp, 187 isis,
+/// 188 ospf, 189 rip, 192 eigrp are the neighbors); `ip route show
+/// table local` renders it as `proto 199`.
+const ANYIP_ROUTE_PROTOCOL: RouteProtocol = RouteProtocol::Other(199);
 
 #[derive(Debug, thiserror::Error)]
 pub enum AnyipError {
@@ -67,6 +94,17 @@ pub enum AnyipError {
     AddressOwned { addr: Ipv4Addr, ifindex: u32 },
     #[error("interface `lo` not found via RTM_GETLINK")]
     NoLoopbackIface,
+    #[error(
+        "a `local {addr}/32` route already exists with protocol {proto:?}, \
+         installed by something other than packetframe; refusing to adopt \
+         or replace it — the anyip address must be exclusively ours \
+         (pick a different phantom address, or remove the foreign route's \
+         owner first)"
+    )]
+    RouteContested {
+        addr: Ipv4Addr,
+        proto: RouteProtocol,
+    },
 }
 
 /// Ensure `local <addr>/32 dev lo` exists in the `local` table.
@@ -84,6 +122,15 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
     if let Some(ifindex) = owning_ifindex(&handle, addr).await? {
         return Err(AnyipError::AddressOwned { addr, ifindex });
     }
+    // A pre-existing local /32 for this address is adopted only when
+    // it wears our protocol tag (a previous daemon life); any other
+    // protocol means another owner got here first, and replacing
+    // their route now means deleting it at our shutdown later.
+    if let Some(proto) = existing_local_route_protocol(&handle, addr).await? {
+        if proto != ANYIP_ROUTE_PROTOCOL {
+            return Err(AnyipError::RouteContested { addr, proto });
+        }
+    }
 
     let lo = lo_ifindex(&handle).await?;
     let route = RouteMessageBuilder::<Ipv4Addr>::new()
@@ -92,10 +139,7 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
         .table_id(LOCAL_TABLE)
         .scope(RouteScope::Host)
         .kind(RouteType::Local)
-        // `Static` rather than the kernel/boot defaults so `ip route
-        // show table local` visibly distinguishes our route from the
-        // kernel's own local entries.
-        .protocol(RouteProtocol::Static)
+        .protocol(ANYIP_ROUTE_PROTOCOL)
         .build();
     handle.route().add(route).replace().execute().await?;
     info!(%addr, "anyip: local /32 ensured on lo (kernel AnyIP)");
@@ -105,6 +149,11 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
 /// Remove the route [`ensure_local_route`] installed. Best-effort by
 /// contract: an already-absent route is success, not an error, so
 /// shutdown never fails on a route someone else already cleaned up.
+///
+/// The delete carries [`ANYIP_ROUTE_PROTOCOL`]; the kernel only
+/// matches routes with that protocol, so a same-destination route
+/// owned by anything else is unreachable from here — it survives as
+/// an ESRCH, which the tolerant arm below reports as success.
 pub async fn remove_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
     let (conn, handle, _) = rtnetlink::new_connection()?;
     tokio::spawn(conn);
@@ -116,7 +165,7 @@ pub async fn remove_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
         .table_id(LOCAL_TABLE)
         .scope(RouteScope::Host)
         .kind(RouteType::Local)
-        .protocol(RouteProtocol::Static)
+        .protocol(ANYIP_ROUTE_PROTOCOL)
         .build();
     match handle.route().del(route).execute().await {
         Ok(()) => {
@@ -150,6 +199,35 @@ async fn owning_ifindex(handle: &Handle, addr: Ipv4Addr) -> Result<Option<u32>, 
         });
         if owned {
             return Ok(Some(msg.header.index));
+        }
+    }
+    Ok(None)
+}
+
+/// The protocol of an existing `local <addr>/32` in the local table,
+/// or `None` when no such route exists. This is the ownership probe:
+/// the caller compares the result against [`ANYIP_ROUTE_PROTOCOL`].
+async fn existing_local_route_protocol(
+    handle: &Handle,
+    addr: Ipv4Addr,
+) -> Result<Option<RouteProtocol>, AnyipError> {
+    let filter = RouteMessageBuilder::<Ipv4Addr>::new().build();
+    let mut routes = handle.route().get(filter).execute();
+    while let Some(msg) = routes.try_next().await? {
+        if msg.header.kind != RouteType::Local
+            || msg.header.destination_prefix_length != 32
+            || u32::from(msg.header.table) != LOCAL_TABLE
+        {
+            continue;
+        }
+        let dst_matches = msg.attributes.iter().any(|attr| {
+            matches!(
+                attr,
+                RouteAttribute::Destination(RouteAddress::Inet(a)) if *a == addr
+            )
+        });
+        if dst_matches {
+            return Ok(Some(msg.header.protocol));
         }
     }
     Ok(None)

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -285,6 +285,25 @@ async fn existing_local_table_entry(
     Ok(None)
 }
 
+/// Blocking wrappers for callers without a live tokio runtime: the
+/// attach preflight (a sync path that runs before the controller's
+/// runtime exists) and unwind/Drop cleanup. Each builds a throwaway
+/// current-thread runtime; both sites are cold one-shots.
+pub fn ensure_local_route_blocking(addr: Ipv4Addr) -> Result<(), AnyipError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(ensure_local_route(addr))
+}
+
+/// See [`ensure_local_route_blocking`].
+pub fn remove_local_route_blocking(addr: Ipv4Addr) -> Result<(), AnyipError> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?
+        .block_on(remove_local_route(addr))
+}
+
 async fn lo_ifindex(handle: &Handle) -> Result<u32, AnyipError> {
     let mut links = handle.link().get().match_name("lo".to_string()).execute();
     match links.try_next().await? {

--- a/crates/modules/fast-path/src/fib/anyip.rs
+++ b/crates/modules/fast-path/src/fib/anyip.rs
@@ -122,15 +122,28 @@ pub enum AnyipError {
     RouteKindConflict { addr: Ipv4Addr, kind: RouteType },
 }
 
+/// Whether [`ensure_local_route`] created the route or adopted one a
+/// previous daemon life left behind. Callers that clean up on
+/// failure must only clean up what they CREATED: unwinding an
+/// adopted route can yank it out from under a concurrently running
+/// daemon that owns it (review finding, PR #196).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnsureOutcome {
+    Created,
+    Adopted,
+}
+
 /// Ensure `local <addr>/32 dev lo` exists in the `local` table.
 ///
 /// Idempotent (`NLM_F_REPLACE`), so the controller can call it before
 /// every listener (re)start: a route someone flushed at runtime is
 /// healed on the next retry rather than requiring a daemon restart.
+/// Reports whether the route was [`EnsureOutcome::Created`] fresh or
+/// [`EnsureOutcome::Adopted`] from a previous daemon life.
 ///
 /// Fails with [`AnyipError::AddressOwned`] if any interface holds
 /// `addr` — see the module docs for why that is a hard refusal.
-pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
+pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<EnsureOutcome, AnyipError> {
     let (conn, handle, _) = rtnetlink::new_connection()?;
     tokio::spawn(conn);
 
@@ -152,6 +165,7 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
     // must not clobber at all; this is the second line of defense
     // behind the directed-broadcast check above, driven by what the
     // routing table actually holds rather than address arithmetic.
+    let mut outcome = EnsureOutcome::Created;
     if let Some((kind, proto)) = existing_local_table_entry(&handle, addr).await? {
         if kind != RouteType::Local {
             return Err(AnyipError::RouteKindConflict { addr, kind });
@@ -159,6 +173,7 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
         if proto != ANYIP_ROUTE_PROTOCOL {
             return Err(AnyipError::RouteContested { addr, proto });
         }
+        outcome = EnsureOutcome::Adopted;
     }
 
     let lo = lo_ifindex(&handle).await?;
@@ -171,8 +186,8 @@ pub async fn ensure_local_route(addr: Ipv4Addr) -> Result<(), AnyipError> {
         .protocol(ANYIP_ROUTE_PROTOCOL)
         .build();
     handle.route().add(route).replace().execute().await?;
-    info!(%addr, "anyip: local /32 ensured on lo (kernel AnyIP)");
-    Ok(())
+    info!(%addr, ?outcome, "anyip: local /32 ensured on lo (kernel AnyIP)");
+    Ok(outcome)
 }
 
 /// Remove the route [`ensure_local_route`] installed. Best-effort by
@@ -299,7 +314,7 @@ async fn existing_local_table_entry(
 /// attach preflight (a sync path that runs before the controller's
 /// runtime exists) and unwind/Drop cleanup. Each builds a throwaway
 /// current-thread runtime; both sites are cold one-shots.
-pub fn ensure_local_route_blocking(addr: Ipv4Addr) -> Result<(), AnyipError> {
+pub fn ensure_local_route_blocking(addr: Ipv4Addr) -> Result<EnsureOutcome, AnyipError> {
     tokio::runtime::Builder::new_current_thread()
         .enable_all()
         .build()?

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -98,6 +98,16 @@ const LISTENER_BACKOFF_INITIAL: Duration = Duration::from_secs(1);
 /// log without being too loud.
 const LISTENER_BACKOFF_MAX: Duration = Duration::from_secs(60);
 
+/// Cadence of the AnyIP reconcile task. The per-retry ensure in the
+/// listener loop only runs when `BgpListener::run` *exits*, and a
+/// flushed route doesn't make a bound listener exit — the socket
+/// stays bound, SYNs silently stop being delivered locally, and the
+/// session dies on hold-timer with nothing to restart the loop
+/// (review finding, PR #196). A periodic replace is the signal-free
+/// fix: one netlink round-trip every 30 s, idempotent, and the feed
+/// heals within one FRR connect-retry of the route coming back.
+const ANYIP_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
+
 #[derive(Debug, thiserror::Error)]
 pub enum ControllerError {
     #[error("tokio runtime build failed: {0}")]
@@ -346,6 +356,7 @@ impl RouteController {
                         backoff = (backoff * 2).min(LISTENER_BACKOFF_MAX);
                     }
                 }));
+
                 integrity = Some(snapshot);
 
                 let loopback_only = listen.ip().is_loopback() && peer_acl.is_empty();
@@ -450,6 +461,10 @@ impl RouteController {
                         }
                         let listener = BgpListener::new(cfg.clone(), prog.clone(), shut.clone())
                             .with_stall_gate(stall.clone());
+                        // (The flushed-while-BOUND case is covered by
+                        // the reconcile task spawned below, not this
+                        // loop — a bound listener gives no exit signal
+                        // when the route disappears.)
                         match listener.run().await {
                             Ok(()) => return,
                             Err(e) => {
@@ -467,6 +482,27 @@ impl RouteController {
                         backoff = (backoff * 2).min(LISTENER_BACKOFF_MAX);
                     }
                 }));
+
+                // AnyIP reconcile: heal the route while the listener
+                // is bound and healthy, which the retry loop above
+                // structurally cannot (see ANYIP_RECONCILE_INTERVAL).
+                // First tick fires immediately and is a no-op replace.
+                if let Some(a) = anyip_addr {
+                    let shut = shutdown_token.clone();
+                    tasks.push(runtime.spawn(async move {
+                        let mut tick = tokio::time::interval(ANYIP_RECONCILE_INTERVAL);
+                        loop {
+                            tokio::select! {
+                                _ = shut.cancelled() => return,
+                                _ = tick.tick() => {
+                                    if let Err(e) = crate::fib::anyip::ensure_local_route(a).await {
+                                        warn!(error = %e, addr = %a, "anyip: reconcile failed");
+                                    }
+                                }
+                            }
+                        }
+                    }));
+                }
                 integrity = Some(snapshot);
 
                 info!(

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -76,6 +76,10 @@ pub enum RouteSourceConfig {
         /// accepted connection whose source IP differs is closed
         /// before the BGP OPEN exchange.
         expected_peer_ip: Option<IpAddr>,
+        /// Install a `local <listen>/32 dev lo` kernel route (AnyIP)
+        /// before binding, remove it on shutdown. See the `anyip`
+        /// module docs for the FRR pairing this exists for.
+        anyip: bool,
     },
 }
 
@@ -100,6 +104,8 @@ pub enum ControllerError {
     Runtime(#[from] std::io::Error),
     #[error("programmer setup failed: {0}")]
     Programmer(#[from] ProgrammerError),
+    #[error("anyip listen-address setup failed: {0}")]
+    Anyip(#[from] crate::fib::anyip::AnyipError),
 }
 
 pub struct RouteController {
@@ -123,6 +129,10 @@ pub struct RouteController {
     /// source, because the health surface says something different —
     /// "not attested by choice" versus "nothing to attest".
     authority_declared_none: bool,
+    /// `Some` when this controller installed an AnyIP local route for
+    /// the BGP listener; removed during `shutdown()` so the route's
+    /// lifetime never exceeds the daemon's.
+    anyip_addr: Option<Ipv4Addr>,
 }
 
 /// The external route feed and the authority the integrity checker
@@ -263,6 +273,7 @@ impl RouteController {
         // integrity checker spawns alongside any feed because both
         // depend on a live bird to cross-check against.
         let mut integrity: Option<SharedSnapshot> = None;
+        let mut anyip_installed: Option<Ipv4Addr> = None;
         match route_source {
             Some(RouteSourceConfig::Bmp {
                 listen,
@@ -353,6 +364,7 @@ impl RouteController {
                 router_id,
                 peer_acl,
                 expected_peer_ip,
+                anyip,
             }) => {
                 let snapshot = shared_snapshot();
                 // Spawn the checker only when a LOCAL authority is named.
@@ -381,6 +393,30 @@ impl RouteController {
                     tasks.push(runtime.spawn(async move { checker.run().await }));
                 }
 
+                // `anyip`: claim the phantom listen address before the
+                // first bind so a fresh start binds on attempt one
+                // instead of eating a backoff cycle. The ownership
+                // check inside `ensure_local_route` is the hard gate:
+                // an interface-owned address is an operator error the
+                // paired FRR would reject too, so attach fails loudly
+                // here rather than converging into a feed that can
+                // never establish (same shape as vpp-offload's
+                // refusal of a live loopback IP, #188).
+                let anyip_addr: Option<Ipv4Addr> = if anyip {
+                    let IpAddr::V4(a) = listen.ip() else {
+                        // Config parse rejects `anyip` on non-v4
+                        // listens; reaching here means the parser and
+                        // this code disagree, which is a bug, not an
+                        // operator error.
+                        unreachable!("config parser permits anyip on IPv4 listens only");
+                    };
+                    runtime.block_on(crate::fib::anyip::ensure_local_route(a))?;
+                    Some(a)
+                } else {
+                    None
+                };
+                anyip_installed = anyip_addr;
+
                 // v0.2.2: same retry-with-backoff pattern as BmpStation
                 // above. See that comment for rationale.
                 let mut cfg = BgpListenerConfig::new(listen, local_as, peer_as, router_id);
@@ -401,6 +437,17 @@ impl RouteController {
                 tasks.push(runtime.spawn(async move {
                     let mut backoff = LISTENER_BACKOFF_INITIAL;
                     loop {
+                        // Self-heal the AnyIP route on every listener
+                        // (re)start: a route flushed at runtime comes
+                        // back on the next retry instead of wedging
+                        // the feed until a daemon restart. Warn-only:
+                        // the bind below is the authoritative failure
+                        // signal and drives the same backoff.
+                        if let Some(a) = anyip_addr {
+                            if let Err(e) = crate::fib::anyip::ensure_local_route(a).await {
+                                warn!(error = %e, addr = %a, "anyip: re-ensure failed");
+                            }
+                        }
                         let listener = BgpListener::new(cfg.clone(), prog.clone(), shut.clone())
                             .with_stall_gate(stall.clone());
                         match listener.run().await {
@@ -468,6 +515,7 @@ impl RouteController {
                 integrity_authority,
                 packetframe_common::config::IntegrityAuthoritySpec::None
             ),
+            anyip_addr: anyip_installed,
         })
     }
 
@@ -515,6 +563,7 @@ impl RouteController {
     pub fn shutdown(mut self) {
         self.shutdown_token.cancel();
         if let Some(runtime) = self.runtime.take() {
+            let anyip_addr = self.anyip_addr.take();
             runtime.block_on(async {
                 for task in self.tasks.drain(..) {
                     match tokio::time::timeout(SHUTDOWN_TIMEOUT, task).await {
@@ -528,6 +577,15 @@ impl RouteController {
                                 SHUTDOWN_TIMEOUT.as_secs()
                             );
                         }
+                    }
+                }
+                // After the listener has drained: remove the AnyIP
+                // route this controller installed. Best-effort — an
+                // already-absent route is success — so shutdown never
+                // wedges on kernel state someone else cleaned up.
+                if let Some(a) = anyip_addr {
+                    if let Err(e) = crate::fib::anyip::remove_local_route(a).await {
+                        warn!(error = %e, addr = %a, "anyip: route removal failed during shutdown");
                     }
                 }
             });

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -421,7 +421,10 @@ impl RouteController {
                         // operator error.
                         unreachable!("config parser permits anyip on IPv4 listens only");
                     };
-                    runtime.block_on(crate::fib::anyip::ensure_local_route(a))?;
+                    // Outcome (created vs adopted) is irrelevant here:
+                    // by contract the controller owns the route either
+                    // way once start() returns.
+                    let _ = runtime.block_on(crate::fib::anyip::ensure_local_route(a))?;
                     Some(a)
                 } else {
                     None

--- a/crates/modules/fast-path/src/fib/controller.rs
+++ b/crates/modules/fast-path/src/fib/controller.rs
@@ -642,3 +642,44 @@ impl RouteController {
         self.prog_handle.clone()
     }
 }
+
+/// The §8.5 preserve-attach exit (SIGTERM/SIGINT) drops modules
+/// without calling `detach`, so [`RouteController::shutdown`] never
+/// runs on the *normal* stop path — and the AnyIP route survived
+/// every ordinary `systemctl stop` (review finding, PR #196). The
+/// pins are meant to outlive the process; the AnyIP route is not: it
+/// serves only this daemon's listener, a dead listener answers
+/// nothing on the phantom address anyway, and the next start with
+/// `anyip` re-installs it before the first bind. So Drop removes it.
+///
+/// Ordering matters: the runtime is torn down FIRST so the reconcile
+/// task cannot re-install the route between our removal and process
+/// exit; the removal then runs on a throwaway current-thread runtime.
+/// After an explicit `shutdown()` both fields are already `None` and
+/// this is a no-op. Drop runs on the daemon's signal-loop thread,
+/// never inside a tokio context, so `shutdown_timeout`/`block_on`
+/// here cannot panic on nested-runtime rules.
+impl Drop for RouteController {
+    fn drop(&mut self) {
+        let Some(runtime) = self.runtime.take() else {
+            return; // explicit shutdown() already ran
+        };
+        self.shutdown_token.cancel();
+        runtime.shutdown_timeout(Duration::from_secs(2));
+        if let Some(addr) = self.anyip_addr.take() {
+            match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => {
+                    if let Err(e) = rt.block_on(crate::fib::anyip::remove_local_route(addr)) {
+                        warn!(error = %e, %addr, "anyip: route removal failed during drop");
+                    }
+                }
+                Err(e) => {
+                    warn!(error = %e, %addr, "anyip: no runtime for route removal during drop");
+                }
+            }
+        }
+    }
+}

--- a/crates/modules/fast-path/src/fib/mod.rs
+++ b/crates/modules/fast-path/src/fib/mod.rs
@@ -18,6 +18,8 @@ pub mod types;
 pub mod integrity_status;
 
 #[cfg(target_os = "linux")]
+pub mod anyip;
+#[cfg(target_os = "linux")]
 pub mod controller;
 
 #[cfg(target_os = "linux")]

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1305,11 +1305,22 @@ pub fn attach(
     // here and controller ownership: any later attach failure
     // removes the route on unwind, so no kernel state outlives a
     // failed attach either.
+    // ... and only in the modes that will start a RouteController:
+    // under kernel-fib a route-source is dormant by design, so
+    // installing (then unwinding) the route would be pure noise, and
+    // failing attach on an address conflict would fail a mode the
+    // conflict cannot affect.
     let mut anyip_guard = AnyipUnwindGuard::new(None);
-    if let Some(addr) = anyip_addr_from_cfg(cfg) {
-        crate::fib::anyip::ensure_local_route_blocking(addr)
-            .map_err(|e| ModuleError::other(MODULE_NAME, format!("anyip preflight: {e}")))?;
-        anyip_guard = AnyipUnwindGuard::new(Some(addr));
+    if matches!(
+        forwarding_mode_from_cfg(cfg),
+        packetframe_common::config::ForwardingMode::CustomFib
+            | packetframe_common::config::ForwardingMode::Compare
+    ) {
+        if let Some(addr) = anyip_addr_from_cfg(cfg) {
+            crate::fib::anyip::ensure_local_route_blocking(addr)
+                .map_err(|e| ModuleError::other(MODULE_NAME, format!("anyip preflight: {e}")))?;
+            anyip_guard = AnyipUnwindGuard::new(Some(addr));
+        }
     }
 
     // v0.2.5: load `finalize` first so its FD is available for the

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -742,6 +742,54 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
     })
 }
 
+/// The anyip phantom address, when `route-source bgp ... anyip` is
+/// configured. Config validation guarantees the address parses as
+/// concrete-unicast IPv4, so a parse failure here is a parser/coder
+/// disagreement, not an operator error.
+fn anyip_addr_from_cfg(cfg: &ModuleConfig<'_>) -> Option<std::net::Ipv4Addr> {
+    cfg.section.directives.iter().find_map(|d| match d {
+        ModuleDirective::RouteSource(packetframe_common::config::RouteSourceSpec::Bgp {
+            addr,
+            anyip: true,
+            ..
+        }) => Some(
+            addr.parse::<std::net::Ipv4Addr>()
+                .expect("config parser permits anyip on concrete IPv4 listens only"),
+        ),
+        _ => None,
+    })
+}
+
+/// Removes the anyip route if `attach` unwinds between the preflight
+/// install and the `RouteController` taking ownership. Disarmed on
+/// success; a disarmed guard's Drop is a no-op. Best-effort removal:
+/// the unwind path is already reporting the real error, and a
+/// leftover tagged route is adopted by the next successful start
+/// anyway — this just keeps kernel state from outliving the failed
+/// attach in the common case.
+struct AnyipUnwindGuard {
+    addr: Option<std::net::Ipv4Addr>,
+}
+
+impl AnyipUnwindGuard {
+    fn new(addr: Option<std::net::Ipv4Addr>) -> Self {
+        Self { addr }
+    }
+    fn disarm(&mut self) {
+        self.addr = None;
+    }
+}
+
+impl Drop for AnyipUnwindGuard {
+    fn drop(&mut self) {
+        if let Some(addr) = self.addr.take() {
+            if let Err(e) = crate::fib::anyip::remove_local_route_blocking(addr) {
+                warn!(error = %e, %addr, "anyip: unwind removal failed after attach error");
+            }
+        }
+    }
+}
+
 /// The `route-source` directive as written, if any. Shared by `load`
 /// (records the attach-time answer) and reconcile's restart-only
 /// guard (compares a SIGHUP's answer against it).
@@ -1236,6 +1284,25 @@ pub fn attach(
     completeness: Option<std::sync::Arc<packetframe_common::fib::TableCompleteness>>,
     feed_session: Option<std::sync::Arc<packetframe_common::fib::FeedSession>>,
 ) -> ModuleResult<Vec<Attachment>> {
+    // `anyip` preflight FIRST, before anything attaches or pins: the
+    // refusals inside it (interface-owned address, directed
+    // broadcast, contested route) are operator errors that must not
+    // cost a `detach --all`. When they fired inside
+    // `RouteController::start` — after the per-iface loop and
+    // `pin_program_and_maps` — the failed attach left orphaned pins
+    // and the next start was refused until a manual detach: the
+    // exact crash-loop §8.5's pin persistence is NOT meant to cause
+    // (review finding, PR #196). The guard covers the window between
+    // here and controller ownership: any later attach failure
+    // removes the route on unwind, so no kernel state outlives a
+    // failed attach either.
+    let mut anyip_guard = AnyipUnwindGuard::new(None);
+    if let Some(addr) = anyip_addr_from_cfg(cfg) {
+        crate::fib::anyip::ensure_local_route_blocking(addr)
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("anyip preflight: {e}")))?;
+        anyip_guard = AnyipUnwindGuard::new(Some(addr));
+    }
+
     // v0.2.5: load `finalize` first so its FD is available for the
     // MUTATION_PROGS[0] population below. Order matters: fast_path's
     // tail_call into MUTATION_PROGS[0] must succeed on every packet
@@ -1720,6 +1787,9 @@ pub fn attach(
             info!("fib-cache enabled (destination cache in front of the FIB LPM)");
         }
         state.route_controller = Some(ctrl);
+        // The controller owns the anyip route from here (its
+        // shutdown/Drop removes it); the attach-scope guard must not.
+        anyip_guard.disarm();
         info!(
             ?forwarding,
             "RouteController started (NeighborResolver + FibProgrammer active)"

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1317,9 +1317,18 @@ pub fn attach(
             | packetframe_common::config::ForwardingMode::Compare
     ) {
         if let Some(addr) = anyip_addr_from_cfg(cfg) {
-            crate::fib::anyip::ensure_local_route_blocking(addr)
+            let outcome = crate::fib::anyip::ensure_local_route_blocking(addr)
                 .map_err(|e| ModuleError::other(MODULE_NAME, format!("anyip preflight: {e}")))?;
-            anyip_guard = AnyipUnwindGuard::new(Some(addr));
+            // Arm the unwind only for a route THIS attach created. An
+            // adopted route may be serving a concurrently running
+            // daemon (e.g. a second `run` that will fail on the first
+            // one's pins moments from now) — unwinding it would break
+            // that daemon's live feed until its reconciler heals it
+            // (review finding, PR #196). An adopted-then-failed attach
+            // leaves the route exactly as orphaned as it found it.
+            if outcome == crate::fib::anyip::EnsureOutcome::Created {
+                anyip_guard = AnyipUnwindGuard::new(Some(addr));
+            }
         }
     }
 
@@ -2181,7 +2190,9 @@ fn populate_mutation_progs(ebpf: &mut Ebpf) -> ModuleResult<()> {
 }
 
 /// The parsed `forwarding-mode` directive (default `kernel-fib`).
-fn forwarding_mode_from_cfg(cfg: &ModuleConfig<'_>) -> packetframe_common::config::ForwardingMode {
+pub(crate) fn forwarding_mode_from_cfg(
+    cfg: &ModuleConfig<'_>,
+) -> packetframe_common::config::ForwardingMode {
     cfg.section
         .directives
         .iter()

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -608,6 +608,17 @@ pub struct ActiveState {
     /// it a reload that changes the authority returns OK and changes
     /// nothing — the checker keeps using the old one (review finding).
     pub integrity_authority: packetframe_common::config::IntegrityAuthoritySpec,
+    /// The `route-source` in force, as attach parsed it (`None` when
+    /// no feed is configured). Retained for the same reason
+    /// `integrity_authority` is: the spec is consumed once when the
+    /// `RouteController` is built, so a SIGHUP that edits it — the
+    /// listen address, the ASNs, `anyip` — has nothing to compare
+    /// against unless the attach-time answer is kept. Without this a
+    /// reload changing `anyip` returned OK while the reconcile task
+    /// kept recreating the old route and shutdown still deleted it:
+    /// accepted config contradicting live kernel state (review
+    /// finding, PR #196).
+    pub route_source_spec: Option<packetframe_common::config::RouteSourceSpec>,
 }
 
 /// One XDP attach. `effective_mode` records what actually stuck in
@@ -727,6 +738,19 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
         route_controller: None,
         attach_settle_time: cfg.global.attach_settle_time,
         integrity_authority: integrity_authority_from_cfg(cfg),
+        route_source_spec: route_source_spec_from_cfg(cfg),
+    })
+}
+
+/// The `route-source` directive as written, if any. Shared by `load`
+/// (records the attach-time answer) and reconcile's restart-only
+/// guard (compares a SIGHUP's answer against it).
+pub fn route_source_spec_from_cfg(
+    cfg: &ModuleConfig<'_>,
+) -> Option<packetframe_common::config::RouteSourceSpec> {
+    cfg.section.directives.iter().find_map(|d| match d {
+        ModuleDirective::RouteSource(spec) => Some(spec.clone()),
+        _ => None,
     })
 }
 
@@ -3493,6 +3517,7 @@ mod tests {
             integrity_authority: packetframe_common::config::IntegrityAuthoritySpec::Birdc {
                 path: None,
             },
+            route_source_spec: None,
         };
 
         let bridge_idx = if_nametoindex(BRIDGE).unwrap();

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1537,6 +1537,7 @@ pub fn attach(
                 router_id,
                 peer_from,
                 peer_ip,
+                anyip,
                 allow_remote: _,
             }) => {
                 let listen: std::net::SocketAddr = format!("{addr}:{port}").parse().ok()?;
@@ -1555,6 +1556,7 @@ pub fn attach(
                     router_id: rid,
                     peer_acl: peer_from.clone(),
                     expected_peer_ip: *peer_ip,
+                    anyip: *anyip,
                 })
             }
             _ => None,

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -769,6 +769,48 @@ fn anyip_addr_from_cfg(cfg: &ModuleConfig<'_>) -> Option<std::net::Ipv4Addr> {
         })
 }
 
+/// Advisory exclusive lock serializing the anyip preflight and the
+/// unwind window across concurrent `packetframe run` invocations.
+/// Blocking by design: the loser of a double-start race waits out
+/// the winner's attach (bounded by settle times), then proceeds to
+/// adopt-and-fail cleanly on the winner's pins. The lock file lives
+/// in the state dir beside the pid file; flock is per-open-file, so
+/// dropping the returned handle releases it on every exit path.
+fn acquire_anyip_lock(state_dir: &Path) -> ModuleResult<std::fs::File> {
+    std::fs::create_dir_all(state_dir).map_err(|e| {
+        ModuleError::other(
+            MODULE_NAME,
+            format!("anyip lock: create {}: {e}", state_dir.display()),
+        )
+    })?;
+    let path = state_dir.join("anyip.lock");
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&path)
+        .map_err(|e| {
+            ModuleError::other(
+                MODULE_NAME,
+                format!("anyip lock: open {}: {e}", path.display()),
+            )
+        })?;
+    // SAFETY: valid fd from the just-opened File; flock has no other
+    // preconditions.
+    let rc = unsafe { libc::flock(std::os::fd::AsRawFd::as_raw_fd(&f), libc::LOCK_EX) };
+    if rc != 0 {
+        return Err(ModuleError::other(
+            MODULE_NAME,
+            format!(
+                "anyip lock: flock {}: {}",
+                path.display(),
+                std::io::Error::last_os_error()
+            ),
+        ));
+    }
+    Ok(f)
+}
+
 /// Removes the anyip route if `attach` unwinds between the preflight
 /// install and the `RouteController` taking ownership. Disarmed on
 /// success; a disarmed guard's Drop is a no-op. Best-effort removal:
@@ -1310,6 +1352,9 @@ pub fn attach(
     // installing (then unwinding) the route would be pure noise, and
     // failing attach on an address conflict would fail a mode the
     // conflict cannot affect.
+    // Declared BEFORE the guard so it drops AFTER it: any unwind
+    // removal happens while the lock is still held.
+    let mut _anyip_lock: Option<std::fs::File> = None;
     let mut anyip_guard = AnyipUnwindGuard::new(None);
     if matches!(
         forwarding_mode_from_cfg(cfg),
@@ -1317,6 +1362,15 @@ pub fn attach(
             | packetframe_common::config::ForwardingMode::Compare
     ) {
         if let Some(addr) = anyip_addr_from_cfg(cfg) {
+            // Serialize preflight→ownership across concurrent starts.
+            // Created-vs-Adopted alone cannot transfer ownership
+            // atomically: two clean starts could both preflight
+            // before either pins, the loser's unwind then deleting
+            // the route the winner is serving (review finding,
+            // PR #196). Under the flock — held for the rest of
+            // attach — the second start observes the first's
+            // completed route as Adopted and never arms deletion.
+            _anyip_lock = Some(acquire_anyip_lock(&state.state_dir)?);
             let outcome = crate::fib::anyip::ensure_local_route_blocking(addr)
                 .map_err(|e| ModuleError::other(MODULE_NAME, format!("anyip preflight: {e}")))?;
             // Arm the unwind only for a route THIS attach created. An

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -743,21 +743,30 @@ pub fn load(cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<ActiveS
 }
 
 /// The anyip phantom address, when `route-source bgp ... anyip` is
-/// configured. Config validation guarantees the address parses as
-/// concrete-unicast IPv4, so a parse failure here is a parser/coder
-/// disagreement, not an operator error.
+/// configured. Selects the FIRST `route-source` directive — the same
+/// one every other consumer selects — and answers for it alone; the
+/// parser rejects duplicates, so first-vs-matching can no longer
+/// diverge, but this helper must not be the place that reintroduces
+/// the split if that ever changes. Config validation guarantees the
+/// address parses as concrete-unicast IPv4, so a parse failure here
+/// is a parser/coder disagreement, not an operator error.
 fn anyip_addr_from_cfg(cfg: &ModuleConfig<'_>) -> Option<std::net::Ipv4Addr> {
-    cfg.section.directives.iter().find_map(|d| match d {
-        ModuleDirective::RouteSource(packetframe_common::config::RouteSourceSpec::Bgp {
-            addr,
-            anyip: true,
-            ..
-        }) => Some(
-            addr.parse::<std::net::Ipv4Addr>()
-                .expect("config parser permits anyip on concrete IPv4 listens only"),
-        ),
-        _ => None,
-    })
+    cfg.section
+        .directives
+        .iter()
+        .find_map(|d| match d {
+            ModuleDirective::RouteSource(spec) => Some(spec),
+            _ => None,
+        })
+        .and_then(|spec| match spec {
+            packetframe_common::config::RouteSourceSpec::Bgp {
+                addr, anyip: true, ..
+            } => Some(
+                addr.parse::<std::net::Ipv4Addr>()
+                    .expect("config parser permits anyip on concrete IPv4 listens only"),
+            ),
+            _ => None,
+        })
 }
 
 /// Removes the anyip route if `attach` unwinds between the preflight

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -98,6 +98,35 @@ fn refuse_route_source_change(state: &ActiveState, cfg: &ModuleConfig<'_>) -> Mo
     Ok(())
 }
 
+/// Restart-only guard for forwarding-mode changes that cross the
+/// controller boundary. The RouteController (and with it the BGP/BMP
+/// listener and any anyip route) is created only at attach, only for
+/// custom-fib/compare. A reload crossing that boundary in either
+/// direction produces runtime state a fresh start with the same
+/// config would not: custom→kernel leaves a live controller
+/// recreating an anyip route the config no longer implies; kernel→
+/// custom flips the data-plane flag with no controller to feed it
+/// (review finding, PR #196). Within the boundary — compare↔custom,
+/// the documented cutover flip — reload remains allowed.
+fn refuse_controller_boundary_change(
+    state: &ActiveState,
+    cfg: &ModuleConfig<'_>,
+) -> ModuleResult<()> {
+    let controller_running = state.route_controller.is_some();
+    let wants_controller = matches!(
+        crate::linux_impl::forwarding_mode_from_cfg(cfg),
+        packetframe_common::config::ForwardingMode::CustomFib
+            | packetframe_common::config::ForwardingMode::Compare
+    );
+    if controller_running != wants_controller {
+        return Err(ModuleError::other(
+            MODULE_NAME,
+            "`forwarding-mode` change crosses the route-controller boundary (kernel-fib              on one side, custom-fib/compare on the other); the controller and any anyip              route it owns are built once at attach — restart required:              systemctl stop packetframe && packetframe detach --all && systemctl start",
+        ));
+    }
+    Ok(())
+}
+
 /// Per-map count of entries added and removed during reconcile.
 #[derive(Default, Debug)]
 pub struct DeltaCount {
@@ -108,6 +137,7 @@ pub struct DeltaCount {
 pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
     refuse_integrity_authority_change(state, cfg)?;
     refuse_route_source_change(state, cfg)?;
+    refuse_controller_boundary_change(state, cfg)?;
     reconcile_cfg(state, cfg)?;
     let v4 = reconcile_allow_v4(state, cfg)?;
     let v6 = reconcile_allow_v6(state, cfg)?;

--- a/crates/modules/fast-path/src/reconcile.rs
+++ b/crates/modules/fast-path/src/reconcile.rs
@@ -76,6 +76,28 @@ fn refuse_integrity_authority_change(
         })
 }
 
+/// Restart-only guard for `route-source`. The controller consumes the
+/// spec once at attach; nothing about it — listen endpoint, ASNs,
+/// ACLs, `anyip` — is hot-applied, so a reload that edits it must be
+/// refused rather than reported OK and ignored. `anyip` is the sharp
+/// edge: post-"successful" reload with the flag removed, the
+/// reconcile task would keep recreating a kernel route the accepted
+/// config no longer declares, and shutdown would still delete it
+/// (review finding, PR #196).
+fn refuse_route_source_change(state: &ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+    if state.route_controller.is_none() {
+        return Ok(());
+    }
+    let wanted = crate::linux_impl::route_source_spec_from_cfg(cfg);
+    if state.route_source_spec != wanted {
+        return Err(ModuleError::other(
+            MODULE_NAME,
+            "`route-source` changed; the feed listener (and any anyip route it owns) is              built once at attach and cannot be hot-swapped — restart required:              systemctl stop packetframe && packetframe detach --all && systemctl start",
+        ));
+    }
+    Ok(())
+}
+
 /// Per-map count of entries added and removed during reconcile.
 #[derive(Default, Debug)]
 pub struct DeltaCount {
@@ -85,6 +107,7 @@ pub struct DeltaCount {
 
 pub fn reconcile(state: &mut ActiveState, cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
     refuse_integrity_authority_change(state, cfg)?;
+    refuse_route_source_change(state, cfg)?;
     reconcile_cfg(state, cfg)?;
     let v4 = reconcile_allow_v4(state, cfg)?;
     let v6 = reconcile_allow_v6(state, cfg)?;

--- a/crates/modules/fast-path/tests/anyip_netns.rs
+++ b/crates/modules/fast-path/tests/anyip_netns.rs
@@ -16,6 +16,9 @@
 //!    someone else (foreign route protocol) is refused at ensure and
 //!    survives our remove untouched — the protocol-scoped delete
 //!    cannot match it.
+//! 5. Directed broadcast: the .3 of a configured /30 is refused —
+//!    `Ipv4Addr::is_broadcast()` only knows 255.255.255.255, so the
+//!    gate reads the kernel's Broadcast address attribute instead.
 //!
 //! Runs inside its own netns so the routes and the veth address it
 //! creates never touch the host (qemu VM) tables. Same harness
@@ -148,6 +151,8 @@ fn enter_netns(name: &str) -> File {
 const PHANTOM: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 2);
 /// The interface-owned address, for the refusal test.
 const OWNED: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+/// The directed broadcast of the veth's 192.0.2.1/30.
+const BCAST: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 3);
 /// TEST-NET-2 address for the contested-route test: pre-installed as
 /// a local /32 with a foreign protocol before ensure runs.
 const CONTESTED: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 9);
@@ -206,6 +211,14 @@ fn anyip_refuses_interface_owned_address() {
     match rt.block_on(ensure_local_route(OWNED)) {
         Err(AnyipError::AddressOwned { addr, .. }) => assert_eq!(addr, OWNED),
         other => panic!("expected AddressOwned for {OWNED}, got {other:?}"),
+    }
+
+    // Same netns, same /30: .3 is the directed broadcast of the
+    // veth's 192.0.2.1/30 — `is_broadcast()` can't see it, the
+    // kernel's Broadcast address attribute can.
+    match rt.block_on(ensure_local_route(BCAST)) {
+        Err(AnyipError::DirectedBroadcast { addr, .. }) => assert_eq!(addr, BCAST),
+        other => panic!("expected DirectedBroadcast for {BCAST}, got {other:?}"),
     }
 }
 

--- a/crates/modules/fast-path/tests/anyip_netns.rs
+++ b/crates/modules/fast-path/tests/anyip_netns.rs
@@ -12,6 +12,10 @@
 //! 3. `remove_local_route` returns the address to unbindable, and a
 //!    second removal is success, not error (shutdown must never
 //!    wedge on a route someone else already cleaned up).
+//! 4. Ownership: a same-destination local route installed by
+//!    someone else (foreign route protocol) is refused at ensure and
+//!    survives our remove untouched — the protocol-scoped delete
+//!    cannot match it.
 //!
 //! Runs inside its own netns so the routes and the veth address it
 //! creates never touch the host (qemu VM) tables. Same harness
@@ -144,6 +148,9 @@ fn enter_netns(name: &str) -> File {
 const PHANTOM: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 2);
 /// The interface-owned address, for the refusal test.
 const OWNED: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+/// TEST-NET-2 address for the contested-route test: pre-installed as
+/// a local /32 with a foreign protocol before ensure runs.
+const CONTESTED: Ipv4Addr = Ipv4Addr::new(198, 51, 100, 9);
 
 fn bindable(addr: Ipv4Addr) -> bool {
     TcpListener::bind(SocketAddr::from((addr, 11790))).is_ok()
@@ -200,4 +207,49 @@ fn anyip_refuses_interface_owned_address() {
         Err(AnyipError::AddressOwned { addr, .. }) => assert_eq!(addr, OWNED),
         other => panic!("expected AddressOwned for {OWNED}, got {other:?}"),
     }
+}
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn anyip_refuses_and_never_deletes_foreign_route() {
+    let names = Names::new("c");
+    let _guard = NetnsGuard::setup(&names);
+    let _ns_fd = enter_netns(&names.netns);
+
+    // A foreign owner's AnyIP route: same shape, different protocol
+    // (66 is iproute2-unassigned and != ANYIP_ROUTE_PROTOCOL's 199).
+    run(&[
+        "ip",
+        "route",
+        "add",
+        "local",
+        "198.51.100.9/32",
+        "dev",
+        "lo",
+        "table",
+        "local",
+        "proto",
+        "66",
+    ]);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime");
+
+    // Ensure refuses the contested address instead of replacing it.
+    match rt.block_on(ensure_local_route(CONTESTED)) {
+        Err(AnyipError::RouteContested { addr, .. }) => assert_eq!(addr, CONTESTED),
+        other => panic!("expected RouteContested for {CONTESTED}, got {other:?}"),
+    }
+
+    // Remove is a no-op against the foreign route: the protocol-scoped
+    // delete can't match it, ESRCH is tolerated as success, and the
+    // route keeps delivering (still bindable = still present).
+    rt.block_on(remove_local_route(CONTESTED))
+        .expect("remove tolerates foreign route");
+    assert!(
+        bindable(CONTESTED),
+        "foreign local route must survive our remove untouched"
+    );
 }

--- a/crates/modules/fast-path/tests/anyip_netns.rs
+++ b/crates/modules/fast-path/tests/anyip_netns.rs
@@ -36,7 +36,9 @@ use std::os::fd::AsRawFd;
 use std::process::Command;
 
 use netlink_packet_route::route::RouteType;
-use packetframe_fast_path::fib::anyip::{ensure_local_route, remove_local_route, AnyipError};
+use packetframe_fast_path::fib::anyip::{
+    ensure_local_route, remove_local_route, AnyipError, EnsureOutcome,
+};
 
 // --- Test setup utilities (copied from tests/netns.rs) -----------------
 
@@ -185,10 +187,17 @@ fn anyip_route_lifecycle_makes_phantom_bindable() {
     // Ensure → bindable. Twice, because the controller re-ensures on
     // every listener retry and the second call must be a no-op, not
     // an EEXIST.
-    rt.block_on(ensure_local_route(PHANTOM)).expect("ensure #1");
+    let first = rt.block_on(ensure_local_route(PHANTOM)).expect("ensure #1");
+    assert_eq!(first, EnsureOutcome::Created, "first ensure creates");
     assert!(bindable(PHANTOM), "phantom bindable after ensure");
-    rt.block_on(ensure_local_route(PHANTOM))
+    let second = rt
+        .block_on(ensure_local_route(PHANTOM))
         .expect("ensure #2 (idempotent)");
+    assert_eq!(
+        second,
+        EnsureOutcome::Adopted,
+        "re-ensure adopts our own tagged route"
+    );
     assert!(bindable(PHANTOM), "phantom still bindable after re-ensure");
 
     // Remove → unbindable again. Twice, because shutdown's removal is

--- a/crates/modules/fast-path/tests/anyip_netns.rs
+++ b/crates/modules/fast-path/tests/anyip_netns.rs
@@ -1,0 +1,203 @@
+//! Integration coverage for `fib::anyip` against a real kernel.
+//!
+//! Three properties, each of which failed silently in some ancestor
+//! of this design and can only be proven against a live netlink:
+//!
+//! 1. `ensure_local_route` makes an unassigned address bindable
+//!    (the whole point of AnyIP), and is idempotent (the controller
+//!    calls it before every listener retry).
+//! 2. `ensure_local_route` refuses an interface-owned address — the
+//!    operator error where `anyip` points at a real interface
+//!    address, which the paired FRR would also reject.
+//! 3. `remove_local_route` returns the address to unbindable, and a
+//!    second removal is success, not error (shutdown must never
+//!    wedge on a route someone else already cleaned up).
+//!
+//! Runs inside its own netns so the routes and the veth address it
+//! creates never touch the host (qemu VM) tables. Same harness
+//! conventions as `neigh_resolver_netns.rs`: utilities copied, not
+//! shared, because each `tests/*.rs` is its own crate.
+
+#![cfg(target_os = "linux")]
+
+use std::ffi::CString;
+use std::fs::File;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener};
+use std::os::fd::AsRawFd;
+use std::process::Command;
+
+use packetframe_fast_path::fib::anyip::{ensure_local_route, remove_local_route, AnyipError};
+
+// --- Test setup utilities (copied from tests/netns.rs) -----------------
+
+struct Names {
+    netns: String,
+    veth_a: String,
+    veth_b: String,
+}
+
+impl Names {
+    fn new(tag: &str) -> Self {
+        // PID suffix separates parallel test *binaries*; the tag
+        // separates the `#[test]` fns inside THIS binary, which run
+        // as threads of one process and therefore share a PID — the
+        // collision the first CI run of this file demonstrated.
+        let suffix = format!("{tag}{:x}", std::process::id() & 0xffff);
+        Names {
+            netns: format!("pfany{suffix}"),
+            veth_a: format!("pfA{suffix}"),
+            veth_b: format!("pfB{suffix}"),
+        }
+    }
+}
+
+struct NetnsGuard {
+    name: String,
+}
+
+impl NetnsGuard {
+    fn setup(names: &Names) -> Self {
+        // Best-effort cleanup of a previous crashed run.
+        let _ = Command::new("ip")
+            .args(["netns", "del", &names.netns])
+            .status();
+        run(&["ip", "netns", "add", &names.netns]);
+        ns_run(&names.netns, &["ip", "link", "set", "lo", "up"]);
+        run(&[
+            "ip",
+            "link",
+            "add",
+            &names.veth_a,
+            "netns",
+            &names.netns,
+            "type",
+            "veth",
+            "peer",
+            "name",
+            &names.veth_b,
+            "netns",
+            &names.netns,
+        ]);
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_a, "up"]);
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_b, "up"]);
+        // An interface-owned address for the refusal test.
+        ns_run(
+            &names.netns,
+            &["ip", "addr", "add", "192.0.2.1/30", "dev", &names.veth_a],
+        );
+        NetnsGuard {
+            name: names.netns.clone(),
+        }
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("ip")
+            .args(["netns", "del", &self.name])
+            .status();
+    }
+}
+
+fn run(args: &[&str]) {
+    let status = Command::new(args[0])
+        .args(&args[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("spawn {args:?}: {e}"));
+    assert!(status.success(), "command failed: {args:?}");
+}
+
+fn ns_run(netns: &str, args: &[&str]) {
+    let mut full = vec!["netns", "exec", netns];
+    full.extend_from_slice(args);
+    let status = Command::new("ip")
+        .args(&full)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn ip {full:?}: {e}"));
+    assert!(status.success(), "command failed: ip {full:?}");
+}
+
+/// Move this thread into the netns. The returned File keeps the ns fd
+/// alive; tasks on a current-thread tokio runtime built afterwards
+/// inherit the netns.
+fn enter_netns(name: &str) -> File {
+    let path = format!("/run/netns/{name}");
+    let f = File::open(&path).unwrap_or_else(|e| panic!("open {path}: {e}"));
+    let rc = unsafe { libc::setns(f.as_raw_fd(), libc::CLONE_NEWNET) };
+    assert_eq!(
+        rc,
+        0,
+        "setns({path}) failed: {}",
+        std::io::Error::last_os_error()
+    );
+    // Sanity: prove we're where we think we are.
+    let c = CString::new("/proc/self/ns/net").unwrap();
+    assert!(!c.as_bytes().is_empty());
+    f
+}
+
+// --- The actual tests ---------------------------------------------------
+
+/// The phantom address: inside TEST-NET-1 but NOT assigned anywhere in
+/// the netns (the veth holds .1/30; .2 is the unused host — the exact
+/// shape of the production pf-feed /30).
+const PHANTOM: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 2);
+/// The interface-owned address, for the refusal test.
+const OWNED: Ipv4Addr = Ipv4Addr::new(192, 0, 2, 1);
+
+fn bindable(addr: Ipv4Addr) -> bool {
+    TcpListener::bind(SocketAddr::from((addr, 11790))).is_ok()
+}
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn anyip_route_lifecycle_makes_phantom_bindable() {
+    let names = Names::new("l");
+    let _guard = NetnsGuard::setup(&names);
+    let _ns_fd = enter_netns(&names.netns);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime");
+
+    // Before: the phantom is not bindable (nothing owns it, no route).
+    assert!(
+        !bindable(PHANTOM),
+        "phantom must start unbindable or the test proves nothing"
+    );
+
+    // Ensure → bindable. Twice, because the controller re-ensures on
+    // every listener retry and the second call must be a no-op, not
+    // an EEXIST.
+    rt.block_on(ensure_local_route(PHANTOM)).expect("ensure #1");
+    assert!(bindable(PHANTOM), "phantom bindable after ensure");
+    rt.block_on(ensure_local_route(PHANTOM))
+        .expect("ensure #2 (idempotent)");
+    assert!(bindable(PHANTOM), "phantom still bindable after re-ensure");
+
+    // Remove → unbindable again. Twice, because shutdown's removal is
+    // best-effort by contract and an absent route is success.
+    rt.block_on(remove_local_route(PHANTOM)).expect("remove #1");
+    assert!(!bindable(PHANTOM), "phantom unbindable after remove");
+    rt.block_on(remove_local_route(PHANTOM))
+        .expect("remove #2 (already gone)");
+}
+
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn anyip_refuses_interface_owned_address() {
+    let names = Names::new("o");
+    let _guard = NetnsGuard::setup(&names);
+    let _ns_fd = enter_netns(&names.netns);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio current-thread runtime");
+
+    match rt.block_on(ensure_local_route(OWNED)) {
+        Err(AnyipError::AddressOwned { addr, .. }) => assert_eq!(addr, OWNED),
+        other => panic!("expected AddressOwned for {OWNED}, got {other:?}"),
+    }
+}

--- a/crates/modules/fast-path/tests/anyip_netns.rs
+++ b/crates/modules/fast-path/tests/anyip_netns.rs
@@ -17,8 +17,10 @@
 //!    survives our remove untouched — the protocol-scoped delete
 //!    cannot match it.
 //! 5. Directed broadcast: the .3 of a configured /30 is refused —
-//!    `Ipv4Addr::is_broadcast()` only knows 255.255.255.255, so the
-//!    gate reads the kernel's Broadcast address attribute instead.
+//!    `Ipv4Addr::is_broadcast()` only knows 255.255.255.255, so two
+//!    kernel-driven gates cover it: the IFA_BROADCAST address
+//!    attribute (when the address was added with a broadcast set)
+//!    and the kernel's broadcast route in table local (always).
 //!
 //! Runs inside its own netns so the routes and the veth address it
 //! creates never touch the host (qemu VM) tables. Same harness
@@ -33,6 +35,7 @@ use std::net::{Ipv4Addr, SocketAddr, TcpListener};
 use std::os::fd::AsRawFd;
 use std::process::Command;
 
+use netlink_packet_route::route::RouteType;
 use packetframe_fast_path::fib::anyip::{ensure_local_route, remove_local_route, AnyipError};
 
 // --- Test setup utilities (copied from tests/netns.rs) -----------------
@@ -214,11 +217,20 @@ fn anyip_refuses_interface_owned_address() {
     }
 
     // Same netns, same /30: .3 is the directed broadcast of the
-    // veth's 192.0.2.1/30 — `is_broadcast()` can't see it, the
-    // kernel's Broadcast address attribute can.
+    // veth's 192.0.2.1/30 — `is_broadcast()` can't see it. Either
+    // defensive layer may fire depending on how the address was
+    // added: `ip addr add x/30` without `brd +` leaves the
+    // IFA_BROADCAST attribute unset (so the address walk misses it)
+    // while the kernel still installs the broadcast route (so the
+    // table probe catches it). Both are correct refusals of the
+    // same hazard.
     match rt.block_on(ensure_local_route(BCAST)) {
         Err(AnyipError::DirectedBroadcast { addr, .. }) => assert_eq!(addr, BCAST),
-        other => panic!("expected DirectedBroadcast for {BCAST}, got {other:?}"),
+        Err(AnyipError::RouteKindConflict { addr, kind }) => {
+            assert_eq!(addr, BCAST);
+            assert_eq!(kind, RouteType::Broadcast);
+        }
+        other => panic!("expected a broadcast refusal for {BCAST}, got {other:?}"),
     }
 }
 

--- a/docs/runbooks/custom-fib.md
+++ b/docs/runbooks/custom-fib.md
@@ -123,6 +123,51 @@ If the session is missing:
   bird hasn't logged a session-establishment failure: `journalctl
   -u bird | tail -50`
 
+### Feeding from FRR instead of bird (`anyip`)
+
+FRR cannot use the loopback pairing bird uses, for two reasons
+diagnosed on a live cutover (2026-08-19):
+
+- zebra treats 127/8 as martian: peer NHT never resolves (`show bgp
+  neighbor` reports `Last reset: ... No path to specified Neighbor`,
+  zero packets, zero log lines) and even with NHT satisfied,
+  `bgp_nexthop_set` finds no interface owning 127.0.0.1 and resets
+  the connection before OPEN.
+- FRR refuses `neighbor <addr>` for ANY address its host owns, at
+  config load: `% Can not configure the local system as neighbor`.
+
+So an FRR-fed packetframe listens on a **phantom address**: pick a
+small subnet on an interface that forwards nothing (a bridge with no
+member ports works), give FRR the gateway address, and point
+packetframe at the unused host address with `anyip`:
+
+```
+route-source bgp 10.255.0.2:1179 local-as 401401 peer-as 401401 \
+  allow-remote peer-from 10.255.0.1/32 anyip
+```
+
+`anyip` makes packetframe install `local 10.255.0.2/32 dev lo`
+(kernel AnyIP) before binding and remove it at shutdown, so the
+route's lifetime never exceeds the daemon's and no hand-installed
+kernel state is needed. The FRR side is an ordinary connected
+neighbor:
+
+```
+neighbor 10.255.0.2 remote-as <asn>
+neighbor 10.255.0.2 port 1179
+neighbor 10.255.0.2 update-source 10.255.0.1
+neighbor 10.255.0.2 timers connect 10
+```
+
+Startup refuses an `anyip` address some interface already owns —
+that shape can never establish (FRR would reject the neighbor), so
+failing attach loudly beats converging into a dead feed. Session
+liveness checks are the FRR flavors of the bird ones above:
+`vtysh -c 'show bgp neighbor 10.255.0.2'` should report Established,
+and `ss -Htnp state established "( sport = :1179 )"` one line.
+Remember `integrity-authority none` — there is no birdc to
+cross-check against and the default would fail blind every 300 s.
+
 ### Is a specific prefix forwarding through custom-fib?
 
 ```sh


### PR DESCRIPTION
## Why

FRR cannot use the loopback pairing bird uses, and refuses to peer with any address its host owns — both walls hit live on the 2026-08-19 bird→FRR cutover (edge1-mci1):

- zebra martians 127/8: peer NHT never resolves (`Last reset: No path to specified Neighbor`, zero packets, zero logs), and past NHT, `bgp_nexthop_set` finds no interface owning 127.0.0.1 and resets before OPEN (NOTIFICATION 5/0).
- config load rejects every owned address: `% Can not configure the local system as neighbor`.

The only viable neighbor address is a **phantom** — routed by this host, owned by nothing — which the kernel serves via an AnyIP `local` route. The fleet prohibits hand-installed kernel state (firmware upgrades wipe it), so the daemon must own the route.

## What

`route-source bgp <addr>:<port> ... allow-remote peer-from <cidr> anyip`

- Installs `local <listen>/32 dev lo` (table `local`, proto static) before the listener's first bind; re-ensures on every retry (replace semantics — a flushed route self-heals); removes during controller shutdown. Route lifetime ⊂ daemon lifetime; the config file stays the single durable artifact.
- Hard-refuses an interface-owned address at attach (same shape as #188's live-IP refusal) — that topology can never establish since the paired FRR rejects it too.
- Parse-gated: requires `allow-remote peer-from`, IPv4-only.

## Testing

- Config parse tests (flag, refusals, v6 rejection) — host suite.
- `tests/anyip_netns.rs` (sudo/qemu): phantom bindable after ensure, idempotent re-ensure, unbindable after remove, double-remove is success, interface-owned refusal.
- fmt + host clippy + all four cross-target clippy runs green locally.

Deployment target: `edge1-mci1-net`, where FRR is already parked in Connect against `10.255.0.2:1179` and PF's listener is in bind-retry — this feature is the last link; no further FRR or PF config changes needed after upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)