### PR TITLE
feat(guard): config grammar + crate skeleton for the tc-egress frame policer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -738,6 +738,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "packetframe-guard"
+version = "0.2.7"
+dependencies = [
+ "packetframe-common",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
 name = "packetframe-probe"
 version = "0.2.7"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/common",
     "crates/cli",
     "crates/modules/fast-path",
+    "crates/modules/guard",
     "crates/modules/probe",
     "crates/modules/vpp-offload",
     "crates/tools/vpp-api-codegen",
@@ -38,6 +39,7 @@ repository = "https://github.com/unredacted/packetframe"
 [workspace.dependencies]
 packetframe-common = { path = "crates/common" }
 packetframe-fast-path = { path = "crates/modules/fast-path" }
+packetframe-guard = { path = "crates/modules/guard" }
 packetframe-probe = { path = "crates/modules/probe" }
 packetframe-vpp-offload = { path = "crates/modules/vpp-offload" }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -463,6 +463,74 @@ pub enum ModuleDirective {
     /// Default ECMP hash tuple width (3, 4, or 5). Written into
     /// `FIB_CONFIG.default_hash_mode` at load time.
     EcmpDefaultHashMode(EcmpHashMode),
+    // --- guard module (tc-egress frame policer). Directive namespace
+    // is shared across module sections; these names are guard's. ---
+    /// `interface <iface>` — the guard attach set: one tc-egress
+    /// cls_bpf classifier per listed interface. **Restart-only**, like
+    /// fast-path's `attach`: the filter and the expected-MAC snapshot
+    /// are attach-time-bound. An `interface` line with no class rules
+    /// naming it is refused at load (a policer that polices nothing
+    /// would attach and report healthy — a silent no-op).
+    GuardInterface {
+        iface: String,
+        line: usize,
+    },
+    /// `arp-ns-ratelimit <iface> rate <n>/<dur> [burst <m>] [monitor]`
+    /// — per-target token bucket over egress ARP requests and ICMPv6
+    /// Neighbor Solicitations: `n` frames per `dur` **per target
+    /// address**, with up to `burst` back-to-back (default: `n`).
+    /// Legitimate kernel resolution (up to 3 probes 1 s apart per
+    /// attempt) passes; a firmware daemon re-probing the same targets
+    /// forever clamps to the configured rate. `monitor` counts
+    /// would-drops without enforcing. Hot-reloadable: SIGHUP rewrites
+    /// the per-ifindex config map; bucket state is deliberately not
+    /// flushed (stale deadlines converge within one old-burst window).
+    GuardArpNsRatelimit {
+        iface: String,
+        rate: u32,
+        per: Duration,
+        burst: u32,
+        monitor: bool,
+        line: usize,
+    },
+    /// `bcast-mcast-ratelimit <iface> rate <n>/<dur> [burst <m>]
+    /// [monitor]` — coarse per-interface token bucket over any egress
+    /// frame with the dst-MAC I/G bit set that no earlier guard class
+    /// terminated (ARP replies/GARP, MLD, LLC/BPDUs, the next noisy
+    /// daemon). Hot-reloadable, same reload semantics as
+    /// `arp-ns-ratelimit`.
+    GuardBcastMcastRatelimit {
+        iface: String,
+        rate: u32,
+        per: Duration,
+        burst: u32,
+        monitor: bool,
+        line: usize,
+    },
+    /// `lldp <iface> drop|monitor` — egress LLDP (ethertype 0x88cc).
+    /// The action is mandatory: `drop` enforces, `monitor` counts
+    /// would-drops. Hot-reloadable. Note LLDP's dst MAC is multicast,
+    /// so with this class disabled LLDP still lands in
+    /// `bcast-mcast-ratelimit`'s budget.
+    GuardLldp {
+        iface: String,
+        monitor: bool,
+        line: usize,
+    },
+    /// `foreign-src <iface> drop|monitor` — drop any egress frame
+    /// whose source MAC is not the interface's own (the "one MAC per
+    /// member per VLAN" invariant IX port security enforces). The
+    /// expected MAC is read from the interface at attach —
+    /// self-referential, so an HA role change needs no config edit,
+    /// but a MAC change on a live interface needs a restart. In
+    /// `monitor` the frame is counted and **continues** through the
+    /// remaining classes (a foreign-MAC ARP storm must still hit the
+    /// ARP limiter). Hot-reloadable (action only).
+    GuardForeignSrc {
+        iface: String,
+        monitor: bool,
+        line: usize,
+    },
 }
 
 /// One side of the [`ModuleDirective::MssClamp`] discriminator
@@ -1520,6 +1588,7 @@ impl Config {
                     ModuleDirective::LocalPrefix { iface, line, .. } => (iface, line),
                     ModuleDirective::LocalPrefix6 { iface, line, .. } => (iface, line),
                     ModuleDirective::FallbackDefault { iface, line, .. } => (iface, line),
+                    ModuleDirective::GuardInterface { iface, line } => (iface, line),
                     _ => continue,
                 };
                 let p = sysfs_net.join(iface);
@@ -1529,6 +1598,104 @@ impl Config {
                         line: *line,
                     });
                 }
+            }
+        }
+        Ok(())
+    }
+
+    /// guard-section validation. Pure config logic — no sysfs — so it
+    /// runs everywhere `parse` does (startup, feasibility, SIGHUP; the
+    /// three call sites must stay in step or reload silently skips
+    /// enforcement — see the loader's reload-validation note).
+    ///
+    /// Rules:
+    /// - an empty `guard` section is refused (same reasoning as
+    ///   vpp-offload: one verdict at the earliest point);
+    /// - duplicate `interface` lines are refused;
+    /// - a class rule naming an interface with no `interface` line is
+    ///   refused (almost certainly a typo, and the rule would silently
+    ///   never take effect);
+    /// - duplicate `(class, interface)` pairs are refused;
+    /// - an `interface` with zero class rules is refused (a policer
+    ///   that polices nothing attaches and reports healthy — a silent
+    ///   no-op, this repo's named enemy).
+    pub fn validate_guard(&self) -> Result<(), ConfigError> {
+        let Some(guard) = self.modules.iter().find(|m| m.name == "guard") else {
+            return Ok(());
+        };
+        if guard.directives.is_empty() {
+            return Err(ConfigError::Parse {
+                line: 0,
+                message: "module guard: section is empty; declare `interface <iface>` \
+                          and at least one class rule, or remove the section"
+                    .to_string(),
+            });
+        }
+
+        // (iface, first-declaration line) for `interface` lines.
+        let mut ifaces: Vec<(&String, usize)> = Vec::new();
+        for d in &guard.directives {
+            if let ModuleDirective::GuardInterface { iface, line } = d {
+                if let Some((_, prev)) = ifaces.iter().find(|(i, _)| *i == iface) {
+                    return Err(ConfigError::Parse {
+                        line: *line,
+                        message: format!(
+                            "module guard: duplicate `interface {iface}` (first declared \
+                             on line {prev})"
+                        ),
+                    });
+                }
+                ifaces.push((iface, *line));
+            }
+        }
+
+        // Class rules: (class-name, iface, line), checked for
+        // undeclared interfaces and per-class duplicates.
+        let mut rules: Vec<(&'static str, &String, usize)> = Vec::new();
+        for d in &guard.directives {
+            let (class, iface, line) = match d {
+                ModuleDirective::GuardArpNsRatelimit { iface, line, .. } => {
+                    ("arp-ns-ratelimit", iface, *line)
+                }
+                ModuleDirective::GuardBcastMcastRatelimit { iface, line, .. } => {
+                    ("bcast-mcast-ratelimit", iface, *line)
+                }
+                ModuleDirective::GuardLldp { iface, line, .. } => ("lldp", iface, *line),
+                ModuleDirective::GuardForeignSrc { iface, line, .. } => {
+                    ("foreign-src", iface, *line)
+                }
+                _ => continue,
+            };
+            if !ifaces.iter().any(|(i, _)| *i == iface) {
+                return Err(ConfigError::Parse {
+                    line,
+                    message: format!(
+                        "module guard: `{class} {iface}` names an interface with no \
+                         `interface {iface}` line; the rule would never take effect"
+                    ),
+                });
+            }
+            if let Some((_, _, prev)) = rules.iter().find(|(c, i, _)| *c == class && *i == iface) {
+                return Err(ConfigError::Parse {
+                    line,
+                    message: format!(
+                        "module guard: duplicate `{class}` for {iface} (first declared \
+                         on line {prev})"
+                    ),
+                });
+            }
+            rules.push((class, iface, line));
+        }
+
+        for (iface, line) in &ifaces {
+            if !rules.iter().any(|(_, i, _)| i == iface) {
+                return Err(ConfigError::Parse {
+                    line: *line,
+                    message: format!(
+                        "module guard: `interface {iface}` declares no rules; add at \
+                         least one class rule for it or remove the line"
+                    ),
+                });
             }
         }
         Ok(())
@@ -2436,11 +2603,182 @@ fn parse_module_directive(line: usize, s: &str) -> Result<ModuleDirective, Confi
             let mode: EcmpHashMode = t.parse().map_err(|e: String| e)?;
             Ok(ModuleDirective::EcmpDefaultHashMode(mode))
         }),
+        "interface" => parse_single_arg(line, rest, "interface", |t| {
+            validate_iface_name(line, "interface", t).map_err(|e| e.to_string())?;
+            Ok(ModuleDirective::GuardInterface {
+                iface: t.to_string(),
+                line,
+            })
+        }),
+        "arp-ns-ratelimit" => {
+            parse_guard_ratelimit(line, rest, "arp-ns-ratelimit", ARP_NS_RATELIMIT_USAGE)
+        }
+        "bcast-mcast-ratelimit" => parse_guard_ratelimit(
+            line,
+            rest,
+            "bcast-mcast-ratelimit",
+            BCAST_MCAST_RATELIMIT_USAGE,
+        ),
+        "lldp" => parse_guard_action(line, rest, "lldp"),
+        "foreign-src" => parse_guard_action(line, rest, "foreign-src"),
         other => Err(ConfigError::parse(
             line,
             format!("unknown directive `{other}` in module section"),
         )),
     }
+}
+
+const ARP_NS_RATELIMIT_USAGE: &str =
+    "arp-ns-ratelimit takes: <iface> rate <n>/<dur> [burst <m>] [monitor]";
+const BCAST_MCAST_RATELIMIT_USAGE: &str =
+    "bcast-mcast-ratelimit takes: <iface> rate <n>/<dur> [burst <m>] [monitor]";
+
+/// Longest token-bucket interval the guard accepts. The BPF side
+/// stores GCRA deadlines in nanoseconds; bounding the interval (and
+/// burst, below) keeps `(burst - 1) * (per / rate)` far from u64
+/// overflow without runtime checks in the datapath.
+const GUARD_RATELIMIT_MAX_PER: Duration = Duration::from_secs(3600);
+const GUARD_RATELIMIT_MAX_BURST: u32 = 65_535;
+
+/// Shared tail parser for the two guard ratelimit directives:
+/// `<iface> rate <n>/<dur> [burst <m>] [monitor]`.
+fn parse_guard_ratelimit<'a>(
+    line: usize,
+    mut rest: impl Iterator<Item = &'a str>,
+    directive: &'static str,
+    usage: &'static str,
+) -> Result<ModuleDirective, ConfigError> {
+    let iface = rest
+        .next()
+        .ok_or_else(|| ConfigError::parse(line, format!("{directive} requires an interface")))?;
+    validate_iface_name(line, directive, iface)?;
+    if rest.next() != Some("rate") {
+        return Err(ConfigError::parse(line, usage));
+    }
+    let rate_tok = rest.next().ok_or_else(|| ConfigError::parse(line, usage))?;
+    let (n_tok, dur_tok) = rate_tok.split_once('/').ok_or_else(|| {
+        ConfigError::parse(
+            line,
+            format!("{directive}: rate must be <n>/<dur> (e.g. 3/60s), got `{rate_tok}`"),
+        )
+    })?;
+    let rate: u32 = n_tok.parse().map_err(|_| {
+        ConfigError::parse(line, format!("{directive}: rate count must be an integer"))
+    })?;
+    if rate == 0 {
+        return Err(ConfigError::parse(
+            line,
+            format!("{directive}: rate count must be >= 1"),
+        ));
+    }
+    let per = parse_duration(line, dur_tok, directive)?;
+    if per.is_zero() {
+        return Err(ConfigError::parse(
+            line,
+            format!("{directive}: rate interval must be non-zero"),
+        ));
+    }
+    if per > GUARD_RATELIMIT_MAX_PER {
+        return Err(ConfigError::parse(
+            line,
+            format!("{directive}: rate interval must be 3600s or less"),
+        ));
+    }
+    // The per-token interval is per/rate; refuse sub-microsecond
+    // emission intervals — they are configuration mistakes (a limiter
+    // admitting >1M frames/s per target limits nothing) and they are
+    // where integer ns math stops being meaningfully accurate.
+    if per.as_nanos() / u128::from(rate) < 1_000 {
+        return Err(ConfigError::parse(
+            line,
+            format!("{directive}: rate exceeds 1 frame per microsecond per target"),
+        ));
+    }
+    let mut burst = rate;
+    let mut monitor = false;
+    let mut tail = rest.next();
+    if tail == Some("burst") {
+        let b_tok = rest.next().ok_or_else(|| ConfigError::parse(line, usage))?;
+        burst = b_tok.parse().map_err(|_| {
+            ConfigError::parse(line, format!("{directive}: burst must be an integer"))
+        })?;
+        if burst == 0 {
+            return Err(ConfigError::parse(
+                line,
+                format!("{directive}: burst must be >= 1"),
+            ));
+        }
+        if burst > GUARD_RATELIMIT_MAX_BURST {
+            return Err(ConfigError::parse(
+                line,
+                format!("{directive}: burst must be {GUARD_RATELIMIT_MAX_BURST} or less"),
+            ));
+        }
+        tail = rest.next();
+    }
+    if tail == Some("monitor") {
+        monitor = true;
+        tail = rest.next();
+    }
+    if tail.is_some() {
+        return Err(ConfigError::parse(line, usage));
+    }
+    let mk = |iface: String| match directive {
+        "arp-ns-ratelimit" => ModuleDirective::GuardArpNsRatelimit {
+            iface,
+            rate,
+            per,
+            burst,
+            monitor,
+            line,
+        },
+        _ => ModuleDirective::GuardBcastMcastRatelimit {
+            iface,
+            rate,
+            per,
+            burst,
+            monitor,
+            line,
+        },
+    };
+    Ok(mk(iface.to_string()))
+}
+
+/// Shared parser for the two action-only guard directives:
+/// `<iface> drop|monitor`. The action is mandatory — a default here
+/// would make `lldp br3998` silently enforce or silently observe, and
+/// either surprise is worse than one more token.
+fn parse_guard_action<'a>(
+    line: usize,
+    mut rest: impl Iterator<Item = &'a str>,
+    directive: &'static str,
+) -> Result<ModuleDirective, ConfigError> {
+    let usage = format!("{directive} takes: <iface> drop|monitor");
+    let iface = rest
+        .next()
+        .ok_or_else(|| ConfigError::parse(line, usage.clone()))?;
+    validate_iface_name(line, directive, iface)?;
+    let monitor = match rest.next() {
+        Some("drop") => false,
+        Some("monitor") => true,
+        _ => return Err(ConfigError::parse(line, usage.clone())),
+    };
+    if rest.next().is_some() {
+        return Err(ConfigError::parse(line, usage));
+    }
+    let iface = iface.to_string();
+    Ok(match directive {
+        "lldp" => ModuleDirective::GuardLldp {
+            iface,
+            monitor,
+            line,
+        },
+        _ => ModuleDirective::GuardForeignSrc {
+            iface,
+            monitor,
+            line,
+        },
+    })
 }
 
 /// Helper: one argument → one `ModuleDirective`. Centralizes the
@@ -5532,5 +5870,160 @@ module fast-path
             format!("{e}").contains("eth4"),
             "the refusal must name the uncovered port: {e}"
         );
+    }
+
+    // --- guard module grammar + validation ---
+
+    /// A full guard section in the documented shape parses, and every
+    /// field lands where the parser promised.
+    #[test]
+    fn guard_section_parses_reference_shape() {
+        let s = "module guard\n\
+                 \x20 interface br3998\n\
+                 \x20 interface br3999\n\
+                 \x20 arp-ns-ratelimit br3998 rate 3/60s burst 3\n\
+                 \x20 lldp br3998 drop\n\
+                 \x20 foreign-src br3998 monitor\n\
+                 \x20 bcast-mcast-ratelimit br3998 rate 50/1s monitor\n\
+                 \x20 arp-ns-ratelimit br3999 rate 2/30s\n";
+        let c = Config::parse(s).unwrap();
+        c.validate_guard().expect("reference shape must validate");
+        let m = &c.modules[0];
+        assert_eq!(m.name, "guard");
+        match &m.directives[2] {
+            ModuleDirective::GuardArpNsRatelimit {
+                iface,
+                rate,
+                per,
+                burst,
+                monitor,
+                ..
+            } => {
+                assert_eq!(iface, "br3998");
+                assert_eq!(*rate, 3);
+                assert_eq!(*per, Duration::from_secs(60));
+                assert_eq!(*burst, 3);
+                assert!(!monitor);
+            }
+            other => panic!("expected GuardArpNsRatelimit, got {other:?}"),
+        }
+        match &m.directives[3] {
+            ModuleDirective::GuardLldp { iface, monitor, .. } => {
+                assert_eq!(iface, "br3998");
+                assert!(!monitor);
+            }
+            other => panic!("expected GuardLldp, got {other:?}"),
+        }
+        match &m.directives[4] {
+            ModuleDirective::GuardForeignSrc { monitor, .. } => assert!(monitor),
+            other => panic!("expected GuardForeignSrc, got {other:?}"),
+        }
+        // burst defaults to the rate count when omitted.
+        match &m.directives[6] {
+            ModuleDirective::GuardArpNsRatelimit { rate, burst, .. } => {
+                assert_eq!(*rate, 2);
+                assert_eq!(*burst, 2);
+            }
+            other => panic!("expected GuardArpNsRatelimit, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn guard_ratelimit_grammar_refusals() {
+        // (body line, expected message fragment)
+        let cases = [
+            ("arp-ns-ratelimit br0 rate 3-60s", "rate must be <n>/<dur>"),
+            ("arp-ns-ratelimit br0 rate 0/60s", "rate count must be >= 1"),
+            (
+                "arp-ns-ratelimit br0 rate 3/0s",
+                "rate interval must be non-zero",
+            ),
+            ("arp-ns-ratelimit br0 rate 3/60m", "duration must end in"),
+            ("arp-ns-ratelimit br0 rate 3/7200s", "3600s or less"),
+            (
+                "arp-ns-ratelimit br0 rate 3/60s burst 0",
+                "burst must be >= 1",
+            ),
+            (
+                "arp-ns-ratelimit br0 rate 3/60s burst 70000",
+                "65535 or less",
+            ),
+            (
+                "bcast-mcast-ratelimit br0 rate 2000000/1s",
+                "1 frame per microsecond",
+            ),
+            ("arp-ns-ratelimit br0 rate 3/60s burst 2 extra", "takes:"),
+            ("arp-ns-ratelimit br0 burst 2", "takes:"),
+            ("lldp br0", "drop|monitor"),
+            ("lldp br0 on", "drop|monitor"),
+            ("foreign-src br0 drop extra", "drop|monitor"),
+        ];
+        for (body, want) in cases {
+            let s = format!("module guard\n  {body}\n");
+            let e = Config::parse(&s).expect_err(body);
+            match e {
+                ConfigError::Parse { line, message } => {
+                    assert_eq!(line, 2, "for `{body}`");
+                    assert!(
+                        message.contains(want),
+                        "for `{body}`: message was `{message}`"
+                    );
+                }
+                other => panic!("expected Parse for `{body}`, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn guard_validation_refusals() {
+        // (config, expected message fragment)
+        let cases = [
+            ("module guard\n".to_string(), "section is empty"),
+            (
+                "module guard\n  interface br0\n  interface br0\n  lldp br0 drop\n".to_string(),
+                "duplicate `interface br0`",
+            ),
+            (
+                "module guard\n  interface br0\n  lldp br0 drop\n  lldp br1 drop\n".to_string(),
+                "no `interface br1` line",
+            ),
+            (
+                "module guard\n  interface br0\n  lldp br0 drop\n  lldp br0 monitor\n".to_string(),
+                "duplicate `lldp` for br0",
+            ),
+            (
+                "module guard\n  interface br0\n  interface br1\n  lldp br0 drop\n".to_string(),
+                "`interface br1` declares no rules",
+            ),
+        ];
+        for (s, want) in cases {
+            let e = Config::parse(&s).unwrap().validate_guard().expect_err(&s);
+            assert!(
+                format!("{e}").contains(want),
+                "for config `{s}`: error was `{e}`"
+            );
+        }
+    }
+
+    /// Guard interfaces join the sysfs existence check exactly like
+    /// fast-path `attach` interfaces.
+    #[test]
+    fn guard_interfaces_are_sysfs_checked() {
+        let dir = tempfile_shim::TempDir::new("guard-sysfs");
+        std::fs::create_dir(dir.path.join("br0")).unwrap();
+        let c = Config::parse(
+            "module guard\n  interface br0\n  interface br1\n  lldp br0 drop\n  lldp br1 drop\n",
+        )
+        .unwrap();
+        let e = c
+            .validate_interfaces_in(&dir.path)
+            .expect_err("br1 does not exist");
+        match e {
+            ConfigError::InterfaceMissing { iface, .. } => assert_eq!(iface, "br1"),
+            other => panic!("expected InterfaceMissing, got {other:?}"),
+        }
+        std::fs::create_dir(dir.path.join("br1")).unwrap();
+        c.validate_interfaces_in(&dir.path)
+            .expect("both interfaces exist now");
     }
 }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1623,14 +1623,6 @@ impl Config {
         let Some(guard) = self.modules.iter().find(|m| m.name == "guard") else {
             return Ok(());
         };
-        if guard.directives.is_empty() {
-            return Err(ConfigError::Parse {
-                line: 0,
-                message: "module guard: section is empty; declare `interface <iface>` \
-                          and at least one class rule, or remove the section"
-                    .to_string(),
-            });
-        }
 
         // (iface, first-declaration line) for `interface` lines.
         let mut ifaces: Vec<(&String, usize)> = Vec::new();
@@ -1647,6 +1639,22 @@ impl Config {
                 }
                 ifaces.push((iface, *line));
             }
+        }
+        // Specifically ≥1 `interface` line, not merely a non-empty
+        // directive list: the directive namespace is shared across
+        // module sections, so `module guard\n  attach eth0 native`
+        // parses — and a raw-emptiness check would wave through a
+        // section whose every directive belongs to another module,
+        // attaching nothing while reporting healthy (review finding,
+        // PR #204).
+        if ifaces.is_empty() {
+            return Err(ConfigError::Parse {
+                line: 0,
+                message: "module guard: section declares no `interface` lines; add \
+                          `interface <iface>` and at least one class rule, or remove \
+                          the section"
+                    .to_string(),
+            });
         }
 
         // Class rules: (class-name, iface, line), checked for
@@ -5978,7 +5986,19 @@ module fast-path
     fn guard_validation_refusals() {
         // (config, expected message fragment)
         let cases = [
-            ("module guard\n".to_string(), "section is empty"),
+            (
+                "module guard\n".to_string(),
+                "declares no `interface` lines",
+            ),
+            // The directive namespace is shared across module sections,
+            // so a guard section holding only another module's
+            // directives parses — it must still be refused (PR #204
+            // review finding: a raw non-emptiness check waved this
+            // through as a silent no-op attach).
+            (
+                "module guard\n  attach eth0 native\n".to_string(),
+                "declares no `interface` lines",
+            ),
             (
                 "module guard\n  interface br0\n  interface br0\n  lldp br0 drop\n".to_string(),
                 "duplicate `interface br0`",

--- a/crates/modules/guard/Cargo.toml
+++ b/crates/modules/guard/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "packetframe-guard"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "PacketFrame guard module: tc-egress frame policer (ARP/NS per-target rate limit, LLDP drop, foreign-src-MAC drop)"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+packetframe-common.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+tracing.workspace = true

--- a/crates/modules/guard/src/cfg.rs
+++ b/crates/modules/guard/src/cfg.rs
@@ -1,0 +1,402 @@
+//! Parsed guard configuration + the BPF wire struct it compiles to.
+//!
+//! Deliberately portable (no cfg gates): `from_directives`,
+//! `restart_only_delta`, and the `GuardIfCfg` layout tests all run on
+//! macOS dev laptops. The Linux-only attach path consumes the result.
+
+use std::time::Duration;
+
+use packetframe_common::config::ModuleDirective;
+
+/// Per-class action byte written into [`GuardIfCfg`]. Plain u8 consts
+/// rather than an enum: the BPF side compares raw bytes, and an enum
+/// would invite a `mem::transmute` on the read path.
+pub const ACTION_DISABLED: u8 = 0;
+pub const ACTION_MONITOR: u8 = 1;
+pub const ACTION_ENFORCE: u8 = 2;
+
+/// Layout version stamped into [`GuardIfCfg::version`]. Bump on any
+/// field change; the BPF side ignores entries whose version it does
+/// not recognize (fail open), which turns a userspace/ELF skew into a
+/// counter anomaly instead of misclassification.
+pub const GUARD_CFG_VERSION: u32 = 1;
+
+/// One ratelimit class rule as configured (pre-compilation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RateRule {
+    pub rate: u32,
+    pub per: Duration,
+    pub burst: u32,
+    pub monitor: bool,
+}
+
+/// One drop/monitor class rule as configured.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActionRule {
+    pub monitor: bool,
+}
+
+/// The full rule set for one guarded interface.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GuardIfaceRules {
+    pub arp_ns: Option<RateRule>,
+    pub bcast_mcast: Option<RateRule>,
+    pub lldp: Option<ActionRule>,
+    pub foreign_src: Option<ActionRule>,
+}
+
+/// Parsed `module guard` section: interfaces in config order, each
+/// with its class rules.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct GuardConfig {
+    pub interfaces: Vec<(String, GuardIfaceRules)>,
+}
+
+impl GuardConfig {
+    /// Build from the section's directives. Re-checks the invariants
+    /// `Config::validate_guard` enforces (undeclared interfaces,
+    /// duplicates, ruleless interfaces) so the module gives the same
+    /// verdict even if a caller skipped the config-level validator.
+    /// Foreign directives (the namespace is shared across module
+    /// sections) are ignored, matching the other modules.
+    pub fn from_directives(directives: &[ModuleDirective]) -> Result<Self, String> {
+        let mut interfaces: Vec<(String, GuardIfaceRules)> = Vec::new();
+        for d in directives {
+            if let ModuleDirective::GuardInterface { iface, .. } = d {
+                if interfaces.iter().any(|(i, _)| i == iface) {
+                    return Err(format!("duplicate `interface {iface}`"));
+                }
+                interfaces.push((iface.clone(), GuardIfaceRules::default()));
+            }
+        }
+
+        fn rules_of<'a>(
+            interfaces: &'a mut [(String, GuardIfaceRules)],
+            iface: &String,
+            class: &str,
+        ) -> Result<&'a mut GuardIfaceRules, String> {
+            interfaces
+                .iter_mut()
+                .find(|(i, _)| i == iface)
+                .map(|(_, r)| r)
+                .ok_or_else(|| {
+                    format!("`{class} {iface}` names an interface with no `interface` line")
+                })
+        }
+
+        for d in directives {
+            match d {
+                ModuleDirective::GuardArpNsRatelimit {
+                    iface,
+                    rate,
+                    per,
+                    burst,
+                    monitor,
+                    ..
+                } => {
+                    let r = rules_of(&mut interfaces, iface, "arp-ns-ratelimit")?;
+                    if r.arp_ns.is_some() {
+                        return Err(format!("duplicate `arp-ns-ratelimit` for {iface}"));
+                    }
+                    r.arp_ns = Some(RateRule {
+                        rate: *rate,
+                        per: *per,
+                        burst: *burst,
+                        monitor: *monitor,
+                    });
+                }
+                ModuleDirective::GuardBcastMcastRatelimit {
+                    iface,
+                    rate,
+                    per,
+                    burst,
+                    monitor,
+                    ..
+                } => {
+                    let r = rules_of(&mut interfaces, iface, "bcast-mcast-ratelimit")?;
+                    if r.bcast_mcast.is_some() {
+                        return Err(format!("duplicate `bcast-mcast-ratelimit` for {iface}"));
+                    }
+                    r.bcast_mcast = Some(RateRule {
+                        rate: *rate,
+                        per: *per,
+                        burst: *burst,
+                        monitor: *monitor,
+                    });
+                }
+                ModuleDirective::GuardLldp { iface, monitor, .. } => {
+                    let r = rules_of(&mut interfaces, iface, "lldp")?;
+                    if r.lldp.is_some() {
+                        return Err(format!("duplicate `lldp` for {iface}"));
+                    }
+                    r.lldp = Some(ActionRule { monitor: *monitor });
+                }
+                ModuleDirective::GuardForeignSrc { iface, monitor, .. } => {
+                    let r = rules_of(&mut interfaces, iface, "foreign-src")?;
+                    if r.foreign_src.is_some() {
+                        return Err(format!("duplicate `foreign-src` for {iface}"));
+                    }
+                    r.foreign_src = Some(ActionRule { monitor: *monitor });
+                }
+                _ => {}
+            }
+        }
+
+        for (iface, rules) in &interfaces {
+            if *rules == GuardIfaceRules::default() {
+                return Err(format!("`interface {iface}` declares no rules"));
+            }
+        }
+        Ok(GuardConfig { interfaces })
+    }
+
+    /// Refuse the config deltas a SIGHUP cannot apply, by name. The
+    /// interface set is attach-time-bound (the tc filter and the
+    /// expected-MAC snapshot are created at attach), so adding or
+    /// removing an `interface` line needs the restart dance. Everything
+    /// else — rates, burst, monitor↔enforce, adding or removing class
+    /// rules on an attached interface — is a per-ifindex config-map
+    /// rewrite and is accepted.
+    pub fn restart_only_delta(&self, new: &Self) -> Result<(), String> {
+        let old_set: Vec<&String> = self.interfaces.iter().map(|(i, _)| i).collect();
+        let new_set: Vec<&String> = new.interfaces.iter().map(|(i, _)| i).collect();
+        for iface in &old_set {
+            if !new_set.contains(iface) {
+                return Err(format!(
+                    "`interface {iface}` was removed; the guard attach set is \
+                     restart-only. Restart the daemon (stop, `packetframe detach`, \
+                     start) for it to take effect."
+                ));
+            }
+        }
+        for iface in &new_set {
+            if !old_set.contains(iface) {
+                return Err(format!(
+                    "`interface {iface}` was added; the guard attach set is \
+                     restart-only. Restart the daemon (stop, `packetframe detach`, \
+                     start) for it to take effect."
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The per-ifindex wire struct written into the BPF `GUARD_CFG` map.
+/// 48 bytes, `#[repr(C)]`, zero implicit padding — layout mirrored in
+/// the BPF crate; the tests below pin size and offsets so drift is a
+/// compile-time/test-time failure, not a misparse on the wire.
+#[repr(C)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub struct GuardIfCfg {
+    /// Expected src MAC, wire bytes 0..4 as a native-endian u32
+    /// (`u32::from_ne_bytes(mac[0..4])`). Compared against a
+    /// `read_unaligned` load at eth offset 6 — raw-byte equality, so
+    /// endianness cancels.
+    pub mac_hi: u32,
+    /// Wire bytes 4..6, same convention.
+    pub mac_lo: u16,
+    pub act_arp: u8,
+    pub act_ns: u8,
+    pub act_lldp: u8,
+    pub act_foreign: u8,
+    pub act_mcast: u8,
+    /// Always written 0; keeps the layout explicit-padding-only.
+    pub _pad0: u8,
+    pub version: u32,
+    /// GCRA emission interval for the ARP-request/NS buckets,
+    /// ns per token (`per / rate`). 0 = bucket bypass (pass).
+    pub ndp_t_ns: u64,
+    /// GCRA burst tolerance: `(burst - 1) * ndp_t_ns`, precomputed
+    /// here so the datapath does no arithmetic beyond add/compare.
+    pub ndp_tau_ns: u64,
+    pub mcast_t_ns: u64,
+    pub mcast_tau_ns: u64,
+}
+
+impl GuardIfCfg {
+    /// Compile one interface's rules + its observed MAC into the wire
+    /// struct. `rate`/`per`/`burst` bounds were enforced at config
+    /// parse (interval ≤ 3600s, per-token ≥ 1µs, burst ≤ 65535), so
+    /// the ns math here cannot overflow u64.
+    pub fn compile(mac: [u8; 6], rules: &GuardIfaceRules) -> Self {
+        let rate_fields = |r: &Option<RateRule>| -> (u8, u64, u64) {
+            match r {
+                None => (ACTION_DISABLED, 0, 0),
+                Some(r) => {
+                    let t_ns = (r.per.as_nanos() / u128::from(r.rate)) as u64;
+                    let tau_ns = u64::from(r.burst - 1) * t_ns;
+                    let act = if r.monitor {
+                        ACTION_MONITOR
+                    } else {
+                        ACTION_ENFORCE
+                    };
+                    (act, t_ns, tau_ns)
+                }
+            }
+        };
+        let action = |a: &Option<ActionRule>| -> u8 {
+            match a {
+                None => ACTION_DISABLED,
+                Some(ActionRule { monitor: true }) => ACTION_MONITOR,
+                Some(ActionRule { monitor: false }) => ACTION_ENFORCE,
+            }
+        };
+        let (ndp_act, ndp_t_ns, ndp_tau_ns) = rate_fields(&rules.arp_ns);
+        let (mcast_act, mcast_t_ns, mcast_tau_ns) = rate_fields(&rules.bcast_mcast);
+        GuardIfCfg {
+            mac_hi: u32::from_ne_bytes([mac[0], mac[1], mac[2], mac[3]]),
+            mac_lo: u16::from_ne_bytes([mac[4], mac[5]]),
+            act_arp: ndp_act,
+            act_ns: ndp_act,
+            act_lldp: action(&rules.lldp),
+            act_foreign: action(&rules.foreign_src),
+            act_mcast: mcast_act,
+            _pad0: 0,
+            version: GUARD_CFG_VERSION,
+            ndp_t_ns,
+            ndp_tau_ns,
+            mcast_t_ns,
+            mcast_tau_ns,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use packetframe_common::config::Config;
+
+    fn guard_directives(body: &str) -> Vec<ModuleDirective> {
+        let c = Config::parse(&format!("module guard\n{body}")).expect("parse");
+        c.modules[0].directives.clone()
+    }
+
+    #[test]
+    fn wire_layout_is_pinned() {
+        use core::mem::{offset_of, size_of};
+        // The BPF crate mirrors this struct by hand. Any change here
+        // must land there in the same commit, and vice versa.
+        assert_eq!(size_of::<GuardIfCfg>(), 48);
+        assert_eq!(offset_of!(GuardIfCfg, mac_hi), 0);
+        assert_eq!(offset_of!(GuardIfCfg, mac_lo), 4);
+        assert_eq!(offset_of!(GuardIfCfg, act_arp), 6);
+        assert_eq!(offset_of!(GuardIfCfg, act_ns), 7);
+        assert_eq!(offset_of!(GuardIfCfg, act_lldp), 8);
+        assert_eq!(offset_of!(GuardIfCfg, act_foreign), 9);
+        assert_eq!(offset_of!(GuardIfCfg, act_mcast), 10);
+        assert_eq!(offset_of!(GuardIfCfg, version), 12);
+        assert_eq!(offset_of!(GuardIfCfg, ndp_t_ns), 16);
+        assert_eq!(offset_of!(GuardIfCfg, ndp_tau_ns), 24);
+        assert_eq!(offset_of!(GuardIfCfg, mcast_t_ns), 32);
+        assert_eq!(offset_of!(GuardIfCfg, mcast_tau_ns), 40);
+    }
+
+    #[test]
+    fn from_directives_round_trip() {
+        let ds = guard_directives(
+            "  interface br0\n\
+             \x20 arp-ns-ratelimit br0 rate 3/60s burst 3\n\
+             \x20 lldp br0 drop\n\
+             \x20 foreign-src br0 monitor\n\
+             \x20 bcast-mcast-ratelimit br0 rate 50/1s monitor\n",
+        );
+        let cfg = GuardConfig::from_directives(&ds).expect("valid section");
+        assert_eq!(cfg.interfaces.len(), 1);
+        let (iface, rules) = &cfg.interfaces[0];
+        assert_eq!(iface, "br0");
+        let arp = rules.arp_ns.as_ref().expect("arp-ns rule");
+        assert_eq!(arp.rate, 3);
+        assert_eq!(arp.per, Duration::from_secs(60));
+        assert_eq!(arp.burst, 3);
+        assert!(!arp.monitor);
+        assert!(!rules.lldp.as_ref().unwrap().monitor);
+        assert!(rules.foreign_src.as_ref().unwrap().monitor);
+        assert!(rules.bcast_mcast.as_ref().unwrap().monitor);
+    }
+
+    #[test]
+    fn from_directives_refusals_match_the_config_validator() {
+        for (body, want) in [
+            ("  lldp br0 drop\n", "no `interface` line"),
+            (
+                "  interface br0\n  interface br0\n  lldp br0 drop\n",
+                "duplicate `interface br0`",
+            ),
+            (
+                "  interface br0\n  lldp br0 drop\n  lldp br0 monitor\n",
+                "duplicate `lldp` for br0",
+            ),
+            ("  interface br0\n", "declares no rules"),
+        ] {
+            let e = GuardConfig::from_directives(&guard_directives(body)).expect_err(body);
+            assert!(e.contains(want), "for `{body}`: error was `{e}`");
+        }
+    }
+
+    #[test]
+    fn restart_only_delta_matrix() {
+        let base =
+            GuardConfig::from_directives(&guard_directives("  interface br0\n  lldp br0 drop\n"))
+                .unwrap();
+
+        // Rate/action/rule changes on the same interface set: accepted.
+        let hot = GuardConfig::from_directives(&guard_directives(
+            "  interface br0\n  lldp br0 monitor\n  arp-ns-ratelimit br0 rate 3/60s\n",
+        ))
+        .unwrap();
+        base.restart_only_delta(&hot).expect("hot delta accepted");
+
+        // Added interface: refused, naming it.
+        let added = GuardConfig::from_directives(&guard_directives(
+            "  interface br0\n  interface br1\n  lldp br0 drop\n  lldp br1 drop\n",
+        ))
+        .unwrap();
+        let e = base.restart_only_delta(&added).unwrap_err();
+        assert!(e.contains("`interface br1` was added"), "{e}");
+
+        // Removed interface: refused, naming it.
+        let e = added.restart_only_delta(&base).unwrap_err();
+        assert!(e.contains("`interface br1` was removed"), "{e}");
+    }
+
+    #[test]
+    fn compile_produces_the_documented_wire_values() {
+        let rules = GuardIfaceRules {
+            arp_ns: Some(RateRule {
+                rate: 3,
+                per: Duration::from_secs(60),
+                burst: 3,
+                monitor: false,
+            }),
+            bcast_mcast: Some(RateRule {
+                rate: 50,
+                per: Duration::from_secs(1),
+                burst: 50,
+                monitor: true,
+            }),
+            lldp: Some(ActionRule { monitor: false }),
+            foreign_src: None,
+        };
+        let mac = [0x28, 0x70, 0x4e, 0x47, 0x69, 0xc7];
+        let cfg = GuardIfCfg::compile(mac, &rules);
+        assert_eq!(cfg.mac_hi, u32::from_ne_bytes([0x28, 0x70, 0x4e, 0x47]));
+        assert_eq!(cfg.mac_lo, u16::from_ne_bytes([0x69, 0xc7]));
+        assert_eq!(cfg.act_arp, ACTION_ENFORCE);
+        assert_eq!(cfg.act_ns, ACTION_ENFORCE);
+        assert_eq!(cfg.act_lldp, ACTION_ENFORCE);
+        assert_eq!(cfg.act_foreign, ACTION_DISABLED);
+        assert_eq!(cfg.act_mcast, ACTION_MONITOR);
+        assert_eq!(cfg.version, GUARD_CFG_VERSION);
+        // 60s / 3 = 20s per token; tau = (3-1) * 20s.
+        assert_eq!(cfg.ndp_t_ns, 20_000_000_000);
+        assert_eq!(cfg.ndp_tau_ns, 40_000_000_000);
+        // 1s / 50 = 20ms per token; tau = 49 * 20ms.
+        assert_eq!(cfg.mcast_t_ns, 20_000_000);
+        assert_eq!(cfg.mcast_tau_ns, 980_000_000);
+        // Disabled rate class: t_ns 0 = bucket bypass.
+        let none = GuardIfCfg::compile(mac, &GuardIfaceRules::default());
+        assert_eq!(none.ndp_t_ns, 0);
+        assert_eq!(none.act_arp, ACTION_DISABLED);
+    }
+}

--- a/crates/modules/guard/src/cfg.rs
+++ b/crates/modules/guard/src/cfg.rs
@@ -142,6 +142,14 @@ impl GuardConfig {
             }
         }
 
+        // ≥1 `interface` line, matching `Config::validate_guard` —
+        // the shared directive namespace means a guard section holding
+        // only another module's directives parses to an empty attach
+        // set here, which would load and report healthy while policing
+        // nothing (review finding, PR #204).
+        if interfaces.is_empty() {
+            return Err("section declares no `interface` lines".to_string());
+        }
         for (iface, rules) in &interfaces {
             if *rules == GuardIfaceRules::default() {
                 return Err(format!("`interface {iface}` declares no rules"));
@@ -319,6 +327,10 @@ mod tests {
     fn from_directives_refusals_match_the_config_validator() {
         for (body, want) in [
             ("  lldp br0 drop\n", "no `interface` line"),
+            // Foreign-namespace directives parse in any section; a
+            // guard section containing only them must not become an
+            // empty (silent no-op) attach set.
+            ("  attach eth0 native\n", "declares no `interface` lines"),
             (
                 "  interface br0\n  interface br0\n  lldp br0 drop\n",
                 "duplicate `interface br0`",

--- a/crates/modules/guard/src/lib.rs
+++ b/crates/modules/guard/src/lib.rs
@@ -1,0 +1,156 @@
+//! PacketFrame guard module: a tc-**egress** frame policer.
+//!
+//! Polices locally-originated L2 frames the platform's firmware emits
+//! uncontrollably (UniFi udapi-server ARP/NS storms, lldpd, the HA
+//! standby's MAC leaking onto IX VLANs). Fixed frame classes, each
+//! per-interface and monitor-or-enforce:
+//!
+//! 1. ARP requests + ICMPv6 Neighbor Solicitations — per-target-IP
+//!    GCRA rate limit (legitimate kernel resolution passes; same-
+//!    target storms clamp).
+//! 2. LLDP (ethertype 0x88cc) — drop.
+//! 3. Foreign source MAC (anything but the interface's own) — drop.
+//! 4. Catch-all broadcast/multicast — coarse per-interface rate limit.
+//!
+//! tc egress is the only eBPF hook that observes this traffic class:
+//! it is kernel egress (including AF_PACKET injections like arping's),
+//! invisible to XDP (ingress-only), NIC ntuple/MCAM (RX-only), and the
+//! vpp-offload dataplane (which never carries kernel-originated
+//! frames). That remains true at every stage of the vpp-offload
+//! roadmap, so this module is permanent architecture, not a stopgap.
+//!
+//! **Slice status:** config model, state-file, and pin-path layers are
+//! in place; the BPF datapath and the Linux attach/detach lifecycle
+//! land in the next slice, and the CLI does not construct this module
+//! until the slice after that.
+
+pub mod cfg;
+pub mod pin;
+pub mod tc_links;
+
+use std::path::PathBuf;
+
+use packetframe_common::module::{
+    HealthCtx, HealthReport, HookType, HookUse, LoaderCtx, MetricsWriter, Module, ModuleConfig,
+    ModuleError, ModuleResult,
+};
+
+use crate::cfg::GuardConfig;
+
+pub const MODULE_NAME: &str = "guard";
+
+/// SPEC §3.2 hook priority. Guard is a policer, not a forwarder; it
+/// sits outside the 1000–1999 forwarding range. Recorded, not yet
+/// consulted (single-module-per-hook dispatch).
+pub const GUARD_PRIORITY: u16 = 100;
+
+#[derive(Default)]
+pub struct GuardModule {
+    /// Parsed section, set by `load`.
+    config: Option<GuardConfig>,
+    /// Captured at `load` (`attach` receives no ctx).
+    bpffs_root: Option<PathBuf>,
+    state_dir: Option<PathBuf>,
+}
+
+impl GuardModule {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Module for GuardModule {
+    fn name(&self) -> &'static str {
+        MODULE_NAME
+    }
+
+    fn hook_spec(&self) -> Vec<HookUse> {
+        vec![HookUse {
+            hook: HookType::TcEgress,
+            priority: GUARD_PRIORITY,
+        }]
+    }
+
+    fn load(&mut self, cfg: &ModuleConfig<'_>, ctx: &LoaderCtx<'_>) -> ModuleResult<()> {
+        let parsed = GuardConfig::from_directives(&cfg.section.directives)
+            .map_err(|e| ModuleError::other(MODULE_NAME, format!("module guard: {e}")))?;
+        self.config = Some(parsed);
+        self.bpffs_root = Some(ctx.bpffs_root.to_path_buf());
+        self.state_dir = Some(ctx.state_dir.to_path_buf());
+        Ok(())
+    }
+
+    fn attach(
+        &mut self,
+        _cfg: &ModuleConfig<'_>,
+    ) -> ModuleResult<Vec<packetframe_common::module::Attachment>> {
+        // Next slice: per-interface clsact + netlink cls_bpf egress
+        // attach, GUARD_CFG population, guard-tc-links.json persistence,
+        // pinning. Returns no `Attachment`s even then (the shared
+        // attachments.json registry is single-module; guard's teardown
+        // truth is its own state file, the vpp-offload precedent).
+        Err(ModuleError::not_implemented(MODULE_NAME))
+    }
+
+    fn reconfigure(&mut self, _cfg: &ModuleConfig<'_>) -> ModuleResult<()> {
+        Err(ModuleError::not_implemented(MODULE_NAME))
+    }
+
+    fn detach(&mut self) -> ModuleResult<()> {
+        // Nothing can be attached while `attach` is unimplemented;
+        // no-op is the honest answer for this slice.
+        Ok(())
+    }
+
+    fn sample_metrics(&self, _out: &mut MetricsWriter<'_>) -> ModuleResult<()> {
+        Ok(())
+    }
+
+    fn health_check(&self, _ctx: &HealthCtx) -> ModuleResult<HealthReport> {
+        Ok(HealthReport::healthy())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use packetframe_common::config::Config;
+
+    /// `load` accepts a valid section and refuses an invalid one with
+    /// the module name in the message — the same verdict the config
+    /// validator gives, per the "one verdict at the earliest point"
+    /// rule.
+    #[test]
+    fn load_parses_and_refuses() {
+        let good = Config::parse("module guard\n  interface br0\n  lldp br0 drop\n").unwrap();
+        let bad = Config::parse("module guard\n  lldp br0 drop\n").unwrap();
+        let global = packetframe_common::config::GlobalConfig::default();
+        let ctx = LoaderCtx {
+            bpffs_root: std::path::Path::new("/sys/fs/bpf/packetframe"),
+            state_dir: std::path::Path::new("/var/lib/packetframe/state"),
+        };
+
+        let mut m = GuardModule::new();
+        m.load(
+            &ModuleConfig {
+                section: &good.modules[0],
+                global: &global,
+            },
+            &ctx,
+        )
+        .expect("valid section loads");
+        assert!(m.config.is_some());
+
+        let mut m = GuardModule::new();
+        let e = m
+            .load(
+                &ModuleConfig {
+                    section: &bad.modules[0],
+                    global: &global,
+                },
+                &ctx,
+            )
+            .expect_err("orphan rule refused");
+        assert!(format!("{e}").contains("no `interface` line"), "{e}");
+    }
+}

--- a/crates/modules/guard/src/pin.rs
+++ b/crates/modules/guard/src/pin.rs
@@ -1,0 +1,168 @@
+//! bpffs pin path construction + lifecycle helpers for the guard.
+//!
+//! Mirror of fast-path's `pin.rs`; when one is updated, the other
+//! likely needs the same change. Separate file (not a shared helper)
+//! because each module hardcodes its own `MODULE_NAME`, map list, and
+//! program list. Two deliberate divergences:
+//!
+//! - **No `links/` directory.** tc cls_bpf filters cannot be pinned as
+//!   bpf_links (their lifetime is the clsact qdisc's); the guard's
+//!   attach state lives in `guard-tc-links.json` instead. Only
+//!   programs and maps are pinned here.
+//! - **No paced removal.** Removing a tc filter does not bounce the
+//!   link the way an XDP detach does on rvu-nicpf, so the bridge-
+//!   member pacing fast-path needs on detach does not apply.
+//!
+//! v0.1 semantics are shared: startup refuses when pins already exist
+//! from a prior invocation; `packetframe detach --all` is the recovery
+//! path.
+
+use std::path::{Path, PathBuf};
+
+use crate::MODULE_NAME;
+
+/// Every guard map that gets pinned. Order is not significant.
+/// Append-only; new maps go at the end.
+pub const MAP_NAMES: [&str; 4] = [
+    "GUARD_CFG",
+    "GUARD_NDP_BUCKETS",
+    "GUARD_MCAST_BUCKETS",
+    "GUARD_STATS",
+];
+
+/// The guard's tc-egress classifier program basename.
+pub const PROGRAM_NAME: &str = "guard_egress";
+
+/// All pinned program basenames in this module. Append-only.
+pub const PROGRAM_NAMES: [&str; 1] = [PROGRAM_NAME];
+
+pub fn module_root(bpffs_root: &Path) -> PathBuf {
+    bpffs_root.join(MODULE_NAME)
+}
+
+pub fn progs_dir(bpffs_root: &Path) -> PathBuf {
+    module_root(bpffs_root).join("progs")
+}
+
+pub fn maps_dir(bpffs_root: &Path) -> PathBuf {
+    module_root(bpffs_root).join("maps")
+}
+
+pub fn program_path(bpffs_root: &Path) -> PathBuf {
+    progs_dir(bpffs_root).join(PROGRAM_NAME)
+}
+
+pub fn map_path(bpffs_root: &Path, name: &str) -> PathBuf {
+    maps_dir(bpffs_root).join(name)
+}
+
+/// Create the module's pin subdirectories if missing. The bpffs root
+/// itself must already be mounted; [`packetframe_common::probe`]'s
+/// `bpffs` probe checks that.
+pub fn ensure_dirs(bpffs_root: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(progs_dir(bpffs_root))?;
+    std::fs::create_dir_all(maps_dir(bpffs_root))?;
+    Ok(())
+}
+
+/// True when any pinned object exists under the module's pin root.
+/// Startup checks this before fresh-loading; pinned state from a prior
+/// invocation must be cleaned via `packetframe detach --all` first.
+pub fn has_existing_pins(bpffs_root: &Path) -> bool {
+    for sub in [progs_dir(bpffs_root), maps_dir(bpffs_root)] {
+        let entries = match std::fs::read_dir(&sub) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if entries.flatten().next().is_some() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Remove every pin under the module's pin root. Called by
+/// `packetframe detach`. Missing files and missing directories are
+/// not errors; the post-condition is "no pins", regardless of
+/// starting state. No kernel-attach side effects here — the tc
+/// filters are torn down separately from `guard-tc-links.json`.
+pub fn remove_all(bpffs_root: &Path) -> std::io::Result<()> {
+    for sub in [maps_dir(bpffs_root), progs_dir(bpffs_root)] {
+        let entries = match std::fs::read_dir(&sub) {
+            Ok(e) => e,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        };
+        for entry in entries.flatten() {
+            match std::fs::remove_file(entry.path()) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_shape() {
+        let root = Path::new("/sys/fs/bpf/packetframe");
+        assert_eq!(
+            module_root(root),
+            Path::new("/sys/fs/bpf/packetframe/guard")
+        );
+        assert_eq!(
+            program_path(root),
+            Path::new("/sys/fs/bpf/packetframe/guard/progs/guard_egress")
+        );
+        assert_eq!(
+            map_path(root, "GUARD_STATS"),
+            Path::new("/sys/fs/bpf/packetframe/guard/maps/GUARD_STATS")
+        );
+    }
+
+    #[test]
+    fn has_existing_pins_false_when_empty() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        assert!(!has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn has_existing_pins_true_when_program_pinned() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        std::fs::write(program_path(&dir), b"fake").unwrap();
+        assert!(has_existing_pins(&dir));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn remove_all_cleans_every_subdir_and_is_idempotent() {
+        let dir = tempdir();
+        ensure_dirs(&dir).unwrap();
+        std::fs::write(program_path(&dir), b"fake").unwrap();
+        std::fs::write(map_path(&dir, "GUARD_STATS"), b"fake").unwrap();
+        remove_all(&dir).unwrap();
+        assert!(!has_existing_pins(&dir));
+        remove_all(&dir).unwrap(); // second removal is a no-op
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    fn tempdir() -> PathBuf {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static N: AtomicU64 = AtomicU64::new(0);
+        let p = std::env::temp_dir().join(format!(
+            "pf-guard-pin-{}-{}",
+            std::process::id(),
+            N.fetch_add(1, Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+}

--- a/crates/modules/guard/src/tc_links.rs
+++ b/crates/modules/guard/src/tc_links.rs
@@ -1,0 +1,139 @@
+//! Persistence for the guard's tc-egress filter attachments.
+//!
+//! Mirror of fast-path's `tc_links.rs`; when one is updated, the other
+//! likely needs the same change. Separate file (not a shared helper)
+//! because the state filename differs per module — fast-path's
+//! `detach` tears down everything in the shared `tc-links.json`
+//! unconditionally, so guard records living there would be destroyed
+//! by a fast-path-scoped detach. Records here are **always egress**
+//! (per-module convention; fast-path's are always ingress), so no
+//! direction field is stored.
+//!
+//! Netlink cls_bpf filters cannot be pinned as bpf_links: their
+//! lifetime is the clsact qdisc's, so the kernel attach survives
+//! process exit inherently. What does NOT survive is aya's in-process
+//! `SchedClassifierLink` — it detaches on Drop — so the attach path
+//! reads the kernel-assigned `(priority, handle)` pair, persists it
+//! here, and forgets the link. `packetframe detach` reconstructs each
+//! filter via `SchedClassifierLink::attached()` and detaches it.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+const GUARD_TC_LINKS_FILENAME: &str = "guard-tc-links.json";
+
+#[derive(Debug, Error)]
+pub enum TcLinksError {
+    #[error("I/O error on {path:?}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("JSON error on {path:?}: {source}")]
+    Json {
+        path: PathBuf,
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TcLinksFile {
+    pub links: Vec<TcLinkRecord>,
+}
+
+/// One attached cls_bpf filter: the tuple
+/// `SchedClassifierLink::attached()` needs to reconstruct it
+/// (attach type is always egress for the guard).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TcLinkRecord {
+    pub iface: String,
+    pub priority: u16,
+    pub handle: u32,
+}
+
+pub fn file_path(state_dir: &Path) -> PathBuf {
+    state_dir.join(GUARD_TC_LINKS_FILENAME)
+}
+
+/// Atomic write-then-rename, mirroring fast-path's `tc_links::save`.
+pub fn save(state_dir: &Path, file: &TcLinksFile) -> Result<(), TcLinksError> {
+    let path = file_path(state_dir);
+    let tmp = path.with_extension("json.tmp");
+    let json = serde_json::to_string_pretty(file).map_err(|source| TcLinksError::Json {
+        path: path.clone(),
+        source,
+    })?;
+    std::fs::create_dir_all(state_dir).map_err(|source| TcLinksError::Io {
+        path: state_dir.to_path_buf(),
+        source,
+    })?;
+    std::fs::write(&tmp, json).map_err(|source| TcLinksError::Io {
+        path: tmp.clone(),
+        source,
+    })?;
+    std::fs::rename(&tmp, &path).map_err(|source| TcLinksError::Io { path, source })
+}
+
+/// `Ok(None)` when the file doesn't exist (no tc attaches recorded).
+pub fn load(state_dir: &Path) -> Result<Option<TcLinksFile>, TcLinksError> {
+    let path = file_path(state_dir);
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(source) => return Err(TcLinksError::Io { path, source }),
+    };
+    serde_json::from_str(&raw)
+        .map(Some)
+        .map_err(|source| TcLinksError::Json { path, source })
+}
+
+/// Missing file is fine (idempotent teardown).
+pub fn remove(state_dir: &Path) -> Result<(), TcLinksError> {
+    let path = file_path(state_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(source) => Err(TcLinksError::Io { path, source }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_and_idempotent_remove() {
+        let dir = std::env::temp_dir().join(format!("pf-guard-tc-links-{}", std::process::id()));
+        let file = TcLinksFile {
+            links: vec![TcLinkRecord {
+                iface: "br3998".into(),
+                priority: 49152,
+                handle: 1,
+            }],
+        };
+        save(&dir, &file).unwrap();
+        let loaded = load(&dir).unwrap().expect("file present");
+        assert_eq!(loaded.links.len(), 1);
+        assert_eq!(loaded.links[0].iface, "br3998");
+        remove(&dir).unwrap();
+        assert!(load(&dir).unwrap().is_none());
+        remove(&dir).unwrap(); // second remove is a no-op
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The filename must never collide with fast-path's
+    /// `tc-links.json` — a fast-path-scoped detach destroys that file.
+    #[test]
+    fn state_filename_is_guard_scoped() {
+        let p = file_path(Path::new("/var/lib/packetframe/state"));
+        assert_eq!(
+            p,
+            Path::new("/var/lib/packetframe/state/guard-tc-links.json")
+        );
+    }
+}


### PR DESCRIPTION
Slice 1 of 4 of the guard module (plan: tc-egress frame policer for the IX-facing bridges).

**Why:** UniFi firmware emits L2 frames the operator cannot configure away — udapi-server runs arping/ndisc6 against every kernel neighbor (SIX blocked the router over the resulting broadcast storms), lldpd leaks LLDP, and the HA standby's MAC leaking onto the KCIX VLAN tripped port security. The durable fix must live in PacketFrame, and tc egress is the only eBPF hook that observes locally-originated kernel egress (XDP is ingress-only, ntuple/MCAM is RX-only, VPP never carries kernel-originated frames) — at every stage of the vpp-offload roadmap.

**This slice** (no behavior change; the CLI does not construct the module yet):
- `module guard` grammar: `interface`, `arp-ns-ratelimit <iface> rate <n>/<dur> [burst <m>] [monitor]`, `bcast-mcast-ratelimit`, `lldp <iface> drop|monitor`, `foreign-src <iface> drop|monitor`
- `Config::validate_guard()` — refuses empty sections, duplicate interfaces, orphan/duplicate class rules, and ruleless interfaces; guard interfaces join the sysfs existence check
- `packetframe-guard` crate skeleton: `GuardConfig::from_directives` re-checking the same invariants, `restart_only_delta` (interface set is restart-only; rates/actions are hot), the 48-byte `GuardIfCfg` wire struct with pinned layout tests, `guard-tc-links.json` persistence (deliberately distinct from fast-path's `tc-links.json`, which fast-path's detach tears down unconditionally), and pin paths under `/sys/fs/bpf/packetframe/guard/`

Next slices: (2) BPF datapath + module lifecycle + TEST_RUN fixtures, (3) CLI wiring + docs, (4) attach/netns integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)