### PR TITLE
fix(fast-path): close the recreated-device hole in tc-datapath teardown

### DIFF
--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1549,7 +1549,7 @@ pub fn attach(
         populate_tc_mutation_progs(&mut state.ebpf)?;
 
         let mut tc_records = Vec::with_capacity(tc_dirs.len());
-        for (iface, _mode, ifindex) in tc_dirs.iter() {
+        for (iface, _mode, _planning_ifindex) in tc_dirs.iter() {
             if attach_count > 0 && !settle_time.is_zero() {
                 info!(
                     settle_secs = settle_time.as_secs_f64(),
@@ -1559,10 +1559,21 @@ pub fn attach(
                 std::thread::sleep(settle_time);
             }
             attach_count += 1;
+            // Re-resolve the ifindex HERE, not the attach_dirs planning
+            // value: tc_attach_iface attaches by NAME, and the planning
+            // resolution is separated from this attach by every earlier
+            // XDP attach plus the settle sleeps. A device recreated in
+            // that window gets the filter on its (new) self, and a
+            // record carrying the stale planning ifindex would make
+            // detach classify it as recreated and drop the record with
+            // the filter still live (review finding, PR #209). The
+            // resolve-to-attach race that remains is the same accepted
+            // TOCTOU as tc_detach_one's.
+            let ifindex = if_nametoindex(iface)?;
             let (priority, handle) = tc_attach_iface(&mut state.ebpf, iface)?;
             tc_records.push(crate::tc_links::TcLinkRecord {
                 iface: iface.clone(),
-                ifindex: *ifindex,
+                ifindex,
                 priority,
                 handle,
             });
@@ -1582,7 +1593,7 @@ pub fn attach(
             .map_err(|e| ModuleError::other(MODULE_NAME, format!("tc-links.json save: {e}")))?;
             state.links.push(LinkRecord {
                 iface: iface.clone(),
-                ifindex: *ifindex,
+                ifindex,
                 effective_mode: AttachMode::Tc,
                 link: LinkHandle::Tc { priority, handle },
             });

--- a/crates/modules/fast-path/src/linux_impl.rs
+++ b/crates/modules/fast-path/src/linux_impl.rs
@@ -1562,6 +1562,7 @@ pub fn attach(
             let (priority, handle) = tc_attach_iface(&mut state.ebpf, iface)?;
             tc_records.push(crate::tc_links::TcLinkRecord {
                 iface: iface.clone(),
+                ifindex: *ifindex,
                 priority,
                 handle,
             });
@@ -2386,9 +2387,10 @@ pub fn tc_attach_iface(ebpf: &mut Ebpf, iface: &str) -> ModuleResult<(u16, u32)>
 /// filter plausibly attached.
 enum TcDetachOutcome {
     /// Goal state reached: the filter was detached, or is provably
-    /// gone already (iface no longer resolvable — the qdisc and its
-    /// filters died with the device — or the netlink delete reported
-    /// ENOENT/EINVAL, i.e. no such filter/qdisc). Record droppable.
+    /// gone already (iface no longer resolvable or recreated under
+    /// the same name — the qdisc and its filters died with the
+    /// original device — or the netlink delete reported ENOENT/EINVAL,
+    /// i.e. no such filter/qdisc). Record droppable.
     Cleared,
     /// The delete failed with the filter plausibly still live
     /// (transient netlink error, EPERM, ...). Record must be retained
@@ -2399,9 +2401,45 @@ enum TcDetachOutcome {
 /// Detach one recorded tc filter. Building block for both the
 /// in-process (`detach(state)`) and out-of-process
 /// ([`tc_detach_from_state_dir`]) teardown paths.
-fn tc_detach_one(iface: &str, priority: u16, handle: u32) -> TcDetachOutcome {
+fn tc_detach_one(
+    iface: &str,
+    expected_ifindex: u32,
+    priority: u16,
+    handle: u32,
+) -> TcDetachOutcome {
     use aya::programs::tc::{SchedClassifierLink, TcAttachType, TcError};
     use aya::programs::{Link as _, ProgramError};
+
+    // A same-name device with a DIFFERENT ifindex is a recreated
+    // device: the recorded filter died with the original (qdisc
+    // lifetime), and `SchedClassifierLink::attached` resolves by name,
+    // so deleting here could remove an unrelated filter on the
+    // replacement whose (priority, handle) happens to match — the
+    // first auto-allocated tuple is common (review finding, guard
+    // PR #205; mirror of guard's tc_detach_one). The check-to-delete
+    // race is accepted: it requires the device to be recreated in
+    // that instant AND the tuple to collide. expected_ifindex == 0 is
+    // a record from a pre-ifindex build (see TcLinkRecord); no attach-
+    // time ifindex to compare, so fall through to the name-resolved
+    // delete those builds did.
+    if expected_ifindex != 0 {
+        match if_nametoindex(iface) {
+            Err(_) => {
+                info!(iface, "iface gone; tc filter died with it");
+                return TcDetachOutcome::Cleared;
+            }
+            Ok(current) if current != expected_ifindex => {
+                info!(
+                    iface,
+                    expected_ifindex,
+                    current,
+                    "iface recreated; the recorded filter died with the old device"
+                );
+                return TcDetachOutcome::Cleared;
+            }
+            Ok(_) => {}
+        }
+    }
 
     // `attached()` only resolves the ifindex; failure means the iface
     // is gone, and qdisc-lifetime filters go with their device.
@@ -2450,7 +2488,7 @@ pub fn tc_detach_from_state_dir(state_dir: &Path) -> ModuleResult<usize> {
     let mut cleared = 0usize;
     let mut retained = Vec::new();
     for rec in file.links {
-        match tc_detach_one(&rec.iface, rec.priority, rec.handle) {
+        match tc_detach_one(&rec.iface, rec.ifindex, rec.priority, rec.handle) {
             TcDetachOutcome::Cleared => {
                 info!(iface = %rec.iface, rec.priority, rec.handle, "tc filter cleared");
                 cleared += 1;
@@ -2836,12 +2874,13 @@ pub fn detach(state: &mut ActiveState) -> ModuleResult<()> {
         info!(iface = %record.iface, "fast-path detaching");
         if let LinkHandle::Tc { priority, handle } = record.link {
             had_tc = true;
-            match tc_detach_one(&record.iface, priority, handle) {
+            match tc_detach_one(&record.iface, record.ifindex, priority, handle) {
                 TcDetachOutcome::Cleared => {}
                 TcDetachOutcome::Failed(e) => {
                     warn!(iface = %record.iface, error = %e, "tc filter detach failed; record retained");
                     tc_retained.push(crate::tc_links::TcLinkRecord {
                         iface: record.iface.clone(),
+                        ifindex: record.ifindex,
                         priority,
                         handle,
                     });

--- a/crates/modules/fast-path/src/tc_links.rs
+++ b/crates/modules/fast-path/src/tc_links.rs
@@ -11,6 +11,10 @@
 //!
 //! Sibling of `registry.rs` (`<state-dir>/tc-links.json` next to
 //! `attachments.json`); same atomic write-then-rename discipline.
+//!
+//! Mirror of guard's `tc_links.rs`; when one is updated, the other
+//! likely needs the same change (guard's header explains why the two
+//! stay separate files).
 
 use std::path::{Path, PathBuf};
 
@@ -47,6 +51,22 @@ pub struct TcLinksFile {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TcLinkRecord {
     pub iface: String,
+    /// The device's ifindex at attach time. Detach verifies it before
+    /// reconstructing the filter: a same-name RECREATED device has a
+    /// new ifindex, the recorded filter died with the original
+    /// (qdisc lifetime), and `SchedClassifierLink::attached` resolves
+    /// by name — a blind delete could remove an unrelated filter on
+    /// the replacement whose `(priority, handle)` happens to match
+    /// (the first auto-allocated tuple is common). Review finding,
+    /// guard PR #205; same hole here.
+    ///
+    /// `#[serde(default)]` = 0 for records written by builds that
+    /// predate this field. 0 is never a real ifindex; detach treats
+    /// it as "unknown, skip the recreated-device check" (the
+    /// pre-field behavior) rather than refusing to tear down a
+    /// legacy deployment's filters.
+    #[serde(default)]
+    pub ifindex: u32,
     pub priority: u16,
     pub handle: u32,
 }
@@ -107,6 +127,7 @@ mod tests {
         let file = TcLinksFile {
             links: vec![TcLinkRecord {
                 iface: "eth5".into(),
+                ifindex: 7,
                 priority: 49152,
                 handle: 1,
             }],
@@ -115,11 +136,22 @@ mod tests {
         let loaded = load(&dir).unwrap().expect("file present");
         assert_eq!(loaded.links.len(), 1);
         assert_eq!(loaded.links[0].iface, "eth5");
+        assert_eq!(loaded.links[0].ifindex, 7);
         assert_eq!(loaded.links[0].priority, 49152);
         assert_eq!(loaded.links[0].handle, 1);
         remove(&dir).unwrap();
         assert!(load(&dir).unwrap().is_none());
         remove(&dir).unwrap(); // second remove is a no-op
         let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A tc-links.json written by a pre-ifindex build must still load:
+    /// deployed routers can carry one across an upgrade, and refusing
+    /// to parse it would strand live filters with no teardown metadata.
+    #[test]
+    fn legacy_record_without_ifindex_loads_as_zero() {
+        let raw = r#"{"links":[{"iface":"eth5","priority":49152,"handle":1}]}"#;
+        let file: TcLinksFile = serde_json::from_str(raw).expect("legacy record parses");
+        assert_eq!(file.links[0].ifindex, 0);
     }
 }

--- a/crates/modules/fast-path/tests/tc_attach.rs
+++ b/crates/modules/fast-path/tests/tc_attach.rs
@@ -12,7 +12,11 @@
 //!    still lists the bpf filter afterwards.
 //! 2. **Out-of-process teardown works from the persisted record.**
 //!    `tc_detach_from_state_dir` reconstructs the filter purely from
-//!    tc-links.json `(iface, priority, handle)` and detaches it.
+//!    tc-links.json `(iface, ifindex, priority, handle)` and detaches
+//!    it.
+//!
+//! Mirror of guard's tests/guard_tc_attach.rs (egress); when one is
+//! updated, the other likely needs the same change.
 //!
 //! Full end-to-end tc forwarding (packet in → bpf_redirect → packet
 //! out the peer) needs a netns + AF_PACKET harness like netns.rs and
@@ -46,6 +50,14 @@ fn run(cmd: &[&str]) {
         .status()
         .unwrap_or_else(|e| panic!("spawning `{}`: {e}", cmd.join(" ")));
     assert!(status.success(), "`{}` failed: {status}", cmd.join(" "));
+}
+
+fn ifindex_of(iface: &str) -> u32 {
+    std::fs::read_to_string(format!("/sys/class/net/{iface}/ifindex"))
+        .unwrap_or_else(|e| panic!("read ifindex of {iface}: {e}"))
+        .trim()
+        .parse()
+        .expect("ifindex parses")
 }
 
 fn tc_filter_listing(iface: &str) -> String {
@@ -102,6 +114,7 @@ fn tc_attach_persists_and_detaches_from_state_dir() {
         &tc_links::TcLinksFile {
             links: vec![tc_links::TcLinkRecord {
                 iface: PEER_A.to_string(),
+                ifindex: ifindex_of(PEER_A),
                 priority,
                 handle,
             }],
@@ -169,6 +182,7 @@ fn tc_detach_clears_records_for_vanished_ifaces() {
         &tc_links::TcLinksFile {
             links: vec![tc_links::TcLinkRecord {
                 iface: "pf-gone0".to_string(), // never created
+                ifindex: 4242,
                 priority: 49152,
                 handle: 1,
             }],
@@ -181,5 +195,93 @@ fn tc_detach_clears_records_for_vanished_ifaces() {
     assert!(
         tc_links::load(&state_dir).expect("load").is_none(),
         "file must be removed once every record is cleared"
+    );
+}
+
+/// The recreated-device scenario from the guard #205 review, which
+/// fast-path shared: a record whose device was deleted and recreated
+/// under the same name must classify as Cleared WITHOUT touching the
+/// replacement — whose own filter commonly lands on the exact same
+/// auto-allocated `(priority, handle)` tuple the stale record names.
+/// Mirror of guard's `detach_spares_filters_on_a_recreated_device`.
+#[test]
+#[ignore = "needs CAP_NET_ADMIN + BPF build; run via `sudo -E cargo test ... -- --ignored`"]
+fn tc_detach_spares_filters_on_a_recreated_device() {
+    if !FAST_PATH_BPF_AVAILABLE {
+        eprintln!("BPF stub in effect (no rustup); skipping tc attach test.");
+        return;
+    }
+    const RE_A: &str = "pf-tcr0";
+    const RE_B: &str = "pf-tcr1";
+    // Own iface pair + state dir so this can run concurrently with the
+    // lifecycle test in the same binary (see DirCleanup note above).
+    struct ReCleanup(std::path::PathBuf);
+    impl Drop for ReCleanup {
+        fn drop(&mut self) {
+            let _ = Command::new("ip").args(["link", "del", RE_A]).status();
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+    let state_dir =
+        std::env::temp_dir().join(format!("pf-tc-recreate-test-{}", std::process::id()));
+    let _cleanup = ReCleanup(state_dir.clone());
+    let _ = Command::new("ip").args(["link", "del", RE_A]).status();
+
+    let load_classifiers = |bpf: &mut aya::Ebpf| {
+        for name in ["tc_finalize", "tc_fast_path"] {
+            let prog: &mut aya::programs::tc::SchedClassifier = bpf
+                .program_mut(name)
+                .unwrap_or_else(|| panic!("{name} present"))
+                .try_into()
+                .unwrap_or_else(|_| panic!("{name} is sched_cls"));
+            prog.load().expect("verifier accepts classifier");
+        }
+    };
+
+    // Original device: attach, record (with its ifindex), then delete
+    // the device — the filter dies with it, the record goes stale.
+    run(&[
+        "ip", "link", "add", RE_A, "type", "veth", "peer", "name", RE_B,
+    ]);
+    let bytes = aligned_bpf_copy();
+    let mut bpf = aya::Ebpf::load(&bytes).expect("aya::Ebpf::load");
+    load_classifiers(&mut bpf);
+    let (priority, handle) = tc_attach_iface(&mut bpf, RE_A).expect("first attach");
+    tc_links::save(
+        &state_dir,
+        &tc_links::TcLinksFile {
+            links: vec![tc_links::TcLinkRecord {
+                iface: RE_A.to_string(),
+                ifindex: ifindex_of(RE_A),
+                priority,
+                handle,
+            }],
+        },
+    )
+    .expect("persist stale-to-be record");
+    run(&["ip", "link", "del", RE_A]);
+
+    // Recreate the same name (new ifindex) and give the REPLACEMENT
+    // its own filter — auto-allocation typically hands back the same
+    // (priority, handle) tuple, the collision the ifindex check
+    // exists for.
+    run(&[
+        "ip", "link", "add", RE_A, "type", "veth", "peer", "name", RE_B,
+    ]);
+    let mut bpf2 = aya::Ebpf::load(&bytes).expect("aya::Ebpf::load 2");
+    load_classifiers(&mut bpf2);
+    let (p2, h2) = tc_attach_iface(&mut bpf2, RE_A).expect("attach on replacement");
+    drop(bpf2);
+
+    // Detach from the STALE record: Cleared (the old filter died with
+    // its device), and the replacement's filter survives untouched —
+    // even when the tuples collide.
+    let cleared = tc_detach_from_state_dir(&state_dir).expect("recreated = cleared");
+    assert_eq!(cleared, 1);
+    let listing = tc_filter_listing(RE_A);
+    assert!(
+        listing.contains("bpf"),
+        "the replacement device's filter (prio {p2}, handle {h2}) must survive a \
+         stale-record detach, got:\n{listing}"
     );
 }

--- a/docs/runbooks/tc-datapath.md
+++ b/docs/runbooks/tc-datapath.md
@@ -268,6 +268,16 @@ tc filter del dev eth5 ingress
 
 (The clsact qdisc itself is harmless to leave in place.)
 
+Records in `tc-links.json` carry the attach-time ifindex; detach uses
+it to recognize a deleted-and-recreated interface (same name, new
+ifindex) and skip the stale record instead of deleting whatever filter
+the replacement device now holds at the recorded `(priority, handle)`.
+Records written by builds that predate the field load with ifindex 0
+and detach by name alone (the old behavior) — no `detach --all` is
+required before upgrading, but if you want the protection on an
+already-attached debugging interface, re-attach it once on the new
+build so the record is rewritten with its ifindex.
+
 Failure posture mirrors XDP: SIGTERM leaves filters attached
 (§8.5 parity — the filter holds its own program reference); a circuit
 breaker trip detaches everything explicitly.


### PR DESCRIPTION
## What

Ports the guard module's recreated-device teardown fix (the #205 Codex review finding, commit 32725a9) to fast-path's tc-datapath, which had the identical hole.

- `TcLinkRecord` gains `ifindex: u32`, recorded at attach time (the attach loop already resolves it).
- `tc_detach_one` verifies the recorded ifindex before reconstructing the filter: a same-name device with a different ifindex is a recreated device — the recorded filter died with the original (qdisc lifetime) — so it's classified `Cleared` without touching the replacement. Same accepted check-to-delete TOCTOU comment as the guard.
- Both teardown paths (`tc_detach_from_state_dir` and in-process `detach()`) pass the recorded ifindex; the retained-on-failure path preserves it.

## Why

`SchedClassifierLink::attached(iface, ...)` resolves the interface **name** to whatever device currently holds it. If the interface was deleted and recreated under the same name, a stale-record detach could delete an unrelated filter on the replacement whose `(priority, handle)` collides — and the first auto-allocated tuple `(49152, 1)` collides routinely.

## Divergence from the guard: legacy records

The guard never shipped without the field; fast-path did, so deployed routers can carry a pre-upgrade `tc-links.json`. The field is `#[serde(default)]`: 0 is never a real ifindex and means "legacy record — skip the recreated-device check and detach by name, exactly the pre-field behavior." No `detach --all` is required before upgrading. Documented in the record's docstring and in `docs/runbooks/tc-datapath.md` (tc mode is debugging-only on the fleet, so the residual legacy-record exposure is small and self-heals on the next re-attach).

## Tests

- `tc_detach_spares_filters_on_a_recreated_device` (integration, qemu CI on both kernels): attach → record → delete device → recreate same name → attach a replacement filter on the (colliding) auto-allocated tuple → detach from the stale record clears it while the replacement's filter survives. Mirror of the guard's test on `feat/guard-integration-tests` (452c04d), per the mirror-file headers.
- `legacy_record_without_ifindex_loads_as_zero` (unit, host): a pre-field JSON record still parses.
- Existing lifecycle/vanished-iface tests updated to carry ifindex.

## Reviewer notes

- Fast-path's `tc_links.rs` also gains the reciprocal mirror-header pointing at the guard's twin (guard's already pointed here).
- Local gates: `cargo fmt --check` and `cargo clippy --workspace --all-targets --all-features -D warnings` pass on all four Linux cross targets; host unit tests green. The new integration test needs the qemu-verifier job to actually execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)