### PR TITLE
chore: re-vendor SOURCE.json from the defused VPP release

### DIFF
--- a/crates/modules/vpp-offload/vpp-api/SOURCE.json
+++ b/crates/modules/vpp-offload/vpp-api/SOURCE.json
@@ -7,6 +7,7 @@
   "arch": "arm64",
   "octeon_pmd": "dev_octeon,net_cn10k,net_cn20k,net_cn9k",
   "patches": "none (upstream verbatim)",
-  "built_by": "unredacted/vpp-unifi@ace465ad2b670049caba22b4872a467ab774a8cf",
-  "workflow_run": "https://github.com/unredacted/vpp-unifi/actions/runs/31655421937"
+  "packaging": "etc/sysctl.d/80-vpp.conf removed from the vpp .deb — applied at every boot, its vm.nr_hugepages=1024 is a 512 GiB hugepage request on 64K-page kernels (bricked a 64 GB EFG 2026-08-21); hugepage sizing belongs to the consumer at attach",
+  "built_by": "unredacted/vpp-unifi@8fe485d606a55cefdf225a58b43c292157450fa5",
+  "workflow_run": "https://github.com/unredacted/vpp-unifi/actions/runs/32511309002"
 }


### PR DESCRIPTION
vpp-unifi#4 rebuilt and replaced `vpp-v26.06-octeon9-bullseye-arm64` in place — the vpp .deb no longer ships `etc/sysctl.d/80-vpp.conf`, the boot-time hugepage sysctl that bricked the primary on 2026-08-21. Its manifest gains a `packaging` field recording the single deviation, plus the new `built_by`/`workflow_run`.

CI diffs `SOURCE.json` against the release's `manifest.json` byte-for-byte, so without this re-vendor the next main run goes red by design. Same VPP commit → the api bundle is byte-identical to the vendored copy (verified with `cmp` per file) and `generated.rs` regenerates with an empty diff — **no wire drift; pure paperwork** per the bump procedure in `vpp-api/README.md`.

One file changed: `SOURCE.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)