### PR TITLE
build(deps): bump rtnetlink 0.22 + netlink-packet-route 0.32 as one slice

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,24 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     groups:
+      # The rust-netlink stack moves in lockstep: rtnetlink re-exports
+      # netlink-packet-route types, so bumping either alone splits the
+      # workspace into two incompatible copies of the crate and every
+      # build job fails E0308 (PRs #194/#195). Group them at every
+      # update-type so the bump always arrives as one mergeable PR.
+      netlink:
+        update-types: ["patch", "minor", "major"]
+        patterns:
+          - "rtnetlink"
+          - "netlink-*"
       # Batch patch/minor ecosystem churn (serde, anyhow, clap etc.)
       # into one weekly PR. Major bumps land as individual PRs.
       userspace-minor:
         update-types: ["patch", "minor"]
         exclude-patterns:
           - "aya*"
+          - "rtnetlink"
+          - "netlink-*"
     ignore:
       # aya stack is pinned tight per SPEC.md §7.1. Still gets updates
       # proposed — they just go through as individual PRs (no grouping).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "98e26a74571b93d1d52a9a5582e7c47aa9464dde57a17ea9841795eef45febd9"
 dependencies = [
  "bitflags",
  "libc",
@@ -842,9 +842,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rtnetlink"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc19f84f710fa2f337617f9bc0400260a94224bde7bae28fd8879f3771ca5784"
+checksum = "ee647c6484f6a1515dba20d2cc884b11bf5d79fcdc7f0defdf18e3620f52c18c"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -854,7 +854,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,8 +76,8 @@ tokio-util = { version = "0.7", default-features = false }
 # pull directly for message parsing where rtnetlink's helpers don't
 # cover what we need. Both pinned tight — rtnetlink has had message-
 # shape changes across minor versions and we rely on specific constants.
-rtnetlink = "0.21"
-netlink-packet-route = "0.30"
+rtnetlink = "0.22"
+netlink-packet-route = "0.32"
 netlink-packet-core = "0.8"
 futures = "0.3"
 # BMP parser for Option F Phase 3's RouteSource. Supports RFC 7854

--- a/crates/modules/fast-path/src/fib/netlink_neigh.rs
+++ b/crates/modules/fast-path/src/fib/netlink_neigh.rs
@@ -1658,9 +1658,7 @@ fn extract_fdb_master(attrs: &[NeighbourAttribute]) -> Option<u32> {
 
 /// v0.2.9: AF_BRIDGE RTM_GETNEIGH dump — the bridge FDB. Returns
 /// `(master, MAC) → port ifindex` for masters in `parents`. Same
-/// dedicated-unicast-connection pattern as [`dump_neighbours`];
-/// `message_mut()` overrides the family because rtnetlink's typed
-/// `set_family` only speaks v4/v6.
+/// dedicated-unicast-connection pattern as [`dump_neighbours`].
 async fn dump_fdb(
     parents: &std::collections::HashSet<u32>,
 ) -> Result<HashMap<(u32, [u8; 6]), u32>, NeighError> {
@@ -1669,9 +1667,11 @@ async fn dump_fdb(
     tokio::spawn(connection);
 
     let mut out: HashMap<(u32, [u8; 6]), u32> = HashMap::new();
-    let mut req = handle.neighbours().get();
-    req.message_mut().header.family = AddressFamily::Bridge;
-    let mut entries = req.execute();
+    let mut entries = handle
+        .neighbours()
+        .get()
+        .set_address_family(AddressFamily::Bridge)
+        .execute();
     while let Some(msg) = entries
         .try_next()
         .await

--- a/crates/modules/vpp-offload/src/drift.rs
+++ b/crates/modules/vpp-offload/src/drift.rs
@@ -762,13 +762,7 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
         RouteAddress, RouteAttribute, RouteLwEnCapType, RouteMessage, RouteType,
     };
     use netlink_packet_route::{AddressFamily, RouteNetlinkMessage};
-    // The `kind()` accessor for an unparsed attribute. Same crate
-    // the message types come from, already a direct dependency.
-    use netlink_packet_core::Nla as _;
     use netlink_sys::{protocols::NETLINK_ROUTE, Socket, SocketAddr};
-
-    /// `RTA_NH_ID` — see [`KernelRoute::via_nexthop_object`].
-    const RTA_NH_ID: u16 = 30;
 
     /// The kernel's name for a lightweight-encap action, for the
     /// operator's message. `None` is the overwhelming majority and is
@@ -898,14 +892,11 @@ pub fn dump_routes() -> Result<Vec<KernelRoute>, String> {
                             // RTA_TABLE carries ids past the u8 header
                             // field — policy tables live up there.
                             RouteAttribute::Table(t) => table = *t,
-                            // RTA_NH_ID (30). The vendored crate does
-                            // not parse it — the constant is commented
-                            // out in its source — so it lands here,
-                            // and a route carrying it names its
-                            // devices nowhere this scan can read.
-                            RouteAttribute::Other(nla) if nla.kind() == RTA_NH_ID => {
-                                nexthop_object = true
-                            }
+                            // RTA_NH_ID: a route carrying it names its
+                            // devices in a nexthop object, nowhere this
+                            // scan can read. See
+                            // [`KernelRoute::via_nexthop_object`].
+                            RouteAttribute::NhId(_) => nexthop_object = true,
                             _ => {}
                         }
                     }


### PR DESCRIPTION
## What changed

- **Cargo.toml / Cargo.lock**: `rtnetlink 0.21 → 0.22` and `netlink-packet-route 0.30 → 0.32` bumped together, resolving to a single `netlink-packet-route 0.32.1` in the lockfile.
- **`crates/modules/vpp-offload/src/drift.rs`**: the nexthop-object tripwire now matches `RouteAttribute::NhId(_)` instead of catching `RTA_NH_ID` under `RouteAttribute::Other` (0.32 parses the attribute natively, so the `Other` arm is never taken anymore). The hand-rolled `RTA_NH_ID` const and `Nla` import are gone with it.
- **`crates/modules/fast-path/src/fib/netlink_neigh.rs`**: `dump_fdb` uses 0.22's new typed `set_address_family(AddressFamily::Bridge)` instead of overriding the family through `message_mut()` (the workaround existed only because 0.21's typed setter spoke v4/v6 only).
- **`.github/dependabot.yml`**: new `netlink` group (patch+minor+major, patterns `rtnetlink` / `netlink-*`), excluded from `userspace-minor`, so the stack always bumps as one PR.

## Why

Supersedes #194 and #195. Dependabot proposed the two bumps separately, but rtnetlink re-exports netlink-packet-route types, so either bump alone splits the workspace into two incompatible copies of the crate — both PRs have had all seven build jobs red with E0308 since Aug 17, and #194's ignore condition for 0.31 shows the same split already happened once before. The dependabot group is the durable fix.

## Reviewer notes

- The drift.rs change is the one thing CI could **not** have caught: the unit tests set `via_nexthop_object` directly on the struct rather than exercising the parser, so a naive combined bump would have gone green while real route dumps silently stopped flagging nexthop-object routes — a clean health surface over a VPP blackhole. Confirmed against 0.32.1 source (`src/route/attribute.rs:357` parses `RTA_NH_ID` into `NhId(u32)`).
- Verified locally with CI's exact gates: `cargo fmt --check`, host `cargo clippy --workspace --all-targets --all-features -- -D warnings`, workspace tests (617 passing), and cross-clippy on all four published Linux targets (the only local gate that compiles the Linux-only implementations touched here).
- After this merges, #194 and #195 should be closed; the new dependabot group stops them from being recreated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)