### PR TITLE
fix(fast-path): proactive resolve must never write neighbours for non-unicast routes

### DIFF
--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -35,7 +35,7 @@ use netlink_packet_core::{NetlinkMessage, NetlinkPayload};
 use netlink_packet_route::{
     link::{LinkAttribute, LinkMessage},
     neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage, NeighbourState},
-    route::RouteAttribute,
+    route::{RouteAttribute, RouteType},
     AddressFamily, RouteNetlinkMessage,
 };
 use rtnetlink::{
@@ -1369,6 +1369,15 @@ impl NetlinkNeighborResolver {
 /// the only cost of a proactive-resolve failure is one-packet latency
 /// on first forward.
 async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
+    // An unspecified nexthop (0.0.0.0 / ::) means "the route is
+    // self-originated" in every BGP dialect that emits it (FRR does,
+    // for locally-originated networks over iBGP). There is no
+    // neighbor to resolve, and the route lookup below would resolve
+    // it to the loopback local route — see the RTN_UNICAST guard.
+    if ip.is_unspecified() {
+        debug!(?ip, "proactive resolve: unspecified nexthop; skipping");
+        return;
+    }
     let (oif, plen) = match ip {
         IpAddr::V4(v4) => {
             let req = RouteMessageBuilder::<IpAddr>::new()
@@ -1417,6 +1426,17 @@ async fn issue_proactive_resolve(handle: &Handle, ip: IpAddr) {
 /// first route returned. Kernel answers via a stream; we only care
 /// about the first entry, subsequent entries for multipath routes
 /// are handled at the programmer level via ECMP groups.
+///
+/// Only an `RTN_UNICAST` result qualifies. Any other kind — local,
+/// broadcast, anycast — means the "nexthop" is an address this box
+/// itself answers for, so there is no neighbor to resolve and the
+/// OIF the kernel reports is `lo`. Writing an `RTM_NEWNEIGH
+/// NUD_NONE` there is not merely useless: it replaces the kernel's
+/// implicit NUD_NOARP handling for that key on the loopback device,
+/// queueing all subsequent local delivery for that address behind an
+/// ARP that can never resolve (2026-08-20 edge1-mci1 incident — the
+/// FRR feed carries nexthop 0.0.0.0 / update-source for
+/// self-originated routes, and each probe of one poisoned `lo`).
 async fn lookup_oif(
     handle: &Handle,
     msg: netlink_packet_route::route::RouteMessage,
@@ -1424,6 +1444,13 @@ async fn lookup_oif(
     let mut routes = handle.route().get(msg).execute();
     match routes.try_next().await {
         Ok(Some(route)) => {
+            if route.header.kind != RouteType::Unicast {
+                debug!(
+                    kind = ?route.header.kind,
+                    "proactive resolve: route is not unicast; no neighbor to resolve"
+                );
+                return None;
+            }
             for attr in route.attributes {
                 if let RouteAttribute::Oif(idx) = attr {
                     return Some(idx);

--- a/crates/modules/fast-path/tests/neigh_resolver_netns.rs
+++ b/crates/modules/fast-path/tests/neigh_resolver_netns.rs
@@ -160,6 +160,23 @@ fn ns_run(netns: &str, cmd: &[&str]) {
     assert!(status.success(), "`ip {}` exited {status}", args.join(" "));
 }
 
+/// Like [`ns_run`] but captures stdout, for `ip neigh show` assertions.
+fn ns_capture(netns: &str, cmd: &[&str]) -> String {
+    let mut args = vec!["netns", "exec", netns];
+    args.extend_from_slice(cmd);
+    let out = Command::new("ip")
+        .args(&args)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn `ip {}`: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "`ip {}` exited {}",
+        args.join(" "),
+        out.status
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
 /// Move the current thread into the netns and return the owned
 /// /var/run/netns/<name> fd. Dropping the fd after the test is fine
 /// the netns itself is torn down via `ip netns del` in NetnsGuard.
@@ -405,6 +422,95 @@ fn resolver_emits_gone_on_neigh_delete() {
             }
         }
         assert!(seen_gone, "expected NeighEvent::Gone for {expected_ip}");
+
+        shutdown.cancel();
+        drop(events_rx);
+        let _ = tokio::time::timeout(Duration::from_secs(2), resolver_task).await;
+    });
+}
+
+/// Regression: 2026-08-20 edge1-mci1 loopback poisoning. FRR's iBGP
+/// feed carries nexthops that are not neighbors at all — 0.0.0.0 for
+/// self-originated routes, and its update-source, an address the box
+/// itself owns. Both route-look-up to the loopback local route, and
+/// `issue_proactive_resolve` used to write `RTM_NEWNEIGH NUD_NONE`
+/// onto `lo` for them, replacing the kernel's implicit NUD_NOARP
+/// handling for that key: every subsequent locally-delivered packet
+/// to that address queued behind an ARP that can never resolve and
+/// was silently dropped (invisible to tcpdump — the drop is before
+/// the dev tap — and to `ip neigh show`, which hides NUD_NONE).
+///
+/// The guard: never probe an unspecified address, and only probe when
+/// the route lookup returns RTN_UNICAST. The control probe proves the
+/// guard didn't disable proactive resolve for real on-link nexthops.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + CAP_SYS_ADMIN; run via sudo -E cargo test -- --ignored"]
+fn proactive_resolve_never_writes_loopback_neighbours() {
+    let names = Names::new();
+    let _guard = NetnsGuard::setup(&names);
+    // lo up, so the local table has the exact shape of a real box
+    // (setup() leaves it down; the poison required live local routes).
+    ns_run(&names.netns, &["ip", "link", "set", "lo", "up"]);
+
+    let netns = names.netns.clone();
+    let veth_a = names.veth_a.clone();
+    let _ns_fd = enter_netns(&names.netns);
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    rt.block_on(async move {
+        let shutdown = CancellationToken::new();
+        let (resolver, events_rx, resolve_handle) = NetlinkNeighborResolver::new(shutdown.clone());
+        let resolver_task = tokio::spawn(resolver.run());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        // The two incident shapes, then a legitimate probe as control.
+        // None of the three is in the startup neigh dump, so all take
+        // the cache-miss path into issue_proactive_resolve.
+        resolve_handle.request_resolve(IpAddr::V4(Ipv4Addr::UNSPECIFIED));
+        resolve_handle.request_resolve(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 254)));
+        resolve_handle.request_resolve(IpAddr::V4(Ipv4Addr::new(198, 51, 100, 77)));
+
+        // Wait until the control probe materializes as a kernel
+        // neighbour entry on veth_a — `nud all` because the entry may
+        // still be in NONE/INCOMPLETE (nobody answers for .77).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let neigh = ns_capture(&netns, &["ip", "neigh", "show", "nud", "all"]);
+            if neigh
+                .lines()
+                .any(|l| l.starts_with("198.51.100.77 ") && l.contains(&veth_a))
+            {
+                break;
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "control probe for 198.51.100.77 never created a neighbour entry \
+                 (guard too broad?); last dump:\n{neigh}"
+            );
+            tokio::time::sleep(Duration::from_millis(200)).await;
+        }
+
+        // With the control probe proven through, the incident shapes
+        // must have left the table — and `lo` — untouched.
+        let neigh = ns_capture(&netns, &["ip", "neigh", "show", "nud", "all"]);
+        for line in neigh.lines() {
+            assert!(
+                !line.contains(" dev lo "),
+                "proactive resolve wrote a loopback neighbour entry: {line}"
+            );
+            assert!(
+                !line.starts_with("0.0.0.0 "),
+                "proactive resolve probed the unspecified address: {line}"
+            );
+            assert!(
+                !line.starts_with("198.51.100.254 "),
+                "proactive resolve probed a box-owned address: {line}"
+            );
+        }
 
         shutdown.cancel();
         drop(events_rx);


### PR DESCRIPTION
## What

Two guards on the proactive-resolve path in `NetlinkNeighborResolver`:

- `issue_proactive_resolve` skips unspecified nexthops (`0.0.0.0` / `::`) — a self-originated route has no neighbour to resolve.
- `lookup_oif` only accepts an `RTN_UNICAST` lookup result. Local / broadcast / anycast means the "nexthop" is an address this box itself answers for, and the OIF the kernel reports for it is `lo`.

Plus a netns regression test (`proactive_resolve_never_writes_loopback_neighbours`) that drives both incident shapes and an on-link control probe through `request_resolve`: `lo` must stay untouched, while the control probe must still create its veth entry — proving the guard doesn't disable proactive resolve for real nexthops.

## Why

2026-08-20 edge1-mci1 incident: the FRR iBGP feed carries nexthops bird never sent — `0.0.0.0` for self-originated routes, and the update-source address the box owns. The resolver route-looked-up each, got the local-table entry with OIF=`lo`, and wrote `RTM_NEWNEIGH NUD_NONE` + `NLM_F_REPLACE` onto the loopback device. That replaces the kernel's implicit NUD_NOARP handling for the key: local delivery queues behind an ARP that can never resolve and is silently dropped in `ip_finish_output2` — before the tcpdump dev tap, with no SNMP counter, invisible to plain `ip neigh show` (which hides `NUD_NONE`), and persisting after daemon stop since neighbour entries outlive the process. IPv4 loopback died box-wide, taking the UniFi management plane (mcad/udapi/inform/DNS/mongo watchdog) with it.

Verified live: `ip neigh show dev lo nud all` on the affected box showed `0.0.0.0 INCOMPLETE` and the route-map v6 nexthop in state NONE; `ip neigh flush dev lo nud all` with the daemon stopped restored loopback delivery immediately.

Not in this slice (tracked separately): BGP keepalive starvation during full-table ingest, and the phantom-nexthop registrations that filled the NEXTHOPS pool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)