### PR TITLE
ci(qemu): skip bench tests under TCG instead of capping them a third time

### DIFF
--- a/.github/workflows/qemu-verifier.yml
+++ b/.github/workflows/qemu-verifier.yml
@@ -181,14 +181,32 @@ jobs:
           # signal 7 [Bus error]` twice in a row on the 6.6 leg, at
           # the same link. 6 GB ⇒ ~3 GB tmpfs restores the margin;
           # hosted runners have 16 GB, so TCG + 6 GB guest is fine.
+          # PACKETFRAME_BENCH_SKIP=1: skip the fast-path bench tests
+          # outright. bpf_test_run executes uninterruptibly, and under
+          # TCG a bench stalls a vCPU past the soft-lockup watchdog;
+          # the per-fire ~35-line splat to the emulated serial console
+          # then compounds until the 20-min job timeout. Two rounds of
+          # PACKETFRAME_BENCH_QUICK capping (per-syscall repeat in
+          # #82, then a ~400-execution total budget) still flaked on
+          # slow 5.15 runners (PR #206, PR #207) — runner speed varies
+          # too much for any fixed budget. Bench numbers under TCG are
+          # meaningless anyway; the benches still run full-mode in
+          # ci.yml's native sudo step and on routers via the
+          # hardware-artifacts bundle.
+          #
+          # watchdog_thresh=60 (default 10, softlockup fires at 2x+2s):
+          # belt-and-braces for the remaining fixture tests — any
+          # uninterruptible test_run syscall can stall a TCG vCPU, and
+          # a splat storm is what turns one stall into a job timeout.
           run_vm() {
             virtme-ng \
               --run "${KERNEL_IMG}" \
               --pwd \
               --memory 6144 \
               --disable-kvm \
+              --append "watchdog_thresh=60" \
               --verbose \
-              -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; export PACKETFRAME_BENCH_QUICK=1; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-guard --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
+              -- bash -c 'set -eux; export HOME=/home/runner; export CARGO_HOME="${HOME}/.cargo"; export RUSTUP_HOME="${HOME}/.rustup"; export PATH="${CARGO_HOME}/bin:${PATH}"; export PACKETFRAME_BENCH_SKIP=1; uname -a; which cargo; cargo test -p packetframe-fast-path --tests -- --ignored --nocapture; cargo test -p packetframe-guard --tests -- --ignored --nocapture; cargo test -p packetframe-probe --tests -- --ignored --nocapture'
           }
           # Retry policy: virtme-ng propagates the guest command's exit
           # status, so a genuine test failure arrives as cargo's 101

--- a/crates/modules/fast-path/tests/bench.rs
+++ b/crates/modules/fast-path/tests/bench.rs
@@ -36,6 +36,10 @@
 //! `PACKETFRAME_BENCH_BASELINE_NS=<ns>` makes the established-flow
 //! forward bench fail if its median exceeds the baseline.
 //!
+//! Other knobs: `PACKETFRAME_BENCH_QUICK=1` caps repeat/call counts,
+//! `PACKETFRAME_BENCH_SKIP=1` skips the benches entirely (set by the
+//! qemu-verifier CI job; see `bench_skip` below).
+//!
 //! **TTL budget:** `BPF_PROG_TEST_RUN` reuses one packet buffer across
 //! all `repeat` iterations inside a syscall, and the forward path
 //! decrements TTL per pass. Forward benches therefore use `ttl: 255`
@@ -55,8 +59,28 @@ use common::{xdp_action, Harness, Ipv4TcpBuilder, StatIdx};
 /// devmap pre-check needs a real entry.
 const LO_IFINDEX: u32 = 1;
 
-/// Quick mode for CI under emulation. The statistics only matter on
-/// real hardware; under qemu TCG the full 1M-execution forward loops
+/// Hard skip knob for CI under emulation. Two rounds of quick-mode
+/// capping (per-syscall repeat in #82, then the ~400-execution total
+/// budget below) still left `bench_custom_fib_*` tripping the 22 s
+/// soft-lockup watchdog on slow TCG runners (PR #206 on 2026-08-25,
+/// PR #207 on 2026-08-26): `bpf_test_run` is uninterruptible, and
+/// TCG's per-execution cost varies enough across hosted runners that
+/// no fixed budget is both meaningful and safe. Benchmark numbers
+/// under emulation were never meaningful anyway, so qemu-verifier.yml
+/// sets this and skips the benches outright; their real homes are
+/// ci.yml's native-speed sudo step (full mode) and the
+/// hardware-artifacts bundle run on routers (`run-tests.sh bench`).
+fn bench_skip() -> bool {
+    if std::env::var_os("PACKETFRAME_BENCH_SKIP").is_some() {
+        eprintln!("PACKETFRAME_BENCH_SKIP set; skipping bench.");
+        true
+    } else {
+        false
+    }
+}
+
+/// Quick mode for constrained-but-native environments. The statistics
+/// only matter on real hardware; under qemu TCG the full 1M-execution forward loops
 /// (a) take double-digit minutes and (b) trip the kernel's 22-second
 /// soft-lockup watchdog inside `bpf_test_run`, whose per-fire ~35-line
 /// splat to the emulated serial console compounds the slowdown until
@@ -156,6 +180,9 @@ fn fwd_packet(tcp_flags: u8) -> Vec<u8> {
 #[test]
 #[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
 fn bench_custom_fib_forward_established() {
+    if bench_skip() {
+        return;
+    }
     let h = custom_fib_harness();
     let pkt = fwd_packet(TCP_FLAG_ACK);
 
@@ -187,6 +214,9 @@ fn bench_custom_fib_forward_established() {
 #[test]
 #[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
 fn bench_custom_fib_forward_syn() {
+    if bench_skip() {
+        return;
+    }
     let h = custom_fib_harness();
     let pkt = fwd_packet(TCP_FLAG_SYN);
 
@@ -202,6 +232,9 @@ fn bench_custom_fib_forward_syn() {
 #[test]
 #[ignore = "needs CAP_BPF + BPF build; run via `sudo -E cargo test --test bench -- --ignored --nocapture`"]
 fn bench_allowlist_miss() {
+    if bench_skip() {
+        return;
+    }
     // No allowlist entries at all: the packet parses, does the two
     // ALLOW_V4 LPM lookups, misses, and XDP_PASSes without mutation,
     // so a single syscall can carry a large repeat.


### PR DESCRIPTION
## Why

The qemu-verifier 5.15 leg soft-lockup flake struck twice in two days (2026-08-25 on #206, 2026-08-26 on #207): `bpf_prog_test_run` executes uninterruptibly, and under TCG `bench_custom_fib_*` stalls a vCPU past the 22 s watchdog; the per-fire ~35-line splat storm on the emulated serial console then times the job out at 20 min. Each hit costs a manual rerun.

This is the **third** round against this flake. #82 capped per-syscall repeat under `PACKETFRAME_BENCH_QUICK`; the follow-up capped total volume to ~400 executions per bench. Slow hosted runners still trip the watchdog, because TCG per-execution cost varies too much across runners for any fixed budget to be both meaningful and safe.

## What

- **`PACKETFRAME_BENCH_SKIP=1`**: the three bench tests early-return with a skip print (same idiom as the BPF-stub gates). Set only in qemu-verifier.yml's in-VM command — bench numbers under emulation were never meaningful.
- The benches keep running full-mode where they mean something: ci.yml's native-speed sudo step (stable there, no `QUICK` set) and the hardware-artifacts SAFE suite on routers (`run-tests.sh` includes `bench`, no skip env).
- Belt-and-braces: guest boots with `watchdog_thresh=60` (`virtme-ng --append`), since any uninterruptible `test_run` in the fixture suites can stall a TCG vCPU too.
- `PACKETFRAME_BENCH_QUICK` stays for constrained-but-native environments.

## Verification

- Cross-target clippy (`--workspace --all-targets --all-features -D warnings`) green on all 4 published targets with `PACKETFRAME_SKIP_BPF_BUILD=1`; `cargo fmt --check` clean.
- Both qemu matrix legs must pass on this PR — the 5.15 leg is the one this fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)