### PR TITLE
test(guard): real egress attach lifecycle + netns end-to-end clamp

### DIFF
--- a/.github/workflows/hardware-artifacts.yml
+++ b/.github/workflows/hardware-artifacts.yml
@@ -424,7 +424,8 @@ jobs:
           #
           # Excluded from the default run, name them explicitly to opt in:
           #   attach, tc_attach, netns, local_prefix_netns,
-          #   neigh_resolver_netns  — create interfaces or netns
+          #   neigh_resolver_netns, guard_tc_attach, guard_netns
+          #     — create interfaces or netns
           #   fib_comparison, fib_programmer_integration — pin maps into a
           #     scratch /sys/fs/bpf/pftestcmp-<pid>-<n> dir (removed on
           #     exit) and mount bpffs if it isn't already mounted

--- a/crates/modules/guard/src/lib.rs
+++ b/crates/modules/guard/src/lib.rs
@@ -19,9 +19,8 @@
 //! frames). That remains true at every stage of the vpp-offload
 //! roadmap, so this module is permanent architecture, not a stopgap.
 //!
-//! **Slice status:** config model, BPF datapath, and the Linux
-//! lifecycle are in place; the CLI does not construct this module
-//! until the next slice, so nothing reaches it at runtime yet.
+//! Operations: `docs/runbooks/guard.md` (monitor→enforce ladder,
+//! counter attribution, triage, recovery).
 
 pub mod cfg;
 pub mod metrics;
@@ -32,7 +31,7 @@ pub mod tc_links;
 #[cfg(target_os = "linux")]
 mod linux_impl;
 #[cfg(target_os = "linux")]
-pub use linux_impl::{detach_from_state_dir, stats_from_pin};
+pub use linux_impl::{detach_from_state_dir, stats_from_pin, tc_attach_egress};
 
 pub use probe_linux::run_feasibility_probes;
 

--- a/crates/modules/guard/src/linux_impl.rs
+++ b/crates/modules/guard/src/linux_impl.rs
@@ -372,7 +372,7 @@ pub(crate) fn sample_metrics(state: &ActiveState, out: &mut String) -> ModuleRes
 /// Attach `guard_egress` to `iface`'s clsact **egress** and return the
 /// kernel-assigned `(priority, handle)`. Mirror of fast-path's
 /// `tc_attach_iface`; see the module doc for the shared rationale.
-fn tc_attach_egress(ebpf: &mut Ebpf, iface: &str) -> ModuleResult<(u16, u32)> {
+pub fn tc_attach_egress(ebpf: &mut Ebpf, iface: &str) -> ModuleResult<(u16, u32)> {
     use aya::programs::tc::{
         qdisc_add_clsact, NlOptions, SchedClassifier, TcAttachOptions, TcAttachType,
     };

--- a/crates/modules/guard/tests/guard_netns.rs
+++ b/crates/modules/guard/tests/guard_netns.rs
@@ -291,11 +291,26 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
         send_frame(&tx, ifindex_a, &storm);
     }
     let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_a));
+    // Assert the pipeline stages in order, each with the counter
+    // snapshot, so a failure names WHERE it broke: program not in the
+    // egress path (total_egress stuck), config lookup missing
+    // (pass_no_cfg), classifier not matching (pass_no_match), or the
+    // limiter not clamping (arp_pass = 40).
+    let stats = h.snapshot();
+    assert!(
+        stats[idx::TOTAL_EGRESS] >= 40,
+        "guard_egress did not run at real egress: stats={stats:?}"
+    );
+    assert_eq!(
+        stats[idx::PASS_NO_CFG],
+        0,
+        "GUARD_CFG lookup missed at real egress (skb->ifindex vs written key?): stats={stats:?}"
+    );
     // Lower bound: the burst. Upper bound: burst plus the refill a
     // slow, ENOBUFS-paced send loop can legitimately admit at 5/s.
     assert!(
         (5..=20).contains(&delivered),
-        "expected ~burst(5) of 40 frames delivered, got {delivered}"
+        "expected ~burst(5) of 40 frames delivered, got {delivered}; stats={stats:?}"
     );
     assert!(
         h.stat(idx::ARP_DROP) >= 20,

--- a/crates/modules/guard/tests/guard_netns.rs
+++ b/crates/modules/guard/tests/guard_netns.rs
@@ -173,22 +173,34 @@ fn send_frame(fd: &OwnedFd, ifindex: u32, frame: &[u8]) {
     sll.sll_ifindex = ifindex as i32;
     sll.sll_halen = 6;
     sll.sll_addr[..6].copy_from_slice(&frame[0..6]);
-    let sent = unsafe {
-        libc::sendto(
-            fd.as_raw_fd(),
-            frame.as_ptr() as *const _,
-            frame.len(),
-            0,
-            &sll as *const _ as *const libc::sockaddr,
-            mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
-        )
-    };
-    assert_eq!(
-        sent,
-        frame.len() as isize,
-        "sendto: {}",
-        std::io::Error::last_os_error()
-    );
+    // Back-to-back sends can outrun the device queue on slow hosts
+    // (GHA runners, TCG qemu) — the kernel answers ENOBUFS, which is
+    // backpressure, not a failure. Retry with a growing pause; the
+    // storm's clamp assertions already tolerate the GCRA refill this
+    // pacing admits (its margin is sized for it).
+    for attempt in 0..50u64 {
+        let sent = unsafe {
+            libc::sendto(
+                fd.as_raw_fd(),
+                frame.as_ptr() as *const _,
+                frame.len(),
+                0,
+                &sll as *const _ as *const libc::sockaddr,
+                mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+            )
+        };
+        if sent == frame.len() as isize {
+            return;
+        }
+        let err = std::io::Error::last_os_error();
+        assert_eq!(
+            err.raw_os_error(),
+            Some(libc::ENOBUFS),
+            "sendto: {err} (only ENOBUFS is retryable)"
+        );
+        std::thread::sleep(Duration::from_millis(1 + attempt));
+    }
+    panic!("sendto: ENOBUFS persisted across 50 retries");
 }
 
 /// Count frames matching `is_ours` arriving within `window`,
@@ -279,12 +291,14 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
         send_frame(&tx, ifindex_a, &storm);
     }
     let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_a));
+    // Lower bound: the burst. Upper bound: burst plus the refill a
+    // slow, ENOBUFS-paced send loop can legitimately admit at 5/s.
     assert!(
-        (5..=15).contains(&delivered),
+        (5..=20).contains(&delivered),
         "expected ~burst(5) of 40 frames delivered, got {delivered}"
     );
     assert!(
-        h.stat(idx::ARP_DROP) >= 25,
+        h.stat(idx::ARP_DROP) >= 20,
         "the clamped tail must be attributed: stats={:?}",
         h.snapshot()
     );

--- a/crates/modules/guard/tests/guard_netns.rs
+++ b/crates/modules/guard/tests/guard_netns.rs
@@ -167,40 +167,44 @@ fn open_packet_socket(ifindex: u32) -> OwnedFd {
     owned
 }
 
-fn send_frame(fd: &OwnedFd, ifindex: u32, frame: &[u8]) {
+/// Send one frame. `true` = the device path accepted it; `false` =
+/// the send failed with ENOBUFS, which at a guarded interface means
+/// **the guard dropped it**: TC_ACT_SHOT at the clsact egress hook
+/// makes `dev_queue_xmit` return `NET_XMIT_DROP`, and AF_PACKET's
+/// `packet_snd` maps that to ENOBUFS (`net_xmit_errno`) — the drop is
+/// reported to the local sender synchronously. This is the guard's
+/// operator-visible fingerprint (a clamped daemon's own sendto fails)
+/// and this test's own discovery: two earlier CI rounds misread it as
+/// queue exhaustion, and a retry-until-accepted loop turned the
+/// limiter into a pacer — every frame eventually earned a token and
+/// 40/40 were delivered, with the ~680 retries counted as drops.
+/// Any errno other than ENOBUFS still panics.
+fn send_frame(fd: &OwnedFd, ifindex: u32, frame: &[u8]) -> bool {
     let mut sll: libc::sockaddr_ll = unsafe { mem::zeroed() };
     sll.sll_family = libc::AF_PACKET as u16;
     sll.sll_ifindex = ifindex as i32;
     sll.sll_halen = 6;
     sll.sll_addr[..6].copy_from_slice(&frame[0..6]);
-    // Back-to-back sends can outrun the device queue on slow hosts
-    // (GHA runners, TCG qemu) — the kernel answers ENOBUFS, which is
-    // backpressure, not a failure. Retry with a growing pause; the
-    // storm's clamp assertions already tolerate the GCRA refill this
-    // pacing admits (its margin is sized for it).
-    for attempt in 0..50u64 {
-        let sent = unsafe {
-            libc::sendto(
-                fd.as_raw_fd(),
-                frame.as_ptr() as *const _,
-                frame.len(),
-                0,
-                &sll as *const _ as *const libc::sockaddr,
-                mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
-            )
-        };
-        if sent == frame.len() as isize {
-            return;
-        }
-        let err = std::io::Error::last_os_error();
-        assert_eq!(
-            err.raw_os_error(),
-            Some(libc::ENOBUFS),
-            "sendto: {err} (only ENOBUFS is retryable)"
-        );
-        std::thread::sleep(Duration::from_millis(1 + attempt));
+    let sent = unsafe {
+        libc::sendto(
+            fd.as_raw_fd(),
+            frame.as_ptr() as *const _,
+            frame.len(),
+            0,
+            &sll as *const _ as *const libc::sockaddr,
+            mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+        )
+    };
+    if sent == frame.len() as isize {
+        return true;
     }
-    panic!("sendto: ENOBUFS persisted across 50 retries");
+    let err = std::io::Error::last_os_error();
+    assert_eq!(
+        err.raw_os_error(),
+        Some(libc::ENOBUFS),
+        "sendto: {err} (only ENOBUFS means policed)"
+    );
+    false
 }
 
 /// Count frames matching `is_ours` arriving within `window`,
@@ -281,21 +285,21 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
     let tx = open_packet_socket(ifindex_a);
     let rx = open_packet_socket(ifindex_b);
 
-    // --- enforce: 40 same-target requests, back-to-back. Burst 5
-    // passes; the tail is dropped at the egress hook and never reaches
-    // the peer. The refill is 200 ms/token and the send loop takes
-    // ~ms, so the margin below is generous, not tight.
+    // --- enforce: 40 same-target requests, back-to-back. Burst 5 is
+    // accepted; every clamped frame is reported to the SENDER as an
+    // ENOBUFS sendto failure (see send_frame) and never reaches the
+    // peer. The loop takes ~ms against a 200 ms/token refill, so at
+    // most a token or two beyond the burst can be legitimately earned.
     let target_a = [206, 81, 82, 21];
     let storm = common::arp_request(SRC_MAC, target_a);
-    for _ in 0..40 {
-        send_frame(&tx, ifindex_a, &storm);
-    }
-    let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_a));
+    let accepted = (0..40)
+        .filter(|_| send_frame(&tx, ifindex_a, &storm))
+        .count() as u64;
+    let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_a)) as u64;
     // Assert the pipeline stages in order, each with the counter
     // snapshot, so a failure names WHERE it broke: program not in the
     // egress path (total_egress stuck), config lookup missing
-    // (pass_no_cfg), classifier not matching (pass_no_match), or the
-    // limiter not clamping (arp_pass = 40).
+    // (pass_no_cfg), or the limiter not clamping.
     let stats = h.snapshot();
     assert!(
         stats[idx::TOTAL_EGRESS] >= 40,
@@ -306,21 +310,32 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
         0,
         "GUARD_CFG lookup missed at real egress (skb->ifindex vs written key?): stats={stats:?}"
     );
-    // Lower bound: the burst. Upper bound: burst plus the refill a
-    // slow, ENOBUFS-paced send loop can legitimately admit at 5/s.
     assert!(
-        (5..=20).contains(&delivered),
-        "expected ~burst(5) of 40 frames delivered, got {delivered}; stats={stats:?}"
+        (5..=8).contains(&accepted),
+        "expected ~burst(5) of 40 sends accepted, got {accepted}; stats={stats:?}"
     );
-    assert!(
-        h.stat(idx::ARP_DROP) >= 20,
-        "the clamped tail must be attributed: stats={:?}",
-        h.snapshot()
+    // The three views of the clamp must agree exactly: sender-visible
+    // accepts == guard's pass counter == frames on the wire, and the
+    // ENOBUFS-rejected remainder == the drop counter. The namespace is
+    // quiet (no addresses, IPv6 off), so nothing else emits ARP.
+    assert_eq!(
+        stats[idx::ARP_PASS],
+        accepted,
+        "arp_pass must equal accepted sends: stats={stats:?}"
     );
-    assert!(h.stat(idx::ARP_PASS) >= 5);
+    assert_eq!(
+        stats[idx::ARP_DROP],
+        40 - accepted,
+        "arp_drop must equal ENOBUFS-rejected sends: stats={stats:?}"
+    );
+    assert_eq!(
+        delivered, accepted,
+        "every accepted frame and nothing else reaches the peer; stats={stats:?}"
+    );
 
-    // --- monitor: fresh target (fresh budget), same storm; everything
-    // is delivered and the would-drops are counted.
+    // --- monitor: fresh target (fresh budget), same storm; every send
+    // is accepted (no ENOBUFS — monitor never SHOTs), everything is
+    // delivered, and the would-drops are counted.
     let rules_mon = GuardIfaceRules {
         arp_ns: Some(RateRule {
             rate: 5,
@@ -333,9 +348,15 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
     h.set_guard_cfg(ifindex_a, GuardIfCfg::compile([0; 6], &rules_mon));
     let target_b = [206, 81, 81, 10];
     let storm = common::arp_request(SRC_MAC, target_b);
-    for _ in 0..40 {
-        send_frame(&tx, ifindex_a, &storm);
-    }
+    let accepted_mon = (0..40)
+        .filter(|_| send_frame(&tx, ifindex_a, &storm))
+        .count();
+    assert_eq!(
+        accepted_mon,
+        40,
+        "monitor mode must never reject a send: stats={:?}",
+        h.snapshot()
+    );
     let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_b));
     assert!(
         delivered >= 35,
@@ -350,7 +371,10 @@ fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
     // Unicast traffic through the guarded iface is untouched either
     // way (the fast exit): a plain IPv4 frame arrives.
     let unicast = common::unicast_ipv4(SRC_MAC, [0xaa, 0, 0, 0, 0, 2]);
-    send_frame(&tx, ifindex_a, &unicast);
+    assert!(
+        send_frame(&tx, ifindex_a, &unicast),
+        "unicast send accepted"
+    );
     let delivered = recv_count(&rx, Duration::from_secs(2), move |f: &[u8]| {
         f.len() >= 14 && f[0..6] == [0xaa, 0, 0, 0, 0, 2] && f[12..14] == [0x08, 0x00]
     });

--- a/crates/modules/guard/tests/guard_netns.rs
+++ b/crates/modules/guard/tests/guard_netns.rs
@@ -1,0 +1,329 @@
+//! End-to-end egress clamp test in a network namespace: attach
+//! `guard_egress` on one end of a veth pair, blast ARP requests
+//! through it via AF_PACKET (exactly how arping injects), and count
+//! what actually reaches the peer.
+//!
+//! This is the test TEST_RUN cannot be: verdicts here are enforced by
+//! the real clsact egress hook on a real device, keyed by the real
+//! `skb->ifindex`, against frames a packet socket injected — the
+//! production data path end to end.
+//!
+//! The netns/packet-socket helpers are duplicated from fast-path's
+//! tests/netns.rs per that file's per-test-file convention (the
+//! shared tests/common holds only the TEST_RUN harness).
+//!
+//! NOT in the hardware-artifacts SAFE suite: it creates a netns and
+//! interfaces.
+
+#![cfg(target_os = "linux")]
+
+mod common;
+
+use std::fs::File;
+use std::mem;
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::process::Command;
+use std::time::{Duration, Instant};
+
+use common::{idx, Harness, LO_IFINDEX};
+use packetframe_guard::cfg::{GuardIfCfg, GuardIfaceRules, RateRule};
+use packetframe_guard::tc_attach_egress;
+
+struct Names {
+    netns: String,
+    veth_a: String,
+    veth_b: String,
+}
+
+impl Names {
+    fn new() -> Self {
+        let suffix = std::process::id() % 10_000;
+        Self {
+            netns: format!("pfgn{suffix:04}"),
+            veth_a: format!("pga{suffix:04}"),
+            veth_b: format!("pgb{suffix:04}"),
+        }
+    }
+}
+
+/// RAII netns: Drop deletes the namespace, which destroys the veths
+/// and, with them, the qdisc-lifetime egress filter.
+struct NetnsGuard {
+    name: String,
+}
+
+impl NetnsGuard {
+    fn setup(names: &Names) -> Self {
+        let _ = Command::new("ip")
+            .args(["netns", "del", &names.netns])
+            .status();
+        run(&["ip", "netns", "add", &names.netns]);
+        // Quiet the namespace: no IPv6 autoconf chatter (DAD NS, RS,
+        // MLD) competing with the frames the test counts. Must run
+        // before `ip link add` (default.* templates new ifaces).
+        ns_run(
+            &names.netns,
+            &["sysctl", "-wq", "net.ipv6.conf.all.disable_ipv6=1"],
+        );
+        ns_run(
+            &names.netns,
+            &["sysctl", "-wq", "net.ipv6.conf.default.disable_ipv6=1"],
+        );
+        ns_run(
+            &names.netns,
+            &[
+                "ip",
+                "link",
+                "add",
+                &names.veth_a,
+                "type",
+                "veth",
+                "peer",
+                "name",
+                &names.veth_b,
+            ],
+        );
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_a, "up"]);
+        ns_run(&names.netns, &["ip", "link", "set", &names.veth_b, "up"]);
+        Self {
+            name: names.netns.clone(),
+        }
+    }
+}
+
+impl Drop for NetnsGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("ip")
+            .args(["netns", "del", &self.name])
+            .status();
+    }
+}
+
+fn run(cmd: &[&str]) {
+    let status = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("spawn `{}`: {e}", cmd.join(" ")));
+    assert!(status.success(), "`{}` exited {status}", cmd.join(" "));
+}
+
+fn ns_run(netns: &str, cmd: &[&str]) {
+    let mut args = vec!["netns", "exec", netns];
+    args.extend_from_slice(cmd);
+    let status = Command::new("ip")
+        .args(&args)
+        .status()
+        .unwrap_or_else(|e| panic!("spawn `ip {}`: {e}", args.join(" ")));
+    assert!(status.success(), "`ip {}` exited {status}", args.join(" "));
+}
+
+/// Move the current thread into the netns (`setns(2)` re-associates
+/// only the calling thread).
+fn enter_netns(netns: &str) -> OwnedFd {
+    let path = format!("/var/run/netns/{netns}");
+    let fd: OwnedFd = File::open(&path)
+        .unwrap_or_else(|e| panic!("open {path}: {e}"))
+        .into();
+    let rc = unsafe { libc::setns(fd.as_raw_fd(), libc::CLONE_NEWNET) };
+    assert_eq!(rc, 0, "setns({path}): {}", std::io::Error::last_os_error());
+    fd
+}
+
+fn if_nametoindex(name: &str) -> u32 {
+    let c = std::ffi::CString::new(name).expect("iface name with NUL");
+    let idx = unsafe { libc::if_nametoindex(c.as_ptr()) };
+    assert!(idx > 0, "if_nametoindex({name}) failed");
+    idx
+}
+
+fn open_packet_socket(ifindex: u32) -> OwnedFd {
+    const ETH_P_ALL: u16 = 0x0003;
+    let proto_be: u16 = ETH_P_ALL.to_be();
+    let fd = unsafe { libc::socket(libc::PF_PACKET, libc::SOCK_RAW, proto_be as i32) };
+    assert!(
+        fd >= 0,
+        "socket(PF_PACKET): {}",
+        std::io::Error::last_os_error()
+    );
+    // SAFETY: kernel returned a valid fd we now own.
+    let owned = unsafe { OwnedFd::from_raw_fd(fd) };
+    let mut sll: libc::sockaddr_ll = unsafe { mem::zeroed() };
+    sll.sll_family = libc::AF_PACKET as u16;
+    sll.sll_protocol = proto_be;
+    sll.sll_ifindex = ifindex as i32;
+    let rc = unsafe {
+        libc::bind(
+            owned.as_raw_fd(),
+            &sll as *const _ as *const libc::sockaddr,
+            mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(
+        rc,
+        0,
+        "bind(PF_PACKET, ifindex={ifindex}): {}",
+        std::io::Error::last_os_error()
+    );
+    owned
+}
+
+fn send_frame(fd: &OwnedFd, ifindex: u32, frame: &[u8]) {
+    let mut sll: libc::sockaddr_ll = unsafe { mem::zeroed() };
+    sll.sll_family = libc::AF_PACKET as u16;
+    sll.sll_ifindex = ifindex as i32;
+    sll.sll_halen = 6;
+    sll.sll_addr[..6].copy_from_slice(&frame[0..6]);
+    let sent = unsafe {
+        libc::sendto(
+            fd.as_raw_fd(),
+            frame.as_ptr() as *const _,
+            frame.len(),
+            0,
+            &sll as *const _ as *const libc::sockaddr,
+            mem::size_of::<libc::sockaddr_ll>() as libc::socklen_t,
+        )
+    };
+    assert_eq!(
+        sent,
+        frame.len() as isize,
+        "sendto: {}",
+        std::io::Error::last_os_error()
+    );
+}
+
+/// Count frames matching `is_ours` arriving within `window`,
+/// discarding everything else the namespace emits.
+fn recv_count(fd: &OwnedFd, window: Duration, is_ours: impl Fn(&[u8]) -> bool) -> usize {
+    let deadline = Instant::now() + window;
+    let mut count = 0usize;
+    let mut buf = [0u8; 2048];
+    loop {
+        let now = Instant::now();
+        if now >= deadline {
+            return count;
+        }
+        let remaining_ms = (deadline - now).as_millis().min(1000) as libc::c_int;
+        let mut pfd = libc::pollfd {
+            fd: fd.as_raw_fd(),
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let rc = unsafe { libc::poll(&mut pfd, 1, remaining_ms) };
+        if rc <= 0 {
+            return count; // timeout (or EINTR-adjacent noise): done
+        }
+        let n = unsafe {
+            libc::recv(
+                fd.as_raw_fd(),
+                buf.as_mut_ptr() as *mut _,
+                buf.len(),
+                libc::MSG_DONTWAIT,
+            )
+        };
+        if n > 0 && is_ours(&buf[..n as usize]) {
+            count += 1;
+        }
+    }
+}
+
+/// `is_ours` for our crafted ARP requests: ARP ethertype + our tpa.
+fn arp_for(target: [u8; 4]) -> impl Fn(&[u8]) -> bool {
+    move |f: &[u8]| f.len() >= 42 && f[12..14] == [0x08, 0x06] && f[38..42] == target
+}
+
+const SRC_MAC: [u8; 6] = [0xaa, 0x00, 0x00, 0x00, 0x00, 0x01];
+
+#[test]
+#[ignore = "needs CAP_BPF + CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test -p packetframe-guard --tests -- --ignored`"]
+fn arp_storm_is_clamped_at_egress_and_monitor_passes() {
+    if !packetframe_guard::GUARD_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping guard netns test.");
+        return;
+    }
+    let names = Names::new();
+    let _netns = NetnsGuard::setup(&names);
+    let _ns_fd = enter_netns(&names.netns);
+
+    let ifindex_a = if_nametoindex(&names.veth_a);
+    let ifindex_b = if_nametoindex(&names.veth_b);
+    assert_ne!(
+        ifindex_a, LO_IFINDEX,
+        "sanity: the guarded iface must not be loopback"
+    );
+
+    // Only the ARP/NS limiter, enforce: rate 5/1s burst 5 per target.
+    // foreign-src stays disabled, so the expected-MAC fields are inert.
+    let mut h = Harness::new();
+    let rules = GuardIfaceRules {
+        arp_ns: Some(RateRule {
+            rate: 5,
+            per: Duration::from_secs(1),
+            burst: 5,
+            monitor: false,
+        }),
+        ..Default::default()
+    };
+    h.set_guard_cfg(ifindex_a, GuardIfCfg::compile([0; 6], &rules));
+    let (_priority, _handle) = tc_attach_egress(&mut h.bpf, &names.veth_a).expect("egress attach");
+
+    let tx = open_packet_socket(ifindex_a);
+    let rx = open_packet_socket(ifindex_b);
+
+    // --- enforce: 40 same-target requests, back-to-back. Burst 5
+    // passes; the tail is dropped at the egress hook and never reaches
+    // the peer. The refill is 200 ms/token and the send loop takes
+    // ~ms, so the margin below is generous, not tight.
+    let target_a = [206, 81, 82, 21];
+    let storm = common::arp_request(SRC_MAC, target_a);
+    for _ in 0..40 {
+        send_frame(&tx, ifindex_a, &storm);
+    }
+    let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_a));
+    assert!(
+        (5..=15).contains(&delivered),
+        "expected ~burst(5) of 40 frames delivered, got {delivered}"
+    );
+    assert!(
+        h.stat(idx::ARP_DROP) >= 25,
+        "the clamped tail must be attributed: stats={:?}",
+        h.snapshot()
+    );
+    assert!(h.stat(idx::ARP_PASS) >= 5);
+
+    // --- monitor: fresh target (fresh budget), same storm; everything
+    // is delivered and the would-drops are counted.
+    let rules_mon = GuardIfaceRules {
+        arp_ns: Some(RateRule {
+            rate: 5,
+            per: Duration::from_secs(1),
+            burst: 5,
+            monitor: true,
+        }),
+        ..Default::default()
+    };
+    h.set_guard_cfg(ifindex_a, GuardIfCfg::compile([0; 6], &rules_mon));
+    let target_b = [206, 81, 81, 10];
+    let storm = common::arp_request(SRC_MAC, target_b);
+    for _ in 0..40 {
+        send_frame(&tx, ifindex_a, &storm);
+    }
+    let delivered = recv_count(&rx, Duration::from_secs(2), arp_for(target_b));
+    assert!(
+        delivered >= 35,
+        "monitor mode must deliver the storm, got {delivered}/40"
+    );
+    assert!(
+        h.stat(idx::ARP_MONITOR) >= 25,
+        "monitor must count the would-drops: stats={:?}",
+        h.snapshot()
+    );
+
+    // Unicast traffic through the guarded iface is untouched either
+    // way (the fast exit): a plain IPv4 frame arrives.
+    let unicast = common::unicast_ipv4(SRC_MAC, [0xaa, 0, 0, 0, 0, 2]);
+    send_frame(&tx, ifindex_a, &unicast);
+    let delivered = recv_count(&rx, Duration::from_secs(2), move |f: &[u8]| {
+        f.len() >= 14 && f[0..6] == [0xaa, 0, 0, 0, 0, 2] && f[12..14] == [0x08, 0x00]
+    });
+    assert_eq!(delivered, 1, "unicast must pass untouched");
+}

--- a/crates/modules/guard/tests/guard_tc_attach.rs
+++ b/crates/modules/guard/tests/guard_tc_attach.rs
@@ -1,0 +1,179 @@
+//! Real tc-egress attach/detach lifecycle on a veth pair. Mirror of
+//! fast-path's tests/tc_attach.rs (ingress); when one is updated, the
+//! other likely needs the same change.
+//!
+//! Covers: clsact creation + the EEXIST path (pre-existing qdisc,
+//! e.g. fast-path's ingress filter on the same iface), the egress
+//! filter landing where `tc filter show ... egress` can see it,
+//! `guard-tc-links.json` persistence, out-of-process detach clearing
+//! the filter while **leaving clsact in place**, and the
+//! vanished-iface teardown branch.
+//!
+//! NOT in the hardware-artifacts SAFE suite: it creates interfaces.
+
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+use packetframe_guard::{aligned_bpf_copy, detach_from_state_dir, tc_attach_egress, tc_links};
+
+const PEER_A: &str = "pf-gdv0";
+const PEER_B: &str = "pf-gdv1";
+
+struct Cleanup {
+    state_dir: std::path::PathBuf,
+}
+
+impl Drop for Cleanup {
+    fn drop(&mut self) {
+        let _ = Command::new("ip").args(["link", "del", PEER_A]).status();
+        let _ = std::fs::remove_dir_all(&self.state_dir);
+    }
+}
+
+fn run(cmd: &[&str]) {
+    let status = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .status()
+        .unwrap_or_else(|e| panic!("spawn `{}`: {e}", cmd.join(" ")));
+    assert!(status.success(), "`{}` exited {status}", cmd.join(" "));
+}
+
+fn capture(cmd: &[&str]) -> String {
+    let out = Command::new(cmd[0])
+        .args(&cmd[1..])
+        .output()
+        .unwrap_or_else(|e| panic!("spawn `{}`: {e}", cmd.join(" ")));
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+fn state_dir(tag: &str) -> std::path::PathBuf {
+    let p = std::env::temp_dir().join(format!("pf-guard-tc-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&p).unwrap();
+    p
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test -p packetframe-guard --tests -- --ignored`"]
+fn egress_attach_persist_detach_lifecycle() {
+    if !packetframe_guard::GUARD_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping guard tc attach test.");
+        return;
+    }
+    let state_dir = state_dir("lifecycle");
+    let _cleanup = Cleanup {
+        state_dir: state_dir.clone(),
+    };
+    let _ = Command::new("ip").args(["link", "del", PEER_A]).status();
+    run(&[
+        "ip", "link", "add", PEER_A, "type", "veth", "peer", "name", PEER_B,
+    ]);
+    run(&["ip", "link", "set", PEER_A, "up"]);
+    run(&["ip", "link", "set", PEER_B, "up"]);
+
+    // Pre-create clsact on PEER_A: the attach must take the EEXIST
+    // path (fast-path's ingress filter would have created it in
+    // production).
+    run(&["tc", "qdisc", "add", "dev", PEER_A, "clsact"]);
+
+    let bytes = aligned_bpf_copy();
+    let mut bpf = aya::Ebpf::load(&bytes).expect("Ebpf::load");
+    {
+        let prog: &mut aya::programs::tc::SchedClassifier = bpf
+            .program_mut("guard_egress")
+            .expect("guard_egress present")
+            .try_into()
+            .expect("sched_cls");
+        prog.load().expect("verifier accepts guard_egress");
+    }
+
+    let (priority, handle) = tc_attach_egress(&mut bpf, PEER_A).expect("egress attach");
+    let shown = capture(&["tc", "filter", "show", "dev", PEER_A, "egress"]);
+    assert!(
+        shown.contains("guard_egress"),
+        "egress filter not visible: {shown}"
+    );
+    // And nothing landed on ingress.
+    let ingress = capture(&["tc", "filter", "show", "dev", PEER_A, "ingress"]);
+    assert!(
+        !ingress.contains("guard_egress"),
+        "guard filter leaked onto ingress: {ingress}"
+    );
+
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: PEER_A.to_string(),
+                priority,
+                handle,
+            }],
+        },
+    )
+    .expect("persist record");
+
+    // The kernel attach must survive the loader: drop the Ebpf (all
+    // FDs close) and tear down purely from persisted state.
+    drop(bpf);
+    let shown = capture(&["tc", "filter", "show", "dev", PEER_A, "egress"]);
+    assert!(
+        shown.contains("guard_egress"),
+        "netlink cls_bpf filter must have qdisc lifetime: {shown}"
+    );
+
+    let cleared =
+        detach_from_state_dir(&state_dir, &state_dir.join("bpffs")).expect("detach clean");
+    assert_eq!(cleared, 1);
+    let shown = capture(&["tc", "filter", "show", "dev", PEER_A, "egress"]);
+    assert!(
+        !shown.contains("guard_egress"),
+        "filter must be gone after detach: {shown}"
+    );
+    // clsact stays: fast-path may share it on the same interface.
+    let qdisc = capture(&["tc", "qdisc", "show", "dev", PEER_A]);
+    assert!(
+        qdisc.contains("clsact"),
+        "detach must never delete the shared clsact qdisc: {qdisc}"
+    );
+    assert!(
+        tc_links::load(&state_dir).unwrap().is_none(),
+        "state file removed after full success"
+    );
+    // Idempotent: a second detach over no state is a clean no-op.
+    assert_eq!(
+        detach_from_state_dir(&state_dir, &state_dir.join("bpffs")).expect("idempotent"),
+        0
+    );
+}
+
+#[test]
+#[ignore = "needs CAP_BPF + CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test -p packetframe-guard --tests -- --ignored`"]
+fn detach_treats_vanished_iface_as_cleared() {
+    if !packetframe_guard::GUARD_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping guard tc attach test.");
+        return;
+    }
+    // No iface is created at all — the record points at a name that
+    // doesn't resolve, which is exactly the state after a device
+    // deletion (qdisc-lifetime filters die with their device). Uses
+    // its own state dir and iface name so it can run concurrently
+    // with the lifecycle test in the same binary (cargo runs tests in
+    // threads; a shared iface-deleting Drop would race).
+    let state_dir = state_dir("vanished");
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: "pf-gd-gone0".to_string(),
+                priority: 49152,
+                handle: 1,
+            }],
+        },
+    )
+    .expect("persist record");
+    let cleared =
+        detach_from_state_dir(&state_dir, &state_dir.join("bpffs")).expect("vanished = cleared");
+    assert_eq!(cleared, 1);
+    assert!(tc_links::load(&state_dir).unwrap().is_none());
+    let _ = std::fs::remove_dir_all(&state_dir);
+}

--- a/crates/modules/guard/tests/guard_tc_attach.rs
+++ b/crates/modules/guard/tests/guard_tc_attach.rs
@@ -53,6 +53,14 @@ fn state_dir(tag: &str) -> std::path::PathBuf {
     p
 }
 
+fn ifindex_of(iface: &str) -> u32 {
+    std::fs::read_to_string(format!("/sys/class/net/{iface}/ifindex"))
+        .unwrap_or_else(|e| panic!("read ifindex of {iface}: {e}"))
+        .trim()
+        .parse()
+        .expect("ifindex parses")
+}
+
 #[test]
 #[ignore = "needs CAP_BPF + CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test -p packetframe-guard --tests -- --ignored`"]
 fn egress_attach_persist_detach_lifecycle() {
@@ -105,6 +113,7 @@ fn egress_attach_persist_detach_lifecycle() {
         &tc_links::TcLinksFile {
             links: vec![tc_links::TcLinkRecord {
                 iface: PEER_A.to_string(),
+                ifindex: ifindex_of(PEER_A),
                 priority,
                 handle,
             }],
@@ -165,6 +174,7 @@ fn detach_treats_vanished_iface_as_cleared() {
         &tc_links::TcLinksFile {
             links: vec![tc_links::TcLinkRecord {
                 iface: "pf-gd-gone0".to_string(),
+                ifindex: 4242,
                 priority: 49152,
                 handle: 1,
             }],
@@ -175,5 +185,93 @@ fn detach_treats_vanished_iface_as_cleared() {
         detach_from_state_dir(&state_dir, &state_dir.join("bpffs")).expect("vanished = cleared");
     assert_eq!(cleared, 1);
     assert!(tc_links::load(&state_dir).unwrap().is_none());
+    let _ = std::fs::remove_dir_all(&state_dir);
+}
+
+/// The recreated-device scenario from the #205 review: a record whose
+/// device was deleted and recreated under the same name must classify
+/// as Cleared WITHOUT touching the replacement — whose own filter
+/// commonly lands on the exact same auto-allocated
+/// `(priority, handle)` tuple the stale record names.
+#[test]
+#[ignore = "needs CAP_BPF + CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test -p packetframe-guard --tests -- --ignored`"]
+fn detach_spares_filters_on_a_recreated_device() {
+    if !packetframe_guard::GUARD_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping guard tc attach test.");
+        return;
+    }
+    const RE_A: &str = "pf-gdr0";
+    const RE_B: &str = "pf-gdr1";
+    struct ReCleanup;
+    impl Drop for ReCleanup {
+        fn drop(&mut self) {
+            let _ = Command::new("ip").args(["link", "del", RE_A]).status();
+        }
+    }
+    let state_dir = state_dir("recreate");
+    let _cleanup = ReCleanup;
+    let _ = Command::new("ip").args(["link", "del", RE_A]).status();
+
+    // Original device: attach, record (with its ifindex), then delete
+    // the device — the filter dies with it, the record goes stale.
+    run(&[
+        "ip", "link", "add", RE_A, "type", "veth", "peer", "name", RE_B,
+    ]);
+    let bytes = aligned_bpf_copy();
+    let mut bpf = aya::Ebpf::load(&bytes).expect("Ebpf::load");
+    {
+        let prog: &mut aya::programs::tc::SchedClassifier = bpf
+            .program_mut("guard_egress")
+            .expect("guard_egress present")
+            .try_into()
+            .expect("sched_cls");
+        prog.load().expect("verifier accepts guard_egress");
+    }
+    let (priority, handle) = tc_attach_egress(&mut bpf, RE_A).expect("first attach");
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: RE_A.to_string(),
+                ifindex: ifindex_of(RE_A),
+                priority,
+                handle,
+            }],
+        },
+    )
+    .expect("persist stale-to-be record");
+    run(&["ip", "link", "del", RE_A]);
+
+    // Recreate the same name (new ifindex) and give the REPLACEMENT
+    // its own guard filter — auto-allocation typically hands back the
+    // same (priority, handle) tuple, the collision the ifindex check
+    // exists for.
+    run(&[
+        "ip", "link", "add", RE_A, "type", "veth", "peer", "name", RE_B,
+    ]);
+    let mut bpf2 = aya::Ebpf::load(&bytes).expect("Ebpf::load 2");
+    {
+        let prog: &mut aya::programs::tc::SchedClassifier = bpf2
+            .program_mut("guard_egress")
+            .expect("guard_egress present")
+            .try_into()
+            .expect("sched_cls");
+        prog.load().expect("verifier accepts guard_egress");
+    }
+    let (p2, h2) = tc_attach_egress(&mut bpf2, RE_A).expect("attach on replacement");
+    drop(bpf2);
+
+    // Detach from the STALE record: Cleared (the old filter died with
+    // its device), and the replacement's filter survives untouched —
+    // even when the tuples collide.
+    let cleared =
+        detach_from_state_dir(&state_dir, &state_dir.join("bpffs")).expect("recreated = cleared");
+    assert_eq!(cleared, 1);
+    let shown = capture(&["tc", "filter", "show", "dev", RE_A, "egress"]);
+    assert!(
+        shown.contains("guard_egress"),
+        "the replacement device's filter (prio {p2}, handle {h2}) must survive a \
+         stale-record detach: {shown}"
+    );
     let _ = std::fs::remove_dir_all(&state_dir);
 }

--- a/docs/runbooks/guard.md
+++ b/docs/runbooks/guard.md
@@ -110,6 +110,21 @@ Attribution notes that will otherwise confuse a 3am reader:
 - `err_parse_*` count fail-open passes on truncated headers. Local
   daemons don't emit runts; sustained movement is worth a tcpdump.
 
+## The ENOBUFS fingerprint
+
+An enforced drop is visible to the **sender**, not just the counters:
+TC_ACT_SHOT at the clsact egress hook makes `dev_queue_xmit` return
+`NET_XMIT_DROP`, which the kernel surfaces to a local AF_PACKET/raw
+sender as a synchronous `ENOBUFS` ("No buffer space available") send
+error. So a clamped daemon logs its own failures — udapi-server's
+arping included — and any local tool that suddenly reports ENOBUFS on
+an IX interface while `packetframe_guard_frames_total{verdict=
+"dropped"}` moves is seeing the guard work, not a buffer problem.
+(Discovered by the netns integration test, whose first CI runs
+misread it as queue exhaustion; a sender that retries on ENOBUFS gets
+paced to exactly the configured rate, which is arguably the politest
+possible outcome.) Monitor mode never produces it.
+
 ## Triage by symptom
 
 - **Neighbor resolution slow/failing on an IX** (peers unreachable,
@@ -117,6 +132,11 @@ Attribution notes that will otherwise confuse a 3am reader:
   `ns/dropped`. If they move in step with the failures, the rate is
   too tight or a legitimate burst pattern exceeds it — flip to
   `monitor` via SIGHUP (instant, no restart) and re-derive the rate.
+- **A local daemon logs "No buffer space available" on a guarded
+  interface**: that's the ENOBUFS fingerprint above — the guard
+  enforcing, not a buffer shortage. Confirm with the `dropped`
+  counters; nothing to fix unless the drops are of traffic you meant
+  to allow.
 - **IX operator still sees storms while enforce is on**: confirm the
   filter exists (`tc filter show dev br3998 egress`), the module is
   healthy in `packetframe status`, and `total_egress` is moving. If


### PR DESCRIPTION
Slice 4 of 4, stacked on #206.

- **guard_tc_attach** (veth, root): production `tc_attach_egress` through the clsact-EEXIST path (pre-created qdisc, as fast-path's ingress filter would leave it), `tc filter show dev X egress` visibility (and absence from ingress), the kernel attach surviving the Ebpf drop (netlink cls_bpf = qdisc lifetime), `detach_from_state_dir` clearing the filter while leaving clsact alone, vanished-iface → Cleared, idempotent re-detach.
- **guard_netns** (netns + veth + AF_PACKET, root): the module's purpose, measured on a real egress hook — a 40-frame same-target ARP storm delivers ~burst(5) under enforce with ≥25 attributed to `arp_drop`; the same storm at a fresh target under monitor delivers ≥35/40 with the would-drops counted; a unicast frame passes untouched. IPv6 disabled in the namespace so autoconf chatter can't perturb the counts.

Both run in the qemu 5.15/6.6 matrix via the existing `--ignored` sweep; both are named in the hardware bundle's excluded list (they create interfaces/netns — the SAFE default stays write-nothing). `guard_tc_attach` is named to dodge the bundle's basename-collision refusal against fast-path's `tc_attach`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)