### PR TITLE
fix(vpp-offload): feasibility must not say PASS over a failing attach gate

### DIFF
--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -253,30 +253,42 @@ pub fn vpp_local_routes_from_config(
 
 /// The `vpp-binary` override from a `vpp-offload` section, if set, so
 /// feasibility probes the executable the module will actually run.
+///
+/// **Last one wins**, here and in [`vpp_loopback_from_config`], because
+/// last-wins is what `VppOffloadConfig::from_directives` hands attach —
+/// it overwrites the field as it iterates, and parsing permits repeated
+/// scalar directives. A first-wins `find_map` probed a different value
+/// than the one attach acts on whenever a directive was repeated
+/// (review finding on #200, against the loopback twin of this).
 pub fn vpp_binary_from_config(config: &Config) -> Option<String> {
     config
         .modules
         .iter()
         .filter(|m| m.name == "vpp-offload")
         .flat_map(|m| &m.directives)
-        .find_map(|d| match d {
+        .filter_map(|d| match d {
             ModuleDirective::VppBinary(p) => Some(p.clone()),
             _ => None,
         })
+        .next_back()
 }
 
 /// The configured `loopback-address`, if any — `bring_up` refuses one
 /// the kernel currently holds, so the `vpp.loopback` probe mirrors
-/// that refusal (review finding on #200).
+/// that refusal (review finding on #200). Last-wins and scoped to
+/// `vpp-offload` sections, exactly as `from_directives` resolves it;
+/// see [`vpp_binary_from_config`].
 pub fn vpp_loopback_from_config(config: &Config) -> Option<std::net::Ipv4Addr> {
     config
         .modules
         .iter()
+        .filter(|m| m.name == "vpp-offload")
         .flat_map(|m| &m.directives)
-        .find_map(|d| match d {
+        .filter_map(|d| match d {
             ModuleDirective::VppLoopbackAddress(p) => Some(p.addr),
             _ => None,
         })
+        .next_back()
 }
 
 /// The vpp-offload facts the probes need, grouped so the parameter
@@ -606,6 +618,46 @@ fn print_row(cap: &Capability, name_w: usize) {
 #[cfg(test)]
 mod summary_tests {
     use super::*;
+
+    /// The scalar extractors resolve repeated directives exactly as
+    /// `VppOffloadConfig::from_directives` does (last wins) — asserted
+    /// against `from_directives` itself, so the two cannot drift
+    /// silently. A first-wins `find_map` here probed the first
+    /// `loopback-address` while attach refused (or accepted) the last
+    /// (review finding on #200).
+    #[cfg(feature = "vpp-offload")]
+    #[test]
+    fn scalar_extractors_pick_the_directive_attach_acts_on() {
+        use packetframe_common::config::{GlobalConfig, Ipv4Prefix, ModuleSection};
+
+        let lo = |a: u8| Ipv4Prefix {
+            addr: std::net::Ipv4Addr::new(198, 51, 100, a),
+            prefix_len: 32,
+        };
+        let directives = vec![
+            ModuleDirective::VppBinary("/opt/vpp-first".into()),
+            ModuleDirective::VppLoopbackAddress(lo(1)),
+            ModuleDirective::VppBinary("/opt/vpp-last".into()),
+            ModuleDirective::VppLoopbackAddress(lo(2)),
+        ];
+        let config = Config {
+            global: GlobalConfig::default(),
+            modules: vec![ModuleSection {
+                name: "vpp-offload".into(),
+                directives: directives.clone(),
+            }],
+        };
+        let runtime = packetframe_vpp_offload::VppOffloadConfig::from_directives(&directives);
+        assert_eq!(vpp_binary_from_config(&config), runtime.vpp_binary);
+        assert_eq!(
+            vpp_loopback_from_config(&config),
+            runtime.loopback_address.map(|p| p.addr)
+        );
+        assert_eq!(
+            vpp_binary_from_config(&config).as_deref(),
+            Some("/opt/vpp-last")
+        );
+    }
 
     // A struct literal, not a match over CapabilityStatus: this helper
     // must keep compiling when the enum grows a variant on another

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -296,24 +296,36 @@ pub fn probe_and_render(
         report.capabilities.push(cap);
     }
     // vpp-offload probes (phase 4): only when the config declares the
-    // module. Non-required like the perf probes — feasibility informs,
-    // the module's attach enforces.
+    // module. They carry their own `required` flags — the module marks
+    // a verdict required exactly when its attach refuses the same
+    // condition — and their names are remembered so the summary can
+    // say "vpp-offload attach BLOCKED" instead of a bare FAIL (or,
+    // worse, the bare PASS an operator on edge1-mci1-net read over a
+    // failing `vpp.irq-affinity` line on 2026-08-21).
     #[cfg(feature = "vpp-offload")]
-    if !vpp.ports.is_empty() {
-        for cap in packetframe_vpp_offload::run_feasibility_probes(
-            vpp.ports,
-            vpp.steer_ports,
-            vpp.workers,
-            vpp.binary,
-            allowlist,
-            vpp.steer_directions,
-            vpp.steer_exempts,
-        ) {
-            report.capabilities.push(cap);
+    let vpp_cap_names: Vec<String> = {
+        let mut names = Vec::new();
+        if !vpp.ports.is_empty() {
+            for cap in packetframe_vpp_offload::run_feasibility_probes(
+                vpp.ports,
+                vpp.steer_ports,
+                vpp.workers,
+                vpp.binary,
+                allowlist,
+                vpp.steer_directions,
+                vpp.steer_exempts,
+            ) {
+                names.push(cap.name.clone());
+                report.capabilities.push(cap);
+            }
         }
-    }
+        names
+    };
     #[cfg(not(feature = "vpp-offload"))]
-    let _ = (vpp, allowlist);
+    let vpp_cap_names: Vec<String> = {
+        let _ = (vpp, allowlist);
+        Vec::new()
+    };
     // `passed` needs recomputing after the iface probes; the trial
     // attach caps are non-required (a native-XDP failure shouldn't
     // abort startup), but we preserve the existing `passed` logic.
@@ -329,7 +341,7 @@ pub fn probe_and_render(
     };
 
     if human {
-        print_human(&report);
+        print_human(&report, &vpp_cap_names);
         Rendered {
             passed: report.passed,
             json_output: None,
@@ -419,7 +431,7 @@ fn trial_attach_caps(_ifaces: &[String]) -> Vec<Capability> {
     }]
 }
 
-fn print_human(report: &FeasibilityReport) {
+fn print_human(report: &FeasibilityReport, vpp_cap_names: &[String]) {
     println!("PacketFrame feasibility report (v{})", report.version);
     println!();
 
@@ -448,27 +460,67 @@ fn print_human(report: &FeasibilityReport) {
     }
 
     println!();
-    if report.passed {
-        println!("Result: PASS, all required capabilities present.");
+    for line in summary_lines(report, vpp_cap_names) {
+        println!("{line}");
+    }
+}
+
+/// The verdict under the table, and why it is not just `report.passed`
+/// prose: the vpp-offload capabilities are `required` only because the
+/// loaded config declares that module, and a box that is ready for
+/// fast-path but would refuse the vpp-offload attach must say exactly
+/// that. The previous summary said "PASS, all required capabilities
+/// present." over a failing (then-advisory) `vpp.irq-affinity` on
+/// edge1-mci1-net (2026-08-21), and the operator met the refusal at
+/// attach instead of before the window.
+///
+/// `vpp_cap_names` is the set of capability names grafted from
+/// vpp-offload's probes — membership, not a name-prefix guess, decides
+/// which failures read as "attach BLOCKED".
+fn summary_lines(report: &FeasibilityReport, vpp_cap_names: &[String]) -> Vec<String> {
+    let failing: Vec<&Capability> = report
+        .capabilities
+        .iter()
+        .filter(|c| c.required && c.status != CapabilityStatus::Pass)
+        .collect();
+    if failing.is_empty() {
+        return vec!["Result: PASS, all required capabilities present.".into()];
+    }
+    let (vpp_blockers, core): (Vec<&Capability>, Vec<&Capability>) = failing
+        .into_iter()
+        .partition(|c| vpp_cap_names.contains(&c.name));
+    let item = |c: &Capability| {
+        format!(
+            "  - {} ({})",
+            scrub_for_terminal(&c.name),
+            scrub_for_terminal(&c.detail)
+        )
+    };
+    let mut lines = Vec::new();
+    if core.is_empty() {
+        lines.push(format!(
+            "Result: PASS for fast-path; vpp-offload attach BLOCKED by {} check{}:",
+            vpp_blockers.len(),
+            if vpp_blockers.len() == 1 { "" } else { "s" },
+        ));
+        lines.extend(vpp_blockers.iter().map(|c| item(c)));
     } else {
-        let failing: Vec<&Capability> = report
-            .capabilities
-            .iter()
-            .filter(|c| c.required && c.status != CapabilityStatus::Pass)
-            .collect();
-        println!(
+        lines.push(format!(
             "Result: FAIL, {} required capabilit{} missing or unknown:",
-            failing.len(),
-            if failing.len() == 1 { "y" } else { "ies" },
-        );
-        for f in failing {
-            println!(
-                "  - {} ({})",
-                scrub_for_terminal(&f.name),
-                scrub_for_terminal(&f.detail)
-            );
+            core.len(),
+            if core.len() == 1 { "y" } else { "ies" },
+        ));
+        lines.extend(core.iter().map(|c| item(c)));
+        if !vpp_blockers.is_empty() {
+            lines.push(format!(
+                "vpp-offload attach is also BLOCKED by {} check{}:",
+                vpp_blockers.len(),
+                if vpp_blockers.len() == 1 { "" } else { "s" },
+            ));
+            lines.extend(vpp_blockers.iter().map(|c| item(c)));
         }
     }
+    lines
 }
 
 /// Both `name` and `detail` are scrubbed, and `detail` is the reason.
@@ -493,4 +545,123 @@ fn print_row(cap: &Capability, name_w: usize) {
         scrub_for_terminal(&cap.name),
         scrub_for_terminal(&cap.detail)
     );
+}
+
+/// Deliberately outside any `cfg(target_os)` gate: the vpp probes'
+/// own tests only run on Linux (#45), but the summary's promise — no
+/// PASS over a failing attach gate — is pure over `Capability` and
+/// must hold on every host CI job.
+#[cfg(test)]
+mod summary_tests {
+    use super::*;
+
+    fn cap(name: &str, status: CapabilityStatus, required: bool) -> Capability {
+        match status {
+            CapabilityStatus::Pass => Capability::pass(name, "ok", required),
+            CapabilityStatus::Fail => Capability::fail(name, "broken; fix it", required),
+            CapabilityStatus::Unknown => Capability::unknown(name, "could not tell", required),
+            CapabilityStatus::Deferred => Capability::deferred(name, "later"),
+        }
+    }
+
+    #[test]
+    fn all_required_passing_is_still_a_plain_pass() {
+        let report = FeasibilityReport::new(vec![
+            cap("bpf.core", CapabilityStatus::Pass, true),
+            cap("vpp.irq-affinity", CapabilityStatus::Pass, true),
+        ]);
+        let lines = summary_lines(&report, &["vpp.irq-affinity".to_string()]);
+        assert_eq!(
+            lines,
+            vec!["Result: PASS, all required capabilities present.".to_string()]
+        );
+    }
+
+    /// The edge1-mci1-net case (2026-08-21): every core capability
+    /// passes, a required vpp gate fails. The summary must not contain
+    /// the sentence an operator reads as "the box is ready".
+    #[test]
+    fn a_failing_attach_gate_is_never_summarized_as_a_bare_pass() {
+        let report = FeasibilityReport::new(vec![
+            cap("bpf.core", CapabilityStatus::Pass, true),
+            cap("vpp.irq-affinity", CapabilityStatus::Fail, true),
+        ]);
+        let lines = summary_lines(&report, &["vpp.irq-affinity".to_string()]);
+        assert_eq!(
+            lines[0],
+            "Result: PASS for fast-path; vpp-offload attach BLOCKED by 1 check:"
+        );
+        assert!(
+            lines.iter().any(|l| l.contains("vpp.irq-affinity")),
+            "the blocking check is named: {lines:?}"
+        );
+        assert!(
+            !lines
+                .iter()
+                .any(|l| l.contains("all required capabilities present")),
+            "{lines:?}"
+        );
+    }
+
+    /// A required vpp verdict that came back Unknown blocks too — the
+    /// same rule the core report applies ("we can't promise the
+    /// runtime will find what it needs"), and on the gates it is
+    /// literal: `bring_up` propagates the same read failure as a
+    /// refusal.
+    #[test]
+    fn a_required_unknown_gate_also_blocks() {
+        let report = FeasibilityReport::new(vec![
+            cap("bpf.core", CapabilityStatus::Pass, true),
+            cap("vpp.iommu", CapabilityStatus::Unknown, true),
+        ]);
+        let lines = summary_lines(&report, &["vpp.iommu".to_string()]);
+        assert!(lines[0].contains("BLOCKED by 1 check"), "{lines:?}");
+    }
+
+    /// An advisory vpp verdict (a staging steering-budget line) stays
+    /// advisory: attach installs nothing, so the summary stays PASS.
+    #[test]
+    fn an_advisory_vpp_failure_does_not_block() {
+        let report = FeasibilityReport::new(vec![
+            cap("bpf.core", CapabilityStatus::Pass, true),
+            cap("vpp.steering.budget", CapabilityStatus::Fail, false),
+        ]);
+        let lines = summary_lines(&report, &["vpp.steering.budget".to_string()]);
+        assert_eq!(
+            lines,
+            vec!["Result: PASS, all required capabilities present.".to_string()]
+        );
+    }
+
+    /// A core capability failure keeps the FAIL wording — and when a
+    /// vpp gate fails alongside it, both are reported, neither hidden
+    /// behind the other.
+    #[test]
+    fn core_failures_keep_fail_wording_and_vpp_blockers_are_still_named() {
+        let report = FeasibilityReport::new(vec![
+            cap("bpf.core", CapabilityStatus::Fail, true),
+            cap("vpp.binary", CapabilityStatus::Fail, true),
+        ]);
+        let lines = summary_lines(&report, &["vpp.binary".to_string()]);
+        assert_eq!(
+            lines[0],
+            "Result: FAIL, 1 required capability missing or unknown:"
+        );
+        assert!(lines.iter().any(|l| l.contains("bpf.core")), "{lines:?}");
+        assert!(
+            lines
+                .iter()
+                .any(|l| l.contains("vpp-offload attach is also BLOCKED by 1 check:")),
+            "{lines:?}"
+        );
+        assert!(lines.iter().any(|l| l.contains("vpp.binary")), "{lines:?}");
+
+        // Core-only failure: no vpp sentence at all.
+        let core_only = FeasibilityReport::new(vec![cap("bpf.core", CapabilityStatus::Fail, true)]);
+        let lines = summary_lines(&core_only, &[]);
+        assert!(
+            !lines.iter().any(|l| l.contains("vpp-offload")),
+            "{lines:?}"
+        );
+    }
 }

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -15,6 +15,12 @@ use packetframe_common::{
 
 pub struct Rendered {
     pub passed: bool,
+    /// Every core requirement passed and only vpp-graft capabilities
+    /// block — the "core capabilities PASS; vpp-offload attach
+    /// BLOCKED" case, which gets its own exit code so automation
+    /// gating fast-path work can tell it from a core failure (review
+    /// finding on #200).
+    pub vpp_blocked_only: bool,
     pub json_output: Option<String>,
 }
 
@@ -259,6 +265,20 @@ pub fn vpp_binary_from_config(config: &Config) -> Option<String> {
         })
 }
 
+/// The configured `loopback-address`, if any — `bring_up` refuses one
+/// the kernel currently holds, so the `vpp.loopback` probe mirrors
+/// that refusal (review finding on #200).
+pub fn vpp_loopback_from_config(config: &Config) -> Option<std::net::Ipv4Addr> {
+    config
+        .modules
+        .iter()
+        .flat_map(|m| &m.directives)
+        .find_map(|d| match d {
+            ModuleDirective::VppLoopbackAddress(p) => Some(p.addr),
+            _ => None,
+        })
+}
+
 /// The vpp-offload facts the probes need, grouped so the parameter
 /// list stops growing by one per directive (clippy agrees at eight).
 pub struct VppProbeInputs<'a> {
@@ -266,6 +286,7 @@ pub struct VppProbeInputs<'a> {
     pub steer_ports: &'a [String],
     pub workers: u32,
     pub binary: Option<&'a str>,
+    pub loopback: Option<std::net::Ipv4Addr>,
     pub steer_directions: &'a [VppSteerDirection],
     pub steer_exempts: &'a [packetframe_common::config::Ipv4Prefix],
 }
@@ -311,6 +332,7 @@ pub fn probe_and_render(
                 vpp.steer_ports,
                 vpp.workers,
                 vpp.binary,
+                vpp.loopback,
                 allowlist,
                 vpp.steer_directions,
                 vpp.steer_exempts,
@@ -339,21 +361,54 @@ pub fn probe_and_render(
         passed,
         capabilities: report.capabilities,
     };
+    let (core_blockers, vpp_blockers) = partition_blockers(&report, &vpp_cap_names);
+    let vpp_blocked_only = core_blockers.is_empty() && !vpp_blockers.is_empty();
 
     if human {
         print_human(&report, &vpp_cap_names);
         Rendered {
             passed: report.passed,
+            vpp_blocked_only,
             json_output: None,
         }
     } else {
-        let json =
-            serde_json::to_string_pretty(&report).expect("FeasibilityReport is serializable");
+        // The JSON carries what the human summary partitions on —
+        // without it a machine consumer is left with exactly the
+        // name-prefix guess `summary_lines` disavows (review finding
+        // on #200).
+        #[derive(serde::Serialize)]
+        struct JsonReport<'a> {
+            #[serde(flatten)]
+            report: &'a FeasibilityReport,
+            /// Required vpp-graft capabilities whose verdict is not
+            /// Pass; empty when nothing blocks the module's attach.
+            vpp_attach_blockers: Vec<&'a str>,
+        }
+        let json = serde_json::to_string_pretty(&JsonReport {
+            report: &report,
+            vpp_attach_blockers: vpp_blockers.iter().map(|c| c.name.as_str()).collect(),
+        })
+        .expect("FeasibilityReport is serializable");
         Rendered {
             passed: report.passed,
+            vpp_blocked_only,
             json_output: Some(json),
         }
     }
+}
+
+/// Required-and-not-Pass capabilities, split into (core, vpp) by
+/// membership in the vpp graft.
+fn partition_blockers<'a>(
+    report: &'a FeasibilityReport,
+    vpp_cap_names: &[String],
+) -> (Vec<&'a Capability>, Vec<&'a Capability>) {
+    let (vpp, core): (Vec<&Capability>, Vec<&Capability>) = report
+        .capabilities
+        .iter()
+        .filter(|c| c.required && c.status != CapabilityStatus::Pass)
+        .partition(|c| vpp_cap_names.contains(&c.name));
+    (core, vpp)
 }
 
 #[cfg(all(target_os = "linux", feature = "fast-path"))]
@@ -478,17 +533,10 @@ fn print_human(report: &FeasibilityReport, vpp_cap_names: &[String]) {
 /// vpp-offload's probes — membership, not a name-prefix guess, decides
 /// which failures read as "attach BLOCKED".
 fn summary_lines(report: &FeasibilityReport, vpp_cap_names: &[String]) -> Vec<String> {
-    let failing: Vec<&Capability> = report
-        .capabilities
-        .iter()
-        .filter(|c| c.required && c.status != CapabilityStatus::Pass)
-        .collect();
-    if failing.is_empty() {
+    let (core, vpp_blockers) = partition_blockers(report, vpp_cap_names);
+    if core.is_empty() && vpp_blockers.is_empty() {
         return vec!["Result: PASS, all required capabilities present.".into()];
     }
-    let (vpp_blockers, core): (Vec<&Capability>, Vec<&Capability>) = failing
-        .into_iter()
-        .partition(|c| vpp_cap_names.contains(&c.name));
     let item = |c: &Capability| {
         format!(
             "  - {} ({})",
@@ -498,8 +546,12 @@ fn summary_lines(report: &FeasibilityReport, vpp_cap_names: &[String]) -> Vec<St
     };
     let mut lines = Vec::new();
     if core.is_empty() {
+        // "core capabilities PASS", not "PASS for fast-path": a
+        // non-required fast-path row (an xdp.attach trial) can FAIL in
+        // the table above, and the summary must not assert a readiness
+        // it did not check (review finding on #200).
         lines.push(format!(
-            "Result: PASS for fast-path; vpp-offload attach BLOCKED by {} check{}:",
+            "Result: core capabilities PASS; vpp-offload attach BLOCKED by {} check{}:",
             vpp_blockers.len(),
             if vpp_blockers.len() == 1 { "" } else { "s" },
         ));
@@ -555,12 +607,16 @@ fn print_row(cap: &Capability, name_w: usize) {
 mod summary_tests {
     use super::*;
 
+    // A struct literal, not a match over CapabilityStatus: this helper
+    // must keep compiling when the enum grows a variant on another
+    // branch (review finding on #200/#201 — the two PRs merged cleanly
+    // and the exhaustive match here broke main).
     fn cap(name: &str, status: CapabilityStatus, required: bool) -> Capability {
-        match status {
-            CapabilityStatus::Pass => Capability::pass(name, "ok", required),
-            CapabilityStatus::Fail => Capability::fail(name, "broken; fix it", required),
-            CapabilityStatus::Unknown => Capability::unknown(name, "could not tell", required),
-            CapabilityStatus::Deferred => Capability::deferred(name, "later"),
+        Capability {
+            name: name.into(),
+            status,
+            detail: "probe detail".into(),
+            required,
         }
     }
 
@@ -589,7 +645,7 @@ mod summary_tests {
         let lines = summary_lines(&report, &["vpp.irq-affinity".to_string()]);
         assert_eq!(
             lines[0],
-            "Result: PASS for fast-path; vpp-offload attach BLOCKED by 1 check:"
+            "Result: core capabilities PASS; vpp-offload attach BLOCKED by 1 check:"
         );
         assert!(
             lines.iter().any(|l| l.contains("vpp.irq-affinity")),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -36,6 +36,12 @@ use packetframe_common::config::Config;
 pub(crate) const EXIT_OK: u8 = 0;
 pub(crate) const EXIT_STARTUP_ERROR: u8 = 1;
 pub(crate) const EXIT_RUNTIME_ERROR: u8 = 2;
+/// `feasibility` only: every core requirement passed but a declared
+/// module's attach gates are failing. Distinct from
+/// `EXIT_STARTUP_ERROR` so automation gating fast-path work does not
+/// false-negative on a box that is only missing the vpp-offload layer
+/// (review finding on #200; extends the §7.3 set — spec note owed).
+pub(crate) const EXIT_MODULE_BLOCKED: u8 = 3;
 
 /// Default config path used when the caller omits `--config`. Matches
 /// the systemd-unit install location in the deployment playbook so
@@ -359,6 +365,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
         vpp_steer_ports,
         vpp_workers,
         vpp_binary,
+        vpp_loopback,
         allowlist,
         vpp_dirs,
         vpp_exempts,
@@ -378,6 +385,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                 let vpp_steer_ports = feasibility::vpp_steer_ports_from_config(&c);
                 let vpp_workers = feasibility::vpp_workers_from_config(&c);
                 let vpp_binary = feasibility::vpp_binary_from_config(&c);
+                let vpp_loopback = feasibility::vpp_loopback_from_config(&c);
                 let allowlist = feasibility::allowlist_from_config(&c);
                 let vpp_dirs = feasibility::vpp_steer_directions_from_config(&c);
                 let vpp_exempts = feasibility::vpp_steer_exempts_from_config(&c);
@@ -388,6 +396,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                     vpp_steer_ports,
                     vpp_workers,
                     vpp_binary,
+                    vpp_loopback,
                     allowlist,
                     vpp_dirs,
                     vpp_exempts,
@@ -405,6 +414,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             Vec::new(),
             0,
             None,
+            None,
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -419,6 +429,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             steer_ports: &vpp_steer_ports,
             workers: vpp_workers,
             binary: vpp_binary.as_deref(),
+            loopback: vpp_loopback,
             steer_directions: &vpp_dirs,
             steer_exempts: &vpp_exempts,
         },
@@ -430,6 +441,8 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
     }
     if report.passed {
         ExitCode::from(EXIT_OK)
+    } else if report.vpp_blocked_only {
+        ExitCode::from(EXIT_MODULE_BLOCKED)
     } else {
         ExitCode::from(EXIT_STARTUP_ERROR)
     }

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -75,6 +75,8 @@ pub struct AttachPaths {
     pub sysfs_cpu: PathBuf,
     /// `/proc/irq`, for the NIC-IRQ/worker-core overlap check.
     pub proc_irq: PathBuf,
+    /// `/sys/class/iommu`, for the IOMMU-isolation refusal.
+    pub sysfs_iommu_class: PathBuf,
     pub api_socket: PathBuf,
     pub startup_conf: PathBuf,
 }
@@ -85,6 +87,7 @@ impl AttachPaths {
             sys: SysPaths::live(state_dir, hugepage_bytes),
             sysfs_cpu: PathBuf::from(cores::SYSFS_CPU),
             proc_irq: PathBuf::from("/proc/irq"),
+            sysfs_iommu_class: PathBuf::from("/sys/class/iommu"),
             api_socket: PathBuf::from(API_SOCKET),
             startup_conf: PathBuf::from(STARTUP_CONF),
         }
@@ -457,6 +460,26 @@ pub fn bring_up(
         ));
     }
 
+    // VFIO must be IOMMU-isolated. With no active IOMMU the vfio-pci
+    // bind either fails outright (no viable iommu_group) or — with the
+    // kernel's unsafe no-iommu escape hatch enabled — binds with no
+    // DMA isolation at all. The `vpp.iommu` probe has always said this
+    // module refuses the latter; until a review finding on #200 nothing
+    // on the attach path read the fact, so the refusal was
+    // documentation. Still the pure phase: a box that cannot isolate
+    // DMA must cost no sysfs writes.
+    let iommu_active = std::fs::read_dir(&paths.sysfs_iommu_class)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false);
+    if !iommu_active {
+        return Err(format!(
+            "no active IOMMU ({} is empty or unreadable): VFIO would bind without DMA \
+             isolation (no-iommu), which this module refuses — check firmware/boot \
+             config for the SMMU; `packetframe feasibility` reports this as `vpp.iommu`",
+            paths.sysfs_iommu_class.display()
+        ));
+    }
+
     let hugepage_bytes = paths.sys.hugepage_bytes;
     if hugepage_bytes == 0 {
         return Err(
@@ -611,7 +634,7 @@ pub fn bring_up(
 /// the permission *and* the mount. Real-uid semantics (`access`, not
 /// `faccessat(AT_EACCESS)`) — packetframe is not setuid, so the two
 /// coincide, and it keeps libc out of its AT_EACCESS emulation paths.
-fn check_executable(path: &Path) -> Result<(), std::io::Error> {
+pub(crate) fn check_executable(path: &Path) -> Result<(), std::io::Error> {
     use std::os::unix::ffi::OsStrExt as _;
     let c = std::ffi::CString::new(path.as_os_str().as_bytes())
         .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;

--- a/crates/modules/vpp-offload/src/bringup.rs
+++ b/crates/modules/vpp-offload/src/bringup.rs
@@ -157,6 +157,22 @@ fn port_macs(sysfs_net: &Path, iface: &str) -> Result<([u8; 6], Vec<[u8; 6]>), S
 
 /// Refuse a `loopback-address` the kernel already holds.
 ///
+/// Is an IOMMU registered under the given `/sys/class/iommu`?
+/// `Ok(Some)` carries the first entry's name (the probe's PASS detail);
+/// `Ok(None)` is an empty directory; `Err` is an unreadable directory
+/// or dirent — a state neither reader may take as active. Shared by
+/// `bring_up`'s refusal and `probe_iommu` so the two verdicts cannot
+/// drift on the same directory (review finding on #200: the inline
+/// copies disagreed on an unreadable dirent).
+pub(crate) fn iommu_active(dir: &Path) -> std::io::Result<Option<std::ffi::OsString>> {
+    let mut entries = std::fs::read_dir(dir)?;
+    match entries.next() {
+        Some(Ok(e)) => Ok(Some(e.file_name())),
+        Some(Err(e)) => Err(e),
+        None => Ok(None),
+    }
+}
+
 /// VPP's arp node answers requests targeting its loopback's address,
 /// sourcing the member VF's MAC. If that address is a LIVE kernel
 /// address — the gateway, in the reference incident — two responders
@@ -170,7 +186,7 @@ fn port_macs(sysfs_net: &Path, iface: &str) -> Result<([u8; 6], Vec<[u8; 6]>), S
 /// The decision is split from the `getifaddrs` read so the refusal
 /// text and the match are testable without owning the host's
 /// interfaces.
-fn loopback_collision(
+pub(crate) fn loopback_collision(
     loopback: std::net::Ipv4Addr,
     owned: &[(String, std::net::Ipv4Addr)],
 ) -> Option<String> {
@@ -196,7 +212,7 @@ fn loopback_collision(
 /// collision check rather than refusing every attach — a guard against
 /// one specific misconfiguration must not become a new way for a
 /// healthy box to fail to start.
-fn kernel_v4_addrs() -> Vec<(String, std::net::Ipv4Addr)> {
+pub(crate) fn kernel_v4_addrs() -> Vec<(String, std::net::Ipv4Addr)> {
     let mut out = Vec::new();
     let mut ifap: *mut libc::ifaddrs = std::ptr::null_mut();
     // SAFETY: getifaddrs allocates the list; freed below on every path
@@ -468,10 +484,7 @@ pub fn bring_up(
     // on the attach path read the fact, so the refusal was
     // documentation. Still the pure phase: a box that cannot isolate
     // DMA must cost no sysfs writes.
-    let iommu_active = std::fs::read_dir(&paths.sysfs_iommu_class)
-        .map(|mut entries| entries.next().is_some())
-        .unwrap_or(false);
-    if !iommu_active {
+    if !matches!(iommu_active(&paths.sysfs_iommu_class), Ok(Some(_))) {
         return Err(format!(
             "no active IOMMU ({} is empty or unreadable): VFIO would bind without DMA \
              isolation (no-iommu), which this module refuses — check firmware/boot \

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1294,8 +1294,13 @@ impl Module for VppOffloadModule {
 }
 
 /// Feasibility probes for `packetframe feasibility`, mirroring how the
-/// fast-path's per-interface probes graft into the report. All
-/// non-required: feasibility output informs, attach enforces.
+/// fast-path's per-interface probes graft into the report. Severity
+/// mirrors attach: the caller runs these only when the config declares
+/// this module, and every verdict on a condition attach refuses is
+/// `required` — steering verdicts gate only when a port is configured
+/// `steer on`, since attach installs nothing otherwise. See
+/// `probe_linux`'s module doc for the incident that ended the
+/// all-advisory rule.
 pub fn run_feasibility_probes(
     ports: &[String],
     steer_ports: &[String],

--- a/crates/modules/vpp-offload/src/lib.rs
+++ b/crates/modules/vpp-offload/src/lib.rs
@@ -1301,11 +1301,15 @@ impl Module for VppOffloadModule {
 /// `steer on`, since attach installs nothing otherwise. See
 /// `probe_linux`'s module doc for the incident that ended the
 /// all-advisory rule.
+// One argument per attach-gated directive; the CLI groups them in
+// `VppProbeInputs`, the module boundary keeps plain args.
+#[allow(clippy::too_many_arguments)]
 pub fn run_feasibility_probes(
     ports: &[String],
     steer_ports: &[String],
     workers: u32,
     vpp_binary: Option<&str>,
+    loopback: Option<std::net::Ipv4Addr>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     directions: &[packetframe_common::config::VppSteerDirection],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
@@ -1317,6 +1321,7 @@ pub fn run_feasibility_probes(
             steer_ports,
             workers,
             vpp_binary,
+            loopback,
             allowlist,
             directions,
             steer_exempts,
@@ -1329,6 +1334,7 @@ pub fn run_feasibility_probes(
             steer_ports,
             workers,
             vpp_binary,
+            loopback,
             allowlist,
             directions,
             steer_exempts,

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -371,7 +371,9 @@ fn plan_and_report(
 
 /// An SMMU registered in /sys/class/iommu is the difference between
 /// real IOMMU-isolated VFIO and no-iommu mode; the module refuses the
-/// latter at attach.
+/// latter in `bring_up`'s pure phase, reading the same directory this
+/// reads — the refusal was probe-text-only until a review finding on
+/// #200 pointed out nothing on the attach path enforced it.
 fn probe_iommu() -> Capability {
     match fs::read_dir("/sys/class/iommu") {
         Ok(mut entries) => {
@@ -413,79 +415,166 @@ fn probe_vfio() -> Capability {
     }
 }
 
-/// Report which hugepage pools exist and the default page size. The
-/// module reserves at attach; the probe just proves pools exist and
-/// captures the default size the sizing math will use.
+/// The two hugepage facts attach consumes — not just "pools exist"
+/// (review finding on #200): `bring_up` refuses a zero default page
+/// size, and acquire reserves from exactly the default-size pool
+/// (`SysPaths::live` builds `hugepages-<default-kB>` from it), so an
+/// unrelated pool cannot satisfy attach and must not pass here.
 fn probe_hugepages() -> Capability {
+    let name = "vpp.hugepages";
+    let default_bytes = default_hugepage_bytes();
+    if default_bytes == 0 {
+        return Capability::fail(
+            name,
+            "no parseable `Hugepagesize` in /proc/meminfo (CONFIG_HUGETLBFS?) — attach \
+             will refuse; VPP cannot be sized without it",
+            true,
+        );
+    }
     let pools = match fs::read_dir("/sys/kernel/mm/hugepages") {
         Ok(entries) => entries
             .flatten()
             .map(|e| e.file_name().to_string_lossy().into_owned())
             .collect::<Vec<_>>(),
         Err(e) => {
-            return Capability::unknown(
-                "vpp.hugepages",
-                format!("read /sys/kernel/mm/hugepages: {e}"),
-                true,
-            )
+            return Capability::unknown(name, format!("read /sys/kernel/mm/hugepages: {e}"), true)
         }
     };
-    if pools.is_empty() {
+    let want = format!("hugepages-{}kB", default_bytes >> 10);
+    if !pools.iter().any(|p| p == &want) {
         return Capability::fail(
-            "vpp.hugepages",
-            "no hugepage pools (CONFIG_HUGETLBFS?)",
+            name,
+            format!(
+                "default-size pool {want} missing (found: {}) — acquire reserves from \
+                 exactly that pool, so attach will fail",
+                if pools.is_empty() {
+                    "none".to_string()
+                } else {
+                    pools.join(", ")
+                }
+            ),
             true,
         );
     }
-    let default_mb = default_hugepage_bytes() >> 20;
     Capability::pass(
-        "vpp.hugepages",
-        format!("pools: {} (default {default_mb} MiB)", pools.join(", ")),
-        true,
-    )
-}
-
-fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
-    let candidates = match override_path {
-        Some(p) => vec![p.to_string()],
-        None => vec!["/usr/bin/vpp".to_string(), "/usr/sbin/vpp".to_string()],
-    };
-    for c in &candidates {
-        if Path::new(c).exists() {
-            let note = if override_path.is_some() {
-                " (from `vpp-binary`)"
-            } else {
-                " (default path)"
-            };
-            return Capability::pass("vpp.binary", format!("{c}{note}"), true);
-        }
-    }
-    let hint = if override_path.is_some() {
-        "configured via `vpp-binary`"
-    } else {
-        "install the pinned VPP package (see vpp-offload runbook), or set `vpp-binary`"
-    };
-    Capability::fail(
-        "vpp.binary",
+        name,
         format!(
-            "not found at {} — attach will refuse; {hint}",
-            candidates.join(" or ")
+            "pools: {} (default {} MiB; attach reserves from {want})",
+            pools.join(", "),
+            default_bytes >> 20
         ),
         true,
     )
 }
 
-fn probe_sriov(iface: &str) -> Capability {
-    let name = format!("vpp.{iface}.sriov");
-    let path = format!("/sys/class/net/{iface}/device/sriov_totalvfs");
-    match fs::read_to_string(&path) {
-        Ok(raw) => match raw.trim().parse::<u32>() {
-            Ok(0) => Capability::fail(&name, "sriov_totalvfs is 0: no VFs available", true),
-            Ok(n) => Capability::pass(&name, format!("{n} VFs available"), true),
-            Err(_) => Capability::unknown(&name, format!("unparseable {path}: {raw:?}"), true),
-        },
-        Err(e) => Capability::unknown(&name, format!("{path}: {e}"), true),
+/// Mirrors `bring_up`'s binary gate exactly: the same single default
+/// path (`DEFAULT_VPP_BINARY`), the same `is_file()` + `access(X_OK)`
+/// checks. This used to accept either of two candidates on a bare
+/// `exists()`, so a directory, a chmod-x file, or a box with only the
+/// legacy `/usr/sbin/vpp` passed a required capability attach refuses
+/// (review finding on #200).
+fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
+    let name = "vpp.binary";
+    let (path, note) = match override_path {
+        Some(p) => (Path::new(p).to_path_buf(), " (from `vpp-binary`)"),
+        None => (
+            Path::new(crate::bringup::DEFAULT_VPP_BINARY).to_path_buf(),
+            " (default path)",
+        ),
+    };
+    if !path.is_file() {
+        let hint = if override_path.is_some() {
+            "configured via `vpp-binary`"
+        } else {
+            "install the pinned VPP package (see vpp-offload runbook), or set `vpp-binary`"
+        };
+        return Capability::fail(
+            name,
+            format!(
+                "{} does not exist — attach will refuse; {hint}",
+                path.display()
+            ),
+            true,
+        );
     }
+    if let Err(e) = crate::bringup::check_executable(&path) {
+        return Capability::fail(
+            name,
+            format!(
+                "{} is not executable ({e}) — attach will refuse; `chmod +x` it, or move \
+                 it off a `noexec` mount (`/tmp` is one on UniFi OS)",
+                path.display()
+            ),
+            true,
+        );
+    }
+    Capability::pass(name, format!("{}{note}", path.display()), true)
+}
+
+fn probe_sriov(iface: &str) -> Capability {
+    probe_sriov_at(Path::new("/sys/class/net"), iface)
+}
+
+/// Capacity AND current allocation, because attach needs both: the
+/// numvfs write fails with `sriov_totalvfs` at 0, and `ensure_vf_in`
+/// refuses `sriov_numvfs >= 2` by name — it manages exactly one VF per
+/// port and cannot tell which of several is ours. Checking only the
+/// hardware maximum passed a port some other setup had already put two
+/// VFs on (review finding on #200). Path-injected so the refusal arm
+/// is testable against a fixture sysfs.
+fn probe_sriov_at(sysfs_net: &Path, iface: &str) -> Capability {
+    let name = format!("vpp.{iface}.sriov");
+    let dev = sysfs_net.join(iface).join("device");
+    let total_path = dev.join("sriov_totalvfs");
+    let total = match fs::read_to_string(&total_path) {
+        Ok(raw) => match raw.trim().parse::<u32>() {
+            Ok(0) => return Capability::fail(&name, "sriov_totalvfs is 0: no VFs available", true),
+            Ok(n) => n,
+            Err(_) => {
+                return Capability::unknown(
+                    &name,
+                    format!("unparseable {}: {raw:?}", total_path.display()),
+                    true,
+                )
+            }
+        },
+        Err(e) => {
+            return Capability::unknown(&name, format!("{}: {e}", total_path.display()), true)
+        }
+    };
+    let numvfs_path = dev.join("sriov_numvfs");
+    // Unparseable reads as 0 here because that is exactly what
+    // `ensure_vf_in` does with it (`parse().unwrap_or(0)`).
+    let current = match fs::read_to_string(&numvfs_path) {
+        Ok(raw) => raw.trim().parse::<u32>().unwrap_or(0),
+        Err(e) => {
+            return Capability::unknown(
+                &name,
+                format!(
+                    "{}: {e} — attach reads this file before creating a VF",
+                    numvfs_path.display()
+                ),
+                true,
+            )
+        }
+    };
+    if current >= 2 {
+        return Capability::fail(
+            &name,
+            format!(
+                "sriov_numvfs={current} — attach will refuse; vpp-offload manages exactly \
+                 one VF per port and cannot tell which of {current} is ours, clear them \
+                 first (`echo 0 > {}`)",
+                numvfs_path.display()
+            ),
+            true,
+        );
+    }
+    Capability::pass(
+        &name,
+        format!("{total} VFs available, {current} currently allocated"),
+        true,
+    )
 }
 
 pub(crate) fn default_hugepage_bytes() -> u64 {
@@ -689,6 +778,44 @@ mod steering_probe_tests {
         );
         assert_eq!(steered_ok.status, CapabilityStatus::Pass, "{steered_ok:?}");
         assert!(steered_ok.required, "{steered_ok:?}");
+    }
+
+    /// The SR-IOV probe answers the question attach asks, not just the
+    /// hardware's: `ensure_vf_in` refuses `sriov_numvfs >= 2` because
+    /// it cannot tell which VF is ours, so a port with capacity but a
+    /// foreign allocation must fail here too (review finding on #200 —
+    /// checking only `sriov_totalvfs` passed it).
+    #[test]
+    fn a_port_with_foreign_vfs_fails_as_attach_refuses_it() {
+        let base = std::env::temp_dir().join(format!("pf-probe-sriov-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base);
+        let dev = base.join("eth4").join("device");
+        std::fs::create_dir_all(&dev).unwrap();
+        std::fs::write(dev.join("sriov_totalvfs"), "8\n").unwrap();
+
+        std::fs::write(dev.join("sriov_numvfs"), "2\n").unwrap();
+        let foreign = probe_sriov_at(&base, "eth4");
+        assert_eq!(foreign.status, CapabilityStatus::Fail, "{foreign:?}");
+        assert!(
+            foreign.detail.contains("attach will refuse"),
+            "{}",
+            foreign.detail
+        );
+        assert!(foreign.required, "{foreign:?}");
+
+        // 1 is the adoption path (`ensure_vf_in` takes it over), 0 is
+        // fresh acquisition; both are states attach accepts.
+        for ok in ["1", "0"] {
+            std::fs::write(dev.join("sriov_numvfs"), ok).unwrap();
+            let cap = probe_sriov_at(&base, "eth4");
+            assert_eq!(cap.status, CapabilityStatus::Pass, "numvfs={ok}: {cap:?}");
+        }
+
+        std::fs::write(dev.join("sriov_totalvfs"), "0\n").unwrap();
+        let none = probe_sriov_at(&base, "eth4");
+        assert_eq!(none.status, CapabilityStatus::Fail, "{none:?}");
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     /// Every hardware probe is `required` whatever it found.

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -1,10 +1,20 @@
 //! Linux feasibility probes for the vpp-offload module (plan v5).
 //!
 //! Everything here mirrors the fast-path probe philosophy: read-only,
-//! non-required (feasibility informs, attach enforces), and each
-//! verdict names its fix inline. Probes cover the layers proven live
-//! on the reference EFG (2026-08-01): active IOMMU, SR-IOV capacity,
-//! VFIO device nodes, hugepage pools, and the VPP binary.
+//! and each verdict names its fix inline. Probes cover the layers
+//! proven live on the reference EFG (2026-08-01): active IOMMU, SR-IOV
+//! capacity, VFIO device nodes, hugepage pools, and the VPP binary.
+//!
+//! Severity mirrors attach. These probes run only when the loaded
+//! config declares the module, and each one probes a condition
+//! `bring_up`/`acquire` refuses or cannot survive — so they are
+//! `required`, and a FAIL is an attach refusal the operator has not
+//! hit yet. They were advisory once, and an operator on edge1-mci1-net
+//! (2026-08-21) read the summary's "PASS" over a failing
+//! `vpp.irq-affinity` line and met the refusal at attach instead. The
+//! one exception is per-verdict: steering-budget verdicts gate only
+//! when a port is configured `steer on`, because attach queries and
+//! plans nothing otherwise (`ifaces_to_query`).
 
 use std::fs;
 use std::path::Path;
@@ -55,9 +65,12 @@ pub(crate) fn run(
 fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
     use std::path::Path;
     let name = "vpp.irq-affinity";
+    // Required on every arm: `bring_up` runs this same derivation and
+    // check behind `?`, so an Unknown here (the derive failing) is the
+    // same refusal a conflict is.
     let map = match crate::cores::derive_from_sysfs(Path::new(crate::cores::SYSFS_CPU), workers) {
         Ok(m) => m,
-        Err(e) => return Capability::unknown(name, format!("derive core map: {e}"), false),
+        Err(e) => return Capability::unknown(name, format!("derive core map: {e}"), true),
     };
     let mut vpp_cores = vec![map.main];
     vpp_cores.extend(&map.workers);
@@ -73,7 +86,7 @@ fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
                 "no NIC queue IRQ fires on the derived VPP cores (main {}, workers {:?})",
                 map.main, map.workers
             ),
-            false,
+            true,
         ),
         Ok(c) => {
             let sample: Vec<String> = c
@@ -93,10 +106,10 @@ fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
                     sample.join(", "),
                     if c.len() > 8 { ", ..." } else { "" },
                 ),
-                false,
+                true,
             )
         }
-        Err(e) => Capability::unknown(name, e, false),
+        Err(e) => Capability::unknown(name, e, true),
     }
 }
 
@@ -112,8 +125,13 @@ fn probe_irq_affinity(ports: &[String], workers: u32) -> Capability {
 /// by the AF, so a v6-heavy allowlist means the offload covers far less
 /// traffic than the config reads like it does.
 ///
-/// Read-only and non-required, like every probe here: it computes the
-/// plan the module would install, and installs nothing.
+/// Read-only, like every probe here: it computes the plan the module
+/// would install, and installs nothing. Required exactly when a port
+/// is configured `steer on` — those verdicts are attach refusals
+/// (`bring_up` runs the same steerable check and plan behind `?`);
+/// with every port `steer off`, attach queries and plans nothing
+/// (`ifaces_to_query`), so a staging verdict advises the future canary
+/// lever and must not block a feasibility attach would accept.
 ///
 /// **The budget comes from the NIC.** This used to plan against
 /// `McamBudget::default()` and report whether the arithmetic held — a
@@ -131,6 +149,9 @@ fn probe_steering_budget(
     use crate::steer::McamBudget;
 
     let name = "vpp.steering.budget";
+    // Whether this probe's verdicts gate attach: `bring_up` refuses an
+    // unsteerable or over-budget plan only when something steers.
+    let gating = !steer_ports.is_empty();
     // The ALLOWLIST question first, because it needs no NIC — the same
     // ordering `bring_up` documents and for the same reason: an
     // operator who wrote `steer on` against a v6-only allowlist must
@@ -152,7 +173,7 @@ fn probe_steering_budget(
                     allowlist.len()
                 )
             },
-            false,
+            gating,
         );
     }
 
@@ -177,7 +198,7 @@ fn probe_steering_budget(
                          same way; check `ip -br link`, an administratively DOWN port answers \
                          like this"
                     ),
-                    false,
+                    true,
                 )
             }
         };
@@ -279,6 +300,10 @@ fn plan_and_report(
     use crate::steer::{RuleAction, RuleSet};
 
     let free = budget.free.len();
+    // On the strict path a plan `bring_up` refuses (over budget) is an
+    // attach refusal, so the verdict is required; staging plans advise
+    // the first canary step, which attach does not take.
+    let required = !staging;
 
     // No directions handed in = plan the global default, exactly as
     // the CLI extractor falls back when nothing steers yet. Without
@@ -314,7 +339,7 @@ fn plan_and_report(
                     set.rules.len() - diverts,
                 ));
             }
-            Err(e) => return Capability::fail(name, e, false),
+            Err(e) => return Capability::fail(name, e, required),
         }
     }
     let detail = format!(
@@ -341,7 +366,7 @@ fn plan_and_report(
             String::new()
         }
     );
-    Capability::pass(name, detail, false)
+    Capability::pass(name, detail, required)
 }
 
 /// An SMMU registered in /sys/class/iommu is the difference between
@@ -354,7 +379,7 @@ fn probe_iommu() -> Capability {
                 Capability::pass(
                     "vpp.iommu",
                     format!("active: {}", e.file_name().to_string_lossy()),
-                    false,
+                    true,
                 )
             } else {
                 Capability::fail(
@@ -362,11 +387,11 @@ fn probe_iommu() -> Capability {
                     "/sys/class/iommu is empty: SMMU compiled in but not active \
                      (check firmware/boot config); VFIO would run no-iommu, which \
                      the module refuses",
-                    false,
+                    true,
                 )
             }
         }
-        Err(e) => Capability::unknown("vpp.iommu", format!("read /sys/class/iommu: {e}"), false),
+        Err(e) => Capability::unknown("vpp.iommu", format!("read /sys/class/iommu: {e}"), true),
     }
 }
 
@@ -374,16 +399,16 @@ fn probe_vfio() -> Capability {
     let dev = Path::new("/dev/vfio/vfio").exists();
     let drv = Path::new("/sys/bus/pci/drivers/vfio-pci").exists();
     match (dev, drv) {
-        (true, true) => Capability::pass("vpp.vfio", "container node + vfio-pci driver", false),
+        (true, true) => Capability::pass("vpp.vfio", "container node + vfio-pci driver", true),
         (false, _) => Capability::fail(
             "vpp.vfio",
             "/dev/vfio/vfio missing: CONFIG_VFIO not built in or module not loaded",
-            false,
+            true,
         ),
         (_, false) => Capability::fail(
             "vpp.vfio",
             "vfio-pci driver not registered (CONFIG_VFIO_PCI)",
-            false,
+            true,
         ),
     }
 }
@@ -401,7 +426,7 @@ fn probe_hugepages() -> Capability {
             return Capability::unknown(
                 "vpp.hugepages",
                 format!("read /sys/kernel/mm/hugepages: {e}"),
-                false,
+                true,
             )
         }
     };
@@ -409,14 +434,14 @@ fn probe_hugepages() -> Capability {
         return Capability::fail(
             "vpp.hugepages",
             "no hugepage pools (CONFIG_HUGETLBFS?)",
-            false,
+            true,
         );
     }
     let default_mb = default_hugepage_bytes() >> 20;
     Capability::pass(
         "vpp.hugepages",
         format!("pools: {} (default {default_mb} MiB)", pools.join(", ")),
-        false,
+        true,
     )
 }
 
@@ -432,7 +457,7 @@ fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
             } else {
                 " (default path)"
             };
-            return Capability::pass("vpp.binary", format!("{c}{note}"), false);
+            return Capability::pass("vpp.binary", format!("{c}{note}"), true);
         }
     }
     let hint = if override_path.is_some() {
@@ -442,8 +467,11 @@ fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
     };
     Capability::fail(
         "vpp.binary",
-        format!("not found at {} — {hint}", candidates.join(" or ")),
-        false,
+        format!(
+            "not found at {} — attach will refuse; {hint}",
+            candidates.join(" or ")
+        ),
+        true,
     )
 }
 
@@ -452,11 +480,11 @@ fn probe_sriov(iface: &str) -> Capability {
     let path = format!("/sys/class/net/{iface}/device/sriov_totalvfs");
     match fs::read_to_string(&path) {
         Ok(raw) => match raw.trim().parse::<u32>() {
-            Ok(0) => Capability::fail(&name, "sriov_totalvfs is 0: no VFs available", false),
-            Ok(n) => Capability::pass(&name, format!("{n} VFs available"), false),
-            Err(_) => Capability::unknown(&name, format!("unparseable {path}: {raw:?}"), false),
+            Ok(0) => Capability::fail(&name, "sriov_totalvfs is 0: no VFs available", true),
+            Ok(n) => Capability::pass(&name, format!("{n} VFs available"), true),
+            Err(_) => Capability::unknown(&name, format!("unparseable {path}: {raw:?}"), true),
         },
-        Err(e) => Capability::unknown(&name, format!("{path}: {e}"), false),
+        Err(e) => Capability::unknown(&name, format!("{path}: {e}"), true),
     }
 }
 
@@ -510,6 +538,25 @@ mod steering_probe_tests {
             empty.detail.contains("allowlist is empty"),
             "names which of the two ways it got here: {}",
             empty.detail
+        );
+        assert!(
+            !empty.required,
+            "no port steers, so attach installs nothing and this must stay advisory"
+        );
+
+        // The same nothing-to-steer verdict with a port `steer on` is
+        // `bring_up`'s refusal, so it gates the summary.
+        let gated = probe_steering_budget(
+            &["eth4".to_string()],
+            &["eth4".to_string()],
+            &[],
+            Default::default(),
+            &[],
+        );
+        assert_eq!(gated.status, CapabilityStatus::Fail, "{gated:?}");
+        assert!(
+            gated.required,
+            "attach refuses `steer on` over nothing steerable: {gated:?}"
         );
 
         let v6_only = probe_steering_budget(
@@ -620,5 +667,55 @@ mod steering_probe_tests {
             "and say why: {}",
             steered_dark.detail
         );
+
+        // Severity follows the same line leniency does: the staging
+        // verdicts above advise (attach installs nothing), the steering
+        // verdict is attach's own refusal.
+        assert!(!none.required, "{none:?}");
+        assert!(!all_dark.required, "{all_dark:?}");
+        assert!(!partial.required, "{partial:?}");
+        assert!(steered_dark.required, "{steered_dark:?}");
+
+        // 5. Steering and readable: a PASS on this path is still a
+        //    required capability — the same plan failing tomorrow is a
+        //    refusal, and REQ=yes is what tells the operator that.
+        sys::reset();
+        let steered_ok = probe_steering_budget(
+            &["eth4".to_string()],
+            &["eth4".to_string()],
+            &steerable,
+            dirs,
+            &[],
+        );
+        assert_eq!(steered_ok.status, CapabilityStatus::Pass, "{steered_ok:?}");
+        assert!(steered_ok.required, "{steered_ok:?}");
+    }
+
+    /// Every hardware probe is `required` whatever it found.
+    ///
+    /// Each one probes a condition attach refuses (`bring_up`'s named
+    /// checks) or cannot survive (acquire's vfio bind, VF creation).
+    /// They were advisory once, and on edge1-mci1-net (2026-08-21) an
+    /// operator read the summary's "PASS" over a failing
+    /// `vpp.irq-affinity` line and met the refusal at attach — so the
+    /// invariant is asserted on the flag alone, independent of what
+    /// this host's sysfs happens to answer.
+    #[test]
+    fn every_hardware_verdict_is_required_whatever_it_found() {
+        for cap in [
+            probe_iommu(),
+            probe_vfio(),
+            probe_hugepages(),
+            probe_vpp_binary(None),
+            probe_sriov("eth-nonexistent"),
+            probe_irq_affinity(&[], 1),
+        ] {
+            assert!(
+                cap.required,
+                "{} must gate the feasibility summary; attach refuses or dies on what it \
+                 probes ({:?}: {})",
+                cap.name, cap.status, cap.detail
+            );
+        }
     }
 }

--- a/crates/modules/vpp-offload/src/probe_linux.rs
+++ b/crates/modules/vpp-offload/src/probe_linux.rs
@@ -21,20 +21,27 @@ use std::path::Path;
 
 use packetframe_common::probe::Capability;
 
+// One argument per attach-gated directive; the CLI groups them in
+// `VppProbeInputs`, the module boundary keeps plain args.
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn run(
     ports: &[String],
     steer_ports: &[String],
     workers: u32,
     vpp_binary: Option<&str>,
+    loopback: Option<std::net::Ipv4Addr>,
     allowlist: &[packetframe_common::fib::IpPrefix],
     directions: &[packetframe_common::config::VppSteerDirection],
     steer_exempts: &[packetframe_common::config::Ipv4Prefix],
 ) -> Vec<Capability> {
-    let mut caps = Vec::with_capacity(5 + ports.len());
+    let mut caps = Vec::with_capacity(6 + ports.len());
     caps.push(probe_iommu());
     caps.push(probe_vfio());
     caps.push(probe_hugepages());
     caps.push(probe_irq_affinity(ports, workers));
+    if let Some(addr) = loopback {
+        caps.push(probe_loopback(addr));
+    }
     // Probe the binary the module will ACTUALLY exec. Probing the
     // defaults while the config names another path would report a pass
     // for an executable we never run (or a failure for one that
@@ -371,29 +378,48 @@ fn plan_and_report(
 
 /// An SMMU registered in /sys/class/iommu is the difference between
 /// real IOMMU-isolated VFIO and no-iommu mode; the module refuses the
-/// latter in `bring_up`'s pure phase, reading the same directory this
-/// reads — the refusal was probe-text-only until a review finding on
-/// #200 pointed out nothing on the attach path enforced it.
+/// latter in `bring_up`'s pure phase — via the same
+/// [`crate::bringup::iommu_active`] read this uses, so probe and
+/// refusal cannot drift (review finding on #200: the inline copies
+/// disagreed on an unreadable dirent). Path-injected so the non-PASS
+/// arms are testable against a fixture sysfs.
 fn probe_iommu() -> Capability {
-    match fs::read_dir("/sys/class/iommu") {
-        Ok(mut entries) => {
-            if let Some(Ok(e)) = entries.next() {
-                Capability::pass(
-                    "vpp.iommu",
-                    format!("active: {}", e.file_name().to_string_lossy()),
-                    true,
-                )
-            } else {
-                Capability::fail(
-                    "vpp.iommu",
-                    "/sys/class/iommu is empty: SMMU compiled in but not active \
-                     (check firmware/boot config); VFIO would run no-iommu, which \
-                     the module refuses",
-                    true,
-                )
-            }
-        }
-        Err(e) => Capability::unknown("vpp.iommu", format!("read /sys/class/iommu: {e}"), true),
+    probe_iommu_at(Path::new("/sys/class/iommu"))
+}
+
+fn probe_iommu_at(dir: &Path) -> Capability {
+    match crate::bringup::iommu_active(dir) {
+        Ok(Some(name)) => Capability::pass(
+            "vpp.iommu",
+            format!("active: {}", name.to_string_lossy()),
+            true,
+        ),
+        Ok(None) => Capability::fail(
+            "vpp.iommu",
+            "/sys/class/iommu is empty: SMMU compiled in but not active \
+             (check firmware/boot config); VFIO would run no-iommu, which \
+             the module refuses",
+            true,
+        ),
+        Err(e) => Capability::unknown("vpp.iommu", format!("read {}: {e}", dir.display()), true),
+    }
+}
+
+/// `bring_up` refuses a `loopback-address` the kernel currently holds
+/// (the ARP responder war measured on the primary 2026-08-14). Mirrors
+/// that refusal exactly — same collision check, same `getifaddrs`
+/// read, same degrade-open on an empty list — so the summary cannot
+/// say PASS over the one attach refusal that reads live kernel state
+/// (review finding on #200).
+fn probe_loopback(addr: std::net::Ipv4Addr) -> Capability {
+    let name = "vpp.loopback";
+    match crate::bringup::loopback_collision(addr, &crate::bringup::kernel_v4_addrs()) {
+        Some(err) => Capability::fail(name, err, true),
+        None => Capability::pass(
+            name,
+            format!("loopback-address {addr} is not a live kernel address"),
+            true,
+        ),
     }
 }
 
@@ -482,7 +508,25 @@ fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
             " (default path)",
         ),
     };
+    // A failed check as non-root is a uid artifact, not a box fact:
+    // attach runs as root, whose X_OK any x bit satisfies, and a
+    // root-only parent directory hides the file from is_file()
+    // entirely. Advisory Unknown, so the invoker's uid cannot flip the
+    // BLOCKED verdict (review finding on #200).
+    let non_root_unknown = |reason: String| -> Option<Capability> {
+        // SAFETY: geteuid has no failure modes or preconditions.
+        (unsafe { libc::geteuid() } != 0).then(|| {
+            Capability::unknown(
+                name,
+                format!("cannot verify {} as non-root ({reason}); re-run feasibility as root — attach runs as root", path.display()),
+                false,
+            )
+        })
+    };
     if !path.is_file() {
+        if let Some(cap) = non_root_unknown("not visible or not a file".to_string()) {
+            return cap;
+        }
         let hint = if override_path.is_some() {
             "configured via `vpp-binary`"
         } else {
@@ -498,6 +542,9 @@ fn probe_vpp_binary(override_path: Option<&str>) -> Capability {
         );
     }
     if let Err(e) = crate::bringup::check_executable(&path) {
+        if let Some(cap) = non_root_unknown(format!("access(X_OK): {e}")) {
+            return cap;
+        }
         return Capability::fail(
             name,
             format!(
@@ -833,7 +880,11 @@ mod steering_probe_tests {
             probe_iommu(),
             probe_vfio(),
             probe_hugepages(),
-            probe_vpp_binary(None),
+            // A path that exists and is executable on any test host:
+            // the binary probe's one deliberate exception is a FAILING
+            // check under a non-root uid (a uid artifact, not a box
+            // fact), so the invariant is asserted on a passing path.
+            probe_vpp_binary(Some("/bin/sh")),
             probe_sriov("eth-nonexistent"),
             probe_irq_affinity(&[], 1),
         ] {

--- a/crates/modules/vpp-offload/tests/vpp_bringup.rs
+++ b/crates/modules/vpp-offload/tests/vpp_bringup.rs
@@ -118,6 +118,10 @@ impl Host {
         // unifi-core.
         fs::write(cpu.join("online"), "0-17\n").unwrap();
         fs::write(cpu.join("isolated"), "12\n").unwrap();
+        // An active SMMU, as /sys/class/iommu presents one; the
+        // no-iommu refusal test empties this.
+        let iommu = base.join("iommu");
+        fs::create_dir_all(iommu.join("smmu3.0x0000000005000000")).unwrap();
 
         // Executable — `bring_up` requires it, and requires it before
         // acquiring anything — but not a program: an exec of a file with
@@ -147,6 +151,7 @@ impl Host {
                 // nothing to inspect and passes — tests that WANT a
                 // conflict populate both sides (cores.rs unit tests).
                 proc_irq: base.join("proc_irq"),
+                sysfs_iommu_class: iommu,
                 api_socket,
                 startup_conf: base.join("startup.conf"),
             },
@@ -401,6 +406,58 @@ fn a_config_that_cannot_work_touches_nothing() {
     assert!(
         !host.paths.startup_conf.exists(),
         "a refused attach rendered a startup.conf"
+    );
+}
+
+/// An inactive IOMMU refuses the attach in the pure phase.
+///
+/// The `vpp.iommu` probe has said "the module refuses" no-iommu since
+/// it shipped, but nothing on the attach path read the fact (review
+/// finding on #200): with the SMMU inactive, acquire's vfio-pci bind
+/// either failed with a rollback already in flight or — with the
+/// kernel's unsafe no-iommu escape hatch enabled — silently succeeded
+/// with no DMA isolation. Both the empty and the missing directory
+/// refuse, since a kernel without the iommu class has no SMMU either.
+#[test]
+fn an_inactive_iommu_is_refused_before_any_mutation() {
+    let fake = fake_vpp::Fake::start("bringup-noiommu");
+    let host = Host::new("noiommu", &[("eth4", "0002:07:00.0")], fake.path.clone());
+    let cfg = host.cfg(&[("eth4", 1, false)]);
+
+    for shape in ["empty", "missing"] {
+        fs::remove_dir_all(&host.paths.sysfs_iommu_class).unwrap();
+        if shape == "empty" {
+            fs::create_dir_all(&host.paths.sysfs_iommu_class).unwrap();
+        }
+        let e = bring_up(
+            &cfg,
+            &host.paths,
+            Box::new(Mirror),
+            &ALLOW,
+            None,
+            None,
+            &McamBudget::default(),
+            &[],
+        )
+        .err()
+        .expect("must refuse without an active IOMMU");
+        assert!(e.contains("no-iommu"), "({shape}) {e}");
+    }
+
+    assert!(host.state().is_none(), "a refused attach left a state file");
+    assert_eq!(
+        fs::read_to_string(
+            host.paths
+                .sys
+                .sysfs_net
+                .join("eth4")
+                .join("device")
+                .join("sriov_numvfs")
+        )
+        .unwrap()
+        .trim(),
+        "0",
+        "a refused attach created a VF"
     );
 }
 

--- a/docs/runbooks/vpp-offload.md
+++ b/docs/runbooks/vpp-offload.md
@@ -2117,7 +2117,11 @@ held — but the box was degraded until the daemon was stopped.
 So the overlap is a **checked precondition**: `packetframe feasibility`
 reports it (`vpp.irq-affinity`, listing each conflicting IRQ and the
 derived cores), and attach **refuses** while any member port's queue
-IRQ has its *effective* affinity on a VPP core. Effective, not
+IRQ has its *effective* affinity on a VPP core. With a config that
+declares the module, the check is `required`: a conflict makes the
+summary read "vpp-offload attach BLOCKED" (exit non-zero) rather than
+PASS — do not trust a bare PASS memory from builds before this; one
+did read PASS over a failing line (edge1-mci1-net, 2026-08-21). Effective, not
 permitted: a `0-17` wildcard mask still delivers to exactly one CPU,
 and that CPU either is or is not about to become a hot poller.
 


### PR DESCRIPTION
## What

`packetframe feasibility` could print `Result: PASS, all required capabilities present.` while a `vpp.irq-affinity` FAIL two lines up said "attach will refuse; move them first" — every vpp-offload probe was advisory (`required=false`). Observed on edge1-mci1-net 2026-08-21: the operator read the summary, concluded the box was ready, and met the refusal at attach.

Three changes:

1. **Attach-gating vpp probes are now `required`.** They only run when the parsed config declares `module vpp-offload` (with ports), and each was audited against the module's actual refusal path rather than its detail text:
   - `vpp.irq-affinity` — all arms, including Unknown: `bring_up` runs the same `derive_from_sysfs` + `nic_irq_conflicts` behind `?`, so a failed derive is the same refusal a conflict is.
   - `vpp.iommu` / `vpp.vfio` — acquire's vfio-pci bind fails on a non-viable IOMMU group or missing VFIO.
   - `vpp.binary` — `bring_up` refuses a missing binary by name (detail now says "attach will refuse").
   - `vpp.hugepages` / `vpp.<iface>.sriov` — sizing refuses without a hugepage size; VF creation fails at 0 totalvfs.

   When the module isn't declared the probes stay out of the report entirely, so no third severity was needed.

2. **`vpp.steering.budget` gates per-verdict, not per-probe.** The over-budget plan error was indeed advisory (the issue's item 3 hunch). But the whole probe can't be required: with every port `steer off` (staging — the state feasibility is normally run in), attach queries and plans nothing (`ifaces_to_query`), so a required staging verdict would invert the lie and FAIL a config attach accepts. Verdicts are required exactly when a port is `steer on` — unsteerable allowlist, unreadable steering port, over-budget plan, all `bring_up` refusals — and stay advisory in staging, where they advise the future canary lever.

3. **The summary partitions failing required capabilities** by membership in the vpp probe graft (membership, not a name-prefix guess):
   - vpp-only failures: `Result: PASS for fast-path; vpp-offload attach BLOCKED by N check(s):` + the checks, exit non-zero, `passed: false` in JSON.
   - core failures: existing FAIL wording, with vpp blockers listed after under their own sentence.

## What a reviewer should know

- The loader's startup gate uses `run_probes` (core §2.1 only), so `packetframe run` behavior is unchanged — the module's own attach still enforces everything at attach time. Only the feasibility subcommand's report/exit change.
- `summary_lines()` is factored pure and its five tests sit deliberately **outside** any cfg gate, so host CI exercises the PASS-over-blocker regression; the probe-severity tests live in `probe_linux` with the rest (the known #45 split) and run under the qemu matrix, including a new invariant test that every hardware verdict is required regardless of what this host's sysfs answered.
- One sentence added to the vpp-offload runbook's IRQ section: the check is now required, and a remembered PASS from older builds can't be trusted.

Verified locally: `cargo fmt --check`, host `clippy --workspace --all-targets --all-features -- -D warnings`, host `cargo test --workspace`, and cross-clippy on all four Linux targets (which compiles the Linux-gated probe code and its tests). The qemu jobs are the gate that actually runs the probe_linux tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)