### PR TITLE
feat(guard): CLI wiring + docs — the module is now reachable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ PacketFrame is a modular eBPF data plane written in pure Rust (aya + aya-ebpf). 
 - `crates/common/`: config parser (SPEC.md §6), `Module` trait (§3.2), §2.1 capability probes, custom-FIB trait shapes (`fib/mod.rs`)
 - `crates/cli/`: the `packetframe` binary (clap subcommands: `feasibility`, `run`, `detach`, `status`, `fib`, `probe`)
 - `crates/modules/fast-path/`: fast-path module including the custom-FIB control plane under `src/fib/`
+- `crates/modules/guard/`: tc-egress frame policer (ARP/NS per-target rate limit, LLDP drop, foreign-src-MAC drop, bcast/mcast catch-all) for the IX-facing bridges; runbook at `docs/runbooks/guard.md`
 - `conf/example.conf`: reference config per SPEC.md §4.8
 - `docs/runbooks/custom-fib.md`: Option F operations runbook (healthy state, triage by symptom, cutover + rollback, Phase 4 config snippets)
 - `.github/workflows/`: `ci.yml` (fmt/clippy/test + 4× cross-build), `qemu-verifier.yml` (integration tests on 5.15 + 6.6 kernels), `release.yml` (tag-triggered tarballs), `hardware-artifacts.yml` (per-main-push aarch64 test-binary + CLI bundle for on-router runs)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "libc",
  "packetframe-common",
  "packetframe-fast-path",
+ "packetframe-guard",
  "packetframe-probe",
  "packetframe-vpp-offload",
  "serde",

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -538,3 +538,62 @@ module fast-path
 # AF (error 710, no v6 extraction in the vendor NPC profile), so v6 stays
 # on the XDP custom-FIB path. v6 `allow-prefix6` entries are counted and
 # skipped, not attempted.
+
+# --- guard (tc-egress frame policer) ----------------------------------------
+# Polices locally-originated L2 frames the platform's firmware emits
+# uncontrollably: UniFi's udapi-server runs arping/ndisc6 against every
+# kernel neighbor (the resulting broadcast storms got this fleet blocked
+# from an IX), lldpd leaks LLDP, and an HA standby's MAC appearing on an
+# IX VLAN trips port security. tc egress is the only eBPF hook that
+# observes kernel egress (XDP is ingress-only, NIC filters are RX-only,
+# and the vpp-offload dataplane never carries kernel-originated frames),
+# so this module stays load-bearing at every stage of the vpp-offload
+# roadmap.
+#
+# RUN MONITOR FIRST. Every class takes `monitor` (count, don't enforce);
+# deploy with monitor, watch packetframe_guard_frames_total{verdict=
+# "monitored"} for a quiet week, then flip to enforce via SIGHUP. The
+# monitor counters exactly predict enforce behavior (the rate limiter
+# advances identically in both modes).
+#
+# `interface` lines are RESTART-ONLY (the filter and the expected-MAC
+# snapshot are attach-time-bound; the restart dance is stop →
+# `packetframe detach` → start). Every class rule is HOT-RELOADABLE:
+# rates, burst, and monitor↔enforce apply on SIGHUP with no reattach.
+# An `interface` with no class rules, or a rule naming an undeclared
+# interface, is refused at load.
+#
+# The boot window before packetframe.service attaches is NOT covered —
+# keep any switch-side ACL backstop until the counters have earned the
+# fabric operator's trust.
+#
+# module guard
+#   interface br3998              # the IX-facing bridges; one egress
+#   interface br3999              # classifier per listed interface
+#
+#   arp-ns-ratelimit br3998 rate 3/60s burst 3
+#                                 # per-TARGET token bucket over ARP
+#                                 # requests + ICMPv6 NS. burst 3 covers
+#                                 # the kernel's full resolution cycle
+#                                 # (3 probes at 1/s, mcast_solicit=3),
+#                                 # so legitimate resolution never
+#                                 # clamps; a daemon re-probing the same
+#                                 # target forever gets 1 per 20s.
+#   lldp br3998 drop              # ethertype 0x88cc
+#   foreign-src br3998 drop       # src MAC != the interface's own (the
+#                                 # "one MAC per member per VLAN" rule
+#                                 # IX port security enforces). Expected
+#                                 # MAC is read from the interface at
+#                                 # attach - self-referential, survives
+#                                 # HA role changes without config edits.
+#   bcast-mcast-ratelimit br3998 rate 50/1s monitor
+#                                 # coarse per-interface catch-all for
+#                                 # every other broadcast/multicast
+#                                 # frame (MLD, LLC/BPDUs, GARP, the
+#                                 # next noisy daemon). Start in monitor
+#                                 # and size the rate from the observed
+#                                 # counters before enforcing.
+#
+#   arp-ns-ratelimit br3999 rate 3/60s burst 3
+#   lldp br3999 drop
+#   foreign-src br3999 drop

--- a/conf/example.conf
+++ b/conf/example.conf
@@ -550,6 +550,10 @@ module fast-path
 # so this module stays load-bearing at every stage of the vpp-offload
 # roadmap.
 #
+# Requires the fast-path section (guard v1 runs alongside the fast-path
+# daemon; the startup capability gate and metrics exporter assume it —
+# a guard-only config is refused at load).
+#
 # RUN MONITOR FIRST. Every class takes `monitor` (count, don't enforce);
 # deploy with monitor, watch packetframe_guard_frames_total{verdict=
 # "monitored"} for a quiet week, then flip to enforce via SIGHUP. The

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 packetframe-common.workspace = true
 packetframe-fast-path = { workspace = true, optional = true }
 packetframe-vpp-offload = { workspace = true, optional = true }
+packetframe-guard = { workspace = true, optional = true }
 packetframe-probe = { workspace = true, optional = true }
 
 anyhow.workspace = true
@@ -30,9 +31,10 @@ libc.workspace = true
 signal-hook.workspace = true
 
 [features]
-default = ["fast-path", "probe", "vpp-offload"]
+default = ["fast-path", "guard", "probe", "vpp-offload"]
 fast-path = ["dep:packetframe-fast-path"]
 vpp-offload = ["dep:packetframe-vpp-offload"]
+guard = ["dep:packetframe-guard"]
 probe = ["dep:packetframe-probe"]
 
 # cargo-deb metadata. CI builds the .deb in the release workflow via

--- a/crates/cli/src/feasibility.rs
+++ b/crates/cli/src/feasibility.rs
@@ -38,6 +38,26 @@ pub fn attach_ifaces_from_config(config: &Config) -> Vec<String> {
     ifaces
 }
 
+/// Interfaces named by `interface` lines in a `guard` section, if
+/// any. Empty when the module isn't configured — the guard probes
+/// then stay out of the report entirely.
+pub fn guard_ifaces_from_config(config: &Config) -> Vec<String> {
+    let mut ifaces = Vec::new();
+    for m in &config.modules {
+        if m.name != "guard" {
+            continue;
+        }
+        for d in &m.directives {
+            if let ModuleDirective::GuardInterface { iface, .. } = d {
+                if !ifaces.contains(iface) {
+                    ifaces.push(iface.clone());
+                }
+            }
+        }
+    }
+    ifaces
+}
+
 /// Interfaces named by `port` lines in a `vpp-offload` section, if
 /// any. Empty when the module isn't configured — the vpp probes then
 /// stay out of the report entirely.
@@ -308,6 +328,7 @@ pub fn probe_and_render(
     attach_ifaces: &[String],
     vpp: &VppProbeInputs<'_>,
     allowlist: &[IpPrefix],
+    guard_ifaces: &[String],
     human: bool,
 ) -> Rendered {
     let mut report = run_probes(bpffs_root);
@@ -360,6 +381,16 @@ pub fn probe_and_render(
         let _ = (vpp, allowlist);
         Vec::new()
     };
+    // guard probes: only when the config declares the module. All
+    // non-required (feasibility informs, the module's attach enforces).
+    #[cfg(feature = "guard")]
+    if !guard_ifaces.is_empty() {
+        for cap in packetframe_guard::run_feasibility_probes(guard_ifaces) {
+            report.capabilities.push(cap);
+        }
+    }
+    #[cfg(not(feature = "guard"))]
+    let _ = guard_ifaces;
     // `passed` needs recomputing after the iface probes; the trial
     // attach caps are non-required (a native-XDP failure shouldn't
     // abort startup), but we preserve the existing `passed` logic.

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -1059,6 +1059,26 @@ fn reconfigure_from_signal(
     allowlist.publish(crate::feasibility::allowlist_from_config(&new_config));
 
     let mut failures: Vec<String> = Vec::new();
+    // Additions are restart-only, symmetric with the removal refusal
+    // below: the module set is fixed at startup, so a section with no
+    // loaded module cannot be constructed here. Without this, adding
+    // `module guard` and reloading wrote an OK marker while no guard
+    // existed — the operator believes the documented monitor/enforce
+    // protection is active when nothing is attached (review finding,
+    // PR #206).
+    for section in &new_config.modules {
+        if !modules.iter().any(|(name, _)| name == &section.name) {
+            tracing::warn!(
+                module = %section.name,
+                "module added to config; reconfigure cannot construct it \
+                 (the module set is restart-only)"
+            );
+            failures.push(format!(
+                "{}: added to config (restart required)",
+                section.name
+            ));
+        }
+    }
     for (name, module) in modules.iter_mut() {
         let section = match new_config.modules.iter().find(|m| &m.name == name) {
             Some(s) => s,
@@ -1521,25 +1541,36 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // alone — the first version of this teardown ran unconditionally and
     // would have terminated a VPP the operator never asked about, purely
     // because it shares the state dir.
-    let (bpffs_root, state_dir, settle_time, config_has_vpp, config_has_guard) = match config {
+    let (
+        bpffs_root,
+        state_dir,
+        settle_time,
+        config_has_fast_path,
+        config_has_vpp,
+        config_has_guard,
+    ) = match config {
         Some(p) => {
             let c = Config::from_file(p).map_err(|e| format!("config parse: {e}"))?;
+            let has_fast_path = c.modules.iter().any(|m| m.name == "fast-path");
             let has_vpp = c.modules.iter().any(|m| m.name == "vpp-offload");
             let has_guard = c.modules.iter().any(|m| m.name == "guard");
             (
                 c.global.bpffs_root,
                 c.global.state_dir,
                 c.global.attach_settle_time,
+                has_fast_path,
                 has_vpp,
                 has_guard,
             )
         }
-        // No config at all: nothing scopes the request, so only `--all`
-        // authorises reaching past fast-path.
+        // No config at all: nothing scopes the request. fast-path is
+        // torn down (the historical bare-`detach` recovery semantics);
+        // only `--all` authorises reaching past it.
         None => (
             PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
             PathBuf::from(packetframe_common::config::DEFAULT_STATE_DIR),
             packetframe_common::config::DEFAULT_ATTACH_SETTLE_TIME,
+            true,
             false,
             false,
         ),
@@ -1606,10 +1637,25 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     )]
     let mut errors: Vec<String> = Vec::new();
 
+    // fast-path follows the same scoping rule as the other modules now
+    // that a config without a fast-path section is legitimate (a
+    // guard-only scoping config, the fastpath-only.conf inverse): a
+    // scoped detach must not interrupt forwarding the operator never
+    // asked about. A bare `detach` (no config) still tears fast-path
+    // down — the historical recovery semantics.
     #[cfg(feature = "fast-path")]
-    if let Err(e) = detach_fast_path(&bpffs_root, &state_dir, settle_time) {
-        errors.push(e);
+    if all || config_has_fast_path {
+        if let Err(e) = detach_fast_path(&bpffs_root, &state_dir, settle_time) {
+            errors.push(e);
+        }
+    } else {
+        tracing::info!(
+            "fast-path state left alone: this detach is scoped to the supplied config; \
+             use `--all` to tear down modules it does not declare"
+        );
     }
+    #[cfg(not(feature = "fast-path"))]
+    let _ = (config_has_fast_path, settle_time);
 
     #[cfg(feature = "vpp-offload")]
     if all || config_has_vpp {

--- a/crates/cli/src/loader.rs
+++ b/crates/cli/src/loader.rs
@@ -119,6 +119,9 @@ pub fn run(config_path: &Path) -> Result<(), RunError> {
     config
         .validate_vpp_offload()
         .map_err(|e| RunError::Startup(e.to_string()))?;
+    config
+        .validate_guard()
+        .map_err(|e| RunError::Startup(e.to_string()))?;
 
     // Fail fast if metrics-textfile can't be written, the exporter
     // would retry silently every 15s otherwise.
@@ -341,6 +344,15 @@ fn run_linux(config: Config, config_path: &Path) -> Result<(), RunError> {
                     m.set_feed_session(h.clone());
                 }
                 modules.push((section.name.clone(), Box::new(m) as Box<dyn Module>));
+            }
+            #[cfg(feature = "guard")]
+            "guard" => {
+                // No cross-module setters: the guard reads only its
+                // own section plus the interface state at attach.
+                modules.push((
+                    section.name.clone(),
+                    Box::new(packetframe_guard::GuardModule::new()) as Box<dyn Module>,
+                ));
             }
             other => {
                 return Err(RunError::Startup(format!(
@@ -1019,6 +1031,15 @@ fn reconfigure_from_signal(
         write_reconfigure_marker(&marker_path, &format!("ERR validate: {e}"));
         return Published::No;
     }
+    // Same rule for the guard section: every validator that runs at
+    // startup must also run at reload, or SIGHUP silently applies a
+    // config startup would refuse (the incident this comment block
+    // exists to prevent).
+    if let Err(e) = new_config.validate_guard() {
+        tracing::error!(error = %e, "SIGHUP config is unsafe to apply; keeping current config");
+        write_reconfigure_marker(&marker_path, &format!("ERR validate: {e}"));
+        return Published::No;
+    }
 
     // After the two refusals above and before the module loop: a
     // rejected reload changes nothing, including this, and a module
@@ -1500,15 +1521,17 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // alone — the first version of this teardown ran unconditionally and
     // would have terminated a VPP the operator never asked about, purely
     // because it shares the state dir.
-    let (bpffs_root, state_dir, settle_time, config_has_vpp) = match config {
+    let (bpffs_root, state_dir, settle_time, config_has_vpp, config_has_guard) = match config {
         Some(p) => {
             let c = Config::from_file(p).map_err(|e| format!("config parse: {e}"))?;
             let has_vpp = c.modules.iter().any(|m| m.name == "vpp-offload");
+            let has_guard = c.modules.iter().any(|m| m.name == "guard");
             (
                 c.global.bpffs_root,
                 c.global.state_dir,
                 c.global.attach_settle_time,
                 has_vpp,
+                has_guard,
             )
         }
         // No config at all: nothing scopes the request, so only `--all`
@@ -1517,6 +1540,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
             PathBuf::from(packetframe_common::config::DEFAULT_BPFFS_ROOT),
             PathBuf::from(packetframe_common::config::DEFAULT_STATE_DIR),
             packetframe_common::config::DEFAULT_ATTACH_SETTLE_TIME,
+            false,
             false,
         ),
     };
@@ -1577,7 +1601,7 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
     // nothing can push. Not a CI configuration (clippy runs
     // `--all-features`), but a warning is a warning.
     #[cfg_attr(
-        not(any(feature = "fast-path", feature = "vpp-offload")),
+        not(any(feature = "fast-path", feature = "vpp-offload", feature = "guard")),
         allow(unused_mut)
     )]
     let mut errors: Vec<String> = Vec::new();
@@ -1599,11 +1623,55 @@ pub fn detach(config: Option<&Path>, all: bool) -> Result<(), String> {
         );
     }
     #[cfg(not(feature = "vpp-offload"))]
-    let _ = (all, config_has_vpp);
+    let _ = config_has_vpp;
+
+    // Same scoping rule as vpp-offload: a detach scoped to a config
+    // without a guard section must leave the guard's egress filters
+    // alone; `--all` is the recovery path every guard error message
+    // advertises, so it must actually reach them.
+    #[cfg(feature = "guard")]
+    if all || config_has_guard {
+        if let Err(e) = detach_guard(&bpffs_root, &state_dir) {
+            errors.push(e);
+        }
+    } else {
+        tracing::info!(
+            "guard state left alone: this detach is scoped to the supplied config; \
+             use `--all` to tear down modules it does not declare"
+        );
+    }
+    #[cfg(not(feature = "guard"))]
+    let _ = config_has_guard;
+    #[cfg(not(any(feature = "vpp-offload", feature = "guard")))]
+    let _ = all;
 
     if !errors.is_empty() {
         return Err(errors.join("; AND "));
     }
+    Ok(())
+}
+
+/// The guard half of `detach`: state-file-driven teardown of the
+/// egress filters + pins (no live loader required — netlink cls_bpf
+/// filters have qdisc lifetime). Same split-out rationale as
+/// `detach_fast_path`: its errors aggregate rather than abort the
+/// other modules' teardown.
+#[cfg(all(feature = "guard", target_os = "linux"))]
+fn detach_guard(bpffs_root: &Path, state_dir: &Path) -> Result<(), String> {
+    match packetframe_guard::detach_from_state_dir(state_dir, bpffs_root) {
+        Ok(cleared) => {
+            if cleared > 0 {
+                tracing::info!(cleared, "guard tc egress filters detached");
+            }
+            Ok(())
+        }
+        Err(e) => Err(format!("guard: {e}")),
+    }
+}
+
+#[cfg(all(feature = "guard", not(target_os = "linux")))]
+fn detach_guard(_bpffs_root: &Path, _state_dir: &Path) -> Result<(), String> {
+    // Nothing can be attached on a stub platform.
     Ok(())
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -369,6 +369,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
         allowlist,
         vpp_dirs,
         vpp_exempts,
+        guard_ifaces,
     ) = match &config {
         Some(path) => match Config::from_file(path) {
             Ok(c) => {
@@ -380,6 +381,10 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                     eprintln!("vpp-offload config check failed: {e}");
                     return ExitCode::from(EXIT_STARTUP_ERROR);
                 }
+                if let Err(e) = c.validate_guard() {
+                    eprintln!("guard config check failed: {e}");
+                    return ExitCode::from(EXIT_STARTUP_ERROR);
+                }
                 let ifaces = feasibility::attach_ifaces_from_config(&c);
                 let vpp_ports = feasibility::vpp_ports_from_config(&c);
                 let vpp_steer_ports = feasibility::vpp_steer_ports_from_config(&c);
@@ -389,6 +394,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                 let allowlist = feasibility::allowlist_from_config(&c);
                 let vpp_dirs = feasibility::vpp_steer_directions_from_config(&c);
                 let vpp_exempts = feasibility::vpp_steer_exempts_from_config(&c);
+                let guard_ifaces = feasibility::guard_ifaces_from_config(&c);
                 (
                     c.global.bpffs_root,
                     ifaces,
@@ -400,6 +406,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
                     allowlist,
                     vpp_dirs,
                     vpp_exempts,
+                    guard_ifaces,
                 )
             }
             Err(e) => {
@@ -415,6 +422,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             0,
             None,
             None,
+            Vec::new(),
             Vec::new(),
             Vec::new(),
             Vec::new(),
@@ -434,6 +442,7 @@ fn run_feasibility(config: Option<PathBuf>, human: bool) -> ExitCode {
             steer_exempts: &vpp_exempts,
         },
         &allowlist,
+        &guard_ifaces,
         human,
     );
     if let Some(json) = report.json_output {

--- a/crates/cli/src/metrics.rs
+++ b/crates/cli/src/metrics.rs
@@ -102,15 +102,33 @@ fn write_once(
     modules: &ModuleGauges,
     uptime_seconds: u64,
 ) -> Result<(), String> {
-    let stats = packetframe_fast_path::stats_from_pin(bpffs_root)
-        .map_err(|e| format!("read STATS pin: {e}"))?;
-    let mut body = packetframe_fast_path::metrics::render_textfile(&stats, uptime_seconds);
-    // Custom-FIB occupancy gauges (Option F, Phase 3.8). Best-effort:
-    // `fib_status_from_pin` returns a default snapshot when the pins
-    // aren't readable (e.g., kernel-fib mode), and the renderer
-    // handles that by emitting zeros + a `mode=\"kernel-fib\"` one-hot.
-    let fib = packetframe_fast_path::fib_status_from_pin(bpffs_root);
-    body.push_str(&packetframe_fast_path::metrics::render_fib_gauges(&fib));
+    // Best-effort like every other block: an unreadable fast-path
+    // STATS pin loses fast-path's counters for this tick, never the
+    // whole file. This used to be a fatal early return, which starved
+    // OTHER modules' gauges of publication whenever fast-path's pins
+    // were absent — during a detached window, and structurally for a
+    // config that doesn't declare fast-path at all: the guard's
+    // monitor-first rollout reads exactly those module gauges (review
+    // finding, PR #206).
+    let mut body = String::new();
+    match packetframe_fast_path::stats_from_pin(bpffs_root) {
+        Ok(stats) => {
+            body.push_str(&packetframe_fast_path::metrics::render_textfile(
+                &stats,
+                uptime_seconds,
+            ));
+            // Custom-FIB occupancy gauges (Option F, Phase 3.8).
+            // Best-effort: `fib_status_from_pin` returns a default
+            // snapshot when the pins aren't readable (e.g., kernel-fib
+            // mode), and the renderer handles that by emitting zeros +
+            // a `mode="kernel-fib"` one-hot.
+            let fib = packetframe_fast_path::fib_status_from_pin(bpffs_root);
+            body.push_str(&packetframe_fast_path::metrics::render_fib_gauges(&fib));
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "fast-path STATS pin unavailable this tick");
+        }
+    }
     // Host softirq pressure. `time_squeeze` is the one early signal
     // for the silent generic-XDP TX drop mechanism (2026-08-13,
     // w12–w19), which no packetframe counter, qdisc stat, or tcpdump

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -1732,6 +1732,26 @@ impl Config {
                 });
             }
         }
+
+        // v1 rides the fast-path daemon (the vpp-offload precedent):
+        // the startup feasibility gate's REQUIRED probes are the
+        // fast-path module's (XDP, LPM/devmap, redirect helpers —
+        // none of which a tc-egress policer needs), so a guard-only
+        // config would be refused for capabilities it never uses,
+        // several confusing steps downstream. Requiring the section
+        // makes the limitation explicit at the earliest point;
+        // deriving the probe set from the configured modules lifts it
+        // later. Checked LAST so a malformed guard section reports
+        // its own specific problem first.
+        if !self.modules.iter().any(|m| m.name == "fast-path") {
+            return Err(ConfigError::Parse {
+                line: 0,
+                message: "module guard: requires a `module fast-path` section (guard v1 \
+                          runs alongside the fast-path daemon; the startup capability \
+                          gate assumes it — a guard-only config cannot start)"
+                    .to_string(),
+            });
+        }
         Ok(())
     }
 }
@@ -5912,7 +5932,9 @@ module fast-path
     /// field lands where the parser promised.
     #[test]
     fn guard_section_parses_reference_shape() {
-        let s = "module guard\n\
+        let s = "module fast-path\n\
+                 \x20 attach eth0 generic\n\
+                 module guard\n\
                  \x20 interface br3998\n\
                  \x20 interface br3999\n\
                  \x20 arp-ns-ratelimit br3998 rate 3/60s burst 3\n\
@@ -5922,7 +5944,7 @@ module fast-path
                  \x20 arp-ns-ratelimit br3999 rate 2/30s\n";
         let c = Config::parse(s).unwrap();
         c.validate_guard().expect("reference shape must validate");
-        let m = &c.modules[0];
+        let m = &c.modules[1];
         assert_eq!(m.name, "guard");
         match &m.directives[2] {
             ModuleDirective::GuardArpNsRatelimit {
@@ -6041,6 +6063,15 @@ module fast-path
                 "module guard\n  interface br0\n  interface br1\n  lldp br0 drop\n".to_string(),
                 "`interface br1` declares no rules",
             ),
+            // A fully valid guard section without a fast-path section:
+            // v1 rides the fast-path daemon (the startup capability
+            // gate assumes it), so guard-only is refused explicitly
+            // rather than several confusing steps downstream (review
+            // finding, PR #206).
+            (
+                "module guard\n  interface br0\n  lldp br0 drop\n".to_string(),
+                "requires a `module fast-path` section",
+            ),
         ];
         for (s, want) in cases {
             let e = Config::parse(&s).unwrap().validate_guard().expect_err(&s);
@@ -6057,7 +6088,7 @@ module fast-path
     #[test]
     fn guard_interface_count_is_capped_at_the_map_size() {
         let over = |n: usize| {
-            let mut s = String::from("module guard\n");
+            let mut s = String::from("module fast-path\n  attach eth0 generic\nmodule guard\n");
             for i in 0..n {
                 s.push_str(&format!("  interface br{i}\n  lldp br{i} drop\n"));
             }

--- a/crates/modules/guard/src/linux_impl.rs
+++ b/crates/modules/guard/src/linux_impl.rs
@@ -131,7 +131,30 @@ pub(crate) fn load(
 /// FIRST (fail-open defaults mean there is never an attached-but-
 /// unconfigured window), then clsact + egress filter, then the state-
 /// file record. Pins after the loop.
+///
+/// A mid-way failure unwinds the guard's OWN partial state: the
+/// loader's startup unwind covers modules whose attach *succeeded*,
+/// never the one failing, and netlink filters have qdisc lifetime —
+/// without this they would keep enforcing behind a failed startup
+/// (review finding, PR #206). The per-attach record saves make the
+/// state file name everything live, so the standalone teardown is the
+/// rollback.
 pub(crate) fn attach(state: &mut ActiveState, settle_time: Duration) -> ModuleResult<()> {
+    if let Err(e) = attach_all(state, settle_time) {
+        let cleanup = match detach_from_state_dir(&state.state_dir, &state.bpffs_root) {
+            Ok(0) => "nothing was attached yet".to_string(),
+            Ok(n) => format!("{n} partially-attached filter(s) rolled back"),
+            Err(de) => {
+                format!("partial-state rollback ALSO failed ({de}); run `packetframe detach --all`")
+            }
+        };
+        state.attached.clear();
+        return Err(ModuleError::other(MODULE_NAME, format!("{e}; {cleanup}")));
+    }
+    Ok(())
+}
+
+fn attach_all(state: &mut ActiveState, settle_time: Duration) -> ModuleResult<()> {
     pin::ensure_dirs(&state.bpffs_root)
         .map_err(|e| ModuleError::other(MODULE_NAME, format!("create pin dirs: {e}")))?;
 

--- a/docs/runbooks/guard.md
+++ b/docs/runbooks/guard.md
@@ -55,7 +55,15 @@ module guard
   answers the IX operator's reply-only-mode blackhole objection.
 - Refused at load: an empty section, duplicate `interface` lines, a
   class rule naming an undeclared interface, duplicate
-  `(class, interface)` pairs, an `interface` with zero rules.
+  `(class, interface)` pairs, an `interface` with zero rules, more
+  interfaces than the datapath's config map holds (64), and a guard
+  section without a fast-path section — guard v1 runs alongside the
+  fast-path daemon (the startup capability gate assumes it), the same
+  explicit dependency vpp-offload declares.
+- Adding or removing a *module section* is restart-only: a SIGHUP that
+  introduces `module guard` is refused by name (the daemon cannot
+  construct modules after startup) — reload only reconciles rules on a
+  guard that attached at start.
 
 ## The monitor→enforce ladder
 

--- a/docs/runbooks/guard.md
+++ b/docs/runbooks/guard.md
@@ -1,0 +1,167 @@
+# guard — tc-egress frame policer
+
+Operational runbook for the `guard` module: what it polices, the
+monitor→enforce ladder, counter reading, triage, and recovery.
+
+## What it is, in one paragraph
+
+A tc-**egress** cls_bpf classifier on configured interfaces (in
+production: the IX-facing bridges) that polices locally-originated L2
+frames the platform's firmware emits uncontrollably. Four fixed
+classes, each per-interface and independently `monitor` or enforce:
+per-target rate-limited ARP requests / IPv6 Neighbor Solicitations,
+dropped LLDP, dropped foreign-source-MAC frames, and a coarse
+broadcast/multicast catch-all. It exists because udapi-server's
+arping/ndisc6 storms got this fleet blocked from an IX, LLDP/BPDU
+leaks and a leaked standby MAC tripped IX port security — and because
+**tc egress is the only eBPF hook that can see this traffic**: it is
+kernel egress (including AF_PACKET injections like arping's),
+invisible to XDP (ingress-only), NIC ntuple/MCAM (RX-only), and VPP
+(never carries kernel-originated frames). That stays true at every
+stage of the vpp-offload roadmap, so the guard is permanent
+architecture, not a stopgap.
+
+## What it deliberately does NOT cover
+
+- **The boot window.** Filters attach when `packetframe.service`
+  starts; between kernel-up and attach, firmware daemons can spray.
+  Keep the switch-side ACL backstop until the fabric operator agrees
+  to relax it.
+- **Frames the agg switches originate.** PF runs on the router;
+  switch-originated LLDP/BPDUs are the switch-config tooling's job.
+- **Ingress traffic.** Dropping inbound attacks is a different module
+  (ddos, XDP/MCAM — see the plan history); the guard never inspects
+  received frames.
+
+## Config in one screen
+
+```
+module guard
+  interface br3998                              # RESTART-ONLY
+  arp-ns-ratelimit br3998 rate 3/60s burst 3    # hot
+  lldp br3998 drop                              # hot
+  foreign-src br3998 drop                       # hot
+  bcast-mcast-ratelimit br3998 rate 50/1s monitor
+```
+
+- `interface` set: restart-only (stop → `packetframe detach` → start).
+  Everything else reconciles on SIGHUP with no reattach and no bucket
+  reset.
+- The rate limiter is per **target address** (ARP tpa / NS target),
+  not per frame class: `rate 3/60s burst 3` means each target gets a
+  3-frame burst then 1 per 20 s. Burst 3 covers the kernel's full
+  resolution cycle (3 probes at 1 s intervals, `mcast_solicit=3`), so
+  legitimate neighbor resolution never clamps — the property that
+  answers the IX operator's reply-only-mode blackhole objection.
+- Refused at load: an empty section, duplicate `interface` lines, a
+  class rule naming an undeclared interface, duplicate
+  `(class, interface)` pairs, an `interface` with zero rules.
+
+## The monitor→enforce ladder
+
+1. Deploy every class with `monitor`. Confirm
+   `packetframe status` shows the module healthy and
+   `packetframe_guard_frames_total{verdict="monitored"}` moving where
+   you expect (udapi's ARP cadence should show up within minutes).
+2. Let it sit long enough to cover a provisioning cycle and a quiet
+   night. Anything unexpected in `class="bcast_mcast"` monitored
+   counts — identify before enforcing; that class is the blast-radius
+   one.
+3. Flip `lldp` and `foreign-src` to `drop` first (SIGHUP). Both are
+   unambiguous violations; neither has a legitimate emitter on an IX
+   port.
+4. Flip `arp-ns-ratelimit` to enforce. Watch
+   `verdict="dropped"` — it should match what `monitored` predicted
+   exactly (the limiter's state advances identically in both modes).
+5. Enforce `bcast-mcast-ratelimit` last, with a rate sized from the
+   observed monitored baseline plus headroom.
+
+## Counters
+
+Two Prometheus families, both in the standard textfile:
+
+- `packetframe_guard_frames_total{class, verdict}` — class ∈
+  `{arp, ns, lldp, foreign_src, bcast_mcast}`, verdict ∈
+  `{passed, dropped, monitored}`. `monitored` = would-have-dropped.
+- `packetframe_guard_<name>_total` bookkeeping: `total_egress`,
+  `pass_no_cfg`, `pass_no_match`, `err_parse_*`.
+
+Attribution notes that will otherwise confuse a 3am reader:
+
+- **`foreign_src` monitored is non-terminal**: the frame is counted
+  and continues through the remaining classes, so one frame can move
+  `foreign_src/monitored` AND an `arp/*` counter. Every other counter
+  is exclusive; `total_egress` equals the sum of the terminal ones.
+- With the `lldp` class disabled, LLDP still lands in
+  `bcast_mcast` (its dst MAC is multicast). Same for ARP *replies*,
+  GARP, and NS behind IPv6 extension headers — the catch-all is the
+  backstop for everything ND-shaped the specific classes don't parse.
+- `pass_no_cfg` should be ~0 in steady state; sustained movement means
+  frames egressing an attached interface whose config-map entry is
+  missing or version-skewed — a bug, report it.
+- `err_parse_*` count fail-open passes on truncated headers. Local
+  daemons don't emit runts; sustained movement is worth a tcpdump.
+
+## Triage by symptom
+
+- **Neighbor resolution slow/failing on an IX** (peers unreachable,
+  `ip neigh` stuck in `INCOMPLETE`): check `arp/dropped` +
+  `ns/dropped`. If they move in step with the failures, the rate is
+  too tight or a legitimate burst pattern exceeds it — flip to
+  `monitor` via SIGHUP (instant, no restart) and re-derive the rate.
+- **IX operator still sees storms while enforce is on**: confirm the
+  filter exists (`tc filter show dev br3998 egress`), the module is
+  healthy in `packetframe status`, and `total_egress` is moving. If
+  the storm is on a VLAN/interface the guard isn't attached to,
+  remember frames the *switch* originates never traverse the router.
+- **Module health row `attach:<iface>` Degraded, "interface
+  vanished"**: the device was deleted; qdisc-lifetime filters die with
+  their device, nothing is leaked. Restart after the interface is
+  back.
+- **Startup refuses with "existing pins"**: prior invocation's state;
+  run the standard recovery (below). v0.1 never adopts in place.
+
+## Recovery / teardown
+
+`packetframe detach` (config-scoped — only when the config has a
+guard section) or `packetframe detach --all` tears down the egress
+filters from `guard-tc-links.json` and removes the pins under
+`<bpffs-root>/guard/`. The clsact qdisc is deliberately left in place
+(fast-path may share it on the same interface). A detach that cannot
+prove a filter is gone retains its record and errors — rerun it, or
+as a last resort `tc filter del dev <iface> egress`.
+
+Manual state check:
+
+```
+tc filter show dev br3998 egress          # the classifier
+cat /var/lib/packetframe/state/guard-tc-links.json
+ls /sys/fs/bpf/packetframe/guard/{progs,maps}
+```
+
+## Coexistence with fast-path / vpp-offload
+
+- fast-path (tc ingress on some ports) and guard (tc egress) share one
+  clsact qdisc per interface; attach order doesn't matter and each
+  module's detach removes only its own filter.
+- Guard state lives in `guard-tc-links.json` — **never** in
+  fast-path's `tc-links.json`, which fast-path's detach tears down
+  unconditionally.
+- vpp-offload steering has no interaction: MCAM diverts ingress before
+  the kernel; VPP's own egress bypasses kernel tc; the frames guard
+  polices never enter either path. Kernel neighbor resolution (which
+  VPP's adjacencies are mirrored from) keeps working under enforce by
+  design of the per-target rate limit.
+
+## Implementation notes an operator may need once
+
+- Rate limiting is GCRA: one deadline word per bucket, `burst`
+  back-to-back then 1 per `interval/rate`, idle targets decay back to
+  full burst. Buckets are hash-indexed with **collision = shared
+  budget** (strictly stricter, never evasion); 4096 slots for ARP/NS
+  targets, 256 for the per-interface catch-all.
+- A rate increase applied by SIGHUP can leave a hot target clamped for
+  up to one *old* burst window (stale deadlines are not flushed);
+  converges on its own.
+- The expected MAC for `foreign-src` is snapshotted at attach. If an
+  interface's MAC legitimately changes, restart the daemon.


### PR DESCRIPTION
Slice 3 of 4, stacked on #205.

- Loader: `"guard"` match arm (cfg-gated `guard` feature, in the default set); no cross-module setters — guard reads only its own section plus interface state at attach.
- `validate_guard` wired at **all three** validation sites (startup, feasibility, SIGHUP) per the recorded reload-validation incident.
- `detach` scoping: `config_has_guard` alongside `config_has_vpp`; `detach_guard` errors aggregate with the other modules' rather than short-circuiting. `--all` reaches guard state always — every guard error message advertises it as the recovery path, so it has to actually work.
- Feasibility: `guard_ifaces_from_config` extractor + non-required probes (`guard.bpf.embedded`, `guard.kernel.cls_bpf` via common's now-pub kconfig readers, `guard.iface.<name>`).
- Docs: commented `module guard` block in example.conf (monitor-first, `rate 3/60s burst 3` with the mcast_solicit=3 rationale), `docs/runbooks/guard.md` (monitor→enforce ladder, counter-attribution notes incl. the non-terminal foreign_src/monitored counter, triage by symptom, recovery, coexistence with fast-path's shared clsact), CLAUDE.md repo-layout line.

Verifiable: `packetframe feasibility --config <guard section>` renders the guard capabilities; startup/SIGHUP refuse invalid guard sections by name; scoped detach leaves guard filters alone while `--all` clears them. The attach/netns integration tests land in slice 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)